### PR TITLE
Add workflow for firmware, fix simulator build, trigger builds on PR

### DIFF
--- a/.github/workflows/build-firmware.yaml
+++ b/.github/workflows/build-firmware.yaml
@@ -4,16 +4,19 @@ on: [push,pull_request]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
     
     strategy:
+      # Let all builds finish even if one fails early
       fail-fast: false
       matrix:
+        # What boards should we build for? In the 'include' section below,
+        # set up what each of these boards needs to build.
         build-target: [frankenso, mre-f4, mre-f7]
         build-type: [debug, release]
         
         include:
+          # Board configurations
           - build-target: frankenso
             efi-cpu: ARCH_STM32F4
             efi-board: st_stm32f4
@@ -26,6 +29,7 @@ jobs:
             efi-cpu: ARCH_STM32F7
             efi-board: microrusefi
 
+          # Debug vs. release configuration
           - build-type: debug
             extra-params: -DDUMMY
             build-debug-level-opt: -O0 -ggdb -g3
@@ -51,6 +55,7 @@ jobs:
     - name: Test Compiler
       run: arm-none-eabi-gcc -v
   
+    # Build the firmware!
     - name: Build Firmware
       working-directory: ./firmware/
       run: make -j4 PROJECT_BOARD=${{matrix.efi-board}} PROJECT_CPU=${{matrix.efi-cpu}} EXTRA_PARAMS="${{matrix.extra-params}}" DEBUG_LEVEL_OPT='${{matrix.build-debug-level-opt}}'

--- a/.github/workflows/build-firmware.yaml
+++ b/.github/workflows/build-firmware.yaml
@@ -1,0 +1,69 @@
+name: Build Firmware
+
+on: [push,pull_request]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    
+    strategy:
+      fail-fast: false
+      matrix:
+        build-target: [frankenso, mre-f4, mre-f7]
+        build-type: [debug, release]
+        
+        include:
+          - build-target: frankenso
+            efi-cpu: ARCH_STM32F4
+            efi-board: st_stm32f4
+            
+          - build-target: mre-f4
+            efi-cpu: ARCH_STM32F4
+            efi-board: microrusefi
+            
+          - build-target: mre-f7
+            efi-cpu: ARCH_STM32F7
+            efi-board: microrusefi
+
+          - build-type: debug
+            extra-params: -DDUMMY
+            build-debug-level-opt: -O0 -ggdb -g3
+
+          - build-type: release
+            extra-params: -DEFI_ENABLE_ASSERTS=FALSE -DCH_DBG_ENABLE_TRACE=FALSE -DCH_DBG_ENABLE_ASSERTS=FALSE -DCH_DBG_ENABLE_STACK_CHECK=FALSE -DCH_DBG_FILL_THREADS=FALSE -DCH_DBG_THREADS_PROFILING=FALSE
+            build-debug-level-opt: -O2 -ggdb -g3
+    
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        fetch-depth: 1
+        submodules: recursive
+  
+    # Build machines don't have arm-none-eabi gcc, so let's download it and put it on the path
+    - name: Download & Install GCC
+      run: |
+        wget 'https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2019q4/RC2.1/gcc-arm-none-eabi-9-2019-q4-major-x86_64-linux.tar.bz2?revision=6e63531f-8cb1-40b9-bbfc-8a57cdfc01b4&la=en&hash=F761343D43A0587E8AC0925B723C04DBFB848339' -O compiler.tar.bz2
+        tar -xvf compiler.tar.bz2
+        echo "::add-path::`pwd`/gcc-arm-none-eabi-9-2019-q4-major/bin"
+  
+    # Make sure the compiler we just downloaded works - just print out the version
+    - name: Test Compiler
+      run: arm-none-eabi-gcc -v
+  
+    - name: Build Firmware
+      working-directory: ./firmware/
+      run: make -j4 PROJECT_BOARD=${{matrix.efi-board}} PROJECT_CPU=${{matrix.efi-cpu}} EXTRA_PARAMS="${{matrix.extra-params}}" DEBUG_LEVEL_OPT='${{matrix.build-debug-level-opt}}'
+      
+    # The next two steps upload the bin and elf as build artifacts
+    - name: Upload elf
+      uses: actions/upload-artifact@v1
+      with:
+        name: firmware-${{matrix.build-target}}-${{matrix.build-type}}-elf
+        path: ./firmware/build/rusefi.elf
+        
+    - name: Upload bin
+      uses: actions/upload-artifact@v1
+      with:
+        name: firmware-${{matrix.build-target}}-${{matrix.build-type}}-bin
+        path: ./firmware/build/rusefi.bin

--- a/.github/workflows/build-firmware.yaml
+++ b/.github/workflows/build-firmware.yaml
@@ -1,4 +1,4 @@
-name: Build Firmware
+name: Firmware CI
 
 on: [push,pull_request]
 

--- a/.github/workflows/build-simulator.disabled_since_need_32bit_yaml
+++ b/.github/workflows/build-simulator.disabled_since_need_32bit_yaml
@@ -1,6 +1,6 @@
 name: simulator ci
 
-on: [push]
+on: [push,pull_request]
 
 jobs:
   build:

--- a/.github/workflows/build-simulator.yaml
+++ b/.github/workflows/build-simulator.yaml
@@ -6,14 +6,16 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-    
+
     steps:
+    - name: Install Simulator Deps
+      run: sudo apt-get install gcc-multilib g++-multilib
+
     - uses: actions/checkout@v1
       with:
         fetch-depth: 1
         submodules: recursive
-      
+
     - name: Build Simulator
       working-directory: ./simulator/
       run: make -j4
-      

--- a/.github/workflows/build-simulator.yaml
+++ b/.github/workflows/build-simulator.yaml
@@ -1,4 +1,4 @@
-name: simulator ci
+name: Simulator CI
 
 on: [push,pull_request]
 

--- a/.github/workflows/build-simulator.yaml
+++ b/.github/workflows/build-simulator.yaml
@@ -9,7 +9,7 @@ jobs:
 
     steps:
     - name: Install Simulator Deps
-      run: sudo apt-get install gcc-multilib g++-multilib
+      run: sudo apt-get update && sudo apt-get install -y gcc-multilib g++-multilib
 
     - uses: actions/checkout@v1
       with:

--- a/.github/workflows/build-unit-tests.yaml
+++ b/.github/workflows/build-unit-tests.yaml
@@ -1,6 +1,6 @@
 name: unit test ci
 
-on: [push]
+on: [push,pull_request]
 
 jobs:
   build:

--- a/.github/workflows/build-unit-tests.yaml
+++ b/.github/workflows/build-unit-tests.yaml
@@ -1,4 +1,4 @@
-name: unit test ci
+name: Unit Test CI
 
 on: [push,pull_request]
 


### PR DESCRIPTION
Build firmware in ci.  This runs both for pushes (ci) and on PRs (gate).

Currently builds firmware for boards [frankenso, mre-f4, mre-f7] and configurations [debug, release].

Edit: also triggers on PR

Edit 2: also fixes simulator build