### PR TITLE
Fix CJ125 postState() debug output

### DIFF
--- a/firmware/hw_layer/sensors/CJ125.cpp
+++ b/firmware/hw_layer/sensors/CJ125.cpp
@@ -427,8 +427,10 @@ static msg_t cjThread(void)
 		cjSetMode(lambda > 1.0f ? CJ125_MODE_NORMAL_17 : CJ125_MODE_NORMAL_8);
 #endif
 
+#if 0
 		// Update console output variables
 		cjPostState(&tsOutputChannels);
+#endif
 
 		switch (state) {
 		case CJ125_PREHEAT:


### PR DESCRIPTION
Oops. Some debug code left...
Call to cjPostState() should be only in status_loop.cpp and only for debugMode==DBG_CJ125.