### PR TITLE
VVT\CAM settings #671

### DIFF
--- a/firmware/tunerstudio/rusefi.ini
+++ b/firmware/tunerstudio/rusefi.ini
@@ -320,8 +320,9 @@ page = 1
 	unused_board_984_27		= bits,    U32,   	984, [27:27], "false", "true"
 	unused_board_984_28		= bits,    U32,   	984, [28:28], "false", "true"
 	unused_board_984_29		= bits,    U32,   	984, [29:29], "false", "true"
-	unused_board_984_30		= bits,    U32,   	984, [30:30], "false", "true"
-	CamSensorUse			= bits,    U32,   	984, [31:31], "false", "true"
+	; unused_board_984_30		= bits,    U32,   	984, [30:30], "false", "true"
+	camSensorType			= bits,    U32,   	984, [30:30], "cam", "vvt"
+	camSensorUse			= bits,    U32,   	984, [31:31], "false", "true"
 	logicAnalyzerPins1			 = bits, U32, 988, [0:6], "INVALID", "PA1", "PA2", "PA3", "INVALID", "PA5", "PA6", "PA7", "PA8", "PA9", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "PA15", "INVALID", "INVALID", "INVALID", "PB3", "PB4", "PB5", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "PC6", "PC7", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "PE5", "PE6", "INVALID", "INVALID", "PE9", "INVALID", "PE11", "INVALID", "INVALID", "INVALID", "INVALID", "NONE", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID"
 	logicAnalyzerPins2			 = bits, U32, 992, [0:6], "INVALID", "PA1", "PA2", "PA3", "INVALID", "PA5", "PA6", "PA7", "PA8", "PA9", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "PA15", "INVALID", "INVALID", "INVALID", "PB3", "PB4", "PB5", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "PC6", "PC7", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "PE5", "PE6", "INVALID", "INVALID", "PE9", "INVALID", "PE11", "INVALID", "INVALID", "INVALID", "INVALID", "NONE", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID"
 	logicAnalyzerPins3			 = bits, U32, 996, [0:6], "INVALID", "PA1", "PA2", "PA3", "INVALID", "PA5", "PA6", "PA7", "PA8", "PA9", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "PA15", "INVALID", "INVALID", "INVALID", "PB3", "PB4", "PB5", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "PC6", "PC7", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "PE5", "PE6", "INVALID", "INVALID", "PE9", "INVALID", "PE11", "INVALID", "INVALID", "INVALID", "INVALID", "NONE", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID"
@@ -886,7 +887,8 @@ page = 1
 	trigger_useOnlyFirstChannel = "This option could be used if your second trigger channel is broken"
 	tachOutputPin = "This implementation produces one pulse per engine cycle. See also dizzySparkOutputPin."
 	vvtCamSensorUseRise = "Use rise or fall signal front"
-	CamSensorUse = "Use CAM Sensor or VVT"
+	camSensorType = "Use CAM Sensor or VVT"
+	camSensorUse = "Use CAM/VVT or not"
 	measureMapOnlyInOneCylinder = "Useful for individual intakes"
 	sensorChartMode = "rusEfi console Sensor Sniffer mode"
 	isVerboseIAC = "Print details into rusEfi console"
@@ -2014,23 +2016,24 @@ cmd_stop_engine              = "w\x00\x99\x00\x00"
 	dialog = triggerConfiguration_settings,	"Settings Trigger"
 		field = "Trigger type",							trigger_type
 		field = "Operation mode / speed",				operationMode
-		field = "Cam Sensor Use",						CamSensorUse, {operationMode != 2}
+		field = "Use Cam Sensor",						camSensorUse
+		field = "Cam Sensor Type",						camSensorType,						{camSensorUse != 0}
 		field = "With VR sensors only rising edge has reliable position"
 		field = "use only rising edge",					useOnlyRisingEdgeForTrigger    
 	    field = "!Reminder that 4-stroke cycle is 720 degrees"
 	    field = "Trigger Angle Offset",         		globalTriggerAngleOffset
 		field = "#Custom Trigger"
