### PR TITLE
Missing CHPRINTF_USE_FLOAT in simulator's chconf.h

### DIFF
--- a/win32_functional_tests/chconf.h
+++ b/win32_functional_tests/chconf.h
@@ -28,6 +28,8 @@
 #ifndef _CHCONF_H_
 #define _CHCONF_H_
 
+#define CHPRINTF_USE_FLOAT          	TRUE
+
 /*===========================================================================*/
 /**
  * @name System timers settings


### PR DESCRIPTION
That should one of the simulator bug (#379)