### PR TITLE
Fix build for case-sensitive filesystems

### DIFF
--- a/firmware/config/boards/nucleo_f767/board.mk
+++ b/firmware/config/boards/nucleo_f767/board.mk
@@ -1,11 +1,11 @@
 # List of all the board related files.
 BOARDSRC = $(CHIBIOS)/os/hal/boards/ST_NUCLEO144_F767ZI/board.c
-BOARDSRC_CPP = $(PROJECT_DIR)/config/boards/NUCLEO_F767/board_configuration.cpp
+BOARDSRC_CPP = $(PROJECT_DIR)/config/boards/nucleo_f767/board_configuration.cpp
 
 # Required include directories
-BOARDINC = $(PROJECT_DIR)/config/boards/NUCLEO_F767 $(PROJECT_DIR)/config/stm32f7ems
+BOARDINC = $(PROJECT_DIR)/config/boards/nucleo_f767 $(PROJECT_DIR)/config/stm32f7ems
 
-LDSCRIPT= $(PROJECT_DIR)/config/boards/NUCLEO_F767/STM32F76xxI.ld
+LDSCRIPT= $(PROJECT_DIR)/config/boards/nucleo_f767/STM32F76xxI.ld
 
 # Override DEFAULT_ENGINE_TYPE
 DDEFS += -DDEFAULT_ENGINE_TYPE=CUSTOM_ENGINE -DSTM32F767xx


### PR DESCRIPTION
Filesystems other than NTFS (for example, `ext4` on Linux) are case sensitive.