### PR TITLE
Workarounds for GCC 8

### DIFF
--- a/firmware/controllers/algo/aux_pid.cpp
+++ b/firmware/controllers/algo/aux_pid.cpp
@@ -134,7 +134,7 @@ void stopAuxPins(void) {
 
 void initAuxPid(Logging *sharedLogger) {
 	chThdCreateStatic(auxPidThreadStack, sizeof(auxPidThreadStack), LOWPRIO,
-			(tfunc_t) auxPidThread, NULL);
+			(tfunc_t)(void*) auxPidThread, NULL);
 
 	logger = sharedLogger;
 

--- a/firmware/controllers/alternatorController.cpp
+++ b/firmware/controllers/alternatorController.cpp
@@ -167,7 +167,7 @@ void initAlternatorCtrl(Logging *sharedLogger) {
 				engineConfiguration->alternatorPwmFrequency, 0.1, applyAlternatorPinState);
 	}
 	chThdCreateStatic(alternatorControlThreadStack, sizeof(alternatorControlThreadStack), LOWPRIO,
-			(tfunc_t) AltCtrlThread, NULL);
+			(tfunc_t)(void*) AltCtrlThread, NULL);
 }
 
 #endif /* EFI_ALTERNATOR_CONTROL */

--- a/firmware/controllers/electronic_throttle.cpp
+++ b/firmware/controllers/electronic_throttle.cpp
@@ -371,7 +371,7 @@ void initElectronicThrottle(void) {
 
 	pid.reset();
 
-	chThdCreateStatic(etbTreadStack, sizeof(etbTreadStack), NORMALPRIO, (tfunc_t) etbThread, NULL);
+	chThdCreateStatic(etbTreadStack, sizeof(etbTreadStack), NORMALPRIO, (tfunc_t)(void*) etbThread, NULL);
 }
 
 #endif /* EFI_ELECTRONIC_THROTTLE_BODY */

--- a/firmware/controllers/engine_controller.cpp
+++ b/firmware/controllers/engine_controller.cpp
@@ -691,7 +691,7 @@ void initEngineContoller(Logging *sharedLogger DECLARE_ENGINE_PARAMETER_SUFFIX) 
 		return;
 	}
 
