### PR TITLE
Bootloader set default pin states

### DIFF
--- a/firmware/bootloader/src/dfu.h
+++ b/firmware/bootloader/src/dfu.h
@@ -6,7 +6,7 @@
 // This is where the bootloader starts
 #define BOOTLOADER_ADDR    0x08000000
 // Bootloader code max. size, in bytes
-#define BOOTLOADER_SIZE    0x4000
+#define BOOTLOADER_SIZE    0x8000
 // Number of sectors for the bootloader
 #define BOOTLOADER_NUM_SECTORS (BOOTLOADER_SIZE/0x4000)
 
@@ -32,7 +32,7 @@
 #define DFU_ACK_BYTE       0x79  // Acknowledge byte ID
 #define DFU_NACK_BYTE      0x1F  // Not-Acknowledge byte ID
 
-#define DFU_SR5_TIMEOUT_FIRST  MS2ST(100)
+#define DFU_SR5_TIMEOUT_FIRST  MS2ST(200)
 #define DFU_SR5_TIMEOUT_NORMAL MS2ST(1000)
 
 #define MCU_REVISION_MASK  0xfff // MCU Revision ID is needed by DFU protocol

--- a/firmware/bootloader/src/main.cpp
+++ b/firmware/bootloader/src/main.cpp
@@ -38,6 +38,8 @@ int main(void) {
 	// run ChibiOS
 	halInit();
 	chSysInit();
+	// set base pin configuration based on the board
+	setDefaultBasePins(PASS_ENGINE_PARAMETER_SIGNATURE);
 	// set UART pads configuration based on the board
 	setDefaultSerialParameters(PASS_ENGINE_PARAMETER_SIGNATURE);
 	// set SD card configuration also

--- a/firmware/config/boards/ST_STM32F4/board.c
+++ b/firmware/config/boards/ST_STM32F4/board.c
@@ -136,6 +136,13 @@ void setBoardConfigurationOverrides(void) {
 }
 
 /**
+ * @brief   Board-specific pin configuration code overrides. Needed by bootloader code.
+ * @todo    Add your board-specific code, if any.
+ */
+void setPinConfigurationOverrides(void) {
+}
+
+/**
  * @brief   Board-specific Serial configuration code overrides. Needed by bootloader code.
  * @todo    Add your board-specific code, if any.
  */

--- a/firmware/config/boards/ST_STM32F4/board.h
+++ b/firmware/config/boards/ST_STM32F4/board.h
@@ -1345,6 +1345,7 @@ extern "C" {
 #endif
   void boardInit(void);
   void setBoardConfigurationOverrides(void);
+  void setPinConfigurationOverrides(void);
   void setSerialConfigurationOverrides(void);
   void setSdCardConfigurationOverrides(void);
 #ifdef __cplusplus

--- a/firmware/controllers/algo/engine_configuration.cpp
+++ b/firmware/controllers/algo/engine_configuration.cpp
@@ -370,6 +370,11 @@ void setDefaultBasePins(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 	engineConfiguration->fatalErrorPin = GPIOD_14;
 	engineConfiguration->warninigPin = GPIOD_13;
 	engineConfiguration->configResetPin = GPIOB_1;
+#if EFI_PROD_CODE || defined(__DOXYGEN__)
+	// call overrided board-specific serial configuration setup, if needed (for custom boards only)
+	// needed also by bootloader code
+	setPinConfigurationOverrides();
+#endif
 }
 
 // needed also by bootloader code

--- a/firmware/controllers/algo/engine_configuration.h
+++ b/firmware/controllers/algo/engine_configuration.h
@@ -59,6 +59,7 @@ void setConstantDwell(floatms_t dwellMs DECLARE_ENGINE_PARAMETER_SUFFIX);
 void printFloatArray(const char *prefix, float array[], int size);
 
 // needed by bootloader
+void setDefaultBasePins(DECLARE_ENGINE_PARAMETER_SIGNATURE);
 void setDefaultSerialParameters(DECLARE_ENGINE_PARAMETER_SIGNATURE);
 void setDefaultSdCardParameters(DECLARE_ENGINE_PARAMETER_SIGNATURE);
 


### PR DESCRIPTION
The bootloader should set a correct pin state for the board (first of all, the default ignition coils state), otherwise some peripherals would be damaged.