### PR TITLE
Relocate pstack/mstack to DTCM

### DIFF
--- a/firmware/config/boards/nucleo_f767/STM32F76xxI.ld
+++ b/firmware/config/boards/nucleo_f767/STM32F76xxI.ld
@@ -73,11 +73,11 @@ REGION_ALIAS("RAM_INIT_FLASH_LMA", flash0);
 
 /* RAM region to be used for Main stack. This stack accommodates the processing
    of all exceptions and interrupts.*/
-REGION_ALIAS("MAIN_STACK_RAM", ram0);
+REGION_ALIAS("MAIN_STACK_RAM", ram3);
 
 /* RAM region to be used for the process stack. This is the stack used by
    the main() function.*/
-REGION_ALIAS("PROCESS_STACK_RAM", ram0);
+REGION_ALIAS("PROCESS_STACK_RAM", ram3);
 
 /* RAM region to be used for data segment.*/
 REGION_ALIAS("DATA_RAM", ram0);
@@ -87,7 +87,7 @@ REGION_ALIAS("DATA_RAM_LMA", flash0);
 REGION_ALIAS("BSS_RAM", ram0);
 
 /* RAM region to be used for the default heap.*/
-REGION_ALIAS("HEAP_RAM", ram0);
+REGION_ALIAS("HEAP_RAM", ram3);
 
 /* Stack rules inclusion.*/
 INCLUDE rules_stacks.ld


### PR DESCRIPTION
Move stacks (and heap - which we don't use) to DTCM - this certainly won't hurt performance, and will reduce bus contention (not that we had a problem with that).