-		field = "total Tooth Count",					trigger_customTotalToothCount, {trigger_type == 0}
-		field = "skipped Tooth Count",					trigger_customSkippedToothCount, {trigger_type == 0}
+		field = "total Tooth Count",					trigger_customTotalToothCount, 		{trigger_type == 0}
+		field = "skipped Tooth Count",					trigger_customSkippedToothCount,	{trigger_type == 0}
 		
 	dialog = triggerConfiguration_cam,	"Settings CAM"
 	    field = "#Set input pin in Controller->Sensor Inputs->Cam Sync/VVT input"
-		field = "Cam use rise front",					vvtCamSensorUseRise, 		{trigger_type != 80}
+		field = "Cam use rise front",					vvtCamSensorUseRise, 				{trigger_type != 80}
 
 	dialog = triggerConfiguration_vvt,	"Settings VVT"
 	    field = "!Help at the bottom"
-	    field = "VVT mode",								vvtMode, 					{trigger_type != 80}
-	    field = "VVT use rise front",					vvtCamSensorUseRise, 		{trigger_type != 80}
+	    field = "VVT mode",								vvtMode, 							{trigger_type != 80}
+	    field = "VVT use rise front",					vvtCamSensorUseRise, 				{trigger_type != 80}
 	    field = "VVT position display offset",			vvtOffset
 	    field = "VVT display inverted",					vvtDisplayInverted
 	    field = "NB2 from temp",						nb2ratioFrom
@@ -2042,13 +2045,13 @@ cmd_stop_engine              = "w\x00\x99\x00\x00"
 	    field = "Trigger error LED",					triggerErrorPin
 	    field = "Trigger error LED mode",				triggerErrorPinMode
 	    field = "print sync details to console",		isPrintTriggerSynchDetails
-	    field = "Enable noise filtering",				useNoiselessTriggerDecoder, {trigger_type == 8}
+	    field = "Enable noise filtering",				useNoiselessTriggerDecoder, 		{trigger_type == 8}
 		
 	dialog = triggerConfiguration
 		topicHelp = "VVTConfHelp"
 		panel = triggerConfiguration_settings,	North
-		panel = triggerConfiguration_cam,		South, {CamSensorUse != 0 && operationMode != 2}
-		panel = triggerConfiguration_vvt,		South, {CamSensorUse == 0 && operationMode != 2}
+		panel = triggerConfiguration_cam,		South, {camSensorType == 0 && camSensorUse != 0}
+		panel = triggerConfiguration_vvt,		South, {camSensorType > 0 && camSensorUse != 0}
 		panel = triggerConfiguration_IO,		South
 		
 		

--- a/firmware/tunerstudio/rusefi.ini
+++ b/firmware/tunerstudio/rusefi.ini
@@ -321,6 +321,7 @@ page = 1
 	unused_board_984_28		= bits,    U32,   	984, [28:28], "false", "true"
 	unused_board_984_29		= bits,    U32,   	984, [29:29], "false", "true"
 	unused_board_984_30		= bits,    U32,   	984, [30:30], "false", "true"
+	CamSensorUse			= bits,    U32,   	984, [31:31], "false", "true"
 	logicAnalyzerPins1			 = bits, U32, 988, [0:6], "INVALID", "PA1", "PA2", "PA3", "INVALID", "PA5", "PA6", "PA7", "PA8", "PA9", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "PA15", "INVALID", "INVALID", "INVALID", "PB3", "PB4", "PB5", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "PC6", "PC7", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "PE5", "PE6", "INVALID", "INVALID", "PE9", "INVALID", "PE11", "INVALID", "INVALID", "INVALID", "INVALID", "NONE", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID"
 	logicAnalyzerPins2			 = bits, U32, 992, [0:6], "INVALID", "PA1", "PA2", "PA3", "INVALID", "PA5", "PA6", "PA7", "PA8", "PA9", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "PA15", "INVALID", "INVALID", "INVALID", "PB3", "PB4", "PB5", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "PC6", "PC7", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "PE5", "PE6", "INVALID", "INVALID", "PE9", "INVALID", "PE11", "INVALID", "INVALID", "INVALID", "INVALID", "NONE", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID"
 	logicAnalyzerPins3			 = bits, U32, 996, [0:6], "INVALID", "PA1", "PA2", "PA3", "INVALID", "PA5", "PA6", "PA7", "PA8", "PA9", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "PA15", "INVALID", "INVALID", "INVALID", "PB3", "PB4", "PB5", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "PC6", "PC7", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "PE5", "PE6", "INVALID", "INVALID", "PE9", "INVALID", "PE11", "INVALID", "INVALID", "INVALID", "INVALID", "NONE", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID"
