### PR TITLE
Enable link time optimization

### DIFF
--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -61,7 +61,7 @@ endif
 
 # Enable this if you want link time optimizations (LTO)
 ifeq ($(USE_LTO),)
-  USE_LTO = no
+  USE_LTO = yes
 endif
 
 # If enabled, this option allows to compile the application in THUMB mode.


### PR DESCRIPTION
Improves perf a bit, and saves ~10% `.text` and `.data` space.