### PR TITLE
cisnan() warnings fix

### DIFF
--- a/firmware/util/efilib.h
+++ b/firmware/util/efilib.h
@@ -45,7 +45,19 @@ int indexOf(const char *string, char ch);
 float atoff(const char *string);
 int atoi(const char *string);
 
+#if defined(__cplusplus) && defined(__OPTIMIZE__)
+#include <type_traits>
+// "g++ -O2" version, adds more strict type check and yet no "strict-aliasing" warnings!
+#define cisnan(f) ({ \
+	static_assert(sizeof(f) == sizeof(int32_t)); \
+	union cisnanu_t { std::remove_reference_t<decltype(f)> __f; int32_t __i; } __cisnan_u = { f }; \
+	__cisnan_u.__i == 0x7FC00000; \
+})
+#else
+// "g++ -O0" or other C++/C compilers
 #define cisnan(f) (*(((int*) (&f))) == 0x7FC00000)
+#endif /* __cplusplus && __OPTIMIZE__ */
+
 #define UNUSED(x) (void)(x)
   
 int absI(int32_t value);

--- a/firmware/util/math/interpolation.h
+++ b/firmware/util/math/interpolation.h
@@ -46,7 +46,8 @@ int needInterpolationLogging(void);
  */
 template<typename kType>
 int findIndexMsgExt(const char *msg, const kType array[], int size, kType value) {
-	if (cisnan(value)) {
+	float fvalue = (float)value;
+	if (cisnan(fvalue)) {
 		firmwareError(ERROR_NAN_FIND_INDEX, "NaN in findIndex%s", msg);
 		return 0;
 	}


### PR DESCRIPTION
We use a bit of C++ magic to fix tons of these warnings:
```
    util/efilib.h:48:35: warning: dereferencing type-punned pointer will break strict-aliasing rules [-Wstrict-aliasing]
    #define cisnan(f) (*(((int*) (&f))) == 0x7FC00000)
                                   ^
    controllers/error_handling.h:54:59: note: in definition of macro 'efiAssertVoid'
```
Due to the gnu-c++ optimisation, the binary code produced is practically the same as before:
```
      87              	@ aliasing-test.cpp:15: 	if (cisnan(oneDegreeUs)) {
      88 0010 20309FE5 		ldr	r3, .L6+4	@ tmp118,
      89 0014 030050E1 		cmp	r0, r3	@, tmp118
      90 0018 0200000A 		beq	.L5	@,
```
But without optimisation it's slightly larger (by 2-3 opcodes), so we leave it as it was for -O0...