### PR TITLE
Simplify thermistor config

### DIFF
--- a/firmware/config/engines/bmw_e34.cpp
+++ b/firmware/config/engines/bmw_e34.cpp
@@ -152,10 +152,8 @@ void setBmwE34(DECLARE_CONFIG_PARAMETER_SIGNATURE) {
 	engineConfiguration->map.sensor.type = MT_MPX4250;
 
 	// thermistors
-	setThermistorConfiguration(&engineConfiguration->clt, -10, 9300, 20, 2500, 80, 335);
-	engineConfiguration->iat.config.bias_resistor = 2200;
-	setThermistorConfiguration(&engineConfiguration->iat, -10, 9300, 20, 2500, 80, 335);
-	engineConfiguration->clt.config.bias_resistor = 2200;
+	engineConfiguration->clt.config = {-10, 20, 80, 9300, 2500, 335, 2200};
+	engineConfiguration->iat.config = {-10, 20, 80, 9300, 2500, 335, 2200};
 
 //	/**
 //	 * This saves a couple of ticks in trigger emulation methods

--- a/firmware/config/engines/citroenBerlingoTU3JP.cpp
+++ b/firmware/config/engines/citroenBerlingoTU3JP.cpp
@@ -181,14 +181,12 @@ void setCitroenBerlingoTU3JPConfiguration(DECLARE_CONFIG_PARAMETER_SIGNATURE) {
 	 * IAT <OEM ECU>
 	 */
 	engineConfiguration->iat.adcChannel = EFI_ADC_13;
-	setThermistorConfiguration(&engineConfiguration->iat, -20.0, 15600.0, 23.0, 2250.0, 92.0, 240.0);
-	engineConfiguration->iat.config.bias_resistor = 2660;
+	engineConfiguration->iat.config = {-20.0, 23.0, 92.0, 15600.0, 2250.0, 240.0, 2660};
 	/**
 	* CLT <LADA Samara>
 	*/
 	engineConfiguration->clt.adcChannel = EFI_ADC_11;
-	setThermistorConfiguration(&engineConfiguration->clt, -20.0, 28680.0, 25.0, 2796.0, 100.0, 177.0);
-	engineConfiguration->iat.config.bias_resistor = 2660;
+	engineConfiguration->clt.config = {-20.0, 25.0, 100.0, 28680.0, 2796.0, 177.0, 2660};
 	/**
 	 * vBatt
 	 */

--- a/firmware/config/engines/custom_engine.cpp
+++ b/firmware/config/engines/custom_engine.cpp
@@ -114,10 +114,8 @@ void setFrankensoConfiguration(DECLARE_CONFIG_PARAMETER_SIGNATURE) {
 	engineConfiguration->iat.adcChannel = EFI_ADC_11;
 	engineConfiguration->afr.hwChannel = EFI_ADC_13;
 
-	setCommonNTCSensor(&engineConfiguration->clt);
-	engineConfiguration->clt.config.bias_resistor = 2700;
-	setCommonNTCSensor(&engineConfiguration->iat);
-	engineConfiguration->iat.config.bias_resistor = 2700;
+	setCommonNTCSensor(&engineConfiguration->clt, 2700);
+	setCommonNTCSensor(&engineConfiguration->iat, 2700);
 
 
 	/**
@@ -286,8 +284,7 @@ void setEtbTestConfiguration(DECLARE_CONFIG_PARAMETER_SIGNATURE) {
 
 	// EFI_ADC_15 = PC5
 	engineConfiguration->clt.adcChannel = EFI_ADC_15;
-	set10K_4050K(&engineConfiguration->clt);
-	engineConfiguration->clt.config.bias_resistor = 10000;
+	set10K_4050K(&engineConfiguration->clt, 10000);
 
 	// see also setDefaultEtbBiasCurve
 }

--- a/firmware/config/engines/dodge_neon.cpp
+++ b/firmware/config/engines/dodge_neon.cpp
@@ -243,8 +243,7 @@ void setDodgeNeon1995EngineConfiguration(DECLARE_CONFIG_PARAMETER_SIGNATURE) {
 	// set ignition_pin_mode 0
 	boardConfiguration->ignitionPinMode = OM_DEFAULT;
 
-	setThermistorConfiguration(&engineConfiguration->clt, 0, 32500, 30, 7550, 100, 700);
-	engineConfiguration->clt.config.bias_resistor = 2700;
+	engineConfiguration->clt.config = {0, 30, 100, 32500, 7550, 700, 2700};
 
 	engineConfiguration->sensorChartFrequency = 7;
 }
@@ -380,11 +379,8 @@ void setDodgeNeonNGCEngineConfiguration(DECLARE_CONFIG_PARAMETER_SIGNATURE) {
 	 */
 
 
-	setDodgeSensor(&engineConfiguration->clt);
-	engineConfiguration->clt.config.bias_resistor = 10000;
-
-	setDodgeSensor(&engineConfiguration->iat);
-	engineConfiguration->iat.config.bias_resistor = 10000;
+	setDodgeSensor(&engineConfiguration->clt, 10000);
+	setDodgeSensor(&engineConfiguration->iat, 10000);
 
 	/**
 	 * MAP PA0

--- a/firmware/config/engines/dodge_ram.cpp
+++ b/firmware/config/engines/dodge_ram.cpp
@@ -79,11 +79,8 @@ void setDodgeRam1996(DECLARE_CONFIG_PARAMETER_SIGNATURE) {
 //	engineConfiguration->vbattDividerCoeff = ((float) (8.93 + 41.27)) / 8.93 * 2;
 	engineConfiguration->vbattDividerCoeff = 9.6;
 
-	setDodgeSensor(&engineConfiguration->clt);
-	engineConfiguration->clt.config.bias_resistor = 2700;
-
-	setDodgeSensor(&engineConfiguration->iat);
-	engineConfiguration->iat.config.bias_resistor = 2700;
+	setDodgeSensor(&engineConfiguration->clt, 2700);
+	setDodgeSensor(&engineConfiguration->iat, 2700);
 
 	boardConfiguration->useStepperIdle = true;
 }

--- a/firmware/config/engines/ford_1995_inline_6.cpp
+++ b/firmware/config/engines/ford_1995_inline_6.cpp
@@ -51,12 +51,9 @@ void setFordInline6(DECLARE_CONFIG_PARAMETER_SIGNATURE) {
 	engineConfiguration->ignitionOffset = 13;
 	engineConfiguration->extraInjectionOffset = 207.269999;
 
-	setThermistorConfiguration(&engineConfiguration->clt, -10.0, 160310.0, 60.0, 7700.0, 120.0, 1180.0);
-	engineConfiguration->clt.config.bias_resistor = 2700;
-
-	setThermistorConfiguration(&engineConfiguration->iat, -10.0, 160310.0, 60.0, 7700.0, 120.0, 1180.0);
-	engineConfiguration->iat.config.bias_resistor = 2700;
-
+	engineConfiguration->clt.config = {-10, 60, 120, 160310, 7700, 1180, 2700};
+	engineConfiguration->iat.config = {-10, 60, 120, 160310, 7700, 1180, 2700};
+	
 	// 12ch analog board pinout:
 	// input channel 3 is PA7, that's ADC7
 	// input channel 5 is PA4, that's ADC4

--- a/firmware/config/engines/ford_aspire.cpp
+++ b/firmware/config/engines/ford_aspire.cpp
@@ -98,8 +98,8 @@ void setFordAspireEngineConfiguration(DECLARE_CONFIG_PARAMETER_SIGNATURE) {
 	 * 2.1K Ohm @ 24C
 	 * 1K Ohm @ 49C
 	 */
-	setThermistorConfiguration(&engineConfiguration->clt, -20, 18000, 23.8889, 2100, 48.8889, 1000);
-	engineConfiguration->clt.config.bias_resistor = 3300; // that's my custom resistor value!
+	// that's my custom resistor value!
+	engineConfiguration->clt.config = {-20, 23.8889, 48.8889, 18000, 2100, 1000, 3300};
 
 //	engineConfiguration->ignitionPinMode = OM_INVERTED;
 

--- a/firmware/config/engines/ford_festiva.cpp
+++ b/firmware/config/engines/ford_festiva.cpp
@@ -207,10 +207,8 @@ void setFordEscortGt(DECLARE_CONFIG_PARAMETER_SIGNATURE) {
 	boardConfiguration->tunerStudioSerialSpeed = 19200;
 
 	commonFrankensoAnalogInputs(engineConfiguration);
-	setCommonNTCSensor(&engineConfiguration->clt);
-	engineConfiguration->clt.config.bias_resistor = 2700;
-	setCommonNTCSensor(&engineConfiguration->iat);
-	engineConfiguration->iat.config.bias_resistor = 2700;
+	setCommonNTCSensor(&engineConfiguration->clt, 2700);
+	setCommonNTCSensor(&engineConfiguration->iat, 2700);
 
 	// we have a 1999 Auto Miata TB mounted on this car
 	engineConfiguration->tpsMin = 630; // convert 12to10 bit (ADC/4)

--- a/firmware/config/engines/honda_600.cpp
+++ b/firmware/config/engines/honda_600.cpp
@@ -117,10 +117,8 @@ void setHonda600(DECLARE_CONFIG_PARAMETER_SIGNATURE) {
 	engineConfiguration->iat.adcChannel = EFI_ADC_11;
 	engineConfiguration->afr.hwChannel = EFI_ADC_13;
 
-	setCommonNTCSensor(&engineConfiguration->clt);
-	engineConfiguration->clt.config.bias_resistor = 2700;
-	setCommonNTCSensor(&engineConfiguration->iat);
-	engineConfiguration->iat.config.bias_resistor = 2700;
+	setCommonNTCSensor(&engineConfiguration->clt, 2700);
+	setCommonNTCSensor(&engineConfiguration->iat, 2700);
 
 
 	/**

--- a/firmware/config/engines/honda_accord.cpp
+++ b/firmware/config/engines/honda_accord.cpp
@@ -65,13 +65,11 @@ static void setHondaAccordConfigurationCommon(DECLARE_CONFIG_PARAMETER_SIGNATURE
 	 * 18K Ohm @ -20C
 	 * 2.1K Ohm @ 24C
 	 * 100 Ohm @ 120C
+	 * 1500 = same pullup as OEM ECU
 	 */
-	setCommonNTCSensor(&engineConfiguration->clt);
-	engineConfiguration->clt.config.bias_resistor = 1500; // same as OEM ECU
-
-	setCommonNTCSensor(&engineConfiguration->iat);
-	engineConfiguration->iat.config.bias_resistor = 1500; // same as OEM ECU
-
+	setCommonNTCSensor(&engineConfiguration->clt, 1500);
+	setCommonNTCSensor(&engineConfiguration->iat, 1500);
+	
 	// set cranking_charge_angle 35
 	engineConfiguration->crankingChargeAngle = 70;
 	// set cranking_timing_angle 0

--- a/firmware/config/engines/mazda_626.cpp
+++ b/firmware/config/engines/mazda_626.cpp
@@ -71,10 +71,9 @@ void setMazda626EngineConfiguration(DECLARE_CONFIG_PARAMETER_SIGNATURE) {
 	setWholeTimingTable_d(10 PASS_CONFIG_PARAMETER_SUFFIX);
 
 	// http://s1.micp.ru/tOb0U.png
-	setThermistorConfiguration(&engineConfiguration->clt, -15, 5900, 23, 1750, 97, 165);
+	engineConfiguration->clt.config = {-15, 23, 97, 5900, 1750, 165, 2700};
 	// http://s2.micp.ru/I6Cfe.png
-	setThermistorConfiguration(&engineConfiguration->iat, 23, 1750, 41, 810, 97, 165);
-	engineConfiguration->iat.config.bias_resistor = 1820;
+	engineConfiguration->iat.config = {23, 41, 97, 1750, 810, 165, 1820};
 
 //	engineConfiguration->map.sensor.hwChannel = EFI_ADC_4;
 	engineConfiguration->mafAdcChannel = EFI_ADC_NONE;

--- a/firmware/config/engines/mazda_miata.cpp
+++ b/firmware/config/engines/mazda_miata.cpp
@@ -163,11 +163,8 @@ static void commonMiataNa(DECLARE_CONFIG_PARAMETER_SIGNATURE) {
 	boardConfiguration->triggerSimulatorPinModes[0] = OM_OPENDRAIN;
 	boardConfiguration->triggerSimulatorPinModes[1] = OM_OPENDRAIN;
 
-	setCommonNTCSensor(&engineConfiguration->clt);
-	engineConfiguration->clt.config.bias_resistor = 2700;
-	setCommonNTCSensor(&engineConfiguration->iat);
-	engineConfiguration->iat.config.bias_resistor = 2700;
-
+	setCommonNTCSensor(&engineConfiguration->clt, 2700);
+	setCommonNTCSensor(&engineConfiguration->iat, 2700);
 }
 
 void common079721_2351(engine_configuration_s *engineConfiguration, board_configuration_s *boardConfiguration) {

--- a/firmware/config/engines/mazda_miata_1_6.cpp
+++ b/firmware/config/engines/mazda_miata_1_6.cpp
@@ -107,8 +107,8 @@ static void miataNAcommonEngineSettings(DECLARE_CONFIG_PARAMETER_SIGNATURE) {
 
 	engineConfiguration->debugMode = DBG_TRIGGER_COUNTERS;
 
-	setCommonNTCSensor(&engineConfiguration->clt);
-	setCommonNTCSensor(&engineConfiguration->iat);
+	setCommonNTCSensor(&engineConfiguration->clt, 2700);
+	setCommonNTCSensor(&engineConfiguration->iat, 2700);
 
 #if IGN_LOAD_COUNT == DEFAULT_IGN_LOAD_COUNT
 	copyTimingTable(mapBased16IgnitionTable, config->ignitionTable);
@@ -121,9 +121,6 @@ static void miataNAcommonEngineSettings(DECLARE_CONFIG_PARAMETER_SIGNATURE) {
 void miataNAcommon(DECLARE_CONFIG_PARAMETER_SIGNATURE) {
 
 	miataNAcommonEngineSettings(PASS_CONFIG_PARAMETER_SIGNATURE);
-
-	engineConfiguration->clt.config.bias_resistor = 2700;
-	engineConfiguration->iat.config.bias_resistor = 2700;
 
 	boardConfiguration->idle.solenoidPin = GPIOB_9; // this W61 <> W61 jumper, pin 3W
 

--- a/firmware/config/engines/mazda_miata_nb.cpp
+++ b/firmware/config/engines/mazda_miata_nb.cpp
@@ -32,11 +32,8 @@ void setMazdaMiataNb1EngineConfiguration(DECLARE_CONFIG_PARAMETER_SIGNATURE) {
 	// set_firing_order 2
 	engineConfiguration->specs.firingOrder = FO_1_3_4_2;
 
-	setThermistorConfiguration(&engineConfiguration->clt, 0, 32500, 30, 7550, 100, 700);
-	engineConfiguration->clt.config.bias_resistor = 2700;
-
-	setThermistorConfiguration(&engineConfiguration->iat, -10, 160310, 60, 7700, 120.00, 1180);
-	engineConfiguration->iat.config.bias_resistor = 2700;
+	engineConfiguration->clt.config = {0, 30, 100, 32500, 7550, 700, 2700};
+	engineConfiguration->iat.config = {-10, 60, 120.00, 160310, 7700, 1180, 2700};
 
 	engineConfiguration->tps1_1AdcChannel = EFI_ADC_3; // 15 is the old value
 	engineConfiguration->vbattAdcChannel = EFI_ADC_0; // 1 is the old value

--- a/firmware/config/engines/mazda_miata_vvt.cpp
+++ b/firmware/config/engines/mazda_miata_vvt.cpp
@@ -190,9 +190,8 @@ static void setMazdaMiataEngineNB2Defaults(DECLARE_CONFIG_PARAMETER_SIGNATURE) {
 	engineConfiguration->map.sensor.type = MT_GM_3_BAR;
 	setEgoSensor(ES_Innovate_MTX_L PASS_CONFIG_PARAMETER_SUFFIX);
 
-
-	setCommonNTCSensor(&engineConfiguration->clt);
-	setCommonNTCSensor(&engineConfiguration->iat);
+	setCommonNTCSensor(&engineConfiguration->clt, 2700);
+	setCommonNTCSensor(&engineConfiguration->iat, 2700);
 
 	//	0.0825
 	//	0.1375

--- a/firmware/config/engines/me7pnp.cpp
+++ b/firmware/config/engines/me7pnp.cpp
@@ -46,10 +46,8 @@ void vag_18_Turbo(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 
 	boardConfiguration->isFastAdcEnabled = true;
 	engineConfiguration->map.sensor.type = MT_GM_3_BAR;
-	setCommonNTCSensor(&engineConfiguration->clt);
-	engineConfiguration->clt.config.bias_resistor = 2700;
-	setCommonNTCSensor(&engineConfiguration->iat);
-	engineConfiguration->iat.config.bias_resistor = 2700;
+	setCommonNTCSensor(&engineConfiguration->clt, 2700);
+	setCommonNTCSensor(&engineConfiguration->iat, 2700);
 	engineConfiguration->throttlePedalPositionAdcChannel = EFI_ADC_7;
 	//engineConfiguration->tps1_1AdcChannel = PF3;   TODO: ADC channel 3
 	engineConfiguration->map.sensor.hwChannel = EFI_ADC_10;

--- a/firmware/config/engines/mitsubishi.cpp
+++ b/firmware/config/engines/mitsubishi.cpp
@@ -48,10 +48,7 @@ void setMitsubishiConfiguration(DECLARE_CONFIG_PARAMETER_SIGNATURE) {
 //	 */
 //	setThermistorConfiguration(&engineConfiguration->clt, 40, 29150, 70, 10160, 150, 1270);
 
-	setCommonNTCSensor(&engineConfiguration->clt);
-
-
-	engineConfiguration->clt.config.bias_resistor = 2700;
+	setCommonNTCSensor(&engineConfiguration->clt, 2700);
 
 	// Frankenstein: low side - out #1: PC14
 	// Frankenstein: low side - out #2: PC15

--- a/firmware/config/engines/rover_v8.cpp
+++ b/firmware/config/engines/rover_v8.cpp
@@ -99,20 +99,13 @@ void setRoverv8(DECLARE_CONFIG_PARAMETER_SIGNATURE) {
     boardConfiguration->triggerInputPins[0] = GPIOC_6; // 2G YEL/BLU
     boardConfiguration->triggerInputPins[1] = GPIOA_5; // 2E White CKP
 
-    setCommonNTCSensor(&engineConfiguration->clt);
-    engineConfiguration->clt.config.bias_resistor = 2700;
-    setCommonNTCSensor(&engineConfiguration->iat);
-    engineConfiguration->iat.config.bias_resistor = 2700;
+    setCommonNTCSensor(&engineConfiguration->clt, 2700);
+    setCommonNTCSensor(&engineConfiguration->iat, 2700);
 
     engineConfiguration->tps1_1AdcChannel = EFI_ADC_3; //Frankenstein: inp2
     engineConfiguration->vbattAdcChannel = EFI_ADC_0; //Frankenstein: inp5
     engineConfiguration->clt.adcChannel = EFI_ADC_11;
     engineConfiguration->iat.adcChannel = EFI_ADC_13;
-
-    setCommonNTCSensor(&engineConfiguration->clt);
-    engineConfiguration->clt.config.bias_resistor = 2700;
-    setCommonNTCSensor(&engineConfiguration->iat);
-    engineConfiguration->iat.config.bias_resistor = 2700;
 
     /**
      * TPS 0% 0.9v

--- a/firmware/config/engines/toyota_jzs147.cpp
+++ b/firmware/config/engines/toyota_jzs147.cpp
@@ -62,8 +62,8 @@ static void common2jz(DECLARE_CONFIG_PARAMETER_SIGNATURE) {
 	 * http://thesafetyaversionsociety.com/wordpress/wp-content/uploads/2010/08/Troubleshooting-2JZ-GTE.pdf
 	 * pages 44&46
 	 */
-	setThermistorConfiguration(&engineConfiguration->clt, -20, 15000, 40, 1200, 120.0, 200.0);
-	setThermistorConfiguration(&engineConfiguration->iat, -20, 15000, 40, 1200, 120.0, 200.0);
+	engineConfiguration->clt.config = {-20, 40, 120.0, 15000, 1200, 200.0, 2700};
+	engineConfiguration->iat.config = {-20, 40, 120.0, 15000, 1200, 200.0, 2700};
 
 }
 

--- a/firmware/controllers/algo/engine_configuration.cpp
+++ b/firmware/controllers/algo/engine_configuration.cpp
@@ -704,12 +704,10 @@ static void setDefaultEngineConfiguration(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 
 	initEngineNoiseTable(PASS_ENGINE_PARAMETER_SIGNATURE);
 
-	setThermistorConfiguration(&engineConfiguration->clt, 0, 9500, 23.8889, 2100, 48.8889, 1000);
-	engineConfiguration->clt.config.bias_resistor = 1500;
+	engineConfiguration->clt.config = {0, 23.8889, 48.8889, 9500, 2100, 1000, 1500};
 
-	setThermistorConfiguration(&engineConfiguration->iat, 32, 9500, 75, 2100, 120, 1000);
 // todo: this value is way off! I am pretty sure temp coeffs are off also
-	engineConfiguration->iat.config.bias_resistor = 2700;
+	engineConfiguration->iat.config = {32, 75, 120, 9500, 2100, 1000, 2700};
 
 #if EFI_PROD_CODE
 	engineConfiguration->warningPeriod = 10;

--- a/firmware/controllers/sensors/thermistors.cpp
+++ b/firmware/controllers/sensors/thermistors.cpp
@@ -229,24 +229,24 @@ temperature_t getIntakeAirTemperature(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 	return temperature;
 }
 
-void setDodgeSensor(ThermistorConf *thermistorConf) {
-	setThermistorConfiguration(thermistorConf, -40, 336660, 30, 7550, 120, 390);
+void setDodgeSensor(ThermistorConf *thermistorConf, float pullup) {
+	thermistorConf->config = {-40, 30, 120, 336660, 7550, 390, pullup};
 }
 
 // todo: better method name?
-void setCommonNTCSensor(ThermistorConf *thermistorConf) {
+void setCommonNTCSensor(ThermistorConf *thermistorConf, float pullup) {
 	/**
 	 * 18K Ohm @ -20C
 	 * 2.1K Ohm @ 24C
 	 * 294 Ohm @ 80C
 	 * http://www.rexbo.eu/hella/coolant-temperature-sensor-6pt009107121?c=100334&at=3130
 	 */
-	setThermistorConfiguration(thermistorConf, -20, 18000, 23.8889, 2100, 120.0, 100.0);
+	thermistorConf->config = {-20, 23.8889, 120, 18000, 2100, 100, pullup};
 }
 
-void set10K_4050K(ThermistorConf *thermistorConf) {
+void set10K_4050K(ThermistorConf *thermistorConf, float pullup) {
 	// see https://www.taydaelectronics.com/datasheets/A-409.pdf
-	setThermistorConfiguration(thermistorConf, -30, 108000, 25.0, 10000, 130.0, 225);
+	thermistorConf->config = {-30, 25, 130, 108000, 10000, 225, pullup};
 }
 
 #if EFI_PROD_CODE

--- a/firmware/controllers/sensors/thermistors.h
+++ b/firmware/controllers/sensors/thermistors.h
@@ -39,13 +39,10 @@ bool isValidIntakeAirTemperature(temperature_t temperature);
 bool hasIatSensor(DECLARE_ENGINE_PARAMETER_SIGNATURE);
 bool hasCltSensor(DECLARE_ENGINE_PARAMETER_SIGNATURE);
 
-void setThermistorConfiguration(ThermistorConf * tc, float temp1, float r1, float temp2, float r2, float temp3,
-		float r3);
-
 void initThermistors(Logging *sharedLogger DECLARE_ENGINE_PARAMETER_SUFFIX);
 
-void setCommonNTCSensor(ThermistorConf *thermistorConf);
-void setDodgeSensor(ThermistorConf *thermistorConf);
-void set10K_4050K(ThermistorConf *thermistorConf);
+void setCommonNTCSensor(ThermistorConf *thermistorConf, float pullup);
+void setDodgeSensor(ThermistorConf *thermistorConf, float pullup);
+void set10K_4050K(ThermistorConf *thermistorConf, float pullup);
 
 #endif /* THERMISTORS_H_ */

--- a/unit_tests/tests/test_sensors.cpp
+++ b/unit_tests/tests/test_sensors.cpp
@@ -10,7 +10,7 @@
 #include "allsensors.h"
 #include "engine_test_helper.h"
 
-static ThermistorConf tc;
+
 
 TEST(sensors, mapDecoding) {
 	WITH_ENGINE_TEST_HELPER(FORD_INLINE_6_1995);
@@ -55,31 +55,31 @@ TEST(sensors, testTpsRateOfChange) {
 //	assertEquals(25, getTpsRateOfChange());
 }
 
-TEST(sensors, thermistors) {
+TEST(sensors, Thermistor1) {
 
 	ThermistorMath tm;
-	{
-		setThermistorConfiguration(&tc, 32, 9500, 75, 2100, 120, 1000);
-		tm.setConfig(&tc.config);
-		float t = tm.getKelvinTemperatureByResistance(2100);
-		ASSERT_FLOAT_EQ(75 + KELV, t);
+	thermistor_conf_s tc = {32, 75, 120, 9500, 2100, 1000, 0};
+	tm.setConfig(&tc);
 
-		ASSERT_NEAR(-0.003, tm.s_h_a, EPS4D);
-		ASSERT_NEAR(0.001, tm.s_h_b, EPS4D);
-		ASSERT_NEAR(0.0, tm.s_h_c, EPS5D);
+	float t = tm.getKelvinTemperatureByResistance(2100);
+	ASSERT_FLOAT_EQ(75 + KELV, t);
 
-	}
+	ASSERT_NEAR(-0.003, tm.s_h_a, EPS4D);
+	ASSERT_NEAR(0.001, tm.s_h_b, EPS4D);
+	ASSERT_NEAR(0.0, tm.s_h_c, EPS5D);
+}
 
-	{
-		// 2003 Neon sensor
-		setThermistorConfiguration(&tc, 0, 32500, 30, 7550, 100, 700);
-		tm.setConfig(&tc.config);
+TEST(sensors, ThermistorNeon)
+{
+	ThermistorMath tm;
+	// 2003 Neon sensor
+	thermistor_conf_s tc = {0, 30, 100, 32500, 7550, 700, 0};
+	tm.setConfig(&tc);
 
-		float t = tm.getKelvinTemperatureByResistance(38000);
-		ASSERT_NEAR(-2.7983, t - KELV, EPS4D);
+	float t = tm.getKelvinTemperatureByResistance(38000);
+	ASSERT_NEAR(-2.7983, t - KELV, EPS4D);
 
-		assertEqualsM("A", 0.0009, tm.s_h_a);
-		assertEqualsM("B", 0.0003, tm.s_h_b);
-		ASSERT_NEAR(0.0, tm.s_h_c, EPS4D);
-	}
+	assertEqualsM("A", 0.0009, tm.s_h_a);
+	assertEqualsM("B", 0.0003, tm.s_h_b);
+	ASSERT_NEAR(0.0, tm.s_h_c, EPS4D);
 }


### PR DESCRIPTION
You can assign a struct just like any other copyable type(int, float, string, etc) - so we don't need a `setThermistorConfiguration` function.

This change also saves 96 bytes of flash, because this change essentially replaces the old function with a (compiler generated) memcpy.