### PR TITLE
Simulator make: add -r option

### DIFF
--- a/simulator/compile.bat
+++ b/simulator/compile.bat
@@ -1,4 +1,4 @@
 rem this is about CygWin colon issue, .dep files are invalid because of that
 rem rm -rf .dep
 rm -f build/rusefi_simulator.exe
-make
+make -r

--- a/simulator/make_run.bat
+++ b/simulator/make_run.bat
@@ -1,4 +1,4 @@
-make
+make -r
 
 cd build
 rusefi_simulator.exe


### PR DESCRIPTION
"-r, --no-builtin-rules      Disable the built-in implicit rules."
Faster build on some environments.


