### PR TITLE
Fix F7 ADC #854

### DIFF
--- a/firmware/hw_layer/AdcConfiguration.h
+++ b/firmware/hw_layer/AdcConfiguration.h
@@ -22,8 +22,9 @@ public:
 	int conversionCount;
 	int errorsCount;
 	int getAdcValueByIndex(int internalIndex) const;
+	void invalidateSamplesCache();
 
-	adcsample_t samples[ADC_MAX_CHANNELS_COUNT * MAX_ADC_GRP_BUF_DEPTH];
+	__ALIGNED(32) adcsample_t samples[ADC_MAX_CHANNELS_COUNT * MAX_ADC_GRP_BUF_DEPTH];
 
 	int getAdcValueByHwChannel(int hwChannel) const;
 

--- a/firmware/hw_layer/AdcConfiguration.h
+++ b/firmware/hw_layer/AdcConfiguration.h
@@ -24,7 +24,12 @@ public:
 	int getAdcValueByIndex(int internalIndex) const;
 	void invalidateSamplesCache();
 
+	// This must be aligned on a 32-byte boundary, and be a multiple of 32 bytes long.
+	// When we invalidate the cache line(s) for ADC samples, we don't want to nuke any
+	// adjacent data
 	__ALIGNED(32) adcsample_t samples[ADC_MAX_CHANNELS_COUNT * MAX_ADC_GRP_BUF_DEPTH];
+	// Assert multiple of 32 bytes long so we don't stomp on the data after the buffer
+	static_assert(sizeof(samples) % 32 == 0);
 
 	int getAdcValueByHwChannel(int hwChannel) const;
 

--- a/firmware/hw_layer/adc_inputs.cpp
+++ b/firmware/hw_layer/adc_inputs.cpp
@@ -148,7 +148,7 @@ ADC_TwoSamplingDelay_20Cycles,   // cr1
 		0  // Conversion group sequence 1...6
 		};
 
-AdcDevice slowAdc(&adcgrpcfgSlow);
+__ALIGNED(32) AdcDevice slowAdc(&adcgrpcfgSlow);
 
 static ADCConversionGroup adcgrpcfg_fast = { FALSE, 0 /* num_channels */, adc_callback_fast, NULL,
 /* HW dependent part.*/
@@ -189,7 +189,7 @@ ADC_TwoSamplingDelay_5Cycles,   // cr1
 // Conversion group sequence 1...6
 		};
 
