### PR TITLE
const, explicit, and override

### DIFF
--- a/firmware/controllers/algo/accel_enrichment.cpp
+++ b/firmware/controllers/algo/accel_enrichment.cpp
@@ -137,7 +137,7 @@ floatms_t WallFuel::adjust(int injectorIndex, floatms_t M_des DECLARE_ENGINE_PAR
 	return M_cmd;
 }
 
-floatms_t WallFuel::getWallFuel(int injectorIndex) {
+floatms_t WallFuel::getWallFuel(int injectorIndex) const {
 	return wallFuel[injectorIndex];
 }
 

--- a/firmware/controllers/algo/accel_enrichment.h
+++ b/firmware/controllers/algo/accel_enrichment.h
@@ -65,7 +65,7 @@ public:
 	 * @return total adjusted fuel squirt duration once wall wetting is taken into effect
 	 */
 	floatms_t adjust(int injectorIndex, floatms_t target DECLARE_ENGINE_PARAMETER_SUFFIX);
-	floatms_t getWallFuel(int injectorIndex);
+	floatms_t getWallFuel(int injectorIndex) const;
 	void reset();
 private:
 	/**

--- a/firmware/controllers/algo/engine.cpp
+++ b/firmware/controllers/algo/engine.cpp
@@ -165,7 +165,7 @@ Engine::Engine(persistent_config_s *config) {
  * @see scheduleStopEngine()
  * @return true if there is a reason to stop engine
  */
-bool Engine::needToStopEngine(efitick_t nowNt) {
+bool Engine::needToStopEngine(efitick_t nowNt) const {
 	return stopEngineRequestTimeNt != 0 &&
 			nowNt - stopEngineRequestTimeNt	< 3 * US2NT(US_PER_SECOND_LL);
 }
@@ -307,7 +307,7 @@ void Engine::checkShutdown() {
 #endif /* EFI_MAIN_RELAY_CONTROL */
 }
 
-bool Engine::isInShutdownMode() {
+bool Engine::isInShutdownMode() const {
 #if EFI_MAIN_RELAY_CONTROL
 	if (stopEngineRequestTimeNt == 0)	// the shutdown procedure is not started
 		return false;

--- a/firmware/controllers/algo/engine.h
+++ b/firmware/controllers/algo/engine.h
@@ -112,7 +112,7 @@ public:
 #endif /* EFI_ENGINE_CONTROL */
 
 	WallFuel wallFuel;
-	bool needToStopEngine(efitick_t nowNt);
+	bool needToStopEngine(efitick_t nowNt) const;
 	bool etbAutoTune = false;
 	/**
 	 * That's the list of pending spark firing events
@@ -308,7 +308,7 @@ public:
 	 * Allows to finish some long-term shutdown procedures (stepper motor parking etc.)
 	   Returns true if some operations are in progress on background.
 	 */
-	bool isInShutdownMode();
+	bool isInShutdownMode() const;
 
 	monitoring_timestamps_s m;
 

--- a/firmware/controllers/algo/engine.h
+++ b/firmware/controllers/algo/engine.h
@@ -68,7 +68,7 @@ class RpmCalculator;
 
 class Engine {
 public:
-	Engine(persistent_config_s *config);
+	explicit Engine(persistent_config_s *config);
 	Engine();
 	void setConfig(persistent_config_s *config);
 	injection_mode_e getCurrentInjectionMode(DECLARE_ENGINE_PARAMETER_SIGNATURE);

--- a/firmware/controllers/algo/lcd_menu_tree.h
+++ b/firmware/controllers/algo/lcd_menu_tree.h
@@ -62,7 +62,7 @@ public:
 
 class MenuTree {
 public:
-	MenuTree(MenuItem *root);
+	explicit MenuTree(MenuItem *root);
 	void nextItem(void);
 	void back(void);
 	void enterSubMenu(void);

--- a/firmware/controllers/core/efi_wave.cpp
+++ b/firmware/controllers/core/efi_wave.cpp
@@ -21,7 +21,7 @@ void SingleWave::init(pin_state_t *pinStates) {
 	this->pinStates = pinStates;
 }
 
-pin_state_t SingleWave::getState(int switchIndex) {
+pin_state_t SingleWave::getState(int switchIndex) const {
 	pin_state_t state = pinStates[switchIndex];
 	efiAssert(OBD_PCM_Processor_Fault, state == 0 || state == 1, "wave state get", TV_FALL);
 	return state;

--- a/firmware/controllers/core/efi_wave.h
+++ b/firmware/controllers/core/efi_wave.h
@@ -48,7 +48,7 @@ public:
 	 * todo: confirm that we only deal with two states here, no magic '-1'?
 	 * @return HIGH or LOW state at given index
 	 */
-	pin_state_t getState(int switchIndex);
+	pin_state_t getState(int switchIndex) const;
 	void setState(int switchIndex, pin_state_t state);
 
 	// todo: make this private by using 'getState' and 'setState' methods

--- a/firmware/controllers/core/efi_wave.h
+++ b/firmware/controllers/core/efi_wave.h
@@ -42,7 +42,7 @@ typedef trigger_value_e pin_state_t;
 class SingleWave {
 public:
 	SingleWave();
-	SingleWave(pin_state_t *pinStates);
+	explicit SingleWave(pin_state_t *pinStates);
 	void init(pin_state_t *pinStates);
 	/**
 	 * todo: confirm that we only deal with two states here, no magic '-1'?

--- a/firmware/controllers/core/fsio_core.cpp
+++ b/firmware/controllers/core/fsio_core.cpp
@@ -302,7 +302,7 @@ float LECalculator::getValue2(float selfValue, LEElement *fistElementInList DECL
 	return getValue(selfValue PASS_ENGINE_PARAMETER_SUFFIX);
 }
 
-bool LECalculator::isEmpty() {
+bool LECalculator::isEmpty() const {
 	return first == NULL;
 }
 
@@ -348,7 +348,7 @@ void LEElementPool::reset() {
 	index = 0;
 }
 
-int LEElementPool::getSize() {
+int LEElementPool::getSize() const {
 	return index;
 }
 

--- a/firmware/controllers/core/fsio_core.h
+++ b/firmware/controllers/core/fsio_core.h
@@ -84,7 +84,7 @@ public:
 	LEElement *next();
 	void reset();
 	LEElement * parseExpression(const char * line);
-	int getSize();
+	int getSize() const;
 private:
 	int index;
 	int size;
@@ -103,7 +103,7 @@ public:
 	float getValue(float selfValue DECLARE_ENGINE_PARAMETER_SUFFIX);
 	float getValue2(float selfValue, LEElement *fistElementInList DECLARE_ENGINE_PARAMETER_SUFFIX);
 	void add(LEElement *element);
-	bool isEmpty();
+	bool isEmpty() const;
 	void reset();
 	void reset(LEElement *element);
 	le_action_e calcLogAction[MAX_CALC_LOG];

--- a/firmware/controllers/math/pid_auto_tune.cpp
+++ b/firmware/controllers/math/pid_auto_tune.cpp
@@ -784,17 +784,17 @@ bool PID_AutoTune::Runtime(Logging *logger)
   return true;
 }
 
-float PID_AutoTune::GetKp()
+float PID_AutoTune::GetKp() const
 {
   return Kp;
 }
 
-float PID_AutoTune::GetKi()
+float PID_AutoTune::GetKi() const
 {
   return Kp / Ti;
 }
 
-float PID_AutoTune::GetKd()
+float PID_AutoTune::GetKd() const
 {
   return Kp * Td;
 }
@@ -814,7 +814,7 @@ void PID_AutoTune::SetOutputStep(double Step)
   oStep = Step;
 }
 
-double PID_AutoTune::GetOutputStep()
+double PID_AutoTune::GetOutputStep() const
 {
   return oStep;
 }
@@ -824,7 +824,7 @@ void PID_AutoTune::SetControlType(byte type)
   controlType = type;
 }
 
-byte PID_AutoTune::GetControlType()
+byte PID_AutoTune::GetControlType() const
 {
   return controlType;
 }

--- a/firmware/controllers/math/pid_auto_tune.h
+++ b/firmware/controllers/math/pid_auto_tune.h
@@ -59,12 +59,12 @@ struct Tuning
 {
   byte _divisor[3];
 
-  bool PI_controller()
+  bool PI_controller() const
   {
     return _divisor[2] == 0;
   }
 
-  double divisor(byte index)
+  double divisor(byte index) const
   {
     return (double)(_divisor[index] * 0.05);
   }
@@ -113,21 +113,21 @@ public:
 
   void SetOutputStep(double);           // * how far above and below the starting value will
                                         //   the output step?
-  double GetOutputStep();               //
+  double GetOutputStep() const;         //
 
   void SetControlType(byte);            // * Determines tuning algorithm
-  byte GetControlType();                // * Returns tuning algorithm
+  byte GetControlType() const;          // * Returns tuning algorithm
 
   void SetLookbackSec(int);             // * how far back are we looking to identify peaks
-  int GetLookbackSec();                 //
+  int GetLookbackSec() const;           //
 
   void SetNoiseBand(double);            // * the autotune will ignore signal chatter smaller
                                         //   than this value
   double GetNoiseBand();                //   this should be accurately set
 
-  float GetKp();                       // * once autotune is complete, these functions contain the
-  float GetKi();                       //   computed tuning parameters.
-  float GetKd();                       //
+  float GetKp() const;                  // * once autotune is complete, these functions contain the
+  float GetKi() const;                  //   computed tuning parameters.
+  float GetKd() const;                  //
 
   Logging *logger;
   byte peakCount;

--- a/firmware/controllers/scheduling/event_queue.cpp
+++ b/firmware/controllers/scheduling/event_queue.cpp
@@ -88,7 +88,7 @@ bool EventQueue::insertTask(scheduling_s *scheduling, efitime_t timeX, schfunc_t
  * This method is always invoked under a lock
  * @return Get the timestamp of the soonest pending action, skipping all the actions in the past
  */
-efitime_t EventQueue::getNextEventTime(efitime_t nowX) {
+efitime_t EventQueue::getNextEventTime(efitime_t nowX) const {
 	
 	if (head != NULL) {
 		if (head->momentX <= nowX) {
@@ -185,7 +185,7 @@ int EventQueue::executeAll(efitime_t now) {
 	return executionCounter;
 }
 
-int EventQueue::size(void) {
+int EventQueue::size(void) const {
 	scheduling_s *tmp;
 	int result;
 	LL_COUNT(head, tmp, result);
@@ -193,7 +193,7 @@ int EventQueue::size(void) {
 }
 
 #if EFI_UNIT_TEST
-void EventQueue::assertListIsSorted() {
+void EventQueue::assertListIsSorted() const {
 	scheduling_s *current = head;
 	while (current != NULL && current->next != NULL) {
 		efiAssertVoid(CUSTOM_ERR_6623, current->momentX <= current->next->momentX, "list order");

--- a/firmware/controllers/scheduling/event_queue.h
+++ b/firmware/controllers/scheduling/event_queue.h
@@ -56,13 +56,13 @@ public:
 
 	int executeAll(efitime_t now);
 
-	efitime_t getNextEventTime(efitime_t nowUs);
+	efitime_t getNextEventTime(efitime_t nowUs) const;
 	void clear(void);
-	int size(void);
+	int size(void) const;
 	scheduling_s *getForUnitText(int index);
 	void setLateDelay(int value);
 	scheduling_s * getHead();
-	void assertListIsSorted();
+	void assertListIsSorted() const;
 private:
 	bool checkIfPending(scheduling_s *scheduling);
 	/**

--- a/firmware/controllers/scheduling/pwm_generator_logic.h
+++ b/firmware/controllers/scheduling/pwm_generator_logic.h
@@ -113,7 +113,7 @@ private:
 class SimplePwm : public PwmConfig {
 public:
 	SimplePwm();
-	SimplePwm(const char *name);
+	explicit SimplePwm(const char *name);
 	void setSimplePwmDutyCycle(float dutyCycle);
 	pin_state_t pinStates[2];
 	SingleWave sr[1];

--- a/firmware/controllers/scheduling/signal_executor_sleep.h
+++ b/firmware/controllers/scheduling/signal_executor_sleep.h
@@ -12,8 +12,8 @@
 
 class SleepExecutor : public ExecutorInterface {
 public:
-	void scheduleByTimestamp(scheduling_s *scheduling, efitimeus_t timeUs, schfunc_t callback, void *param);
-	void scheduleForLater(scheduling_s *scheduling, int delayUs, schfunc_t callback, void *param);
+	void scheduleByTimestamp(scheduling_s *scheduling, efitimeus_t timeUs, schfunc_t callback, void *param) override;
+	void scheduleForLater(scheduling_s *scheduling, int delayUs, schfunc_t callback, void *param) override;
 };
 
 #endif /* SIGNAL_EXECUTOR_SLEEP_H_ */

--- a/firmware/controllers/system/dc_motor.cpp
+++ b/firmware/controllers/system/dc_motor.cpp
@@ -15,11 +15,11 @@ TwoPinDcMotor::TwoPinDcMotor(SimplePwm* enable, SimplePwm* dir1, SimplePwm* dir2
 {
 }
 
-bool TwoPinDcMotor::isOpenDirection() {
+bool TwoPinDcMotor::isOpenDirection() const {
 	return m_value >= 0;
 }
 
-float TwoPinDcMotor::Get() {
+float TwoPinDcMotor::Get() const {
 	return m_value;
 }
 

--- a/firmware/controllers/system/dc_motor.h
+++ b/firmware/controllers/system/dc_motor.h
@@ -60,8 +60,8 @@ public:
     TwoPinDcMotor(SimplePwm* enable, SimplePwm* dir1, SimplePwm* dir2);
 
     virtual bool Set(float duty) override;
-    float Get();
-    bool isOpenDirection();
+    float Get() const;
+    bool isOpenDirection() const;
 
     void SetType(ControlType type) { m_type = type; }
 };

--- a/firmware/controllers/system/efi_gpio.cpp
+++ b/firmware/controllers/system/efi_gpio.cpp
@@ -218,11 +218,11 @@ NamedOutputPin::NamedOutputPin() : OutputPin() {
 	name = NULL;
 }
 
-const char *NamedOutputPin::getName() {
+const char *NamedOutputPin::getName() const {
 	return name;
 }
 
-const char *NamedOutputPin::getShortName() {
+const char *NamedOutputPin::getShortName() const {
 	return shortName == NULL ? name : shortName;
 }
 
@@ -347,7 +347,7 @@ void OutputPin::setValue(int logicValue) {
 #endif /* EFI_PROD_CODE */
 }
 
-bool OutputPin::getLogicValue() {
+bool OutputPin::getLogicValue() const {
 	return currentLogicValue;
 }
 

--- a/firmware/controllers/system/efi_gpio.h
+++ b/firmware/controllers/system/efi_gpio.h
@@ -74,7 +74,7 @@ private:
 class NamedOutputPin : public OutputPin {
 public:
 	NamedOutputPin();
-	NamedOutputPin(const char *name);
+	explicit NamedOutputPin(const char *name);
 	void setHigh();
 	void setLow();
 	const char *getName();

--- a/firmware/controllers/system/efi_gpio.h
+++ b/firmware/controllers/system/efi_gpio.h
@@ -45,7 +45,7 @@ public:
 
 	void setValue(int logicValue);
 	void toggle();
-	bool getLogicValue();
+	bool getLogicValue() const;
 
 
 #if EFI_GPIO_HARDWARE
@@ -77,8 +77,8 @@ public:
 	explicit NamedOutputPin(const char *name);
 	void setHigh();
 	void setLow();
-	const char *getName();
-	const char *getShortName();
+	const char *getName() const;
+	const char *getShortName() const;
 	/**
 	 * @return true if pin was stopped
 	 */

--- a/firmware/controllers/trigger/decoders/trigger_structure.cpp
+++ b/firmware/controllers/trigger/decoders/trigger_structure.cpp
@@ -98,7 +98,7 @@ int TriggerShape::getSize() const {
 	return privateTriggerDefinitionSize;
 }
 
-int TriggerShape::getTriggerShapeSynchPointIndex() {
+int TriggerShape::getTriggerShapeSynchPointIndex() const {
 	return triggerShapeSynchPointIndex;
 }
 
@@ -154,7 +154,7 @@ void TriggerShape::addEventClamped(angle_t angle, trigger_wheel_e const channelI
 		addEvent(angle / getEngineCycle(operationMode), channelIndex, stateParam);
 }
 
-operation_mode_e TriggerShape::getOperationMode() {
+operation_mode_e TriggerShape::getOperationMode() const {
 	return operationMode;
 }
 
@@ -311,7 +311,7 @@ void TriggerShape::setTriggerSynchronizationGap3(int gapIndex, float syncRatioFr
 /**
  * this method is only used on initialization
  */
-int TriggerShape::findAngleIndex(float target) {
+int TriggerShape::findAngleIndex(float target) const {
 	int engineCycleEventCount = getLength();
 
 	efiAssert(CUSTOM_ERR_ASSERT, engineCycleEventCount > 0, "engineCycleEventCount", 0);

--- a/firmware/controllers/trigger/decoders/trigger_structure.h
+++ b/firmware/controllers/trigger/decoders/trigger_structure.h
@@ -221,7 +221,7 @@ public:
 	 * Deprecated?
 	 */
 	void addEventClamped(angle_t angle, trigger_wheel_e const channelIndex, trigger_value_e const stateParam, float filterLeft, float filterRight);
-	operation_mode_e getOperationMode();
+	operation_mode_e getOperationMode() const;
 
 	void initialize(operation_mode_e operationMode, bool needSecondTriggerInput);
 	void setTriggerSynchronizationGap(float syncRatio);
@@ -236,7 +236,7 @@ public:
 	uint32_t getLength() const;
 	int getSize() const;
 
-	int getTriggerShapeSynchPointIndex();
+	int getTriggerShapeSynchPointIndex() const;
 	void prepareShape();
 
 	/**
@@ -253,7 +253,7 @@ public:
 private:
 	trigger_shape_helper h;
 
-	int findAngleIndex(float angle);
+	int findAngleIndex(float angle) const;
 
 	/**
 	 * Working buffer for 'wave' instance

--- a/firmware/controllers/trigger/rpm_calculator.cpp
+++ b/firmware/controllers/trigger/rpm_calculator.cpp
@@ -38,7 +38,7 @@ extern WaveChart waveChart;
 #define NO_RPM_EVENTS_TIMEOUT_SECS 2
 #endif /* NO_RPM_EVENTS_TIMEOUT_SECS */
 
-float RpmCalculator::getRpmAcceleration() {
+float RpmCalculator::getRpmAcceleration() const {
 	return 1.0 * previousRpmValue / rpmValue;
 }
 
@@ -56,7 +56,7 @@ bool RpmCalculator::isSpinningUp(DECLARE_ENGINE_PARAMETER_SIGNATURE) const {
 	return state == SPINNING_UP;
 }
 
-uint32_t RpmCalculator::getRevolutionCounterSinceStart(void) {
+uint32_t RpmCalculator::getRevolutionCounterSinceStart(void) const {
 	return revolutionCounterSinceStart;
 }
 
@@ -181,7 +181,7 @@ void RpmCalculator::onNewEngineCycle() {
 #endif /* EFI_UNIT_TEST */
 }
 
-uint32_t RpmCalculator::getRevolutionCounter(void) {
+uint32_t RpmCalculator::getRevolutionCounter(void) const {
 	return revolutionCounterSinceBoot;
 }
 

--- a/firmware/controllers/trigger/rpm_calculator.h
+++ b/firmware/controllers/trigger/rpm_calculator.h
@@ -102,19 +102,19 @@ public:
 	 * This method is invoked once per engine cycle right after we calculate new RPM value
 	 */
 	void onNewEngineCycle();
-	uint32_t getRevolutionCounter(void);
+	uint32_t getRevolutionCounter(void) const;
 	void setRpmValue(int value DECLARE_ENGINE_PARAMETER_SUFFIX);
 	/**
 	 * The same as setRpmValue() but without state change.
 	 * We need this to be public because of calling rpmState->assignRpmValue() from rpmShaftPositionCallback()
 	 */
 	void assignRpmValue(int value DECLARE_ENGINE_PARAMETER_SUFFIX);
-	uint32_t getRevolutionCounterSinceStart(void);
+	uint32_t getRevolutionCounterSinceStart(void) const;
 	/**
 	 * RPM rate of change between current RPM and RPM measured during previous engine cycle
 	 * see also SC_RPM_ACCEL
 	 */
-	float getRpmAcceleration();
+	float getRpmAcceleration() const;
 	/**
 	 * This is public because sometimes we cannot afford to call isRunning() and the value is good enough
 	 * Zero if engine is not running

--- a/firmware/controllers/trigger/trigger_central.cpp
+++ b/firmware/controllers/trigger/trigger_central.cpp
@@ -39,7 +39,7 @@ void TriggerCentral::resetAccumSignalData() {
 	memset(accumSignalPrevPeriods, 0, sizeof(accumSignalPrevPeriods));
 }
 
-int TriggerCentral::getHwEventCounter(int index) {
+int TriggerCentral::getHwEventCounter(int index) const {
 	return hwEventCounters[index];
 }
 

--- a/firmware/controllers/trigger/trigger_central.h
+++ b/firmware/controllers/trigger/trigger_central.h
@@ -29,7 +29,7 @@ public:
 	TriggerCentral();
 	void addEventListener(ShaftPositionListener handler, const char *name, Engine *engine);
 	void handleShaftSignal(trigger_event_e signal DECLARE_ENGINE_PARAMETER_SUFFIX);
-	int getHwEventCounter(int index);
+	int getHwEventCounter(int index) const;
 	void resetCounters();
 	void resetAccumSignalData();
 	bool noiseFilter(efitick_t nowNt, trigger_event_e signal DECLARE_ENGINE_PARAMETER_SUFFIX);

--- a/firmware/controllers/trigger/trigger_decoder.cpp
+++ b/firmware/controllers/trigger/trigger_decoder.cpp
@@ -248,7 +248,7 @@ void TriggerStateWithRunningStatistics::runtimeStatistics(efitime_t nowNt DECLAR
 	}
 }
 
-bool TriggerState::isValidIndex(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
+bool TriggerState::isValidIndex(DECLARE_ENGINE_PARAMETER_SIGNATURE) const {
 	return currentCycle.current_index < getTriggerSize();
 }
 

--- a/firmware/controllers/trigger/trigger_decoder.cpp
+++ b/firmware/controllers/trigger/trigger_decoder.cpp
@@ -699,10 +699,6 @@ void initTriggerDecoderLogger(Logging *sharedLogger) {
 	logger = sharedLogger;
 }
 
-efitime_t TriggerState::getStartOfRevolutionIndex() const {
-	return totalEventCountBase;
-}
-
 void TriggerState::runtimeStatistics(efitime_t nowNt DECLARE_ENGINE_PARAMETER_SUFFIX) {
 	UNUSED(nowNt);
 	// empty base implementation

--- a/firmware/controllers/trigger/trigger_decoder.h
+++ b/firmware/controllers/trigger/trigger_decoder.h
@@ -68,7 +68,7 @@ public:
 	 */
 	void onSynchronizationLost(DECLARE_ENGINE_PARAMETER_SIGNATURE);
 
-	bool isValidIndex(DECLARE_ENGINE_PARAMETER_SIGNATURE);
+	bool isValidIndex(DECLARE_ENGINE_PARAMETER_SIGNATURE) const;
 	float getTriggerDutyCycle(int index);
 	TriggerStateCallback triggerCycleCallback;
 

--- a/firmware/controllers/trigger/trigger_decoder.h
+++ b/firmware/controllers/trigger/trigger_decoder.h
@@ -59,7 +59,6 @@ public:
 	void validateCamVvtCounters();
 	void incrementTotalEventCounter();
 	efitime_t getTotalEventCounter() const;
-	efitime_t getStartOfRevolutionIndex() const;
 	void decodeTriggerEvent(trigger_event_e const signal, efitime_t nowUs DECLARE_ENGINE_PARAMETER_SUFFIX);
 	bool validateEventCounters(DECLARE_ENGINE_PARAMETER_SIGNATURE) const;
 	void handleTriggerError(DECLARE_ENGINE_PARAMETER_SIGNATURE);
@@ -151,7 +150,7 @@ public:
 	void movePreSynchTimestamps(DECLARE_ENGINE_PARAMETER_SIGNATURE);
 	float calculateInstantRpm(int *prevIndex, efitime_t nowNt DECLARE_ENGINE_PARAMETER_SUFFIX);
 #if EFI_ENGINE_CONTROL && EFI_SHAFT_POSITION_INPUT
-	virtual void runtimeStatistics(efitime_t nowNt DECLARE_ENGINE_PARAMETER_SUFFIX);
+	void runtimeStatistics(efitime_t nowNt DECLARE_ENGINE_PARAMETER_SUFFIX) override;
 #endif
 	/**
 	 * Update timeOfLastEvent[] on every trigger event - even without synchronization

--- a/firmware/development/engine_sniffer.cpp
+++ b/firmware/development/engine_sniffer.cpp
@@ -105,7 +105,7 @@ void WaveChart::startDataCollection() {
 	collectingData = true;
 }
 
-bool WaveChart::isStartedTooLongAgo() {
+bool WaveChart::isStartedTooLongAgo() const {
 	/**
 	 * Say at 300rpm we should get at least four events per revolution.
 	 * That's 300/60*4=20 events per second
@@ -116,7 +116,7 @@ bool WaveChart::isStartedTooLongAgo() {
 	return startTimeNt != 0 && NT2US(chartDurationNt) > engineConfiguration->engineChartSize * 1000000 / 20;
 }
 
-bool WaveChart::isFull() {
+bool WaveChart::isFull() const {
 	return counter >= CONFIG(engineChartSize);
 }
 

--- a/firmware/development/engine_sniffer.h
+++ b/firmware/development/engine_sniffer.h
@@ -26,8 +26,8 @@ public:
 	void startDataCollection();
 	void publishIfFull();
 	void publish();
-	bool isFull();
-	bool isStartedTooLongAgo();
+	bool isFull() const;
+	bool isStartedTooLongAgo() const;
 private:
 	Logging logging;
 	char timeBuffer[10];

--- a/firmware/hw_layer/AdcConfiguration.h
+++ b/firmware/hw_layer/AdcConfiguration.h
@@ -14,18 +14,18 @@ public:
 	explicit AdcDevice(ADCConversionGroup* hwConfig);
 	void enableChannel(adc_channel_e hwChannelIndex);
 	void enableChannelAndPin(adc_channel_e hwChannelIndex);
-	adc_channel_e getAdcHardwareIndexByInternalIndex(int index);
+	adc_channel_e getAdcHardwareIndexByInternalIndex(int index) const;
 	int internalAdcIndexByHardwareIndex[20];
-	bool isHwUsed(adc_channel_e hwChannel);
-	int size();
+	bool isHwUsed(adc_channel_e hwChannel) const;
+	int size() const;
 	void init(void);
 	int conversionCount;
 	int errorsCount;
-	int getAdcValueByIndex(int internalIndex);
+	int getAdcValueByIndex(int internalIndex) const;
 
 	adcsample_t samples[ADC_MAX_CHANNELS_COUNT * MAX_ADC_GRP_BUF_DEPTH];
 
-	int getAdcValueByHwChannel(int hwChannel);
+	int getAdcValueByHwChannel(int hwChannel) const;
 
 	adc_state values;
 	int channelCount;

--- a/firmware/hw_layer/AdcConfiguration.h
+++ b/firmware/hw_layer/AdcConfiguration.h
@@ -11,7 +11,7 @@
 
 class AdcDevice {
 public:
-	AdcDevice(ADCConversionGroup* hwConfig);
+	explicit AdcDevice(ADCConversionGroup* hwConfig);
 	void enableChannel(adc_channel_e hwChannelIndex);
 	void enableChannelAndPin(adc_channel_e hwChannelIndex);
 	adc_channel_e getAdcHardwareIndexByInternalIndex(int index);

--- a/firmware/hw_layer/adc_inputs.cpp
+++ b/firmware/hw_layer/adc_inputs.cpp
@@ -329,16 +329,16 @@ static void initAdcHwChannel(adc_channel_e hwChannel) {
 	initAdcPin(pin, "hw");
 }
 
-int AdcDevice::size() {
+int AdcDevice::size() const {
 	return channelCount;
 }
 
-int AdcDevice::getAdcValueByHwChannel(int hwChannel) {
+int AdcDevice::getAdcValueByHwChannel(int hwChannel) const {
 	int internalIndex = internalAdcIndexByHardwareIndex[hwChannel];
 	return values.adc_data[internalIndex];
 }
 
-int AdcDevice::getAdcValueByIndex(int internalIndex) {
+int AdcDevice::getAdcValueByIndex(int internalIndex) const {
 	return values.adc_data[internalIndex];
 }
 
@@ -347,7 +347,7 @@ void AdcDevice::init(void) {
 	hwConfig->sqr1 += ADC_SQR1_NUM_CH(size());
 }
 
-bool AdcDevice::isHwUsed(adc_channel_e hwChannelIndex) {
+bool AdcDevice::isHwUsed(adc_channel_e hwChannelIndex) const {
 	for (int i = 0; i < channelCount; i++) {
 		if (hardwareIndexByIndernalAdcIndex[i] == hwChannelIndex) {
 			return true;
@@ -383,7 +383,7 @@ static void printAdcValue(int channel) {
 	scheduleMsg(&logger, "adc voltage : %.2f", volts);
 }
 
-adc_channel_e AdcDevice::getAdcHardwareIndexByInternalIndex(int index) {
+adc_channel_e AdcDevice::getAdcHardwareIndexByInternalIndex(int index) const {
 	return hardwareIndexByIndernalAdcIndex[index];
 }
 

--- a/firmware/hw_layer/hip9011.cpp
+++ b/firmware/hw_layer/hip9011.cpp
@@ -59,9 +59,9 @@ extern EnginePins enginePins;
 uint32_t hipLastExecutionCount;
 
 
-class Hip9011Hardware: public Hip9011HardwareInterface {
-	void sendSyncCommand(unsigned char command);
-	void sendCommand(unsigned char command);
+class Hip9011Hardware : public Hip9011HardwareInterface {
+	void sendSyncCommand(unsigned char command) override;
+	void sendCommand(unsigned char command) override;
 };
 
 static Hip9011Hardware hardware;

--- a/firmware/hw_layer/hip9011_logic.h
+++ b/firmware/hw_layer/hip9011_logic.h
@@ -57,7 +57,7 @@ public:
 
 class HIP9011 {
 public:
-	HIP9011(Hip9011HardwareInterface *hardware);
+	explicit HIP9011(Hip9011HardwareInterface *hardware);
 	void prepareHip9011RpmLookup(float angleWindowWidth);
 	int getIntegrationIndexByRpm(float rpm);
 	void setStateAndCommand(unsigned char cmd);

--- a/firmware/hw_layer/sensors/cj125_logic.cpp
+++ b/firmware/hw_layer/sensors/cj125_logic.cpp
@@ -34,7 +34,7 @@ void CJ125::SetIdleHeater(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 	SetHeater(CJ125_HEATER_IDLE_RATE PASS_ENGINE_PARAMETER_SUFFIX);
 }
 
-bool CJ125::isWorkingState(void) {
+bool CJ125::isWorkingState(void) const {
 	return state != CJ125_ERROR && state != CJ125_INIT && state != CJ125_IDLE;
 }
 
@@ -95,7 +95,7 @@ void CJ125::cjSetMode(cj125_mode_e m) {
 	mode = m;
 }
 
-bool CJ125::isValidState() {
+bool CJ125::isValidState() const {
 	// check if controller is functioning
 	if (!isWorkingState())
 		return false;

--- a/firmware/hw_layer/sensors/cj125_logic.h
+++ b/firmware/hw_layer/sensors/cj125_logic.h
@@ -93,13 +93,13 @@ public:
 	volatile cj125_error_e errorCode = CJ125_ERROR_NONE;
 
 	void setError(cj125_error_e errCode DECLARE_ENGINE_PARAMETER_SUFFIX);
-	bool isWorkingState(void);
+	bool isWorkingState(void) const;
 	void SetHeater(float value DECLARE_ENGINE_PARAMETER_SUFFIX);
 	void SetIdleHeater(DECLARE_ENGINE_PARAMETER_SIGNATURE);
 	void StartHeaterControl(pwm_gen_callback *stateChangeCallback DECLARE_ENGINE_PARAMETER_SUFFIX);
 	void cjIdentify(void);
 	void cjSetMode(cj125_mode_e m);
-	bool isValidState();
+	bool isValidState() const;
 	void cjInitPid(DECLARE_ENGINE_PARAMETER_SIGNATURE);
 };
 

--- a/firmware/hw_layer/stepper.cpp
+++ b/firmware/hw_layer/stepper.cpp
@@ -128,7 +128,7 @@ StepperMotor::StepperMotor() {
 	totalSteps = 0;
 }
 
-int StepperMotor::getTargetPosition() {
+int StepperMotor::getTargetPosition() const {
 	return targetPosition;
 }
 

--- a/firmware/hw_layer/stepper.h
+++ b/firmware/hw_layer/stepper.h
@@ -18,7 +18,7 @@ public:
 			brain_pin_e enablePin, pin_output_mode_e enablePinMode, Logging *sharedLogger);
 	void pulse();
 	void setTargetPosition(int targetPosition);
-	int getTargetPosition();
+	int getTargetPosition() const;
 	void setDirection(bool isIncrementing);
 
 	OutputPin directionPin;

--- a/firmware/util/containers/cyclic_buffer.h
+++ b/firmware/util/containers/cyclic_buffer.h
@@ -25,7 +25,7 @@ class cyclic_buffer
 {
   public:
 	cyclic_buffer();
-    cyclic_buffer(int size);
+    explicit cyclic_buffer(int size);
   //cpctor
     cyclic_buffer(const cyclic_buffer& cb);
   //dtor

--- a/firmware/util/containers/listener_array.h
+++ b/firmware/util/containers/listener_array.h
@@ -27,7 +27,7 @@ public:
 	void clear();
 	void registerCallback(VoidInt handler, void *arg);
 	void registerCallback(Void listener);
-	void invokeJustArgCallbacks();
+	void invokeJustArgCallbacks() const;
 	int currentListenersCount;
 	VoidInt callbacks[MAX_INT_LISTENER_COUNT];
 	void * args[MAX_INT_LISTENER_COUNT];
@@ -83,7 +83,7 @@ void invokeCallbacks(IntListenerArray<MAX_INT_LISTENER_COUNT> *array, int value)
 }
 
 template<int MAX_INT_LISTENER_COUNT>
-void IntListenerArray<MAX_INT_LISTENER_COUNT>::invokeJustArgCallbacks() {
+void IntListenerArray<MAX_INT_LISTENER_COUNT>::invokeJustArgCallbacks() const {
 	for (int i = 0; i < currentListenersCount; i++) {
 		VoidPtr listener = (VoidPtr)(void*)callbacks[i];
 		void *arg = args[i];

--- a/firmware/util/containers/table_helper.h
+++ b/firmware/util/containers/table_helper.h
@@ -21,7 +21,7 @@
 template<int RPM_BIN_SIZE, int LOAD_BIN_SIZE, typename vType>
 class Map3D {
 public:
-	Map3D(const char*name);
+	explicit Map3D(const char*name);
 	Map3D(const char*name, float multiplier);
 	void init(vType table[RPM_BIN_SIZE][LOAD_BIN_SIZE], const float loadBins[LOAD_BIN_SIZE], const float rpmBins[RPM_BIN_SIZE]);
 	float getValue(float xRpm, float y);

--- a/firmware/util/datalogging.h
+++ b/firmware/util/datalogging.h
@@ -44,7 +44,7 @@ public:
 
 class LoggingWithStorage : public Logging {
 public:
-	LoggingWithStorage(const char *name);
+	explicit LoggingWithStorage(const char *name);
 	char DEFAULT_BUFFER[200];
 };
 

--- a/firmware/util/math/interpolation.cpp
+++ b/firmware/util/math/interpolation.cpp
@@ -86,7 +86,7 @@ void FastInterpolation::init(float x1, float y1, float x2, float y2) {
 	b = y1 - a * x1;
 }
 
-float FastInterpolation::getValue(float x) {
+float FastInterpolation::getValue(float x) const {
 	return a * x + b;
 }
 

--- a/firmware/util/math/interpolation.h
+++ b/firmware/util/math/interpolation.h
@@ -171,7 +171,7 @@ public:
 	FastInterpolation();
 	FastInterpolation(float x1, float y1, float x2, float y2);
 	void init(float x1, float y1, float x2, float y2);
-	float getValue(float x);
+	float getValue(float x) const;
 private:
 	float a, b;
 };

--- a/firmware/util/math/pid.cpp
+++ b/firmware/util/math/pid.cpp
@@ -26,7 +26,7 @@ void Pid::initPidClass(pid_s *pid) {
 	reset();
 }
 
-bool Pid::isSame(pid_s *pid) {
+bool Pid::isSame(pid_s *pid) const {
 	return this->pid->pFactor == pid->pFactor
 			&& this->pid->iFactor == pid->iFactor
 			&& this->pid->dFactor == pid->dFactor
@@ -86,27 +86,27 @@ void Pid::reset(void) {
 	resetCounter++;
 }
 
-float Pid::getP(void) {
+float Pid::getP(void) const {
 	return pid->pFactor;
 }
 
-float Pid::getI(void) {
+float Pid::getI(void) const {
 	return pid->iFactor;
 }
 
-float Pid::getPrevError(void) {
+float Pid::getPrevError(void) const {
 	return previousError;
 }
 
-float Pid::getIntegration(void) {
+float Pid::getIntegration(void) const {
 	return iTerm;
 }
 
-float Pid::getD(void) {
+float Pid::getD(void) const {
 	return pid->dFactor;
 }
 
-float Pid::getOffset(void) {
+float Pid::getOffset(void) const {
 	return pid->offset;
 }
 

--- a/firmware/util/math/pid.h
+++ b/firmware/util/math/pid.h
@@ -32,9 +32,9 @@ class Pid {
 
 public:
 	Pid();
-	Pid(pid_s *pid);
+	explicit Pid(pid_s *pid);
 	void initPidClass(pid_s *pid);
-	bool isSame(pid_s *pid);
+	bool isSame(pid_s *pid) const;
 
 	/**
 	 * This version of the methor takes dTime from pid_s
@@ -48,12 +48,12 @@ public:
 	float getUnclampedOutput(float target, float input, float dTime);
 	void updateFactors(float pFactor, float iFactor, float dFactor);
 	virtual void reset(void);
-	float getP(void);
-	float getI(void);
-	float getD(void);
-	float getOffset(void);
-	float getIntegration(void);
-	float getPrevError(void);
+	float getP(void) const;
+	float getI(void) const;
+	float getD(void) const;
+	float getOffset(void) const;
+	float getIntegration(void) const;
+	float getPrevError(void) const;
 	void setErrorAmplification(float coef);
 #if EFI_TUNER_STUDIO
 	void postState(TunerStudioOutputChannels *tsOutputChannels);
@@ -94,11 +94,11 @@ class PidCic : public Pid {
 
 public:
 	PidCic();
-	PidCic(pid_s *pid);
+	explicit PidCic(pid_s *pid);
 
-	virtual void reset(void);
+	void reset(void) override;
 	using Pid::getOutput;
-	virtual float getOutput(float target, float input, float dTime);
+	float getOutput(float target, float input, float dTime) override;
 	
 private:
 	// Circular running-average buffer for I-term, used by CIC-like filter
@@ -109,7 +109,7 @@ private:
 	int totalItermCnt;
 
 private:
-	virtual void updateITerm(float value);
+	void updateITerm(float value) override;
 };
 
 #endif /* PID_H_ */


### PR DESCRIPTION
- Constify things that can be const.
- Explicitify things that can be explicit.
- Use override instead of virtual where appropriate.  Switch from `virtual returntype func()` to `returntype func() override`.  This makes the compiler ensure that the function is _actually_ overriding something, instead of defining a new virtual function.