### PR TITLE
Store table ratio at compile time

### DIFF
--- a/firmware/controllers/actuators/electronic_throttle.cpp
+++ b/firmware/controllers/actuators/electronic_throttle.cpp
@@ -100,7 +100,7 @@ static Pid tuneWorkingPid(&tuneWorkingPidSettings);
 static PID_AutoTune autoTune;
 
 static LoggingWithStorage logger("ETB");
-static pedal2tps_t pedal2tpsMap("Pedal2Tps", 1);
+static pedal2tps_t pedal2tpsMap("Pedal2Tps");
 
 EXTERN_ENGINE;
 

--- a/firmware/controllers/algo/advance_map.cpp
+++ b/firmware/controllers/algo/advance_map.cpp
@@ -35,8 +35,7 @@ extern TunerStudioOutputChannels tsOutputChannels;
 #endif /* EFI_TUNER_STUDIO */
 
 static ign_Map3D_t advanceMap("advance");
-// This coeff in ctor parameter is sufficient for int16<->float conversion!
-static ign_tps_Map3D_t advanceTpsMap("advanceTps", 1.0 / ADVANCE_TPS_STORAGE_MULT);
+static ign_tps_Map3D_t advanceTpsMap("advanceTps");
 static ign_Map3D_t iatAdvanceCorrectionMap("iat corr");
 
 // Init PID later (make it compatible with unit-tests)

--- a/firmware/controllers/algo/engine2.cpp
+++ b/firmware/controllers/algo/engine2.cpp
@@ -24,6 +24,7 @@
 #endif
 
 extern fuel_Map3D_t veMap;
+extern fuel_Map3D_t veTpsMap;
 extern afr_Map3D_t afrMap;
 
 EXTERN_ENGINE