-AdcDevice fastAdc(&adcgrpcfg_fast);
+__ALIGNED(32) AdcDevice fastAdc(&adcgrpcfg_fast);
 
 void doSlowAdc(void) {
 
@@ -256,10 +256,10 @@ static void pwmpcb_fast(PWMDriver *pwmp) {
 float getMCUInternalTemperature(void) {
 #if defined(ADC_CHANNEL_SENSOR)
 	float TemperatureValue = adcToVolts(slowAdc.getAdcValueByHwChannel(ADC_CHANNEL_SENSOR));
-	TemperatureValue -= 0.760; // Subtract the reference voltage at 25°C
+	TemperatureValue -= 0.760; // Subtract the reference voltage at 25ï¿½C
 	TemperatureValue /= .0025; // Divide by slope 2.5mV
 
-	TemperatureValue += 25.0; // Add the 25°C
+	TemperatureValue += 25.0; // Add the 25ï¿½C
 	return TemperatureValue;
 #else
 	return 0;
@@ -340,6 +340,12 @@ int AdcDevice::getAdcValueByHwChannel(int hwChannel) const {
 
 int AdcDevice::getAdcValueByIndex(int internalIndex) const {
 	return values.adc_data[internalIndex];
+}
+
+void AdcDevice::invalidateSamplesCache() {
+#if PROJECT_CPU == ARCH_STM32F7
+	SCB_InvalidateDCache_by_Addr(reinterpret_cast<uint32_t*>(samples), sizeof(samples));
+#endif
 }
 
 void AdcDevice::init(void) {
@@ -432,6 +438,9 @@ int getSlowAdcCounter() {
 static void adc_callback_slow(ADCDriver *adcp, adcsample_t *buffer, size_t n) {
 	(void) buffer;
 	(void) n;
+
+	slowAdc.invalidateSamplesCache();
+
 	efiAssertVoid(CUSTOM_ERR_6671, getCurrentRemainingStack() > 128, "lowstck#9c");
 	/* Note, only in the ADC_COMPLETE state because the ADC driver fires
 	 * an intermediate callback when the buffer is half full. */

--- a/firmware/hw_layer/adc_inputs.cpp
+++ b/firmware/hw_layer/adc_inputs.cpp
@@ -344,6 +344,11 @@ int AdcDevice::getAdcValueByIndex(int internalIndex) const {
 
 void AdcDevice::invalidateSamplesCache() {
 #if PROJECT_CPU == ARCH_STM32F7
+	// The STM32F7xx has a data cache
+	// DMA operations DO NOT invalidate cache lines, since the ARM m7 doesn't have 
+	// anything like a CCI that maintains coherency across multiple bus masters.
+	// As a result, we have to manually invalidate the D-cache any time we (the CPU)
+	// would like to read something that somebody else wrote (ADC via DMA, in this case)
 	SCB_InvalidateDCache_by_Addr(reinterpret_cast<uint32_t*>(samples), sizeof(samples));
 #endif
 }

--- a/firmware/hw_layer/adc_inputs.cpp
+++ b/firmware/hw_layer/adc_inputs.cpp
@@ -148,7 +148,7 @@ ADC_TwoSamplingDelay_20Cycles,   // cr1
 		0  // Conversion group sequence 1...6
 		};
 
-__ALIGNED(32) AdcDevice slowAdc(&adcgrpcfgSlow);
+AdcDevice slowAdc(&adcgrpcfgSlow);
 
 static ADCConversionGroup adcgrpcfg_fast = { FALSE, 0 /* num_channels */, adc_callback_fast, NULL,
 /* HW dependent part.*/
@@ -189,7 +189,7 @@ ADC_TwoSamplingDelay_5Cycles,   // cr1
 // Conversion group sequence 1...6
 		};
 
-__ALIGNED(32) AdcDevice fastAdc(&adcgrpcfg_fast);
+AdcDevice fastAdc(&adcgrpcfg_fast);
 
 void doSlowAdc(void) {
 

--- a/firmware/hw_layer/adc_inputs.cpp
+++ b/firmware/hw_layer/adc_inputs.cpp
@@ -256,10 +256,10 @@ static void pwmpcb_fast(PWMDriver *pwmp) {
 float getMCUInternalTemperature(void) {
 #if defined(ADC_CHANNEL_SENSOR)
 	float TemperatureValue = adcToVolts(slowAdc.getAdcValueByHwChannel(ADC_CHANNEL_SENSOR));
-	TemperatureValue -= 0.760; // Subtract the reference voltage at 25�C
+	TemperatureValue -= 0.760; // Subtract the reference voltage at 25 deg C
 	TemperatureValue /= .0025; // Divide by slope 2.5mV
 
-	TemperatureValue += 25.0; // Add the 25�C
+	TemperatureValue += 25.0; // Add the 25 deg C
 	return TemperatureValue;
 #else
 	return 0;

--- a/firmware/hw_layer/hardware.cpp
+++ b/firmware/hw_layer/hardware.cpp
@@ -196,6 +196,7 @@ extern AdcDevice fastAdc;
  * This method is not in the adc* lower-level file because it is more business logic then hardware.
  */
 void adc_callback_fast(ADCDriver *adcp, adcsample_t *buffer, size_t n) {
+	fastAdc.invalidateSamplesCache();
 
 	(void) buffer;
 	(void) n;


### PR DESCRIPTION
On ARM Cortex M7, only the CPU can invalidate the CPU cache.  So when DMA writes to SRAM, the CPU doesn't know it should re-read.  This change adds an invalidate to the ADC's sample buffer before reading it, so we force a read from SRAM, actually loading the new values.

Fixes #854 