### PR TITLE
move extern tsOutputChannels to header

### DIFF
--- a/firmware/console/binary/tunerstudio.cpp
+++ b/firmware/console/binary/tunerstudio.cpp
@@ -129,10 +129,6 @@ static ts_channel_s tsChannel;
 // this thread wants a bit extra stack
 static THD_WORKING_AREA(tunerstudioThreadStack, 3 * UTILITY_THREAD_STACK_SIZE);
 
-extern TunerStudioOutputChannels tsOutputChannels;
-
-extern tunerstudio_counters_s tsState;
-
 static void resetTs(void) {
 	memset(&tsState, 0, sizeof(tsState));
 }

--- a/firmware/console/binary/tunerstudio.h
+++ b/firmware/console/binary/tunerstudio.h
@@ -29,6 +29,8 @@ typedef struct {
 	int testCommandCounter;
 } tunerstudio_counters_s;
 
+extern tunerstudio_counters_s tsState;
+
 /**
  * handle non CRC wrapped command
  */

--- a/firmware/console/binary/tunerstudio_configuration.h
+++ b/firmware/console/binary/tunerstudio_configuration.h
@@ -180,4 +180,6 @@ typedef struct {
 	/* see also [OutputChannels] in rusefi.input */
 } TunerStudioOutputChannels;
 
+extern TunerStudioOutputChannels tsOutputChannels;
+
 #endif /* TUNERSTUDIO_CONFIGURATION_H_ */

--- a/firmware/console/status_loop.cpp
+++ b/firmware/console/status_loop.cpp
@@ -101,11 +101,6 @@ static volatile bool fullLog = true;
 int warningEnabled = true;
 //int warningEnabled = FALSE;
 
-#if EFI_TUNER_STUDIO
-extern TunerStudioOutputChannels tsOutputChannels;
-extern tunerstudio_counters_s tsState;
-#endif
-
 extern bool hasFirmwareErrorFlag;
 extern int maxTriggerReentraint;
 extern uint32_t maxLockedDuration;
@@ -1009,8 +1004,6 @@ void updateTunerStudioState(TunerStudioOutputChannels *tsOutputChannels DECLARE_
 		;
 	}
 }
