### PR TITLE
Performance improvement: call GetBaseFuel less

### DIFF
--- a/firmware/controllers/algo/engine.cpp
+++ b/firmware/controllers/algo/engine.cpp
@@ -368,13 +368,9 @@ void Engine::periodicFastCallback(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 
 	engine->m.beforeFuelCalc = getTimeNowLowerNt();
 	int rpm = GET_RPM();
-	/**
-	 * we have same assignment of 'getInjectionDuration' to 'injectionDuration' in handleFuel()
-	 * Open question why do we refresh that in two places?
-	 */
+
 	ENGINE(injectionDuration) = getInjectionDuration(rpm PASS_ENGINE_PARAMETER_SUFFIX);
 	engine->m.fuelCalcTime = getTimeNowLowerNt() - engine->m.beforeFuelCalc;
-
 }
 
 void doScheduleStopEngine(DECLARE_ENGINE_PARAMETER_SIGNATURE) {

--- a/firmware/controllers/algo/engine.h
+++ b/firmware/controllers/algo/engine.h
@@ -29,7 +29,7 @@
 #include "global_execution_queue.h"
 #endif /* EFI_UNIT_TEST */
 
-#define FAST_CALLBACK_PERIOD_MS 20
+#define FAST_CALLBACK_PERIOD_MS 5
 
 class RpmCalculator;
 

--- a/firmware/controllers/algo/fuel_math.cpp
+++ b/firmware/controllers/algo/fuel_math.cpp
@@ -220,7 +220,7 @@ int getNumberOfInjections(injection_mode_e mode DECLARE_ENGINE_PARAMETER_SUFFIX)
  * @see getCoilDutyCycle
  */
 percent_t getInjectorDutyCycle(int rpm DECLARE_ENGINE_PARAMETER_SUFFIX) {
-	floatms_t totalInjectiorAmountPerCycle = getInjectionDuration(rpm PASS_ENGINE_PARAMETER_SUFFIX) * getNumberOfInjections(engineConfiguration->injectionMode PASS_ENGINE_PARAMETER_SUFFIX);
+	floatms_t totalInjectiorAmountPerCycle = ENGINE(injectionDuration) * getNumberOfInjections(engineConfiguration->injectionMode PASS_ENGINE_PARAMETER_SUFFIX);
 	floatms_t engineCycleDuration = getEngineCycleDuration(rpm PASS_ENGINE_PARAMETER_SUFFIX);
 	return 100 * totalInjectiorAmountPerCycle / engineCycleDuration;
 }

--- a/firmware/controllers/trigger/main_trigger_callback.cpp
+++ b/firmware/controllers/trigger/main_trigger_callback.cpp
@@ -389,12 +389,6 @@ static ALWAYS_INLINE void handleFuel(const bool limitedFuel, uint32_t trgEventIn
 		ENGINE(engineLoadAccelEnrichment.onEngineCycle(PASS_ENGINE_PARAMETER_SIGNATURE));
 	}
 
-	/**
-	 * we have same assignment of 'getInjectionDuration' to 'injectionDuration' in periodicFastCallback()
-	 * Open question why do we refresh that in two places?
-	 */
-	ENGINE(injectionDuration) = getInjectionDuration(rpm PASS_ENGINE_PARAMETER_SUFFIX);
-
 	for (int injEventIndex = 0; injEventIndex < CONFIG(specs.cylindersCount); injEventIndex++) {
 		InjectionEvent *event = &fs->elements[injEventIndex];
 		uint32_t eventIndex = event->injectionStart.triggerEventIndex;


### PR DESCRIPTION
As shown in #973, both `MainTriggerCallback` and `PeriodicFastCallback` call `GetInjectionDuration`, updating the stored injection duration in the engine state.

The trigger callback calls it for every tooth we actually use (generally all rising or all falling edges).  `GetInjectionDuration` takes about 32us to execute, incurring a 32us cost in every tooth decode interrupt.  On high tooth count triggers, this one call can incur significant CPU cost.  For example, on a 60-2 wheel, it's called 5800 times per second, which amounts to 19% of total CPU load on an STM32F4 at 168MHz.

This change omits the call from MainTriggerCallback, and increases the frequency of the `PeriodicFastCallback` to 200hz to make up for the removal.  Since `PeriodicFastCallback` takes around 100us, this will use a constant 2% CPU (up from 0.5% for PFC previously, plus a variable amount from MainTriggerCallback).

All of the calls made to the various acceleration enrichment algorithms made by `getInjectionDuration` are idempotent, so it's safe to call them whenever without changing the result.  Important state is updated only as needed from the trigger callbacks.