-	chThdCreateStatic(csThreadStack, sizeof(csThreadStack), LOWPRIO, (tfunc_t) csThread, NULL);
+	chThdCreateStatic(csThreadStack, sizeof(csThreadStack), LOWPRIO, (tfunc_t)(void*) csThread, NULL);
 
 #if (EFI_PROD_CODE && EFI_ENGINE_CONTROL) || defined(__DOXYGEN__)
 	/**

--- a/firmware/controllers/idle_thread.cpp
+++ b/firmware/controllers/idle_thread.cpp
@@ -480,7 +480,7 @@ void startIdleThread(Logging*sharedLogger) {
 
 	//scheduleMsg(logger, "initial idle %d", idlePositionController.value);
 
-	chThdCreateStatic(ivThreadStack, sizeof(ivThreadStack), NORMALPRIO, (tfunc_t) ivThread, NULL);
+	chThdCreateStatic(ivThreadStack, sizeof(ivThreadStack), NORMALPRIO, (tfunc_t)(void*) ivThread, NULL);
 
 	// this is idle switch INPUT - sometimes there is a switch on the throttle pedal
 	// this switch is not used yet

--- a/firmware/controllers/injector_central.cpp
+++ b/firmware/controllers/injector_central.cpp
@@ -264,7 +264,7 @@ void runIoTest(int subsystem, int index) {
 
 void initInjectorCentral(Logging *sharedLogger) {
 	logger = sharedLogger;
-	chThdCreateStatic(benchThreadStack, sizeof(benchThreadStack), NORMALPRIO, (tfunc_t) benchThread, NULL);
+	chThdCreateStatic(benchThreadStack, sizeof(benchThreadStack), NORMALPRIO, (tfunc_t)(void*) benchThread, NULL);
 
 	for (int i = 0; i < INJECTION_PIN_COUNT; i++) {
 		is_injector_enabled[i] = true;

--- a/firmware/controllers/malfunction_indicator.cpp
+++ b/firmware/controllers/malfunction_indicator.cpp
@@ -114,7 +114,7 @@ void initMalfunctionIndicator(void) {
 		return;
 	}
 	// create static thread
-	chThdCreateStatic(mfiThreadStack, sizeof(mfiThreadStack), LOWPRIO, (tfunc_t) mfiThread, NULL);
+	chThdCreateStatic(mfiThreadStack, sizeof(mfiThreadStack), LOWPRIO, (tfunc_t)(void*) mfiThread, NULL);
 
 	addConsoleAction("testmil", testMil);
 }

--- a/firmware/controllers/math/biquad.cpp
+++ b/firmware/controllers/math/biquad.cpp
@@ -10,7 +10,7 @@
 EXTERN_ENGINE;
 
 Biquad::Biquad() {
-	a0 = a1 = a2 = b1 = b2;
+	a0 = a1 = a2 = b1 = b2 = 0;
 	z1 = z2 = 0;
 }
 

--- a/firmware/controllers/system/pwm_generator_logic.cpp
+++ b/firmware/controllers/system/pwm_generator_logic.cpp
@@ -30,8 +30,8 @@ SimplePwm::SimplePwm() {
 }
 
 void PwmConfig::baseConstructor() {
-	memset(&scheduling, 0, sizeof(scheduling));
-	memset(&safe, 0, sizeof(safe));
+	memset((void*)&scheduling, 0, sizeof(scheduling));
+	memset((void*)&safe, 0, sizeof(safe));
 	dbgNestingLevel = 0;
 	periodNt = NAN;
 	mode = PM_NORMAL;

--- a/firmware/controllers/trigger/trigger_central.cpp
+++ b/firmware/controllers/trigger/trigger_central.cpp
@@ -65,7 +65,7 @@ efitime_t getStartOfRevolutionIndex(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 
 void TriggerCentral::addEventListener(ShaftPositionListener listener, const char *name, Engine *engine) {
 	print("registerCkpListener: %s\r\n", name);
-	triggerListeneres.registerCallback((VoidInt) listener, engine);
+	triggerListeneres.registerCallback((VoidInt)(void*)listener, engine);
 }
 
 /**
@@ -397,7 +397,7 @@ void TriggerCentral::handleShaftSignal(trigger_event_e signal DECLARE_ENGINE_PAR
 		 * Here we invoke all the listeners - the main engine control logic is inside these listeners
 		 */
 		for (int i = 0; i < triggerListeneres.currentListenersCount; i++) {
-			ShaftPositionListener listener = (ShaftPositionListener) triggerListeneres.callbacks[i];
+			ShaftPositionListener listener = (ShaftPositionListener) (void*) triggerListeneres.callbacks[i];
 			(listener)(signal, triggerIndexForListeners PASS_ENGINE_PARAMETER_SUFFIX);
 		}
 

