### PR TITLE
trigger input: add PAL support

### DIFF
--- a/firmware/hw_layer/hw_layer.mk
+++ b/firmware/hw_layer/hw_layer.mk
@@ -20,7 +20,7 @@ HW_LAYER_EMS_CPP = $(HW_LAYER_EGT_CPP) \
  	$(PROJECT_DIR)/hw_layer/adc_inputs.cpp \
 	$(PROJECT_DIR)/hw_layer/board_test.cpp \
 	$(PROJECT_DIR)/hw_layer/pwm_generator.cpp \
-	$(PROJECT_DIR)/hw_layer/trigger_input_icu.cpp \
+	$(PROJECT_DIR)/hw_layer/trigger_input.cpp \
 	$(PROJECT_DIR)/hw_layer/hip9011.cpp \
 	$(PROJECT_DIR)/hw_layer/hip9011_logic.cpp \
 	$(PROJECT_DIR)/hw_layer/vehicle_speed.cpp \


### PR DESCRIPTION
Use EXTI for trigger inputs.
Tested on custom stm32f765 board using trigger simulation.

Set in halconfig.h
+#define HAL_USE_PAL                            TRUE
+#define PAL_USE_CALLBACKS              TRUE
