### PR TITLE
Fix

### DIFF
--- a/firmware/controllers/core/error_handling.h
+++ b/firmware/controllers/core/error_handling.h
@@ -8,14 +8,13 @@
 #ifndef ERROR_HANDLING_H_
 #define ERROR_HANDLING_H_
 
+#include "global.h"
+#include "obd_error_codes.h"
+
 #ifdef __cplusplus
 extern "C"
 {
 #endif /* __cplusplus */
-
-#include "global.h"
-#include "obd_error_codes.h"
-
 
 /**
  * Something is wrong, but we can live with it: some minor sensor is disconnected
@@ -31,7 +30,7 @@ typedef uint8_t fatal_msg_t[200];
  *
  * see also warning()
  */
-EXTERNC void firmwareError(obd_code_e code, const char *fmt, ...);
+void firmwareError(obd_code_e code, const char *fmt, ...);
 
 #define hasFirmwareError() hasFirmwareErrorFlag
 

--- a/firmware/controllers/system/efi_gpio.cpp
+++ b/firmware/controllers/system/efi_gpio.cpp
@@ -22,16 +22,6 @@
 
 EXTERN_ENGINE;
 
-// C++ helpers go here
-namespace efi
-{
-template <class T, size_t N>
-constexpr size_t size(const T (&)[N])
-{
-    return N;
-}
-} // namespace efi
-
 #if EFI_ENGINE_SNIFFER
 #include "engine_sniffer.h"
 extern WaveChart waveChart;

--- a/firmware/global.h
+++ b/firmware/global.h
@@ -15,6 +15,8 @@
 #ifndef GLOBAL_H_
 #define GLOBAL_H_
 
+#include "common_headers.h"
+
 #ifdef __cplusplus
 extern "C"
 {
@@ -22,7 +24,6 @@ extern "C"
 
 // todo: remove this from here and rely on os_access.h. unfortunately hal.h includes ch.h :(
 #include <hal.h>
-#include "common_headers.h"
 
 // this is about MISRA not liking 'time.h'. todo: figure out something
 #if defined __GNUC__

--- a/firmware/util/efilib.h
+++ b/firmware/util/efilib.h
@@ -75,15 +75,15 @@ float expf_taylor(float x);
 #ifdef __cplusplus
 }
 
-//// C++ helpers go here
-//namespace efi
-//{
-//template <class T, size_t N>
-//constexpr size_t size(const T (&)[N])
-//{
-//    return N;
-//}
-//} // namespace efi
+// C++ helpers go here
+namespace efi
+{
+template <class T, size_t N>
+constexpr size_t size(const T (&)[N])
+{
+    return N;
+}
+} // namespace efi
 
 #endif /* __cplusplus */
 


### PR DESCRIPTION
Don't put header includes inside an `extern "C"` block when that header has its own guards.