### PR TITLE
Default config refactor

### DIFF
--- a/firmware/config/engines/custom_engine.cpp
+++ b/firmware/config/engines/custom_engine.cpp
@@ -82,25 +82,7 @@ void disableLCD(board_configuration_s *boardConfiguration) {
 }
 
 void setMinimalPinsEngineConfiguration(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
-	// not great implementation since we undo values which were set somewhere else
-	// todo: maybe use prepareVoidConfiguration method?
-	boardConfiguration->hip9011CsPin = GPIO_UNASSIGNED;
-	boardConfiguration->hip9011IntHoldPin = GPIO_UNASSIGNED;
-	CONFIGB(canTxPin) = GPIO_UNASSIGNED;
-	CONFIGB(canRxPin) = GPIO_UNASSIGNED;
-	CONFIGB(sdCardCsPin) = GPIO_UNASSIGNED;
-	boardConfiguration->fanPin = GPIO_UNASSIGNED;
-	CONFIGB(idle).solenoidPin = GPIO_UNASSIGNED;
-	boardConfiguration->fuelPumpPin = GPIO_UNASSIGNED;
-	for (int i = 0;i<TRIGGER_INPUT_PIN_COUNT;i++) {
-		CONFIGB(triggerInputPins)[i] = GPIO_UNASSIGNED;
-	}
-	CONFIGB(triggerSimulatorPins)[0] = GPIO_UNASSIGNED;
-	CONFIGB(triggerSimulatorPins)[1] = GPIO_UNASSIGNED;
-	CONFIGB(triggerSimulatorPins)[2] = GPIO_UNASSIGNED;
-	CONFIGB(digitalPotentiometerSpiDevice) = SPI_NONE;
-	engineConfiguration->accelerometerSpiDevice = SPI_NONE;
-	CONFIGB(is_enabled_spi_1) = CONFIGB(is_enabled_spi_2) = CONFIGB(is_enabled_spi_3) = false;
+	// all basic settings are already set in prepareVoidConfiguration(), no need to set anything here
 }
 
 // todo: should this be renamed to 'setFrankensoConfiguration'?

--- a/firmware/controllers/core/fsio_impl.cpp
+++ b/firmware/controllers/core/fsio_impl.cpp
@@ -161,7 +161,7 @@ float getEngineValue(le_action_e action DECLARE_ENGINE_PARAMETER_SUFFIX) {
 static void setFsioAnalogInputPin(const char *indexStr, const char *pinName) {
 // todo: reduce code duplication between all "set pin methods"
 	int index = atoi(indexStr) - 1;
-	if (index < 0 || index >= FSIO_COMMAND_COUNT) {
+	if (index < 0 || index >= FSIO_ANALOG_INPUT_COUNT) {
 		scheduleMsg(logger, "invalid FSIO index: %d", index);
 		return;
 	}


### PR DESCRIPTION
The idea is to separate "hardware" (board-dependent) def-config from "software" def-config.
We remove hw fields from setDefaultConfiguration() and move them into a new setDefaultBoardConfiguration() or prepareVoidConfiguration().
Also, we refactor setMinimalPinsEngineConfiguration() and engineType=MINIMAL_PINS: we want to skip setting hardware pins instead of first setting them and then unsetting.
See multiple comments below on what's going on.

Also, we fix FSIO_ANALOG_INPUT_COUNT.