### PR TITLE
Improve wall wetting AE to use time constant

### DIFF
--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -30,7 +30,7 @@ endif
 
 # C++ specific options here (added to USE_OPT).
 ifeq ($(USE_CPPOPT),)
-  USE_CPPOPT = -std=c++11 -fno-rtti -fno-exceptions -fno-use-cxa-atexit -Werror=write-strings -Werror=type-limits
+  USE_CPPOPT = -std=c++17 -Wno-register -fno-rtti -fno-exceptions -fno-use-cxa-atexit -Werror=write-strings -Werror=type-limits
 endif
 
 # Enable this if you want the linker to remove unused code and data

--- a/firmware/config/engines/dodge_neon.cpp
+++ b/firmware/config/engines/dodge_neon.cpp
@@ -502,11 +502,11 @@ void setDodgeNeonNGCEngineConfiguration(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 	engineConfiguration->tpsAccelLength = 12;
 	engineConfiguration->tpsAccelEnrichmentThreshold = 10;
 
-	engineConfiguration->suckedOffCoef = 0.05;
-	engineConfiguration->addedToWallCoef = 0.40;
+	engineConfiguration->wwaeTau = 1.0f;
+	engineConfiguration->wwaeBeta = 0.40f;
 
-	engineConfiguration->suckedOffCoef = 0;
-	engineConfiguration->addedToWallCoef = 0;
+	engineConfiguration->wwaeTau = 0;
+	engineConfiguration->wwaeBeta = 0;
 
 	boardConfiguration->isSdCardEnabled = false;
 	boardConfiguration->manIdlePosition = 36; // set_idle_pwm 40

--- a/firmware/controllers/algo/engine_configuration_generated_structures.h
+++ b/firmware/controllers/algo/engine_configuration_generated_structures.h
@@ -1,4 +1,4 @@
-// this section was generated automatically by ConfigDefinition.jar based on rusefi_config.txt Sat Jan 05 23:35:34 EST 2019
+// this section was generated automatically by ConfigDefinition.jar based on rusefi_config.txt Sun Jan 06 03:15:03 PST 2019
 // begin
 #ifndef ENGINE_CONFIGURATION_GENERATED_H_
 #define ENGINE_CONFIGURATION_GENERATED_H_
@@ -1602,7 +1602,7 @@ typedef struct {
 	/**
 	 * offset 1808
 	 */
-	float suckedOffCoef;
+	float wwaeTau;
 	/**
 	 * offset 1812
 	 */
@@ -1639,7 +1639,7 @@ typedef struct {
 	 * Wall wetting/evaporation factor/Tau factor/fuel film
 	 * offset 1904
 	 */
-	float addedToWallCoef;
+	float wwaeBeta;
 	/**
 	 * blue LED on discovery by default
 	 * offset 1908
@@ -2321,7 +2321,7 @@ typedef struct {
 	float cltIdleCorr[CLT_CURVE_SIZE];
 	/**
 	 * kg/hour value.
-	 * By the way 2.081989116 kg/h = 1 ft³/m
+	 * By the way 2.081989116 kg/h = 1 ftï¿½/m
 	 * offset 10784
 	 */
 	float mafDecoding[MAF_DECODING_COUNT];
@@ -2472,4 +2472,4 @@ typedef struct {
 
 #endif
 // end
-// this section was generated automatically by ConfigDefinition.jar based on rusefi_config.txt Sat Jan 05 23:35:34 EST 2019
+// this section was generated automatically by ConfigDefinition.jar based on rusefi_config.txt Sun Jan 06 03:15:03 PST 2019

--- a/firmware/controllers/algo/rusefi_generated.h
+++ b/firmware/controllers/algo/rusefi_generated.h
@@ -1071,8 +1071,8 @@
 #define tachPulseDuractionMs_offset_hex 708
 #define tachPulseTriggerIndex_offset 1804
 #define tachPulseTriggerIndex_offset_hex 70c
-#define suckedOffCoef_offset 1808
-#define suckedOffCoef_offset_hex 710
+#define wwaeTau_offset 1808
+#define wwaeTau_offset_hex 710
 #define alternatorControl_offset 1812
 #define alternatorControl_offset_hex 714
 #define alternatorControl_pFactor_offset 1812
@@ -1143,8 +1143,8 @@
 #define idleRpmPid_minValue_offset_hex 76c
 #define idleRpmPid_maxValue_offset 1902
 #define idleRpmPid_maxValue_offset_hex 76e
-#define addedToWallCoef_offset 1904
-#define addedToWallCoef_offset_hex 770
+#define wwaeBeta_offset 1904
+#define wwaeBeta_offset_hex 770
 #define communicationLedPin_offset 1908
 #define communicationLedPin_offset_hex 774
 #define runningLedPin_offset 1912

--- a/firmware/controllers/settings.cpp
+++ b/firmware/controllers/settings.cpp
@@ -1302,10 +1302,10 @@ static void setValue(const char *paramStr, const char *valueStr) {
 		engineConfiguration->step1timing = valueI;
 	} else if (strEqualCaseInsensitive(paramStr, "operation_mode")) {
 		engineConfiguration->operationMode = (operation_mode_e)valueI;
-	} else if (strEqualCaseInsensitive(paramStr, "suckedOffCoef")) {
-		engineConfiguration->suckedOffCoef = valueF;
-	} else if (strEqualCaseInsensitive(paramStr, "addedToWallCoef")) {
-		engineConfiguration->addedToWallCoef = valueF;
+	} else if (strEqualCaseInsensitive(paramStr, "wwaeTau")) {
+		engineConfiguration->wwaeTau = valueF;
+	} else if (strEqualCaseInsensitive(paramStr, "wwaeBeta")) {
+		engineConfiguration->wwaeBeta = valueF;
 	} else if (strEqualCaseInsensitive(paramStr, "cranking_dwell")) {
 		engineConfiguration->ignitionDwellForCrankingMs = valueF;
 	} else if (strEqualCaseInsensitive(paramStr, "targetvbatt")) {

--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -756,7 +756,7 @@ custom pin_mode_e 4 bits,    U32,   @OFFSET@, [0:5], @@pin_mode_e_enum@@
 	float tachPulseDuractionMs;;"ms",        1,     0,    0.0,    100.0,  2
 	int tachPulseTriggerIndex;+Trigger cycle index at which we start tach pulse (performance consideration);"index",     1,     0,    0.0,    360.0,  0
 	
-	float suckedOffCoef;;"%",        1,     0,    0.0,    300.0,  2
+	float wwaeTau;;"%",        1,     0,    0.0,    3.0,  2
 	pid_s alternatorControl;
 	pid_s etb;
 	pid_s warmupAfrPid;
@@ -766,7 +766,7 @@ custom pin_mode_e 4 bits,    U32,   @OFFSET@, [0:5], @@pin_mode_e_enum@@
 	float mapErrorDetectionTooHigh;kPa value which is too high to be true;"kPa",        1,     0,    -100.0,    800.0,  2
 	int step1RpmWindow;RPMs prior to step1rpm point where ignition advance is retarded;"rpm",    1,      0,       0, 3000.0,        2
 	pid_s idleRpmPid;See cltIdleRpmBins
-	float addedToWallCoef;Wall wetting/evaporation factor/Tau factor/fuel film;"%",        1,     0,    0.0,    300.0,  2
+	float wwaeBeta;Wall wetting/evaporation factor/Tau factor/fuel film;"%",        1,     0,    0.0,    1.0,  2
 	brain_pin_e communicationLedPin;blue LED on discovery by default	
 	brain_pin_e runningLedPin;green LED on discovery by default
 	brain_pin_e binarySerialTxPin;	
@@ -968,7 +968,7 @@ float[IAT_CURVE_SIZE] iatFuelCorr;;"%",      1,     0,      0.0,    500.0,   2
 float[CLT_CURVE_SIZE] cltIdleCorrBins;CLT-based idle position multiplier for simple manual idle controller;"C",        1,     0,   -100.0,    250.0,  2
 float[CLT_CURVE_SIZE] cltIdleCorr;    CLT-based idle position multiplier for simple manual idle controller;"%",      1,     0,      0.0,    1000.0,   2
 
-float[MAF_DECODING_COUNT] mafDecoding;kg/hour value.\nBy the way 2.081989116 kg/h = 1 ft³/m;"kg/hour", 1, 0, -500.0, 4000.0, 2
+float[MAF_DECODING_COUNT] mafDecoding;kg/hour value.\nBy the way 2.081989116 kg/h = 1 ftï¿½/m;"kg/hour", 1, 0, -500.0, 4000.0, 2
 float[MAF_DECODING_COUNT] mafDecodingBins;; "V", 1, 0, -5.0, 150.0, 2
 
 angle_table_t ignitionIatCorrTable;

--- a/firmware/tunerstudio/rusefi.ini
+++ b/firmware/tunerstudio/rusefi.ini
@@ -63,7 +63,7 @@ enable2ndByteCanID = false
 
 ; see PAGE_0_SIZE in C source code    
 ; CONFIG_DEFINITION_START
-; this section was generated automatically by ConfigDefinition.jar based on rusefi_config.txt Sat Jan 05 23:35:34 EST 2019
+; this section was generated automatically by ConfigDefinition.jar based on rusefi_config.txt Sun Jan 06 03:15:03 PST 2019
 
 pageSize            = 20000
 page = 1
@@ -552,7 +552,7 @@ page = 1
 	crankingTpsBins					= array, F32,	1768,	[8],	"%", 1, 0, 0.0, 100.0, 2
 	tachPulseDuractionMs			= scalar, F32,	1800,	"ms", 1, 0, 0.0, 100.0, 2
 	tachPulseTriggerIndex			= scalar, S32,	1804,	"index", 1, 0, 0.0, 360.0, 0
-	suckedOffCoef					= scalar, F32,	1808,	"%", 1, 0, 0.0, 300.0, 2
+	wwaeTau							= scalar, F32,	1808,	"%", 1, 0, 0.0, 3.0, 2
 	alternatorControl_pFactor		= scalar, F32,	1812,	"", 1, 0, -10000, 10000, 7
 	alternatorControl_iFactor		= scalar, F32,	1816,	"", 1, 0, -10000, 10000, 7
 	alternatorControl_dFactor		= scalar, F32,	1820,	"", 1, 0, -10000, 10000, 7
@@ -584,7 +584,7 @@ page = 1
 	idleRpmPid_period				= scalar, S16,	1898,	"ms", 1, 0, 0, 3000, 0
 	idleRpmPid_minValue				= scalar, S16,	1900,	"", 1, 0, -3000, 3000.0, 3
 	idleRpmPid_maxValue				= scalar, S16,	1902,	"", 1, 0, -3000, 3000.0, 3
-	addedToWallCoef					= scalar, F32,	1904,	"%", 1, 0, 0.0, 300.0, 2
+	wwaeBeta						= scalar, F32,	1904,	"%", 1, 0, 0.0, 1.0, 2
 	communicationLedPin			 = bits, U32, 1908, [0:6], "PA0", "PA1", "PA2", "PA3", "PA4", "PA5", "PA6", "PA7", "PA8", "PA9", "PA10", "PA11", "PA12", "PA13", "PA14", "PA15", "PB0", "PB1", "PB2", "PB3", "PB4", "PB5", "PB6", "PB7", "PB8", "PB9", "PB10", "PB11", "PB12", "PB13", "PB14", "PB15", "PC0", "PC1", "PC2", "PC3", "PC4", "PC5", "PC6", "PC7", "PC8", "PC9", "PC10", "PC11", "PC12", "PC13", "PC14", "PC15", "PD0", "PD1", "PD2", "PD3", "PD4", "PD5", "PD6", "PD7", "PD8", "PD9", "PD10", "PD11", "PD12", "PD13", "PD14", "PD15", "PE0", "PE1", "PE2", "PE3", "PE4", "PE5", "PE6", "PE7", "PE8", "PE9", "PE10", "PE11", "PE12", "PE13", "PE14", "PE15", "NONE", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID"
 	runningLedPin				 = bits, U32, 1912, [0:6], "PA0", "PA1", "PA2", "PA3", "PA4", "PA5", "PA6", "PA7", "PA8", "PA9", "PA10", "PA11", "PA12", "PA13", "PA14", "PA15", "PB0", "PB1", "PB2", "PB3", "PB4", "PB5", "PB6", "PB7", "PB8", "PB9", "PB10", "PB11", "PB12", "PB13", "PB14", "PB15", "PC0", "PC1", "PC2", "PC3", "PC4", "PC5", "PC6", "PC7", "PC8", "PC9", "PC10", "PC11", "PC12", "PC13", "PC14", "PC15", "PD0", "PD1", "PD2", "PD3", "PD4", "PD5", "PD6", "PD7", "PD8", "PD9", "PD10", "PD11", "PD12", "PD13", "PD14", "PD15", "PE0", "PE1", "PE2", "PE3", "PE4", "PE5", "PE6", "PE7", "PE8", "PE9", "PE10", "PE11", "PE12", "PE13", "PE14", "PE15", "NONE", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID"
 	binarySerialTxPin			 = bits, U32, 1916, [0:6], "PA0", "PA1", "PA2", "PA3", "PA4", "PA5", "PA6", "PA7", "PA8", "PA9", "PA10", "PA11", "PA12", "PA13", "PA14", "PA15", "PB0", "PB1", "PB2", "PB3", "PB4", "PB5", "PB6", "PB7", "PB8", "PB9", "PB10", "PB11", "PB12", "PB13", "PB14", "PB15", "PC0", "PC1", "PC2", "PC3", "PC4", "PC5", "PC6", "PC7", "PC8", "PC9", "PC10", "PC11", "PC12", "PC13", "PC14", "PC15", "PD0", "PD1", "PD2", "PD3", "PD4", "PD5", "PD6", "PD7", "PD8", "PD9", "PD10", "PD11", "PD12", "PD13", "PD14", "PD15", "PE0", "PE1", "PE2", "PE3", "PE4", "PE5", "PE6", "PE7", "PE8", "PE9", "PE10", "PE11", "PE12", "PE13", "PE14", "PE15", "NONE", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID"
@@ -2899,8 +2899,8 @@ cmd_stop_engine              = "w\x00\x99\x00\x00"
 ;		field = "Decel Multiplier",	 			tpsDecelEnleanmentMultiplier
 		
 	dialog = WallWettingAccelPanel, "Wall Wetting (alpha version)"
-		field = "sucked off wall coefficient",          suckedOffCoef
-		field = "added to wall coef",                   addedToWallCoef
+		field = "evaporation time constant",          wwaeTau
+		field = "added to wall coef",                   wwaeBeta
 	
 		
 ;			Tuning->AccelEnrichment

--- a/firmware/tunerstudio/rusefi.input
+++ b/firmware/tunerstudio/rusefi.input
@@ -2044,8 +2044,8 @@ cmd_stop_engine              = "w\x00\x99\x00\x00"
 ;		field = "Decel Multiplier",	 			tpsDecelEnleanmentMultiplier
 		
 	dialog = WallWettingAccelPanel, "Wall Wetting (alpha version)"
-		field = "sucked off wall coefficient",          suckedOffCoef
-		field = "added to wall coef",                   addedToWallCoef
+		field = "evaporation time constant",          wwaeTau
+		field = "added to wall coef",                   wwaeBeta
 	
 		
 ;			Tuning->AccelEnrichment

--- a/firmware/util/efilib.cpp
+++ b/firmware/util/efilib.cpp
@@ -315,3 +315,38 @@ float limitRateOfChange(float newValue, float oldValue, float incrLimitPerSec, f
 		return (incrLimitPerSec <= 0.0f) ? newValue : oldValue + minF(newValue - oldValue, incrLimitPerSec * secsPassed);
 	return (decrLimitPerSec <= 0.0f) ? newValue : oldValue - minF(oldValue - newValue, decrLimitPerSec * secsPassed);
 }
+
+constexpr float constant_e = 2.71828f;
+
+constexpr float expf_taylor_impl(float x, uint8_t n)
+{
+	if (x < -2)
+	{
+		return 0.818f;
+	}
+	else if (x > 0)
+	{
+		return 1;
+	}
+
+	x = x + 1;
+
+	float x_power = x;
+	int fac = 1;
+	float sum = 1;
+
+	for (int i = 1; i <= n; i++)
+	{
+		fac *= i;
+		sum += x_power / fac;
+
+		x_power *= x;
+	}
+
+	return sum / constant_e;
+}
+
+float expf_taylor(float x)
+{
+	return expf_taylor_impl(x, 4);
+}

--- a/firmware/util/efilib.h
+++ b/firmware/util/efilib.h
@@ -68,6 +68,8 @@ bool strEqual(const char *str1, const char *str2);
 // Currently used by air-interp. tCharge mode (see EngineState::updateTChargeK()).
 float limitRateOfChange(float newValue, float oldValue, float incrLimitPerSec, float decrLimitPerSec, float secsPassed);
 
+float expf_taylor(float x);
+
 #ifdef __cplusplus
 }
 #endif /* __cplusplus */

--- a/firmware/util/efilib.h
+++ b/firmware/util/efilib.h
@@ -68,6 +68,8 @@ bool strEqual(const char *str1, const char *str2);
 // Currently used by air-interp. tCharge mode (see EngineState::updateTChargeK()).
 float limitRateOfChange(float newValue, float oldValue, float incrLimitPerSec, float decrLimitPerSec, float secsPassed);
 
+// @brief Compute e^x using a 4th order taylor expansion centered at x=-1.  Provides
+// bogus results outside the range -2 < x < 0.
 float expf_taylor(float x);
 
 #ifdef __cplusplus

--- a/java_console/autotest/src/com/rusefi/AutoTest.java
+++ b/java_console/autotest/src/com/rusefi/AutoTest.java
@@ -144,8 +144,8 @@ public class AutoTest {
 
     private static void test2003DodgeNeon() {
         setEngineType(23);
-        sendCommand("set suckedOffCoef 0");
-        sendCommand("set addedToWallCoef 0");
+        sendCommand("set wwaeTau 0");
+        sendCommand("set wwaeBeta 0");
         sendCommand("set mock_map_voltage 1");
         sendCommand("set mock_vbatt_voltage 1.20");
         sendCommand("disable cylinder_cleanup");

--- a/java_console/models/src/com/rusefi/config/Fields.java
+++ b/java_console/models/src/com/rusefi/config/Fields.java
@@ -1,6 +1,6 @@
 package com.rusefi.config;
 
-// this file was generated automatically by ConfigDefinition.jar based on rusefi_config.txt Sat Jan 05 16:40:23 EST 2019
+// this file was generated automatically by ConfigDefinition.jar based on rusefi_config.txt Sun Jan 06 03:15:03 PST 2019
 public class Fields {
 	public static final int LE_COMMAND_LENGTH = 200;
 	public static final int BLOCKING_FACTOR = 400;
@@ -723,8 +723,8 @@ public class Fields {
 	public static final int tachPulseDuractionMs_offset = 1800;
 	public static final int tachPulseDuractionMs_offset_hex = 708;
 	public static final int tachPulseTriggerIndex_offset = 1804;
-	public static final int suckedOffCoef_offset = 1808;
-	public static final int suckedOffCoef_offset_hex = 710;
+	public static final int wwaeTau_offset = 1808;
+	public static final int wwaeTau_offset_hex = 710;
 	public static final int alternatorControl_offset = 1812;
 	public static final int alternatorControl_offset_hex = 714;
 	public static final int alternatorControl_pFactor_offset = 1812;
@@ -782,8 +782,8 @@ public class Fields {
 	public static final int idleRpmPid_period_offset = 1898;
 	public static final int idleRpmPid_minValue_offset = 1900;
 	public static final int idleRpmPid_maxValue_offset = 1902;
-	public static final int addedToWallCoef_offset = 1904;
-	public static final int addedToWallCoef_offset_hex = 770;
+	public static final int wwaeBeta_offset = 1904;
+	public static final int wwaeBeta_offset_hex = 770;
 	public static final int communicationLedPin_offset = 1908;
 	public static final int communicationLedPin_offset_hex = 774;
 	public static final int runningLedPin_offset = 1912;
@@ -1676,7 +1676,7 @@ public class Fields {
 	public static final Field SPI2MISOMODE = Field.create("SPI2MISOMODE", 1732, FieldType.INT, pin_mode_e);
 	public static final Field TACHPULSEDURACTIONMS = Field.create("TACHPULSEDURACTIONMS", 1800, FieldType.FLOAT);
 	public static final Field TACHPULSETRIGGERINDEX = Field.create("TACHPULSETRIGGERINDEX", 1804, FieldType.INT);
-	public static final Field SUCKEDOFFCOEF = Field.create("SUCKEDOFFCOEF", 1808, FieldType.FLOAT);
+	public static final Field WWAETAU = Field.create("WWAETAU", 1808, FieldType.FLOAT);
 	public static final Field ALTERNATORCONTROL_PFACTOR = Field.create("ALTERNATORCONTROL_PFACTOR", 1812, FieldType.FLOAT);
 	public static final Field ALTERNATORCONTROL_IFACTOR = Field.create("ALTERNATORCONTROL_IFACTOR", 1816, FieldType.FLOAT);
 	public static final Field ALTERNATORCONTROL_DFACTOR = Field.create("ALTERNATORCONTROL_DFACTOR", 1820, FieldType.FLOAT);
@@ -1708,7 +1708,7 @@ public class Fields {
 	public static final Field IDLERPMPID_PERIOD = Field.create("IDLERPMPID_PERIOD", 1898, FieldType.INT);
 	public static final Field IDLERPMPID_MINVALUE = Field.create("IDLERPMPID_MINVALUE", 1900, FieldType.INT);
 	public static final Field IDLERPMPID_MAXVALUE = Field.create("IDLERPMPID_MAXVALUE", 1902, FieldType.INT);
-	public static final Field ADDEDTOWALLCOEF = Field.create("ADDEDTOWALLCOEF", 1904, FieldType.FLOAT);
+	public static final Field WWAEBETA = Field.create("WWAEBETA", 1904, FieldType.FLOAT);
 	public static final Field COMMUNICATIONLEDPIN = Field.create("COMMUNICATIONLEDPIN", 1908, FieldType.INT, brain_pin_e);
 	public static final Field RUNNINGLEDPIN = Field.create("RUNNINGLEDPIN", 1912, FieldType.INT, brain_pin_e);
 	public static final Field BINARYSERIALTXPIN = Field.create("BINARYSERIALTXPIN", 1916, FieldType.INT, brain_pin_e);

--- a/java_console/ui/src/com/rusefi/ui/SettingsTab.java
+++ b/java_console/ui/src/com/rusefi/ui/SettingsTab.java
@@ -104,8 +104,8 @@ public class SettingsTab {
 //        panel.add(UiUtils.wrap(new ConfigField(Fields.IGNITIONOFFSET, "Ignition offset").getContent()));
 //        panel.add(UiUtils.wrap(new ConfigField(Fields.CRANKINGTIMINGANGLE, "Cranking timing").getContent()));
 //
-//        panel.add(UiUtils.wrap(new ConfigField(Fields.ADDEDTOWALLCOEF, "Added to wall").getContent()));
-//        panel.add(UiUtils.wrap(new ConfigField(Fields.SUCKEDOFFCOEF, "Sucked off wall").getContent()));
+//        panel.add(UiUtils.wrap(new ConfigField(Fields.WWAEBETA, "Added to wall").getContent()));
+//        panel.add(UiUtils.wrap(new ConfigField(Fields.WWAETAU, "Sucked off wall").getContent()));
 ////        panel.add(UiUtils.wrap(new ConfigField(Fields.TPSACCELENRICHMENTTHRESHOLD, "TPS accel threshold").getContent()));
 //        panel.add(UiUtils.wrap(new ConfigField(Fields.TPSACCELENRICHMENTMULTIPLIER, "TPS accel coef").getContent()));
 

--- a/unit_tests/Makefile
+++ b/unit_tests/Makefile
@@ -34,7 +34,7 @@ endif
 
 # C++ specific options here (added to USE_OPT).
 ifeq ($(USE_CPPOPT),)
-  USE_CPPOPT = -std=c++11 -fno-rtti -fpermissive -fno-exceptions -fno-use-cxa-atexit
+  USE_CPPOPT = -std=c++17 -fno-rtti -fpermissive -fno-exceptions -fno-use-cxa-atexit
 endif
 
 # Enable this if you want the linker to remove unused code and data

--- a/unit_tests/test.mk
+++ b/unit_tests/test.mk
@@ -4,6 +4,7 @@ TEST_SRC_CPP = unit_test_framework.cpp \
 	global_execution_queue.cpp \
 	test_basic_math/test_find_index.cpp \
 	test_basic_math/test_interpolation_3d.cpp \
+	test_basic_math/test_efilib.cpp \
 	tests/test_util.cpp \
 	tests/test_ion.cpp \
 	tests/test_hip9011.cpp \

--- a/unit_tests/test_basic_math/test_efilib.cpp
+++ b/unit_tests/test_basic_math/test_efilib.cpp
@@ -1,0 +1,23 @@
+/*
+ * test_efilib.cpp
+ *
+ *  Created on: Jan 6, 2019
+ * @author Matthew Kennedy, (c) 2019
+ */
+
+#include "gtest/gtest.h"
+
+#include "efilib.h"
+#include <math.h>
+
+TEST(EfiLibTest, ExpTaylor)
+{
+    float x = -2;
+
+    // test from -2 < x < 0
+    for(float x = -2; x < 0; x += 0.05)
+    {
+        // Compare taylor to libc implementation
+        EXPECT_NEAR(expf_taylor(x), expf(x), 0.01f);
+    }
+}


### PR DESCRIPTION
Previously, AE used a constant for "amount of fuel sucked from wall in one cycle" when in fact that's not how gasoline works.  There's an amount of gasoline sucked off the wall PER TIME, not PER CYCLE.  This change replaces the per-cycle parameter with a time constant (tau) parameter instead.