### PR TITLE
Put back static asserts, fix the mess

### DIFF
--- a/firmware/config/stm32f7ems/chconf.h
+++ b/firmware/config/stm32f7ems/chconf.h
@@ -710,6 +710,9 @@
 
 #ifndef __ASSEMBLER__
 
+#ifdef __cplusplus
+extern "C"
+#endif
 void chDbgPanic3(const char *msg, const char * file, int line);
 #endif
 

--- a/firmware/controllers/core/error_handling.h
+++ b/firmware/controllers/core/error_handling.h
@@ -8,14 +8,13 @@
 #ifndef ERROR_HANDLING_H_
 #define ERROR_HANDLING_H_
 
+#include "global.h"
+#include "obd_error_codes.h"
+
 #ifdef __cplusplus
 extern "C"
 {
 #endif /* __cplusplus */
-
-#include "global.h"
-#include "obd_error_codes.h"
-
 
 /**
  * Something is wrong, but we can live with it: some minor sensor is disconnected
@@ -31,7 +30,7 @@ typedef uint8_t fatal_msg_t[200];
  *
  * see also warning()
  */
-EXTERNC void firmwareError(obd_code_e code, const char *fmt, ...);
+void firmwareError(obd_code_e code, const char *fmt, ...);
 
 #define hasFirmwareError() hasFirmwareErrorFlag
 

--- a/firmware/controllers/system/efi_gpio.cpp
+++ b/firmware/controllers/system/efi_gpio.cpp
@@ -52,18 +52,20 @@ EnginePins::EnginePins() {
 	dizzyOutput.name = PROTOCOL_DIZZY_NAME;
 	tachOut.name = PROTOCOL_TACH_NAME;
 
-	efiAssertVoid(CUSTOM_ERR_PIN_COUNT_TOO_LARGE, (sizeof(sparkNames) / sizeof(char*)) >= IGNITION_PIN_COUNT, "spark pin count");
+	static_assert(efi::size(sparkNames) >= IGNITION_PIN_COUNT, "Too many ignition pins"); 
 	for (int i = 0; i < IGNITION_PIN_COUNT;i++) {
 		enginePins.coils[i].name = sparkNames[i];
 		enginePins.coils[i].shortName = sparkShortNames[i];
 	}
-	efiAssertVoid(CUSTOM_ERR_PIN_COUNT_TOO_LARGE, (sizeof(injectorNames) / sizeof(char*)) >= INJECTION_PIN_COUNT, "inj pin count");
-	for (int i = 0; i < INJECTION_PIN_COUNT;i++) {
+
+	static_assert(efi::size(injectorNames) >= INJECTION_PIN_COUNT, "Too many injection pins"); 
+		for (int i = 0; i < INJECTION_PIN_COUNT;i++) {
 		enginePins.injectors[i].injectorIndex = i;
 		enginePins.injectors[i].name = injectorNames[i];
 		enginePins.injectors[i].shortName = injectorShortNames[i];
 	}
-	efiAssertVoid(CUSTOM_ERR_PIN_COUNT_TOO_LARGE, (sizeof(auxValveShortNames) / sizeof(char*)) >= AUX_DIGITAL_VALVE_COUNT, "aux pin count");
+
+	static_assert(efi::size(auxValveShortNames) >= AUX_DIGITAL_VALVE_COUNT, "Too many aux valve pins"); 
 	for (int i = 0; i < AUX_DIGITAL_VALVE_COUNT;i++) {
 		enginePins.auxValve[i].name = auxValveShortNames[i];
 	}

--- a/firmware/global.h
+++ b/firmware/global.h
@@ -15,11 +15,6 @@
 #ifndef GLOBAL_H_
 #define GLOBAL_H_
 
-#ifdef __cplusplus
-extern "C"
-{
-#endif /* __cplusplus */
-
 // todo: remove this from here and rely on os_access.h. unfortunately hal.h includes ch.h :(
 #include <hal.h>
 #include "common_headers.h"
@@ -96,10 +91,6 @@ typedef unsigned int time_t;
 #endif /* EFI_USE_CCM */
 
 #define getCurrentRemainingStack() getRemainingStack(chThdGetSelfX())
-
-#ifdef __cplusplus
-}
-#endif /* __cplusplus */
 
 
 // 168 ticks in microsecond in case of 168MHz 407

--- a/firmware/util/efilib.h
+++ b/firmware/util/efilib.h
@@ -74,6 +74,17 @@ float expf_taylor(float x);
 
 #ifdef __cplusplus
 }
+
+// C++ helpers go here
+namespace efi
+{
+template <typename T, size_t N>
+constexpr size_t size(const T(&)[N])
+{
+    return N;
+}
+} // namespace efi
+
 #endif /* __cplusplus */
 
 #endif /* EFILIB_H_ */


### PR DESCRIPTION
If you have a header included inside an `extern "C"` block, you need to consider very **very** carefully what you're doing.  Pretty much only function declarations should be inside an `extern "C"`.  No includes, no defines, nothing else.

This change does not alter the compiled binary.