### PR TITLE
Fix accel enrichment for negative fuel pulse

### DIFF
--- a/firmware/controllers/algo/accel_enrichment.cpp
+++ b/firmware/controllers/algo/accel_enrichment.cpp
@@ -60,6 +60,13 @@ floatms_t WallFuel::adjust(int injectorIndex, floatms_t target DECLARE_ENGINE_PA
 
 	floatms_t adjustedFuelPulse = (target - suckedOffWallsAmount) / (1 - addedToWallCoef);
 
+	// We can't inject a negative amount of fuel
+	// If this goes below zero we will be over-fueling slightly,
+	// but that's ok.
+	if(adjustedFuelPulse < 0) {
+		adjustedFuelPulse = 0;
+	}
+
 	float addedToWallsAmount = adjustedFuelPulse * addedToWallCoef;
 	wallFuel[injectorIndex] += addedToWallsAmount - suckedOffWallsAmount;
 	engine->wallFuelCorrection = adjustedFuelPulse - target;


### PR DESCRIPTION
If the target fuel was very small, and there was lots of fuel on the wall, you could get an injector pulse of <0.  This will inject no fuel (like a pulse of 0ms would), but will more importantly screw up the estimate for how much fuel is on the wall.  If the pulse went negative, the model would update as though the injector had sucked fuel back in to the tank.