### PR TITLE
low hanging performance fruit

### DIFF
--- a/firmware/hw_layer/adc_inputs.cpp
+++ b/firmware/hw_layer/adc_inputs.cpp
@@ -459,29 +459,26 @@ static void adc_callback_slow(ADCDriver *adcp, adcsample_t *buffer, size_t n) {
 	(void) buffer;
 	(void) n;
 
-	slowAdc.invalidateSamplesCache();
-
-	efiAssertVoid(CUSTOM_ERR_6671, getCurrentRemainingStack() > 128, "lowstck#9c");
 	/* Note, only in the ADC_COMPLETE state because the ADC driver fires
 	 * an intermediate callback when the buffer is half full. */
 	if (adcp->state == ADC_COMPLETE) {
+		slowAdc.invalidateSamplesCache();
+
+		efiAssertVoid(CUSTOM_ERR_6671, getCurrentRemainingStack() > 128, "lowstck#9c");
+
 		/* Calculates the average values from the ADC samples.*/
 		for (int i = 0; i < slowAdc.size(); i++) {
 			int value = getAvgAdcValue(i, slowAdc.samples, ADC_BUF_DEPTH_SLOW, slowAdc.size());
 			adcsample_t prev = slowAdc.values.adc_data[i];
 			float result = (slowAdcCounter == 0) ? value :
 					CONFIG(slowAdcAlpha) * value + (1 - CONFIG(slowAdcAlpha)) * prev;
-//			if (slowAdcCounter == 0) {
-//				biq[i].initValue(value);
-//			}
-//			float result = biq[i].getValue(value);
 
 			slowAdc.values.adc_data[i] = (int)result;
 		}
 		slowAdcCounter++;
-	}
 
-	AdcSubscription::UpdateSubscribers();
+		AdcSubscription::UpdateSubscribers();
+	}
 }
 
 static char errorMsgBuff[_MAX_FILLER + 2];

--- a/firmware/hw_layer/hardware.cpp
+++ b/firmware/hw_layer/hardware.cpp
@@ -195,8 +195,6 @@ extern AdcDevice fastAdc;
  * This method is not in the adc* lower-level file because it is more business logic then hardware.
  */
 void adc_callback_fast(ADCDriver *adcp, adcsample_t *buffer, size_t n) {
-	fastAdc.invalidateSamplesCache();
-
 	(void) buffer;
 	(void) n;
 	/**
@@ -204,6 +202,8 @@ void adc_callback_fast(ADCDriver *adcp, adcsample_t *buffer, size_t n) {
 	 * intermediate callback when the buffer is half full.
 	 * */
 	if (adcp->state == ADC_COMPLETE) {
+		fastAdc.invalidateSamplesCache();
+
 		/**
 		 * this callback is executed 10 000 times a second, it needs to be as fast as possible
 		 */


### PR DESCRIPTION
We only need to do the cache invalidation if we're actually about to read them, which means we should only do it on complete, not half done.  Same goes for updating ADC subscribers.