### PR TITLE
Update git_reset_to_upstream.bat

### DIFF
--- a/misc/git_scripts/git_reset_to_upstream.bat
+++ b/misc/git_scripts/git_reset_to_upstream.bat
@@ -1,4 +1,4 @@
-git fetch upstream/master
+git fetch upstream
 git checkout master
 git reset --hard upstream/master
 git push origin master -f


### PR DESCRIPTION
removed the offending "/master" from the first line. BAT now works.