--- a/firmware/development/engine_emulator.cpp
+++ b/firmware/development/engine_emulator.cpp
@@ -91,7 +91,7 @@ static void initECUstimulator(Engine *engine) {
 
 	setDiag(1);
 
-	chThdCreateStatic(eeThreadStack, sizeof(eeThreadStack), NORMALPRIO, (tfunc_t) eeThread, engine);
+	chThdCreateStatic(eeThreadStack, sizeof(eeThreadStack), NORMALPRIO, (tfunc_t)(void*) eeThread, engine);
 }
 
 void initEngineEmulator(Logging *sharedLogger, Engine *engine) {

--- a/firmware/development/wave_analyzer.cpp
+++ b/firmware/development/wave_analyzer.cpp
@@ -129,9 +129,9 @@ static void initWave(const char *name, int index) {
 	reader->hw = addWaveAnalyzerDriver("wave input", brainPin);
 
 
-	reader->hw->widthListeners.registerCallback((VoidInt) waAnaWidthCallback, (void*) reader);
+	reader->hw->widthListeners.registerCallback((VoidInt)(void*) waAnaWidthCallback, (void*) reader);
 
-	reader->hw->periodListeners.registerCallback((VoidInt) waIcuPeriodCallback, (void*) reader);
+	reader->hw->periodListeners.registerCallback((VoidInt)(void*) waIcuPeriodCallback, (void*) reader);
 
 
 	print("wave%d input on %s\r\n", index, hwPortname(brainPin));

--- a/firmware/hw_layer/HIP9011.cpp
+++ b/firmware/hw_layer/HIP9011.cpp
@@ -476,7 +476,7 @@ void initHip9011(Logging *sharedLogger) {
 	addConsoleActionI("set_hip_prescalerandsdo", setPrescalerAndSDO);
     addConsoleActionF("set_knock_threshold", setKnockThresh);
     addConsoleActionI("set_max_knock_sub_deg", setMaxKnockSubDeg);
-	chThdCreateStatic(hipTreadStack, sizeof(hipTreadStack), NORMALPRIO, (tfunc_t) hipThread, NULL);
+	chThdCreateStatic(hipTreadStack, sizeof(hipTreadStack), NORMALPRIO, (tfunc_t)(void*) hipThread, NULL);
 }
 
 #endif /* EFI_HIP_9011 */

--- a/firmware/hw_layer/accelerometer.cpp
+++ b/firmware/hw_layer/accelerometer.cpp
@@ -95,7 +95,7 @@ void initAccelerometer(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 	lis302dlWriteRegister(driver, LIS302DL_CTRL_REG2, 0x00); // 4 wire mode
 	lis302dlWriteRegister(driver, LIS302DL_CTRL_REG3, 0x00);
 
-	chThdCreateStatic(ivThreadStack, sizeof(ivThreadStack), NORMALPRIO, (tfunc_t) ivThread, NULL);
+	chThdCreateStatic(ivThreadStack, sizeof(ivThreadStack), NORMALPRIO, (tfunc_t)(void*) ivThread, NULL);
 #endif /* HAL_USE_SPI */
 }
 

--- a/firmware/hw_layer/board_test.cpp
+++ b/firmware/hw_layer/board_test.cpp
@@ -199,7 +199,7 @@ void initBoardTest(void) {
 	btInitOutputPins();
 	blinkAllOutputPins();
 
-	chThdCreateStatic(btThreadStack, sizeof(btThreadStack), NORMALPRIO, (tfunc_t) ivThread, NULL);
+	chThdCreateStatic(btThreadStack, sizeof(btThreadStack), NORMALPRIO, (tfunc_t)(void*) ivThread, NULL);
 	// this code is ugly as hell, I had no time to think. Todo: refactor
 
 #if HAL_USE_ADC || defined(__DOXYGEN__)

--- a/firmware/hw_layer/can_hw.cpp
+++ b/firmware/hw_layer/can_hw.cpp
@@ -333,7 +333,7 @@ void initCan(void) {
 	canStart(&CAND1, &canConfig500);
 #endif /* STM32_CAN_USE_CAN2 */
 
-	chThdCreateStatic(canTreadStack, sizeof(canTreadStack), NORMALPRIO, (tfunc_t) canThread, NULL);
+	chThdCreateStatic(canTreadStack, sizeof(canTreadStack), NORMALPRIO, (tfunc_t)(void*) canThread, NULL);
 
 	startCanPins();
 

--- a/firmware/hw_layer/microsecond_timer.cpp
+++ b/firmware/hw_layer/microsecond_timer.cpp
@@ -152,7 +152,7 @@ void initMicrosecondTimer(void) {
 
 	lastSetTimerTimeNt = getTimeNowNt();
 #if EFI_EMULATE_POSITION_SENSORS
-	chThdCreateStatic(mwThreadStack, sizeof(mwThreadStack), NORMALPRIO, (tfunc_t) mwThread, NULL);
+	chThdCreateStatic(mwThreadStack, sizeof(mwThreadStack), NORMALPRIO, (tfunc_t)(void*) mwThread, NULL);
 #endif /* EFI_ENGINE_EMULATOR */
 
 //	// test code

--- a/firmware/hw_layer/mmc_card.cpp
+++ b/firmware/hw_layer/mmc_card.cpp
@@ -444,7 +444,7 @@ void initMmcCard(void) {
 	mmcObjectInit(&MMCD1); 						// Initializes an instance.
 	mmcStart(&MMCD1, &mmccfg);
 
-	chThdCreateStatic(mmcThreadStack, sizeof(mmcThreadStack), LOWPRIO, (tfunc_t) MMCmonThread, NULL);
+	chThdCreateStatic(mmcThreadStack, sizeof(mmcThreadStack), LOWPRIO, (tfunc_t)(void*) MMCmonThread, NULL);
 
 	addConsoleAction("mountsd", MMCmount);
 	addConsoleActionS("appendtolog", appendToLog);

--- a/firmware/hw_layer/neo6m.cpp
+++ b/firmware/hw_layer/neo6m.cpp
@@ -117,7 +117,7 @@ void initGps(void) {
 	efiSetPadMode("GPS rx", boardConfiguration->gps_rx_pin, PAL_MODE_ALTERNATE(7));
 
 // todo: add a thread which would save location. If the GPS 5Hz - we should save the location each 200 ms
-	chThdCreateStatic(gpsThreadStack, sizeof(gpsThreadStack), LOWPRIO, (tfunc_t)GpsThreadEntryPoint, NULL);
+	chThdCreateStatic(gpsThreadStack, sizeof(gpsThreadStack), LOWPRIO, (tfunc_t)(void*) GpsThreadEntryPoint, NULL);
 
 	addConsoleAction("gpsinfo", &printGpsInfo);
 }

--- a/firmware/hw_layer/sensors/CJ125.cpp
+++ b/firmware/hw_layer/sensors/CJ125.cpp
@@ -644,7 +644,7 @@ void initCJ125(Logging *sharedLogger DECLARE_ENGINE_PARAMETER_SUFFIX) {
 	addConsoleActionI("cj125_set_init2", cjSetInit2);
 #endif /* CJ125_DEBUG */
 
-	chThdCreateStatic(cjThreadStack, sizeof(cjThreadStack), LOWPRIO, (tfunc_t) cjThread, NULL);
+	chThdCreateStatic(cjThreadStack, sizeof(cjThreadStack), LOWPRIO, (tfunc_t)(void*) cjThread, NULL);
 }
 
 #endif /* EFI_CJ125 */

--- a/firmware/hw_layer/servo.cpp
+++ b/firmware/hw_layer/servo.cpp
@@ -79,7 +79,7 @@ void initServo(void) {
 
 
 
-	chThdCreateStatic(seThreadStack, sizeof(seThreadStack), NORMALPRIO, (tfunc_t) seThread, NULL);
+	chThdCreateStatic(seThreadStack, sizeof(seThreadStack), NORMALPRIO, (tfunc_t)(void*) seThread, NULL);
 }
 
 

--- a/firmware/hw_layer/stepper.cpp
+++ b/firmware/hw_layer/stepper.cpp
@@ -178,6 +178,6 @@ void StepperMotor::initialize(brain_pin_e stepPin, brain_pin_e directionPin, pin
 	this->directionPin.setValue(false);
 	this->currentDirection = false;
 
-	chThdCreateStatic(stThreadStack, sizeof(stThreadStack), NORMALPRIO, (tfunc_t) stThread, this);
+	chThdCreateStatic(stThreadStack, sizeof(stThreadStack), NORMALPRIO, (tfunc_t)(void*) stThread, this);
 }
 

--- a/firmware/util/listener_array.h
+++ b/firmware/util/listener_array.h
@@ -85,7 +85,7 @@ void invokeCallbacks(IntListenerArray<MAX_INT_LISTENER_COUNT> *array, int value)
 template<int MAX_INT_LISTENER_COUNT>
 void IntListenerArray<MAX_INT_LISTENER_COUNT>::invokeJustArgCallbacks() {
 	for (int i = 0; i < currentListenersCount; i++) {
-		VoidPtr listener = (VoidPtr)callbacks[i];
+		VoidPtr listener = (VoidPtr)(void*)callbacks[i];
 		void *arg = args[i];
 		(listener)(arg);
 	}


### PR DESCRIPTION
Partial fix for #375 
GCC 8 is way more picky for casting pointers, so we need to make it "forget" the original pointer type by casting to void* first.

Compiles with:
```
arm-none-eabi-gcc (GNU Tools for Arm Embedded Processors 8-2018-q4-major) 8.2.1 20181213 (release) [gcc-8-branch revision 267074]
```
Tried with/without LTO, softp and hardfp.
Not tested on actual hardware.