### PR TITLE
fix wwae for multi cylinder engines

### DIFF
--- a/firmware/console/binary/tunerstudio.cpp
+++ b/firmware/console/binary/tunerstudio.cpp
@@ -265,7 +265,7 @@ static const void * getStructAddr(int structId) {
 	case LDS_ENGINE_STATE_INDEX:
 		return static_cast<engine_state2_s*>(&engine->engineState);
 	case LDS_FUEL_TRIM_STATE_INDEX:
-		return static_cast<wall_fuel_state*>(&engine->wallFuel);
+		return static_cast<wall_fuel_state*>(&engine->wallFuel[0]);
 	case LDS_TRIGGER_CENTRAL_STATE_INDEX:
 		return static_cast<trigger_central_s*>(&engine->triggerCentral);
 	case LDS_TRIGGER_STATE_STATE_INDEX:

--- a/firmware/console/status_loop.cpp
+++ b/firmware/console/status_loop.cpp
@@ -324,8 +324,8 @@ static void printSensors(Logging *log) {
 		// 268
 		reportSensorF(log, GAUGE_NAME_FUEL_PID_CORR, "ms", ENGINE(engineState.running.pidCorrection), 2);
 
-		reportSensorF(log, GAUGE_NAME_FUEL_WALL_AMOUNT, "v", ENGINE(wallFuel).getWallFuel(0), 2);
-		reportSensorF(log, GAUGE_NAME_FUEL_WALL_CORRECTION, "v", ENGINE(wallFuel).wallFuelCorrection, 2);
+		reportSensorF(log, GAUGE_NAME_FUEL_WALL_AMOUNT, "v", ENGINE(wallFuel[0]).getWallFuel(), 2);
+		reportSensorF(log, GAUGE_NAME_FUEL_WALL_CORRECTION, "v", ENGINE(wallFuel[0]).wallFuelCorrection, 2);
 
 		reportSensorI(log, GAUGE_NAME_VERSION, "#", getRusEfiVersion());
 
@@ -754,11 +754,11 @@ void updateTunerStudioState(TunerStudioOutputChannels *tsOutputChannels DECLARE_
 	// 148
 	tsOutputChannels->fuelTankLevel = engine->sensors.fuelTankLevel;
 	// 160
-	tsOutputChannels->wallFuelAmount = ENGINE(wallFuel).getWallFuel(0);
+	tsOutputChannels->wallFuelAmount = ENGINE(wallFuel[0]).getWallFuel();
 	// 164
 	tsOutputChannels->iatCorrection = ENGINE(engineState.running.intakeTemperatureCoefficient);
 	// 168
-	tsOutputChannels->wallFuelCorrection = ENGINE(wallFuel).wallFuelCorrection;
+	tsOutputChannels->wallFuelCorrection = ENGINE(wallFuel[0]).wallFuelCorrection;
 	// 184
 	tsOutputChannels->cltCorrection = ENGINE(engineState.running.coolantTemperatureCoefficient);
 	// 188

--- a/firmware/controllers/algo/accel_enrichment.cpp
+++ b/firmware/controllers/algo/accel_enrichment.cpp
@@ -38,16 +38,12 @@ tps_tps_Map3D_t tpsTpsMap("tpsTps");
 
 static Logging *logger = nullptr;
 
-WallFuel::WallFuel() {
-	resetWF();
-}
-
 void WallFuel::resetWF() {
 	wallFuel = 0;
 }
 
 //
-floatms_t WallFuel::adjust(int injectorIndex, floatms_t desiredFuel DECLARE_ENGINE_PARAMETER_SUFFIX) {
+floatms_t WallFuel::adjust(floatms_t desiredFuel DECLARE_ENGINE_PARAMETER_SUFFIX) {
 	invocationCounter++;
 	if (cisnan(desiredFuel)) {
 		return desiredFuel;
@@ -116,7 +112,7 @@ floatms_t WallFuel::adjust(int injectorIndex, floatms_t desiredFuel DECLARE_ENGI
 		beta = alpha;
 	}
 
-	float fuelFilmMass = wallFuel/*[injectorIndex]*/;
+	float fuelFilmMass = wallFuel;
 	float M_cmd = (desiredFuel - (1 - alpha) * fuelFilmMass) / (1 - beta);
 	
 	// We can't inject a negative amount of fuel
@@ -130,15 +126,15 @@ floatms_t WallFuel::adjust(int injectorIndex, floatms_t desiredFuel DECLARE_ENGI
 	float fuelFilmMassNext = alpha * fuelFilmMass + beta * M_cmd;
 
 	DISPLAY_TEXT(Current_Wall_Fuel_Film);
-	DISPLAY_FIELD(wallFuel)/*[injectorIndex]*/ = fuelFilmMassNext;
+	DISPLAY_FIELD(wallFuel) = fuelFilmMassNext;
 	DISPLAY_TEXT(Fuel correction);
 	DISPLAY_FIELD(wallFuelCorrection) = M_cmd - desiredFuel;
 	DISPLAY_TEXT(ms);
 	return M_cmd;
 }
 
-floatms_t WallFuel::getWallFuel(int injectorIndex) const {
-	return wallFuel/*[injectorIndex]*/;
+floatms_t WallFuel::getWallFuel() const {
+	return wallFuel;
 }
 
 int AccelEnrichment::getMaxDeltaIndex(DECLARE_ENGINE_PARAMETER_SIGNATURE) {

--- a/firmware/controllers/algo/accel_enrichment.h
+++ b/firmware/controllers/algo/accel_enrichment.h
@@ -68,16 +68,14 @@ private:
  */
 class WallFuel : public wall_fuel_state {
 public:
-	WallFuel();
 	/**
 	 * @param target desired squirt duration
 	 * @return total adjusted fuel squirt duration once wall wetting is taken into effect
 	 */
-	floatms_t adjust(int injectorIndex, floatms_t target DECLARE_ENGINE_PARAMETER_SUFFIX);
-	floatms_t getWallFuel(int injectorIndex) const;
+	floatms_t adjust(floatms_t target DECLARE_ENGINE_PARAMETER_SUFFIX);
+	floatms_t getWallFuel() const;
 	void resetWF();
 	int invocationCounter = 0;
-private:
 };
 
 void initAccelEnrichment(Logging *sharedLogger DECLARE_ENGINE_PARAMETER_SUFFIX);

--- a/firmware/controllers/algo/engine.h
+++ b/firmware/controllers/algo/engine.h
@@ -94,7 +94,7 @@ public:
 	IgnitionEventList ignitionEvents;
 #endif /* EFI_ENGINE_CONTROL */
 
-	WallFuel wallFuel;
+	WallFuel wallFuel[INJECTION_PIN_COUNT];
 	bool needToStopEngine(efitick_t nowNt) const;
 	bool etbAutoTune = false;
 	/**

--- a/firmware/controllers/engine_controller.cpp
+++ b/firmware/controllers/engine_controller.cpp
@@ -287,7 +287,11 @@ efitimesec_t getTimeNowSeconds(void) {
 static void resetAccel(void) {
 	engine->engineLoadAccelEnrichment.resetAE();
 	engine->tpsAccelEnrichment.resetAE();
-	engine->wallFuel.resetWF();
+
+	for (int i = 0; i < sizeof(engine->wallFuel) / sizeof(engine->wallFuel[0]); i++)
+	{
+		engine->wallFuel[i].resetWF();
+	}
 }
 
 static int previousSecond;

--- a/firmware/controllers/trigger/main_trigger_callback.cpp
+++ b/firmware/controllers/trigger/main_trigger_callback.cpp
@@ -209,7 +209,9 @@ static ALWAYS_INLINE void handleFuelInjectionEvent(int injEventIndex, InjectionE
 	 * wetting coefficient works the same way for any injection mode, or is something
 	 * x2 or /2?
 	 */
-	const floatms_t injectionDuration = ENGINE(wallFuel).adjust(0/*event->outputs[0]->injectorIndex*/, ENGINE(injectionDuration) PASS_ENGINE_PARAMETER_SUFFIX);
+
+	size_t injectorIndex = event->outputs[0]->injectorIndex;
+	const floatms_t injectionDuration = ENGINE(wallFuel[injectorIndex]).adjust(ENGINE(injectionDuration) PASS_ENGINE_PARAMETER_SUFFIX);
 #if EFI_PRINTF_FUEL_DETAILS
 	printf("fuel injectionDuration=%.2f adjusted=%.2f\t\n", ENGINE(injectionDuration), injectionDuration);
 #endif /*EFI_PRINTF_FUEL_DETAILS */

--- a/unit_tests/tests/test_fuel_wall_wetting.cpp
+++ b/unit_tests/tests/test_fuel_wall_wetting.cpp
@@ -20,8 +20,8 @@ TEST(fuel, testWallWettingEnrichmentMath) {
 	engine->rpmCalculator.setRpmValue(3000 PASS_ENGINE_PARAMETER_SUFFIX);
 
 	// each invocation of 'adjust' changes WallWetting internal state
-	ASSERT_NEAR(16.6666, ENGINE(wallFuel).adjust(0, 10.0 PASS_ENGINE_PARAMETER_SUFFIX), EPS4D);
-	ASSERT_NEAR(16.198, ENGINE(wallFuel).adjust(0, 10.0 PASS_ENGINE_PARAMETER_SUFFIX), EPS4D);
+	ASSERT_NEAR(16.6666, ENGINE(wallFuel[0]).adjust(10.0 PASS_ENGINE_PARAMETER_SUFFIX), EPS4D);
+	ASSERT_NEAR(16.198, ENGINE(wallFuel[0]).adjust(10.0 PASS_ENGINE_PARAMETER_SUFFIX), EPS4D);
 }
 
 TEST(fuel, testWallWettingEnrichmentScheduling) {
@@ -37,13 +37,24 @@ TEST(fuel, testWallWettingEnrichmentScheduling) {
 	eth.fireTriggerEvents2(/* count */ 5, 25 /* ms */);
 	ASSERT_EQ( 1200,  GET_RPM()) << "RPM";
 
-	int expectedInvocationCounter = 4;
-	ASSERT_EQ(expectedInvocationCounter, ENGINE(wallFuel).invocationCounter);
+	int expectedInvocationCounter = 1;
+
+	for	(int i = 0; i < 4; i++) {
+		ASSERT_EQ(expectedInvocationCounter, ENGINE(wallFuel[i]).invocationCounter);
+	}
+
+	// Cylinder 5 doesn't exist - shouldn't have been called!
+	ASSERT_EQ(0, ENGINE(wallFuel[5]).invocationCounter);
 
 	eth.engine.periodicFastCallback(PASS_ENGINE_PARAMETER_SIGNATURE);
 	eth.engine.periodicFastCallback(PASS_ENGINE_PARAMETER_SIGNATURE);
 	eth.engine.periodicFastCallback(PASS_ENGINE_PARAMETER_SIGNATURE);
 
-	// still same 4 - wall wetting is NOT invoked from 'periodicFastCallback'
-	ASSERT_EQ(expectedInvocationCounter, ENGINE(wallFuel).invocationCounter);
+	// still same 1 per cylinder - wall wetting is NOT invoked from 'periodicFastCallback'
+	for	(int i = 0; i < 4; i++) {
+		ASSERT_EQ(expectedInvocationCounter, ENGINE(wallFuel[i]).invocationCounter);
+	}
+
+	// Cylinder 5 doesn't exist - shouldn't have been called!
+	ASSERT_EQ(0, ENGINE(wallFuel[5]).invocationCounter);
 }


### PR DESCRIPTION
Previously, were sharing one state for all cylinders.  This means it would run N times too fast, making the wall wetting parameters wrong.