-
-extern TunerStudioOutputChannels tsOutputChannels;
 
 void prepareTunerStudioOutputs(void) {
 	// sensor state for EFI Analytics Tuner Studio

--- a/firmware/console/tooth_logger.cpp
+++ b/firmware/console/tooth_logger.cpp
@@ -16,8 +16,6 @@
 #include "efilib.h"
 #include "tunerstudio_configuration.h"
 
-extern TunerStudioOutputChannels tsOutputChannels;
-
 static uint16_t buffer[1000] CCM_OPTIONAL;
 static size_t NextIdx = 0;
 static volatile bool ToothLoggerEnabled = false;

--- a/firmware/controllers/actuators/alternator_controller.cpp
+++ b/firmware/controllers/actuators/alternator_controller.cpp
@@ -36,10 +36,6 @@ Pid alternatorPid(altPidS);
 
 static percent_t currentAltDuty;
 
-#if EFI_TUNER_STUDIO
-extern TunerStudioOutputChannels tsOutputChannels;
-#endif /* EFI_TUNER_STUDIO */
-
 static bool currentPlainOnOffState = false;
 static bool shouldResetPid = false;
 

--- a/firmware/controllers/actuators/aux_pid.cpp
+++ b/firmware/controllers/actuators/aux_pid.cpp
@@ -33,10 +33,6 @@ extern fsio8_Map3D_f32t fsioTable1;
 // todo: this is to some extent a copy-paste of alternator_controller. maybe same loop
 // for all PIDs?
 
-#if EFI_TUNER_STUDIO
-extern TunerStudioOutputChannels tsOutputChannels;
-#endif /* EFI_TUNER_STUDIO */
-
 static Logging *logger;
 
 static bool isEnabled(int index) {

--- a/firmware/controllers/actuators/electronic_throttle.cpp
+++ b/firmware/controllers/actuators/electronic_throttle.cpp
@@ -90,9 +90,6 @@
 
 #define ETB_MAX_COUNT 2
 
-#if EFI_TUNER_STUDIO
-extern TunerStudioOutputChannels tsOutputChannels;
-#endif /* EFI_TUNER_STUDIO */
 static bool shouldResetPid = false;
 
 static pid_s tuneWorkingPidSettings;

--- a/firmware/controllers/actuators/idle_thread.cpp
+++ b/firmware/controllers/actuators/idle_thread.cpp
@@ -47,9 +47,7 @@ static StepperMotor iacMotor;
 
 
 static Logging *logger;
-#if EFI_TUNER_STUDIO
-extern TunerStudioOutputChannels tsOutputChannels;
-#endif /* EFI_TUNER_STUDIO */
+
 EXTERN_ENGINE
 ;
 

--- a/firmware/controllers/algo/accel_enrichment.cpp
+++ b/firmware/controllers/algo/accel_enrichment.cpp
@@ -29,7 +29,6 @@
 #include "engine_math.h"
 #if EFI_TUNER_STUDIO
 #include "tunerstudio_configuration.h"
-extern TunerStudioOutputChannels tsOutputChannels;
 #endif /* EFI_TUNER_STUDIO */
 
 EXTERN_ENGINE

--- a/firmware/controllers/algo/advance_map.cpp
+++ b/firmware/controllers/algo/advance_map.cpp
@@ -30,10 +30,6 @@
 EXTERN_ENGINE
 ;
 
-#if EFI_TUNER_STUDIO
-extern TunerStudioOutputChannels tsOutputChannels;
-#endif /* EFI_TUNER_STUDIO */
-
 static ign_Map3D_t advanceMap("advance");
 // This coeff in ctor parameter is sufficient for int16<->float conversion!
 static ign_tps_Map3D_t advanceTpsMap("advanceTps", 1.0 / ADVANCE_TPS_STORAGE_MULT);

--- a/firmware/controllers/algo/engine.cpp
+++ b/firmware/controllers/algo/engine.cpp
@@ -42,10 +42,6 @@ LoggingWithStorage engineLogger("engine");
 EXTERN_ENGINE
 ;
 
-#if EFI_TUNER_STUDIO
-extern TunerStudioOutputChannels tsOutputChannels;
-#endif /* EFI_TUNER_STUDIO */
-
 FsioState::FsioState() {
 #if EFI_ENABLE_ENGINE_WARNING
 	isEngineWarning = FALSE;

--- a/firmware/controllers/algo/engine2.cpp
+++ b/firmware/controllers/algo/engine2.cpp
@@ -32,10 +32,6 @@ EXTERN_ENGINE
 // this does not look exactly right
 extern LoggingWithStorage engineLogger;
 
-#if EFI_TUNER_STUDIO
-extern TunerStudioOutputChannels tsOutputChannels;
-#endif /* EFI_TUNER_STUDIO */
-
 WarningCodeState::WarningCodeState() {
 	clear();
 }

--- a/firmware/controllers/scheduling/single_timer_executor.cpp
+++ b/firmware/controllers/scheduling/single_timer_executor.cpp
@@ -167,10 +167,6 @@ void initSingleTimerExecutorHardware(void) {
 	initMicrosecondTimer();
 }
 
-#if EFI_TUNER_STUDIO
-extern TunerStudioOutputChannels tsOutputChannels;
-#endif /* EFI_TUNER_STUDIO */
-
 void executorStatistics() {
 	if (engineConfiguration->debugMode == DBG_EXECUTOR) {
 #if EFI_TUNER_STUDIO && EFI_SIGNAL_EXECUTOR_ONE_TIMER

--- a/firmware/controllers/trigger/main_trigger_callback.cpp
+++ b/firmware/controllers/trigger/main_trigger_callback.cpp
@@ -68,9 +68,6 @@ static Logging *logger;
 #if ! EFI_UNIT_TEST
 static pid_s *fuelPidS = &persistentState.persistentConfiguration.engineConfiguration.fuelClosedLoopPid;
 static Pid fuelPid(fuelPidS);
-#if EFI_TUNER_STUDIO
-extern TunerStudioOutputChannels tsOutputChannels;
-#endif /* EFI_TUNER_STUDIO */
 #endif
 
 // todo: figure out if this even helps?

--- a/firmware/controllers/trigger/spark_logic.cpp
+++ b/firmware/controllers/trigger/spark_logic.cpp
@@ -14,7 +14,6 @@
 
 #if EFI_TUNER_STUDIO
 #include "tunerstudio_configuration.h"
-extern TunerStudioOutputChannels tsOutputChannels;
 #endif /* EFI_TUNER_STUDIO */
 
 EXTERN_ENGINE;

--- a/firmware/controllers/trigger/trigger_central.cpp
+++ b/firmware/controllers/trigger/trigger_central.cpp
@@ -32,7 +32,6 @@
 
 #if EFI_TUNER_STUDIO
 #include "tunerstudio.h"
-extern TunerStudioOutputChannels tsOutputChannels;
 #endif /* EFI_TUNER_STUDIO */
 
 #if EFI_ENGINE_SNIFFER

--- a/firmware/controllers/trigger/trigger_decoder.cpp
+++ b/firmware/controllers/trigger/trigger_decoder.cpp
@@ -111,10 +111,6 @@ bool printTriggerDebug = false;
 float actualSynchGap;
 #endif /* ! EFI_PROD_CODE */
 
-#if EFI_TUNER_STUDIO
-extern TunerStudioOutputChannels tsOutputChannels;
-#endif /* EFI_TUNER_STUDIO */
-
 static Logging * logger;
 
 /**

--- a/firmware/hw_layer/drivers/gpio/tle8888.c
+++ b/firmware/hw_layer/drivers/gpio/tle8888.c
@@ -45,7 +45,6 @@
 #include "engine_configuration.h"
 EXTERN_CONFIG;
 #include "tunerstudio.h"
-extern TunerStudioOutputChannels tsOutputChannels;
 #endif /* EFI_TUNER_STUDIO */
 
 /*

--- a/firmware/hw_layer/mmc_card.cpp
+++ b/firmware/hw_layer/mmc_card.cpp
@@ -28,10 +28,6 @@
 
 #include "rtc_helper.h"
 
-#if EFI_TUNER_STUDIO
-extern TunerStudioOutputChannels tsOutputChannels;
-#endif
-
 #define SD_STATE_INIT "init"
 #define SD_STATE_MOUNTED "MOUNTED"
 #define SD_STATE_MOUNT_FAILED "MOUNT_FAILED"

--- a/firmware/hw_layer/sensors/cj125.cpp
+++ b/firmware/hw_layer/sensors/cj125.cpp
@@ -23,7 +23,6 @@ EXTERN_ENGINE;
 #include "hardware.h"
 #include "backup_ram.h"
 #include "pin_repository.h"
-extern TunerStudioOutputChannels tsOutputChannels;
 
 static Logging *logger;
 static unsigned char tx_buff[2];

--- a/firmware/init/sensor/init_oil_pressure.cpp
+++ b/firmware/init/sensor/init_oil_pressure.cpp
@@ -8,8 +8,6 @@
 
 EXTERN_ENGINE;
 
-extern TunerStudioOutputChannels tsOutputChannels;
-
 LinearFunc oilpSensorFunc;
 FunctionalSensor oilpSensor(SensorType::OilPressure);
 


### PR DESCRIPTION
After typing it 3 times - I realized we should just move it to the header instead of re-declaring it in every single file.