@@ -203,10 +204,11 @@ void EngineState::periodicFastCallback(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 		 */
 		if (CONFIGB(useTPSBasedVeTable)) {
 			// todo: should we have 'veTpsMap' fuel_Map3D_t variable here?
-			currentRawVE = interpolate3d<float, float>(tps, CONFIG(ignitionTpsBins), IGN_TPS_COUNT, rpm, config->veRpmBins, FUEL_RPM_COUNT, veMap.pointers);
+			currentRawVE = veTpsMap.getValue(rpm, tps);
 		} else {
 			currentRawVE = veMap.getValue(rpm, map);
 		}
+
 		// get VE from the separate table for Idle
 		if (CONFIG(useSeparateVeForIdle)) {
 			float idleVe = interpolate2d("idleVe", rpm, config->idleVeBins, config->idleVe);

--- a/firmware/controllers/algo/engine2.cpp
+++ b/firmware/controllers/algo/engine2.cpp
@@ -203,7 +203,6 @@ void EngineState::periodicFastCallback(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 		 * *0.01 because of https://sourceforge.net/p/rusefi/tickets/153/
 		 */
 		if (CONFIGB(useTPSBasedVeTable)) {
-			// todo: should we have 'veTpsMap' fuel_Map3D_t variable here?
 			currentRawVE = veTpsMap.getValue(rpm, tps);
 		} else {
 			currentRawVE = veMap.getValue(rpm, map);

--- a/firmware/controllers/algo/engine_configuration.cpp
+++ b/firmware/controllers/algo/engine_configuration.cpp
@@ -209,7 +209,7 @@ void setConstantDwell(floatms_t dwellMs DECLARE_CONFIG_PARAMETER_SUFFIX) {
 void setAfrMap(afr_table_t table, float value) {
 	for (int l = 0; l < FUEL_LOAD_COUNT; l++) {
 		for (int rpmIndex = 0; rpmIndex < FUEL_RPM_COUNT; rpmIndex++) {
-			table[l][rpmIndex] = (int)(value * AFR_STORAGE_MULT);
+			table[l][rpmIndex] = (int)(value * afr_Map3D_t::GetStorageRatio());
 		}
 	}
 }
@@ -1363,7 +1363,7 @@ void copyTargetAfrTable(fuel_table_t const source, afr_table_t destination) {
 	// todo: extract a template!
 	for (int loadIndex = 0; loadIndex < FUEL_LOAD_COUNT; loadIndex++) {
 		for (int rpmIndex = 0; rpmIndex < FUEL_RPM_COUNT; rpmIndex++) {
-			destination[loadIndex][rpmIndex] = AFR_STORAGE_MULT * source[loadIndex][rpmIndex];
+			destination[loadIndex][rpmIndex] = source[loadIndex][rpmIndex] * afr_Map3D_t::GetStorageRatio();
 		}
 	}
 }

--- a/firmware/controllers/math/speed_density.cpp
+++ b/firmware/controllers/math/speed_density.cpp
@@ -27,7 +27,7 @@ EXTERN_ENGINE;
 
 fuel_Map3D_t veMap("VE");
 fuel_Map3D_t ve2Map("VE2");
-afr_Map3D_t afrMap("AFR", 1.0 / AFR_STORAGE_MULT);
+afr_Map3D_t afrMap("AFR");
 baroCorr_Map3D_t baroCorrMap("baro");
 
 #define tpMin 0

--- a/firmware/controllers/math/speed_density.cpp
+++ b/firmware/controllers/math/speed_density.cpp
@@ -26,7 +26,7 @@
 EXTERN_ENGINE;
 
 fuel_Map3D_t veMap("VE");
-fuel_Map3D_t ve2Map("VE2");
+fuel_Map3D_t veTpsMap("VE TPS");
 afr_Map3D_t afrMap("AFR");
 baroCorr_Map3D_t baroCorrMap("baro");
 
@@ -175,7 +175,6 @@ void setDefaultVETable(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 
 //	setRpmTableBin(engineConfiguration->ve2RpmBins, FUEL_RPM_COUNT);
 //	setLinearCurve(engineConfiguration->ve2LoadBins, FUEL_LOAD_COUNT, 10, 300, 1);
-//	ve2Map.setAll(0.81);
 
 	setRpmTableBin(config->afrRpmBins, FUEL_RPM_COUNT);
 	afrMap.setAll(14.7);
@@ -187,7 +186,7 @@ void setDefaultVETable(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 
 void initSpeedDensity(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 	veMap.init(config->veTable, config->veLoadBins, config->veRpmBins);
-//	ve2Map.init(engineConfiguration->ve2Table, engineConfiguration->ve2LoadBins, engineConfiguration->ve2RpmBins);
+	veTpsMap.init(config->veTable, engineConfiguration->ignitionTpsBins, config->veRpmBins);
 	afrMap.init(config->afrTable, config->afrLoadBins, config->afrRpmBins);
 	baroCorrMap.init(engineConfiguration->baroCorrTable, engineConfiguration->baroCorrPressureBins, engineConfiguration->baroCorrRpmBins);
 	initMaf2Map();

--- a/firmware/util/containers/table_helper.h
+++ b/firmware/util/containers/table_helper.h
@@ -33,9 +33,7 @@ public:
 		memset(&pointers, 0, sizeof(pointers));
 	}
 
-	void init(vType table[TRpmBins][TLoadBins],
-			  const kType (&loadBins)[TLoadBins],
-			  const kType (&rpmBins)[TRpmBins]) {
+	void init(vType table[TRpmBins][TLoadBins], const kType (&loadBins)[TLoadBins], const kType (&rpmBins)[TRpmBins]) {
 		// this method cannot use logger because it's invoked before everything
 		// that's because this method needs to be invoked before initial configuration processing
 		// and initial configuration load is done prior to logging initialization
@@ -55,13 +53,12 @@ public:
 			return NAN;
 		}
 		// todo: we have a bit of a mess: in TunerStudio, RPM is X-axis
-		return interpolate3d<vType, kType>(y, loadBins, TLoadBins, xRpm, rpmBins, TRpmBins, pointers) /
-			   GetStorageRatio();
+		return interpolate3d<TRpmBins, TLoadBins>(y, loadBins, xRpm, rpmBins, pointers) / GetStorageRatio();
 	}
 
 	void setAll(vType value) {
 		efiAssertVoid(CUSTOM_ERR_6573, initialized, "map not initialized");
-	
+
 		for (int l = 0; l < TLoadBins; l++) {
 			for (int r = 0; r < TRpmBins; r++) {
 				pointers[l][r] = value * GetStorageRatio();
@@ -73,16 +70,19 @@ public:
 		return static_cast<float>(TStorageRatio::num) / TStorageRatio::den;
 	}
 
+	vType *pointers[TLoadBins];
+
 private:
 	const kType *loadBins = nullptr;
 	const kType *rpmBins = nullptr;
-	vType *pointers[TLoadBins];
+
 	bool initialized = false;
 	const char *name;
 };
 
 template <int RPM_BIN_SIZE, int LOAD_BIN_SIZE, typename vType, typename kType>
-void copy2DTable(const vType (&source)[LOAD_BIN_SIZE][RPM_BIN_SIZE], vType (&destination)[LOAD_BIN_SIZE][RPM_BIN_SIZE]) {
+void copy2DTable(const vType (&source)[LOAD_BIN_SIZE][RPM_BIN_SIZE],
+				 vType (&destination)[LOAD_BIN_SIZE][RPM_BIN_SIZE]) {
 	for (int k = 0; k < LOAD_BIN_SIZE; k++) {
 		for (int rpmIndex = 0; rpmIndex < RPM_BIN_SIZE; rpmIndex++) {
 			destination[k][rpmIndex] = source[k][rpmIndex];

--- a/firmware/util/math/interpolation.h
+++ b/firmware/util/math/interpolation.h
@@ -100,8 +100,8 @@ int findIndexMsgExt(const char *msg, const kType array[], int size, kType value)
 /**
  * @brief	Two-dimensional table lookup with linear interpolation
  */
-template<typename vType, typename kType>
-float interpolate3d(float x, const kType xBin[], int xBinSize, float y, const kType yBin[], int yBinSize, vType* map[]) {
+template<int TXSize, int TYSize, typename vType, typename kType>
+float interpolate3d(float x, const kType xBin[], float y, const kType yBin[], vType* map[]) {
 	if (cisnan(x)) {
 		warning(CUSTOM_INTEPOLATE_ERROR_3, "%.2f: x is NaN in interpolate3d", x);
 		return NAN;
@@ -111,12 +111,12 @@ float interpolate3d(float x, const kType xBin[], int xBinSize, float y, const kT
 		return NAN;
 	}
 
-	int xIndex = findIndexMsgExt<kType>("x", xBin, xBinSize, x);
+	int xIndex = findIndexMsgExt<kType>("x", xBin, TXSize, x);
 #if	DEBUG_INTERPOLATION
 	if (needInterpolationLogging())
 		printf("X index=%d\r\n", xIndex);
 #endif /* DEBUG_INTERPOLATION */
-	int yIndex = findIndexMsgExt<kType>("y", yBin, yBinSize, y);
+	int yIndex = findIndexMsgExt<kType>("y", yBin, TYSize, y);
 	if (xIndex < 0 && yIndex < 0) {
 #if	DEBUG_INTERPOLATION
 		if (needInterpolationLogging())
@@ -130,7 +130,7 @@ float interpolate3d(float x, const kType xBin[], int xBinSize, float y, const kT
 		if (needInterpolationLogging())
 			printf("X is smaller than smallest cell in table: %dr\n", xIndex);
 #endif /* DEBUG_INTERPOLATION */
-		if (yIndex == yBinSize - 1)
+		if (yIndex == TYSize - 1)
 			return map[0][yIndex];
 		kType keyMin = yBin[yIndex];
 		kType keyMax = yBin[yIndex + 1];
@@ -145,7 +145,7 @@ float interpolate3d(float x, const kType xBin[], int xBinSize, float y, const kT
 		if (needInterpolationLogging())
 			printf("Y is smaller than smallest cell in table: %d\r\n", yIndex);
 #endif /* DEBUG_INTERPOLATION */
-		if (xIndex == xBinSize - 1)
+		if (xIndex == TXSize - 1)
 			return map[xIndex][0];
 		kType key1 = xBin[xIndex];
 		kType key2 = xBin[xIndex + 1];
@@ -155,15 +155,15 @@ float interpolate3d(float x, const kType xBin[], int xBinSize, float y, const kT
 		return interpolateMsg("out3d", key1, value1, key2, value2, x);
 	}
 
-	if (xIndex == xBinSize - 1 && yIndex == yBinSize - 1) {
+	if (xIndex == TXSize - 1 && yIndex == TYSize - 1) {
 #if	DEBUG_INTERPOLATION
 		if (needInterpolationLogging())
 			printf("X and Y are larger than largest cell in table: %d %d\r\n", xIndex, yIndex);
 #endif /* DEBUG_INTERPOLATION */
-		return map[xBinSize - 1][yBinSize - 1];
+		return map[TXSize - 1][TYSize - 1];
 	}
 
-	if (xIndex == xBinSize - 1) {
+	if (xIndex == TXSize - 1) {
 #if	DEBUG_INTERPOLATION
 		if (needInterpolationLogging())
 			printf("TODO BETTER LOGGING x overflow %d\r\n", yIndex);
@@ -178,7 +178,7 @@ float interpolate3d(float x, const kType xBin[], int xBinSize, float y, const kT
 		return interpolateMsg("out3d", key1, value1, key2, value2, y);
 	}
 
-	if (yIndex == yBinSize - 1) {
+	if (yIndex == TYSize - 1) {
 #if	DEBUG_INTERPOLATION
 		if (needInterpolationLogging())
 			printf("Y is larger than largest cell in table: %d\r\n", yIndex);
@@ -227,8 +227,7 @@ float interpolate3d(float x, const kType xBin[], int xBinSize, float y, const kT
 	}
 #endif /* DEBUG_INTERPOLATION */
 
-	float result = interpolateMsg("3d", keyMin, keyMinValue, keyMax, keyMaxValue, y);
-	return result;
+	return interpolateMsg("3d", keyMin, keyMinValue, keyMax, keyMaxValue, y);
 }
 void setCurveValue(float bins[], float values[], int size, float key, float value);
 void initInterpolation(Logging *sharedLogger);

--- a/unit_tests/main.cpp
+++ b/unit_tests/main.cpp
@@ -6,19 +6,12 @@
  */
 
 
-#include <stdlib.h>
+#include <cstdlib>
 
 #include "global.h"
-#include "test_interpolation_3d.h"
-#include "test_find_index.h"
 
 #include "engine_configuration.h"
 
-#include "afm2mapConverter.h"
-#include "test_signal_executor.h"
-#include "trigger_central.h"
-#include "map_resize.h"
-#include "engine_math.h"
 #include "engine_test_helper.h"
 #include "gtest/gtest.h"
 

--- a/unit_tests/test_basic_math/test_interpolation_3d.cpp
+++ b/unit_tests/test_basic_math/test_interpolation_3d.cpp
@@ -25,7 +25,7 @@ float *map[5] = { map0, map1, map2, map3, map4 };
 
 
 static float getValue(float rpm, float maf) {
-	return interpolate3d(rpm, rpmBins, 5, maf, mafBins, 4, map);
+	return interpolate3d<5, 4>(rpm, rpmBins, maf, mafBins, map);
 }
 
 static void newTestToComfirmInterpolation() {


### PR DESCRIPTION
Since the ratio from stored value to "real" value in a table can't change at runtime, we should store and compute it all at compile time.  This change uses `std::ratio` to embed the ratio in the type, instead of expecting consumers to remember to use it.

Also moves implementation up in to the declaration, to prevent having to re-write the full templated type every single time (see old file, line 110 for an example).