### PR TITLE
Implement ST-recommended workaround for #663

### DIFF
--- a/firmware/hw_layer/stm32f4/mpu_util.cpp
+++ b/firmware/hw_layer/stm32f4/mpu_util.cpp
@@ -325,10 +325,10 @@ void initSpiModule(SPIDriver *driver, brain_pin_e sck, brain_pin_e miso,
 		int mosiMode,
 		int misoMode) {
 
-	efiSetPadMode("SPI clock", sck,	PAL_MODE_ALTERNATE(getSpiAf(driver)) + sckMode);
+	efiSetPadMode("SPI clock", sck,	PAL_MODE_ALTERNATE(getSpiAf(driver)) + sckMode | PAL_STM32_OSPEED_HIGHEST);
 
-	efiSetPadMode("SPI master out", mosi, PAL_MODE_ALTERNATE(getSpiAf(driver)) + mosiMode);
-	efiSetPadMode("SPI master in ", miso, PAL_MODE_ALTERNATE(getSpiAf(driver)) + misoMode);
+	efiSetPadMode("SPI master out", mosi, PAL_MODE_ALTERNATE(getSpiAf(driver)) + mosiMode | PAL_STM32_OSPEED_HIGHEST);
+	efiSetPadMode("SPI master in ", miso, PAL_MODE_ALTERNATE(getSpiAf(driver)) + misoMode | PAL_STM32_OSPEED_HIGHEST);
 }
 
 void initSpiCs(SPIConfig *spiConfig, brain_pin_e csPin) {

--- a/firmware/hw_layer/stm32f4/mpu_util.cpp
+++ b/firmware/hw_layer/stm32f4/mpu_util.cpp
@@ -325,10 +325,10 @@ void initSpiModule(SPIDriver *driver, brain_pin_e sck, brain_pin_e miso,
 		int mosiMode,
 		int misoMode) {
 
-	efiSetPadMode("SPI clock", sck,	PAL_MODE_ALTERNATE(getSpiAf(driver)) + sckMode | PAL_STM32_OSPEED_HIGHEST);
+	efiSetPadMode("SPI clock", sck,	PAL_MODE_ALTERNATE(getSpiAf(driver)) | sckMode | PAL_STM32_OSPEED_HIGHEST);
 
-	efiSetPadMode("SPI master out", mosi, PAL_MODE_ALTERNATE(getSpiAf(driver)) + mosiMode | PAL_STM32_OSPEED_HIGHEST);
-	efiSetPadMode("SPI master in ", miso, PAL_MODE_ALTERNATE(getSpiAf(driver)) + misoMode | PAL_STM32_OSPEED_HIGHEST);
+	efiSetPadMode("SPI master out", mosi, PAL_MODE_ALTERNATE(getSpiAf(driver)) | mosiMode | PAL_STM32_OSPEED_HIGHEST);
+	efiSetPadMode("SPI master in ", miso, PAL_MODE_ALTERNATE(getSpiAf(driver)) | misoMode | PAL_STM32_OSPEED_HIGHEST);
 }
 
 void initSpiCs(SPIConfig *spiConfig, brain_pin_e csPin) {


### PR DESCRIPTION
Setting SPI pins to high speed mode fixes #663.  This isn't required on non-f405/407/415/417 parts, but the vast majority of MCUs running rusEfi are f407.  No negative consequence on chips that don't require the workaround.

Info on the silicon defect can be found in this document, section 2.5.2:
https://www.st.com/content/ccc/resource/technical/document/errata_sheet/0a/98/58/84/86/b6/47/a2/DM00037591.pdf/files/DM00037591.pdf/jcr:content/translations/en.DM00037591.pdf