### PR TITLE
Fix mystery 400ns-1us pulse at MCU startup

### DIFF
--- a/firmware/controllers/system/efi_gpio.cpp
+++ b/firmware/controllers/system/efi_gpio.cpp
@@ -468,9 +468,12 @@ void OutputPin::initPin(const char *msg, brain_pin_e brainPin, const pin_output_
 
 	this->currentLogicValue = INITIAL_PIN_STATE;
 
-	efiSetPadMode(msg, brainPin, mode);
-
+	// The order of the next two calls may look strange, which is a good observation.
+	// We call them in this order so that the pin is set to a known state BEFORE
+	// it's enabled.  Enabling the pin then setting it could result in a (brief)
+	// mystery state being driven on the pin (potentially dangerous).
 	setDefaultPinState(outputMode);
+	efiSetPadMode(msg, brainPin, mode);
 #endif /* EFI_GPIO_HARDWARE */
 }
 


### PR DESCRIPTION
If we set the output state (ie high vs low) before enabling the pin, we prevent a spurrious blip.

This manifested as (and was discovered by) ignition outputs giving a 400ns-1us blip as they were initialized.  This change prevents any such blips from occurring by setting the state of the pin before we actually enable it, so it will immediately do the right thing.