### PR TITLE
Coasting Fuel Cut Fixes

### DIFF
--- a/firmware/controllers/algo/engine_configuration.cpp
+++ b/firmware/controllers/algo/engine_configuration.cpp
@@ -492,6 +492,7 @@ static void setDefaultFuelCutParameters(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 	engineConfiguration->coastingFuelCutRpmLow = 1300;
 	engineConfiguration->coastingFuelCutRpmHigh = 1500;
 	engineConfiguration->coastingFuelCutTps = 2;
+	engineConfiguration->coastingFuelCupMap = 30;
 	engineConfiguration->coastingFuelCutClt = 30;
 }
 

--- a/firmware/controllers/algo/engine_configuration.cpp
+++ b/firmware/controllers/algo/engine_configuration.cpp
@@ -492,7 +492,7 @@ static void setDefaultFuelCutParameters(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 	engineConfiguration->coastingFuelCutRpmLow = 1300;
 	engineConfiguration->coastingFuelCutRpmHigh = 1500;
 	engineConfiguration->coastingFuelCutTps = 2;
-	engineConfiguration->coastingFuelCupMap = 30;
+	engineConfiguration->coastingFuelCutMap = 30;
 	engineConfiguration->coastingFuelCutClt = 30;
 }
 

--- a/firmware/controllers/algo/engine_configuration_generated_structures.h
+++ b/firmware/controllers/algo/engine_configuration_generated_structures.h
@@ -1,4 +1,4 @@
-// this section was generated automatically by ConfigDefinition.jar based on rusefi_config.txt Sun Jun 17 14:48:08 EDT 2018
+// this section was generated automatically by ConfigDefinition.jar based on rusefi_config.txt Fri Jun 22 11:35:17 CDT 2018
 // begin
 #ifndef ENGINE_CONFIGURATION_GENERATED_H_
 #define ENGINE_CONFIGURATION_GENERATED_H_
