### PR TITLE
Fix some maf logic

### DIFF
--- a/firmware/console/status_loop.cpp
+++ b/firmware/console/status_loop.cpp
@@ -245,7 +245,7 @@ static void printSensors(Logging *log) {
 	reportSensorF(log, fileFormat, GAUGE_NAME_ACCEL_Y, "G", engine->sensors.accelerometer.y, 3);
 
 	if (hasMafSensor()) {
-		reportSensorF(log, fileFormat, "maf", "V", getMaf(PASS_ENGINE_PARAMETER_SIGNATURE), 2);
+		reportSensorF(log, fileFormat, "maf", "V", getMafVoltage(PASS_ENGINE_PARAMETER_SIGNATURE), 2);
 		reportSensorF(log, fileFormat, "mafr", "kg/hr", getRealMaf(PASS_ENGINE_PARAMETER_SIGNATURE), 2);
 	}
 
@@ -689,7 +689,7 @@ void updateTunerStudioState(TunerStudioOutputChannels *tsOutputChannels DECLARE_
 	tsOutputChannels->coolantTemperature = coolant;
 	tsOutputChannels->intakeAirTemperature = intake;
 	tsOutputChannels->throttlePositon = tps;
-	tsOutputChannels->massAirFlowVoltage = hasMafSensor() ? getMaf(PASS_ENGINE_PARAMETER_SIGNATURE) : 0;
+	tsOutputChannels->massAirFlowVoltage = hasMafSensor() ? getMafVoltage(PASS_ENGINE_PARAMETER_SIGNATURE) : 0;
 	// For air-interpolated tCharge mode, we calculate a decent massAirFlow approximation, so we can show it to users even without MAF sensor!
     tsOutputChannels->massAirFlow = hasMafSensor() ? getRealMaf(PASS_ENGINE_PARAMETER_SIGNATURE) : engine->engineState.airFlow;
     tsOutputChannels->oilPressure = engine->sensors.oilPressure;

--- a/firmware/controllers/actuators/lcd_controller.cpp
+++ b/firmware/controllers/actuators/lcd_controller.cpp
@@ -293,7 +293,7 @@ static void showLine(lcd_line_e line, int screenY) {
 		return;
 	case LL_MAF_V:
 		if (hasMafSensor()) {
-			lcdPrintf("MAF: %.2fv", getMaf(PASS_ENGINE_PARAMETER_SIGNATURE));
+			lcdPrintf("MAF: %.2fv", getMafVoltage(PASS_ENGINE_PARAMETER_SIGNATURE));
 		} else {
 			lcdPrintf("MAF: none");
 		}

--- a/firmware/controllers/algo/engine.cpp
+++ b/firmware/controllers/algo/engine.cpp
@@ -195,16 +195,6 @@ void Engine::preCalculate(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 #else
 	adcToVoltageInputDividerCoefficient = engineConfigurationPtr->analogInputDividerCoefficient;
 #endif
-
-	/**
-	 * Here we prepare a fast, index-based MAF lookup from a slower curve description
-	 */
-	for (int i = 0; i < MAF_DECODING_CACHE_SIZE; i++) {
-		float volts = i / MAF_DECODING_CACHE_MULT;
-		float maf = interpolate2d("maf", volts, config->mafDecodingBins,
-				config->mafDecoding);
-		mafDecodingLookup[i] = maf;
-	}
 }
 
 void Engine::setConfig(persistent_config_s *config) {

--- a/firmware/controllers/algo/engine.h
+++ b/firmware/controllers/algo/engine.h
@@ -283,12 +283,6 @@ public:
 	 */
 	uint32_t engineCycleEventCount = 0;
 
-	/**
-	 * fast kg/hour MAF decoding lookup table with ~0.2 volt step
-	 * This table is build based on MAF decoding curve
-	 */
-	float mafDecodingLookup[MAF_DECODING_CACHE_SIZE];
-
 	void preCalculate(DECLARE_ENGINE_PARAMETER_SIGNATURE);
 
 	void watchdog();

--- a/firmware/controllers/core/fsio_impl.cpp
+++ b/firmware/controllers/core/fsio_impl.cpp
@@ -124,7 +124,7 @@ float getEngineValue(le_action_e action DECLARE_ENGINE_PARAMETER_SUFFIX) {
 	case LE_METHOD_RPM:
 		return engine->rpmCalculator.getRpm();
 	case LE_METHOD_MAF:
-		return getMaf(PASS_ENGINE_PARAMETER_SIGNATURE);
+		return getRealMaf(PASS_ENGINE_PARAMETER_SIGNATURE);
 	case LE_METHOD_MAP:
 		return getMap(PASS_ENGINE_PARAMETER_SIGNATURE);
 	case LE_METHOD_INTAKE_VVT:

--- a/firmware/controllers/math/engine_math.cpp
+++ b/firmware/controllers/math/engine_math.cpp
@@ -60,9 +60,10 @@ float getEngineLoadT(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 			warning(CUSTOM_MAF_NEEDED, "MAF sensor needed for current fuel algorithm");
 			return NAN;
 		}
-		return getMafT(engineConfiguration);
+		return getMafVoltage(PASS_ENGINE_PARAMETER_SIGNATURE);
 	case LM_SPEED_DENSITY:
 		// SD engine load is used for timing lookup but not for fuel calculation
+		[[fallthrough]]
 	case LM_MAP:
 		return getMap(PASS_ENGINE_PARAMETER_SIGNATURE);
 	case LM_ALPHA_N:

--- a/firmware/controllers/obd2.cpp
+++ b/firmware/controllers/obd2.cpp
@@ -167,7 +167,7 @@ static void handleGetDataRequest(CANRxFrame *rx) {
 		break;
 	case PID_INTAKE_MAF:
 		scheduleMsg(&logger, "Got MAF request");
-		obdSendValue(1, pid, 2, getMaf(PASS_ENGINE_PARAMETER_SIGNATURE) * 100.0f);	// grams/sec	(A*256+B)/100
+		obdSendValue(1, pid, 2, getRealMaf(PASS_ENGINE_PARAMETER_SIGNATURE) * 100.0f);	// grams/sec	(A*256+B)/100
 		break;
 	case PID_THROTTLE:
 		scheduleMsg(&logger, "Got throttle request");

--- a/firmware/controllers/sensors/maf.cpp
+++ b/firmware/controllers/sensors/maf.cpp
@@ -9,8 +9,8 @@ EXTERN_ENGINE
 /**
  * @return MAF sensor voltage
  */
-float getMaf(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
-	return getMafT(engineConfiguration);
+float getMafVoltage(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
+	return getVoltageDivided("maf", engineConfiguration->mafAdcChannel);
 }
 
 bool hasMafSensor(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
@@ -21,11 +21,9 @@ bool hasMafSensor(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
  * @return kg/hour value
  */
 float getRealMaf(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
-	int mafAdc = getAdcValue("maf", engineConfiguration->mafAdcChannel);
-	/**
-	 * here we drop from 12 bit ADC to 8 bit index
-	 */
-	return engine->mafDecodingLookup[mafAdc >> 4];
+	float volts = getMafVoltage(PASS_ENGINE_PARAMETER_SIGNATURE);
+
+	return interpolate2d("maf", volts, config->mafDecodingBins, config->mafDecoding);
 }
 
 static void fillTheRest(persistent_config_s *e, int i) {

--- a/firmware/controllers/sensors/maf.h
+++ b/firmware/controllers/sensors/maf.h
@@ -2,7 +2,7 @@
  * @file    maf.h
  * @brief
  *
- * by the way 2.081989116 kg/h = 1 ft³/m
+ * by the way 2.081989116 kg/h = 1 ftï¿½/m
  *
  *
  * @date Nov 15, 2013
@@ -14,8 +14,7 @@
 
 #include "global.h"
 
-#define getMafT(ec) (getVoltageDivided("maf", ec->mafAdcChannel))
-float getMaf(DECLARE_ENGINE_PARAMETER_SIGNATURE);
+float getMafVoltage(DECLARE_ENGINE_PARAMETER_SIGNATURE);
 bool hasMafSensor(DECLARE_ENGINE_PARAMETER_SIGNATURE);
 float getRealMaf(DECLARE_ENGINE_PARAMETER_SIGNATURE);
 

--- a/firmware/controllers/sensors/maf.h
+++ b/firmware/controllers/sensors/maf.h
@@ -2,7 +2,7 @@
  * @file    maf.h
  * @brief
  *
- * by the way 2.081989116 kg/h = 1 ft�/m
+ * by the way 2.081989116 kg/h = 1 ft^3/min
  *
  *
  * @date Nov 15, 2013

--- a/unit_tests/tests/test_engine_math.cpp
+++ b/unit_tests/tests/test_engine_math.cpp
@@ -92,21 +92,6 @@ TEST(misc, testIgnitionMapGenerator) {
     assertEqualsM2("20@800", 14.2, getInitialAdvance(800, 20, 36), 0.2);
 }
 
-TEST(misc, testMafLookup) {
-	printf("*************************************************** testMafLookup\r\n");
-
-	WITH_ENGINE_TEST_HELPER(FORD_ESCORT_GT);
-
-	setBosch0280218037(config);
-	engine->preCalculate(PASS_ENGINE_PARAMETER_SIGNATURE);
-
-	assertEqualsM("@0", -34.5000, engine->mafDecodingLookup[0]);
-	assertEqualsM("@1", -33.7875, engine->mafDecodingLookup[1]);
-	assertEqualsM("@2", -33.0750, engine->mafDecodingLookup[2]);
-	assertEqualsM("@200", 313.8826, engine->mafDecodingLookup[200]);
-	ASSERT_EQ( 738,  engine->mafDecodingLookup[255]) << "@255";
-}
-
 float getMap(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 	return engine->mockMapValue;
 }

--- a/unit_tests/tests/test_trigger_decoder.cpp
+++ b/unit_tests/tests/test_trigger_decoder.cpp
@@ -674,7 +674,7 @@ static void setTestBug299(EngineTestHelper *eth) {
 	ASSERT_EQ( 0,  engine->engineState.injectorLag) << "lag";
 
 	testMafValue = 0;
-	ASSERT_EQ( 0,  getMaf(PASS_ENGINE_PARAMETER_SIGNATURE)) << "maf";
+	ASSERT_EQ( 0,  getMafVoltage(PASS_ENGINE_PARAMETER_SIGNATURE)) << "maf";
 
 	ASSERT_EQ( 3000,  GET_RPM()) << "setTestBug299: RPM";
 
@@ -682,7 +682,7 @@ static void setTestBug299(EngineTestHelper *eth) {
 	assertEqualsM("duty for maf=0", 7.5, getInjectorDutyCycle(GET_RPM() PASS_ENGINE_PARAMETER_SUFFIX));
 
 	testMafValue = 3;
-	ASSERT_EQ( 3,  getMaf(PASS_ENGINE_PARAMETER_SIGNATURE)) << "maf";
+	ASSERT_EQ( 3,  getMafVoltage(PASS_ENGINE_PARAMETER_SIGNATURE)) << "maf";
 }
 
 static void assertInjectors(const char *msg, int value0, int value1) {


### PR DESCRIPTION
- Remove maf decoding cache.  It isn't on a particularly hot path, so the negligable performance gains aren't worth it.  Also, chopping down to 0.2 volt increments loses so much resolution that MAF wouldn't actually work very well.
- `getMafVoltage` now gets the voltage at the maf pin
- `getRealMaf` gets the mass flow rate, in kg/hr (TODO: should we do kg/s or g/s instead?

This change makes a negligible change to compiled image size, but saves 1KB (!) of RAM.