@@ -885,6 +886,7 @@ page = 1
 	trigger_useOnlyFirstChannel = "This option could be used if your second trigger channel is broken"
 	tachOutputPin = "This implementation produces one pulse per engine cycle. See also dizzySparkOutputPin."
 	vvtCamSensorUseRise = "Use rise or fall signal front"
+	CamSensorUse = "Use CAM Sensor or VVT"
 	measureMapOnlyInOneCylinder = "Useful for individual intakes"
 	sensorChartMode = "rusEfi console Sensor Sniffer mode"
 	isVerboseIAC = "Print details into rusEfi console"
@@ -2012,6 +2014,7 @@ cmd_stop_engine              = "w\x00\x99\x00\x00"
 	dialog = triggerConfiguration_settings,	"Settings Trigger"
 		field = "Trigger type",							trigger_type
 		field = "Operation mode / speed",				operationMode
+		field = "Cam Sensor Use",						CamSensorUse, {operationMode != 2}
 		field = "With VR sensors only rising edge has reliable position"
 		field = "use only rising edge",					useOnlyRisingEdgeForTrigger    
 	    field = "!Reminder that 4-stroke cycle is 720 degrees"
@@ -2019,23 +2022,40 @@ cmd_stop_engine              = "w\x00\x99\x00\x00"
 		field = "#Custom Trigger"
 		field = "total Tooth Count",					trigger_customTotalToothCount, {trigger_type == 0}
 		field = "skipped Tooth Count",					trigger_customSkippedToothCount, {trigger_type == 0}
+		
+	dialog = triggerConfiguration_cam,	"Settings CAM"
+	    field = "#Set input pin in Controller->Sensor Inputs->Cam Sync/VVT input"
+		field = "Cam use rise front",					vvtCamSensorUseRise, 		{trigger_type != 80}
 
-	dialog = triggerConfiguration_IO,	"Settings I/O"
-	    field = "!https://rusefi.com/wiki/index.php?title=Manual:Software:VVT"
-	    field = "VVT mode",								vvtMode, {trigger_type != 80}
-	    field = "VVT use rise front",					vvtCamSensorUseRise, {trigger_type != 80}
+	dialog = triggerConfiguration_vvt,	"Settings VVT"
+	    field = "!Help at the bottom"
+	    field = "VVT mode",								vvtMode, 					{trigger_type != 80}
+	    field = "VVT use rise front",					vvtCamSensorUseRise, 		{trigger_type != 80}
 	    field = "VVT position display offset",			vvtOffset
 	    field = "VVT display inverted",					vvtDisplayInverted
 	    field = "NB2 from temp",						nb2ratioFrom
 	    field = "NB2 to temp",							nb2ratioTo
 	    field = "nbVvtIndex",							nbVvtIndex
+		
+		
+	dialog = triggerConfiguration_IO,	"Settings I/O"
 	    field = "Trigger error LED",					triggerErrorPin
 	    field = "Trigger error LED mode",				triggerErrorPinMode
 	    field = "print sync details to console",		isPrintTriggerSynchDetails
 	    field = "Enable noise filtering",				useNoiselessTriggerDecoder, {trigger_type == 8}
+		
 	dialog = triggerConfiguration
+		topicHelp = "VVTConfHelp"
 		panel = triggerConfiguration_settings,	North
+		panel = triggerConfiguration_cam,		South, {CamSensorUse != 0 && operationMode != 2}
+		panel = triggerConfiguration_vvt,		South, {CamSensorUse == 0 && operationMode != 2}
 		panel = triggerConfiguration_IO,		South
+		
+		
+	help = VVTConfHelp, "VVT/CAM Configuration"
+        text = "VVT mode configuration help"
+        webHelp = "https://rusefi.com/wiki/index.php?title=Manual:Software:VVT"
+
 
 ;			Engine->Injection Settings
 	dialog = injChars, "Injector Settings",	yAxis


### PR DESCRIPTION
Select the ordinary CAM sensor in a separate block in the trigger configuration and use either the cam sensor or VVT cam sensor separately
Cam Sensor displays only pinout for VVT \ CAM input and if there are any functions related to Cam Sensor.
In the second case, that is, the VVT cam sensor activates all other functions related to VVT