@@ -2126,9 +2126,10 @@ typedef struct {
 	 */
 	int16_t pidExtraForLowRpm;
 	/**
+	 *  maximum manifold pressure for fuel cut
 	 * offset 3386
 	 */
-	int16_t unusedInt16;
+	int16_t coastingFuelCutMap;
 	/**
 	 * CLT-based idle position for coasting (used in Auto-PID Idle mode)
 	 * offset 3388
@@ -2388,4 +2389,4 @@ typedef struct {
 
 #endif
 // end
-// this section was generated automatically by ConfigDefinition.jar based on rusefi_config.txt Sun Jun 17 14:48:08 EDT 2018
+// this section was generated automatically by ConfigDefinition.jar based on rusefi_config.txt Fri Jun 22 11:35:17 CDT 2018

--- a/firmware/controllers/algo/fuel_math.cpp
+++ b/firmware/controllers/algo/fuel_math.cpp
@@ -262,17 +262,19 @@ float getFuelCutOffCorrection(efitick_t nowNt, int rpm DECLARE_ENGINE_PARAMETER_
 	// coasting fuel cut-off correction
 	if (boardConfiguration->coastingFuelCutEnabled) {
 		percent_t tpsPos = getTPS(PASS_ENGINE_PARAMETER_SIGNATURE);
+		float map = getMap();
 	
 		// gather events
+		bool mapDeactivate = (map >= CONFIG(coastingFuelCutMap));
 		bool tpsDeactivate = (tpsPos >= CONFIG(coastingFuelCutTps));
 		bool cltDeactivate = cisnan(engine->sensors.clt) ? false : (engine->sensors.clt < (float)CONFIG(coastingFuelCutClt));
 		bool rpmDeactivate = (rpm < CONFIG(coastingFuelCutRpmLow));
 		bool rpmActivate = (rpm > CONFIG(coastingFuelCutRpmHigh));
 		
 		// state machine (coastingFuelCutStartTime is also used as a flag)
-		if (!tpsDeactivate && !cltDeactivate && rpmActivate) {
+		if (!mapDeactivate && !tpsDeactivate && !cltDeactivate && rpmActivate) {
 			ENGINE(engineState.coastingFuelCutStartTime) = nowNt;
-		} else if (tpsDeactivate || rpmDeactivate || cltDeactivate) {
+		} else if (mapDeactivate || tpsDeactivate || rpmDeactivate || cltDeactivate) {
 			ENGINE(engineState.coastingFuelCutStartTime) = 0;
 		}
 		// enable fuelcut?

--- a/firmware/controllers/algo/rusefi_generated.h
+++ b/firmware/controllers/algo/rusefi_generated.h
@@ -1562,8 +1562,8 @@
 #define coastingFuelCutClt_offset_hex d36
 #define pidExtraForLowRpm_offset 3384
 #define pidExtraForLowRpm_offset_hex d38
-#define unusedInt16_offset 3386
-#define unusedInt16_offset_hex d3a
+#define coastingFuelCutMap_offset 3386
+#define coastingFuelCutMap_offset_hex d3a
 #define iacCoastingBins_offset 3388
 #define iacCoastingBins_offset_hex d3c
 #define iacCoasting_offset 3452

--- a/firmware/controllers/trigger/main_trigger_callback.cpp
+++ b/firmware/controllers/trigger/main_trigger_callback.cpp
@@ -249,7 +249,7 @@ static ALWAYS_INLINE void handleFuelInjectionEvent(int injEventIndex, InjectionE
 	// If somebody commanded an impossibly short injection, do nothing.
 	// Durations under 50us-ish aren't safe for the scheduler
 	// as their order may be swapped, resulting in a stuck open injector
-	if (injectionDuration < 0.050)
+	if (injectionDuration < 0.050f)
 	{
 		return;
 	}

--- a/firmware/controllers/trigger/main_trigger_callback.cpp
+++ b/firmware/controllers/trigger/main_trigger_callback.cpp
@@ -245,6 +245,15 @@ static ALWAYS_INLINE void handleFuelInjectionEvent(int injEventIndex, InjectionE
 		warning(CUSTOM_OBD_NEG_INJECTION, "Negative injection pulse %.2f", injectionDuration);
 		return;
 	}
+
+	// If somebody commanded an impossibly short injection, do nothing.
+	// Durations under 50us-ish aren't safe for the scheduler
+	// as their order may be swapped, resulting in a stuck open injector
+	if (injectionDuration < 0.050)
+	{
+		return;
+	}
+
 	floatus_t durationUs = MS2US(injectionDuration);
 
 

--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -900,11 +900,11 @@ float[CRANKING_ADVANCE_CURVE_SIZE] crankingAdvance    ;Optional timing advance t
 	brain_pin_e[SERVO_COUNT iterate] servoOutputPins;todo: more comments
 	int16_t coastingFuelCutRpmHigh;;"rpm",        1,     0,  0,    5000,  0
 	int16_t coastingFuelCutRpmLow;;"rpm",        1,     0,  0,    5000,  0
-	int16_t coastingFuelCutTps;percent between 0 and 100;"%",        1,     0,  0,    100,  0
+	int16_t coastingFuelCutTps;percent between 0 and 100;"%",        1,     0,  0,    100,  1
 	int16_t coastingFuelCutClt;Fuel cutoff is deactivated if CLT<threshold;"C",        1,     0,  -100,    100,  0
 	
 	int16_t pidExtraForLowRpm;+Increases PID reaction for RPM<target by adding extra percent to PID-error;"%",        1,     0,  0,    100,  0
-	int16_t unusedInt16;
+	int16_t coastingFuelCutMap; maximum manifold pressure for fuel cut;"kPa", 1, 0, 0, 250, 0
 	
 float[CLT_CURVE_SIZE] iacCoastingBins;CLT-based idle position for coasting (used in Auto-PID Idle mode);"C",        1,     0,   -100.0,    250.0,  2
 float[CLT_CURVE_SIZE] iacCoasting;    CLT-based idle position for coasting (used in Auto-PID Idle mode);"%",      1,     0,      0.0,    100.0,   2

--- a/firmware/tunerstudio/rusefi.ini
+++ b/firmware/tunerstudio/rusefi.ini
@@ -63,7 +63,7 @@ enable2ndByteCanID = false
 
 ; see PAGE_0_SIZE in C source code    
 ; CONFIG_DEFINITION_START
-; this section was generated automatically by ConfigDefinition.jar based on rusefi_config.txt Sun Jun 17 20:01:54 EDT 2018
+; this section was generated automatically by ConfigDefinition.jar based on rusefi_config.txt Fri Jun 22 11:35:17 CDT 2018
 
 pageSize            = 20000
 page = 1
@@ -781,10 +781,10 @@ page = 1
 	servoOutputPins8			 = bits, U32, 3372, [0:6], "PA0", "PA1", "PA2", "PA3", "PA4", "PA5", "PA6", "PA7", "PA8", "PA9", "PA10", "PA11", "PA12", "PA13", "PA14", "PA15", "PB0", "PB1", "PB2", "PB3", "PB4", "PB5", "PB6", "PB7", "PB8", "PB9", "PB10", "PB11", "PB12", "PB13", "PB14", "PB15", "PC0", "PC1", "PC2", "PC3", "PC4", "PC5", "PC6", "PC7", "PC8", "PC9", "PC10", "PC11", "PC12", "PC13", "PC14", "PC15", "PD0", "PD1", "PD2", "PD3", "PD4", "PD5", "PD6", "PD7", "PD8", "PD9", "PD10", "PD11", "PD12", "PD13", "PD14", "PD15", "PE0", "PE1", "PE2", "PE3", "PE4", "PE5", "PE6", "PE7", "PE8", "PE9", "PE10", "PE11", "PE12", "PE13", "PE14", "PE15", "NONE", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID"
 	coastingFuelCutRpmHigh			= scalar, S16,	3376,	"rpm", 1, 0, 0, 5000, 0
 	coastingFuelCutRpmLow			= scalar, S16,	3378,	"rpm", 1, 0, 0, 5000, 0
-	coastingFuelCutTps				= scalar, S16,	3380,	"%", 1, 0, 0, 100, 0
+	coastingFuelCutTps				= scalar, S16,	3380,	"%", 1, 0, 0, 100, 1
 	coastingFuelCutClt				= scalar, S16,	3382,	"C", 1, 0, -100, 100, 0
 	pidExtraForLowRpm				= scalar, S16,	3384,	"%", 1, 0, 0, 100, 0
-;no TS info - skipping unusedInt16 offset 3386
+	coastingFuelCutMap				= scalar, S16,	3386,	"kPa", 1, 0, 0, 250, 0
 	iacCoastingBins					= array, F32,	3388,	[16],	"C", 1, 0, -100.0, 250.0, 2
 	iacCoasting						= array, F32,	3452,	[16],	"%", 1, 0, 0.0, 100.0, 2
 ;no TS info - skipping unusedEnd offset 3516

--- a/java_console/models/src/com/rusefi/config/Fields.java
+++ b/java_console/models/src/com/rusefi/config/Fields.java
@@ -1,6 +1,6 @@
 package com.rusefi.config;
 
-// this file was generated automatically by ConfigDefinition.jar based on rusefi_config.txt Sun Jun 17 14:48:08 EDT 2018
+// this file was generated automatically by ConfigDefinition.jar based on rusefi_config.txt Fri Jun 22 11:35:17 CDT 2018
 public class Fields {
 	public static final int LE_COMMAND_LENGTH = 200;
 	public static final int BLOCKING_FACTOR = 400;
@@ -1033,7 +1033,7 @@ public class Fields {
 	public static final int coastingFuelCutTps_offset = 3380;
 	public static final int coastingFuelCutClt_offset = 3382;
 	public static final int pidExtraForLowRpm_offset = 3384;
-	public static final int unusedInt16_offset = 3386;
+	public static final int coastingFuelCutMap_offset = 3386;
 	public static final int iacCoastingBins_offset = 3388;
 	public static final int iacCoasting_offset = 3452;
 	public static final int unusedEnd_offset = 3516;
@@ -1865,7 +1865,7 @@ public class Fields {
 	public static final Field COASTINGFUELCUTTPS = Field.create("COASTINGFUELCUTTPS", 3380, FieldType.INT);
 	public static final Field COASTINGFUELCUTCLT = Field.create("COASTINGFUELCUTCLT", 3382, FieldType.INT);
 	public static final Field PIDEXTRAFORLOWRPM = Field.create("PIDEXTRAFORLOWRPM", 3384, FieldType.INT);
-	public static final Field UNUSEDINT16 = Field.create("UNUSEDINT16", 3386, FieldType.INT);
+	public static final Field COASTINGFUELCUTMAP = Field.create("COASTINGFUELCUTMAP", 3386, FieldType.INT);
 	public static final Field FSIOFORMULAS1 = Field.create("FSIOFORMULAS1", 6672, FieldType.INT);
 	public static final Field FSIOFORMULAS2 = Field.create("FSIOFORMULAS2", 6872, FieldType.INT);
 	public static final Field FSIOFORMULAS3 = Field.create("FSIOFORMULAS3", 7072, FieldType.INT);

--- a/unit_tests/test_fuelCut.cpp
+++ b/unit_tests/test_fuelCut.cpp
@@ -28,6 +28,7 @@ void testCoastingFuelCut() {
 	engineConfiguration->coastingFuelCutRpmHigh = 1500;
 	engineConfiguration->coastingFuelCutTps = 2;
 	engineConfiguration->coastingFuelCutClt = 30;
+	engineConfiguration->coastingFuelCutMap = 100;
 	// set cranking threshold
 	engineConfiguration->cranking.rpm = 999;
 	// configure TPS


### PR DESCRIPTION
This PR solves two problems:
1) When fuel is cut, getInjectionDuration returns zero duration, so that no fuel is injected (as desired).  However, when handleFuelInjectionEvent goes to schedule the opening and closing of the injectors schedules two events very close together (sometimes exactly on top of each other).  These events sometimes get swapped in order of execution by the scheduler, so the injector will STICK OPEN FLOODING THE ENGINE.  I discovered this when driving, and the coasting fuel cut caused my O2 sensors to read full scale rich.

![image](https://user-images.githubusercontent.com/568254/41796404-0588b58a-762c-11e8-9f5b-851014437467.png)

Here's an example of that condition while running on the bench.  Note that it sometimes sticks open, and sometimes doesn't because it's a tossup between whether the opening or closing event gets scheduled first.

This fix for this problem adds a check in handleFuelInjectionEvent to skip scheduling injections with very small (< 50us) duration.

2) An additional check is added for a maximum MAP pressure at which fuel is cut during coasting.  On my car the first ~3 percent of the throttle travel does quite a bit, so a threshold for manifold pressure is required so that fuel isn't cut under light throttle, only when actually coasting.  This also provides flexibility so that a throttle position sensor isn't strictly required to use the feature.

ps: Andrey check your email for my signed contributor agreement