### PR TITLE
Use templated array references

### DIFF
--- a/firmware/config/engines/dodge_neon.cpp
+++ b/firmware/config/engines/dodge_neon.cpp
@@ -310,7 +310,7 @@ void setDodgeNeonNGCEngineConfiguration(DECLARE_CONFIG_PARAMETER_SIGNATURE) {
 	//engineConfiguration->fuelAlgorithm = LM_ALPHA_N; // I want to start with a simple Alpha-N
 
 	setFuelLoadBin(0, 100 PASS_CONFIG_PARAMETER_SUFFIX);
-	setLinearCurve(config->ignitionLoadBins, IGN_LOAD_COUNT, 20, 120, 1);
+	setLinearCurve(config->ignitionLoadBins, 20, 120, 1);
 
 	setAlgorithm(LM_SPEED_DENSITY PASS_CONFIG_PARAMETER_SUFFIX);
 

--- a/firmware/config/engines/ford_festiva.cpp
+++ b/firmware/config/engines/ford_festiva.cpp
@@ -149,7 +149,7 @@ void setFordEscortGt(DECLARE_CONFIG_PARAMETER_SIGNATURE) {
 	engineConfiguration->crankingTimingAngle = 3;
 	engineConfiguration->crankingChargeAngle = 70;
 
-	setLinearCurve(config->ignitionLoadBins, IGN_LOAD_COUNT, 20, 105, 5);
+	setLinearCurve(config->ignitionLoadBins, 20, 105, 5);
 	setWholeTimingTable_d(10 PASS_CONFIG_PARAMETER_SUFFIX);
 	// set_whole_fuel_map 5
 	setWholeFuelMap(5 PASS_CONFIG_PARAMETER_SUFFIX);

--- a/firmware/config/engines/sachs.cpp
+++ b/firmware/config/engines/sachs.cpp
@@ -85,8 +85,8 @@ void setSachs(DECLARE_CONFIG_PARAMETER_SIGNATURE) {
 	// todo: extract a method? figure out something smarter
 	setFuelRpmBin(800, 15000 PASS_CONFIG_PARAMETER_SUFFIX);
 	setTimingRpmBin(800, 15000 PASS_CONFIG_PARAMETER_SUFFIX);
-	setLinearCurve(config->veRpmBins, FUEL_RPM_COUNT, 15000, 7000, 1);
-	setLinearCurve(config->afrRpmBins, FUEL_RPM_COUNT, 15000, 7000, 1);
+	setLinearCurve(config->veRpmBins, 15000, 7000, 1);
+	setLinearCurve(config->afrRpmBins, 15000, 7000, 1);
 
 	engineConfiguration->hasFrequencyReportingMapSensor = true;
 	boardConfiguration->frequencyReportingMapInputPin = GPIOC_6;

--- a/firmware/controllers/actuators/electronic_throttle.cpp
+++ b/firmware/controllers/actuators/electronic_throttle.cpp
@@ -480,8 +480,8 @@ void setBoschVNH2SP30Curve(DECLARE_CONFIG_PARAMETER_SIGNATURE) {
 void setDefaultEtbParameters(DECLARE_CONFIG_PARAMETER_SIGNATURE) {
 	CONFIG(etbIdleThrottleRange) = 5;
 
-	setLinearCurveAny<uint8_t>(config->pedalToTpsPedalBins, PEDAL_TO_TPS_SIZE, /*from*/0, /*to*/100, 1);
-	setLinearCurveAny<uint8_t>(config->pedalToTpsRpmBins, PEDAL_TO_TPS_SIZE, /*from*/0, /*to*/8000 / RPM_1_BYTE_PACKING_MULT, 1);
+	setLinearCurve(config->pedalToTpsPedalBins, /*from*/0, /*to*/100, 1);
+	setLinearCurve(config->pedalToTpsRpmBins, /*from*/0, /*to*/8000 / RPM_1_BYTE_PACKING_MULT, 1);
 
 	for (int pedalIndex = 0;pedalIndex<PEDAL_TO_TPS_SIZE;pedalIndex++) {
 		for (int rpmIndex = 0;rpmIndex<PEDAL_TO_TPS_SIZE;rpmIndex++) {

--- a/firmware/controllers/algo/advance_map.cpp
+++ b/firmware/controllers/algo/advance_map.cpp
@@ -224,12 +224,12 @@ angle_t getAdvance(int rpm, float engineLoad DECLARE_ENGINE_PARAMETER_SUFFIX) {
 }
 
 void setDefaultIatTimingCorrection(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
-	setLinearCurve(config->ignitionIatCorrLoadBins, IGN_LOAD_COUNT, /*from*/CLT_CURVE_RANGE_FROM, 110, 1);
+	setLinearCurve(config->ignitionIatCorrLoadBins, /*from*/CLT_CURVE_RANGE_FROM, 110, 1);
 #if IGN_LOAD_COUNT == DEFAULT_IGN_LOAD_COUNT
 	memcpy(config->ignitionIatCorrRpmBins, iatTimingRpmBins, sizeof(iatTimingRpmBins));
 	copyTimingTable(defaultIatTiming, config->ignitionIatCorrTable);
 #else
-	setLinearCurve(config->ignitionIatCorrLoadBins, IGN_RPM_COUNT, /*from*/0, 6000, 1);
+	setLinearCurve(config->ignitionIatCorrLoadBins, /*from*/0, 6000, 1);
 #endif /* IGN_LOAD_COUNT == DEFAULT_IGN_LOAD_COUNT */
 }
 

--- a/firmware/controllers/algo/engine_configuration.cpp
+++ b/firmware/controllers/algo/engine_configuration.cpp
@@ -208,7 +208,7 @@ void setConstantDwell(floatms_t dwellMs DECLARE_CONFIG_PARAMETER_SUFFIX) {
 	for (int i = 0; i < DWELL_CURVE_SIZE; i++) {
 		engineConfiguration->sparkDwellRpmBins[i] = 1000 * i;
 	}
-	setLinearCurve(engineConfiguration->sparkDwellValues, DWELL_CURVE_SIZE, dwellMs, dwellMs, 0.01);
+	setLinearCurve(engineConfiguration->sparkDwellValues, dwellMs, dwellMs, 0.01);
 }
 
 void setAfrMap(afr_table_t table, float value) {
@@ -248,9 +248,9 @@ void setWholeIgnitionIatCorr(float value DECLARE_CONFIG_PARAMETER_SUFFIX) {
 }
 
 void setFuelTablesLoadBin(float minValue, float maxValue DECLARE_CONFIG_PARAMETER_SUFFIX) {
-	setLinearCurve(config->injPhaseLoadBins, FUEL_LOAD_COUNT, minValue, maxValue, 1);
-	setLinearCurve(config->veLoadBins, FUEL_LOAD_COUNT, minValue, maxValue, 1);
-	setLinearCurve(config->afrLoadBins, FUEL_LOAD_COUNT, minValue, maxValue, 1);
+	setLinearCurve(config->injPhaseLoadBins, minValue, maxValue, 1);
+	setLinearCurve(config->veLoadBins, minValue, maxValue, 1);
+	setLinearCurve(config->afrLoadBins, minValue, maxValue, 1);
 }
 
 void setTimingMap(ignition_table_t map, float value) {
@@ -450,11 +450,11 @@ static void setDefaultFuelCutParameters(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 static void setDefaultCrankingSettings(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 	CONFIG(useTLE8888_cranking_hack) = true;
 
-	setLinearCurve(engineConfiguration->crankingTpsCoef, CRANKING_CURVE_SIZE, /*from*/1, /*to*/1, 1);
-	setLinearCurve(engineConfiguration->crankingTpsBins, CRANKING_CURVE_SIZE, 0, 100, 1);
+	setLinearCurve(engineConfiguration->crankingTpsCoef, /*from*/1, /*to*/1, 1);
+	setLinearCurve(engineConfiguration->crankingTpsBins, 0, 100, 1);
 
-	setLinearCurve(config->cltCrankingCorrBins, CLT_CRANKING_CURVE_SIZE, CLT_CURVE_RANGE_FROM, 100, 1);
-	setLinearCurve(config->cltCrankingCorr, CLT_CRANKING_CURVE_SIZE, 1.0, 1.0, 1);
+	setLinearCurve(config->cltCrankingCorrBins, CLT_CURVE_RANGE_FROM, 100, 1);
+	setLinearCurve(config->cltCrankingCorr, 1.0, 1.0, 1);
 
 	config->crankingFuelCoef[0] = 2.8; // base cranking fuel adjustment coefficient
 	config->crankingFuelBins[0] = -20; // temperature in C
@@ -510,7 +510,7 @@ static void setDefaultCrankingSettings(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
  * see also setTargetRpmCurve()
  */
 static void setDefaultIdleSpeedTarget(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
-	setLinearCurve(engineConfiguration->cltIdleRpmBins, CLT_CURVE_SIZE, CLT_CURVE_RANGE_FROM, 140, 10);
+	setLinearCurve(engineConfiguration->cltIdleRpmBins, CLT_CURVE_RANGE_FROM, 140, 10);
 
 	setCurveValue(engineConfiguration->cltIdleRpmBins, engineConfiguration->cltIdleRpm, CLT_CURVE_SIZE, -30, 1350);
 	setCurveValue(engineConfiguration->cltIdleRpmBins, engineConfiguration->cltIdleRpm, CLT_CURVE_SIZE, -20, 1300);
@@ -548,8 +548,8 @@ static void setCanFrankensoDefaults(DECLARE_CONFIG_PARAMETER_SIGNATURE) {
  * see also setDefaultIdleSpeedTarget()
  */
 void setTargetRpmCurve(int rpm DECLARE_CONFIG_PARAMETER_SUFFIX) {
-	setLinearCurve(engineConfiguration->cltIdleRpmBins, CLT_CURVE_SIZE, CLT_CURVE_RANGE_FROM, 90, 10);
-	setLinearCurve(engineConfiguration->cltIdleRpm, CLT_CURVE_SIZE, rpm, rpm, 10);
+	setLinearCurve(engineConfiguration->cltIdleRpmBins, CLT_CURVE_RANGE_FROM, 90, 10);
+	setLinearCurve(engineConfiguration->cltIdleRpm, rpm, rpm, 10);
 }
 
 int getTargetRpmForIdleCorrection(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
@@ -639,17 +639,17 @@ static void setDefaultEngineConfiguration(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 	engineConfiguration->alternatorControl.minValue = 10;
 	engineConfiguration->alternatorControl.maxValue = 90;
 
-	setLinearCurve(engineConfiguration->cltTimingBins, CLT_TIMING_CURVE_SIZE, CLT_CURVE_RANGE_FROM, 120, 1);
-	setLinearCurve(engineConfiguration->cltTimingExtra, CLT_TIMING_CURVE_SIZE, 0, 0, 1);
+	setLinearCurve(engineConfiguration->cltTimingBins, CLT_CURVE_RANGE_FROM, 120, 1);
+	setLinearCurve(engineConfiguration->cltTimingExtra, 0, 0, 1);
 
-	setLinearCurve(engineConfiguration->fsioCurve1Bins, FSIO_CURVE_16, 0, 100, 1);
-	setLinearCurve(engineConfiguration->fsioCurve1, FSIO_CURVE_16, 0, 100, 1);
+	setLinearCurve(engineConfiguration->fsioCurve1Bins, 0, 100, 1);
+	setLinearCurve(engineConfiguration->fsioCurve1, 0, 100, 1);
 
-	setLinearCurve(engineConfiguration->fsioCurve2Bins, FSIO_CURVE_16, 0, 100, 1);
-	setLinearCurve(engineConfiguration->fsioCurve2, FSIO_CURVE_16, 30, 170, 1);
+	setLinearCurve(engineConfiguration->fsioCurve2Bins, 0, 100, 1);
+	setLinearCurve(engineConfiguration->fsioCurve2, 30, 170, 1);
 
-	setLinearCurve(engineConfiguration->fsioCurve3Bins, FSIO_CURVE_8, 0, 100, 1);
-	setLinearCurve(engineConfiguration->fsioCurve4Bins, FSIO_CURVE_8, 0, 100, 1);
+	setLinearCurve(engineConfiguration->fsioCurve3Bins, 0, 100, 1);
+	setLinearCurve(engineConfiguration->fsioCurve4Bins, 0, 100, 1);
 
 
 	setDefaultWarmupIdleCorrection(PASS_CONFIG_PARAMETER_SIGNATURE);
@@ -677,10 +677,10 @@ static void setDefaultEngineConfiguration(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 	setTimingLoadBin(1.2, 4.4 PASS_CONFIG_PARAMETER_SUFFIX);
 	setTimingRpmBin(800, 7000 PASS_CONFIG_PARAMETER_SUFFIX);
 
-	setLinearCurve(engineConfiguration->map.samplingAngleBins, MAP_ANGLE_SIZE, 800, 7000, 1);
-	setLinearCurve(engineConfiguration->map.samplingAngle, MAP_ANGLE_SIZE, 100, 130, 1);
-	setLinearCurve(engineConfiguration->map.samplingWindowBins, MAP_ANGLE_SIZE, 800, 7000, 1);
-	setLinearCurve(engineConfiguration->map.samplingWindow, MAP_ANGLE_SIZE, 50, 50, 1);
+	setLinearCurve(engineConfiguration->map.samplingAngleBins, 800, 7000, 1);
+	setLinearCurve(engineConfiguration->map.samplingAngle, 100, 130, 1);
+	setLinearCurve(engineConfiguration->map.samplingWindowBins, 800, 7000, 1);
+	setLinearCurve(engineConfiguration->map.samplingWindow, 50, 50, 1);
 
 	// set_whole_timing_map 3
 	setWholeFuelMap(3 PASS_CONFIG_PARAMETER_SUFFIX);
@@ -696,19 +696,19 @@ static void setDefaultEngineConfiguration(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 	setFuelTablesLoadBin(10, 160 PASS_CONFIG_PARAMETER_SUFFIX);
 	setDefaultIatTimingCorrection(PASS_ENGINE_PARAMETER_SIGNATURE);
 
-	setLinearCurve(engineConfiguration->mapAccelTaperBins, FSIO_TABLE_8, 0, 32, 4);
-	setLinearCurve(engineConfiguration->mapAccelTaperMult, FSIO_TABLE_8, 1, 1, 1);
+	setLinearCurve(engineConfiguration->mapAccelTaperBins, 0, 32, 4);
+	setLinearCurve(engineConfiguration->mapAccelTaperMult, 1, 1, 1);
 
-	setLinearCurve(config->tpsTpsAccelFromRpmBins, FSIO_TABLE_8, 0, 100, 10);
-	setLinearCurve(config->tpsTpsAccelToRpmBins, FSIO_TABLE_8, 0, 100, 10);
+	setLinearCurve(config->tpsTpsAccelFromRpmBins, 0, 100, 10);
+	setLinearCurve(config->tpsTpsAccelToRpmBins, 0, 100, 10);
 
-	setLinearCurve(config->fsioTable1LoadBins, FSIO_TABLE_8, 20, 120, 10);
+	setLinearCurve(config->fsioTable1LoadBins, 20, 120, 10);
 	setRpmTableBin(config->fsioTable1RpmBins, FSIO_TABLE_8);
-	setLinearCurve(config->fsioTable2LoadBins, FSIO_TABLE_8, 20, 120, 10);
+	setLinearCurve(config->fsioTable2LoadBins, 20, 120, 10);
 	setRpmTableBin(config->fsioTable2RpmBins, FSIO_TABLE_8);
-	setLinearCurve(config->fsioTable3LoadBins, FSIO_TABLE_8, 20, 120, 10);
+	setLinearCurve(config->fsioTable3LoadBins, 20, 120, 10);
 	setRpmTableBin(config->fsioTable3RpmBins, FSIO_TABLE_8);
-	setLinearCurve(config->fsioTable4LoadBins, FSIO_TABLE_8, 20, 120, 10);
+	setLinearCurve(config->fsioTable4LoadBins, 20, 120, 10);
 	setRpmTableBin(config->fsioTable4RpmBins, FSIO_TABLE_8);
 
 	initEngineNoiseTable(PASS_ENGINE_PARAMETER_SIGNATURE);

--- a/firmware/controllers/math/engine_math.cpp
+++ b/firmware/controllers/math/engine_math.cpp
@@ -525,11 +525,11 @@ void prepareOutputSignals(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 #endif /* EFI_ENGINE_CONTROL */
 
 void setFuelRpmBin(float from, float to DECLARE_CONFIG_PARAMETER_SUFFIX) {
-	setTableBin(config->fuelRpmBins, FUEL_RPM_COUNT, from, to);
+	setLinearCurve(config->fuelRpmBins, from, to);
 }
 
 void setFuelLoadBin(float from, float to DECLARE_CONFIG_PARAMETER_SUFFIX) {
-	setTableBin(config->fuelLoadBins, FUEL_LOAD_COUNT, from, to);
+	setLinearCurve(config->fuelLoadBins, from, to);
 }
 
 void setTimingRpmBin(float from, float to DECLARE_CONFIG_PARAMETER_SUFFIX) {
@@ -537,7 +537,7 @@ void setTimingRpmBin(float from, float to DECLARE_CONFIG_PARAMETER_SUFFIX) {
 }
 
 void setTimingLoadBin(float from, float to DECLARE_CONFIG_PARAMETER_SUFFIX) {
-	setTableBin(config->ignitionLoadBins, IGN_LOAD_COUNT, from, to);
+	setLinearCurve(config->ignitionLoadBins, from, to);
 }
 
 /**
@@ -548,11 +548,11 @@ void setAlgorithm(engine_load_mode_e algo DECLARE_CONFIG_PARAMETER_SUFFIX) {
 	if (algo == LM_ALPHA_N) {
 		setTimingLoadBin(20, 120 PASS_CONFIG_PARAMETER_SUFFIX);
 	} else if (algo == LM_SPEED_DENSITY) {
-		setLinearCurve(config->ignitionLoadBins, IGN_LOAD_COUNT, 20, 120, 3);
+		setLinearCurve(config->ignitionLoadBins, 20, 120, 3);
 		buildTimingMap(35 PASS_CONFIG_PARAMETER_SUFFIX);
 	}
 }
 
 void setFlatInjectorLag(float value DECLARE_CONFIG_PARAMETER_SUFFIX) {
-	setArrayValues(engineConfiguration->injector.battLagCorr, VBAT_INJECTOR_CURVE_SIZE, value);
+	setArrayValues(engineConfiguration->injector.battLagCorr, value);
 }

--- a/firmware/controllers/math/speed_density.cpp
+++ b/firmware/controllers/math/speed_density.cpp
@@ -174,14 +174,14 @@ void setDefaultVETable(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 	veMap.setAll(80);
 
 //	setRpmTableBin(engineConfiguration->ve2RpmBins, FUEL_RPM_COUNT);
-//	setLinearCurve(engineConfiguration->ve2LoadBins, FUEL_LOAD_COUNT, 10, 300, 1);
+//	setLinearCurve(engineConfiguration->ve2LoadBins, 10, 300, 1);
 //	ve2Map.setAll(0.81);
 
 	setRpmTableBin(config->afrRpmBins, FUEL_RPM_COUNT);
 	afrMap.setAll(14.7);
 
 	setRpmTableBin(engineConfiguration->baroCorrRpmBins, BARO_CORR_SIZE);
-	setLinearCurve(engineConfiguration->baroCorrPressureBins, BARO_CORR_SIZE, 75, 105, 1);
+	setLinearCurve(engineConfiguration->baroCorrPressureBins, 75, 105, 1);
 	for (int i = 0; i < BARO_CORR_SIZE;i++) {
 		for (int j = 0; j < BARO_CORR_SIZE;j++) {
 			// Default baro table is all 1.0, we can't recommend a reasonable default here

--- a/firmware/controllers/sensors/map.h
+++ b/firmware/controllers/sensors/map.h
@@ -26,10 +26,10 @@ float getMapByVoltage(float voltage DECLARE_ENGINE_PARAMETER_SUFFIX);
 float decodePressure(float voltage, air_pressure_sensor_config_s * mapConfig DECLARE_ENGINE_PARAMETER_SUFFIX);
 float validateMap(float mapKPa DECLARE_ENGINE_PARAMETER_SUFFIX);
 
-#define KPA_PER_PSI 6.89475728
+#define KPA_PER_PSI 6.89475728f
 
 // PSI (relative to atmosphere) to kPa (relative to vacuum)
-#define PSI2KPA(psi)  (101.32500411216164 + KPA_PER_PSI * (psi))
+#define PSI2KPA(psi)  (101.32500411216164f + KPA_PER_PSI * (psi))
 
 #define INHG2KPA(inhg) ((inhg) * 3.386375)
 #define KPA2INHG(kpa) ((kpa) / 3.386375)

--- a/firmware/controllers/settings.cpp
+++ b/firmware/controllers/settings.cpp
@@ -1146,11 +1146,11 @@ static void getValue(const char *paramStr) {
 }
 
 static void setFsioCurve1Value(float value) {
-	setLinearCurve(engineConfiguration->fsioCurve1, FSIO_CURVE_16, value, value, 1);
+	setLinearCurve(engineConfiguration->fsioCurve1, value, value, 1);
 }
 
 static void setFsioCurve2Value(float value) {
-	setLinearCurve(engineConfiguration->fsioCurve2, FSIO_CURVE_16, value, value, 1);
+	setLinearCurve(engineConfiguration->fsioCurve2, value, value, 1);
 }
 
 typedef struct {

--- a/firmware/util/containers/table_helper.cpp
+++ b/firmware/util/containers/table_helper.cpp
@@ -18,10 +18,6 @@ void setRpmBin(float array[], int size, float idleRpm, float topRpm) {
 	array[size - 1] = topRpm;
 }
 
-void setTableBin(float array[], int size, float from, float to) {
-	setLinearCurve(array, size, from, to, 0.01);
-}
-
 /**
  * initialize RPM table axis using default RPM range
  */

--- a/firmware/util/containers/table_helper.h
+++ b/firmware/util/containers/table_helper.h
@@ -163,15 +163,14 @@ void setRpmBin(float array[], int size, float idleRpm, float topRpm);
 
 void setTableBin(float array[], int size, float from, float to);
 
-#define setArrayValues(array, size, value) setTableBin(array, size, value, value)
-
 /**
  * @param precision for example '0.1' for one digit fractional part
  */
-template<typename vType>
-void setLinearCurveAny(vType array[], int size, float from, float to, float precision) {
-	for (int i = 0; i < size; i++) {
-		float value = interpolateMsg("setLinearCurve", 0, from, size - 1, to, i);
+template<typename TValue, int TSize>
+void setLinearCurve(TValue (&array)[TSize], float from, float to, float precision) {
+	for (int i = 0; i < TSize; i++) {
+		float value = interpolateMsg("setLinearCurve", 0, from, TSize - 1, to, i);
+
 		/**
 		 * rounded values look nicer, also we want to avoid precision mismatch with Tuner Studio
 		 */
@@ -179,7 +178,18 @@ void setLinearCurveAny(vType array[], int size, float from, float to, float prec
 	}
 }
 
-#define setLinearCurve setLinearCurveAny<float>
+template<typename TValue, int TSize>
+void setLinearCurve(TValue (&array)[TSize], float from, float to) {
+	setLinearCurve(array, from, to, 0.01f);
+}
+
+template<typename TValue, int TSize>
+void setArrayValues(TValue (&array)[TSize], TValue value) {
+	for (int i = 0; i < TSize; i++) {
+		array[i] = value;
+	}
+}
+
 void setRpmTableBin(float array[], int size);
 
 #endif /* TABLE_HELPER_H_ */

--- a/firmware/util/containers/table_helper.h
+++ b/firmware/util/containers/table_helper.h
@@ -161,13 +161,11 @@ typedef Map3D<PEDAL_TO_TPS_SIZE, PEDAL_TO_TPS_SIZE, uint8_t, uint8_t> pedal2tps_
 
 void setRpmBin(float array[], int size, float idleRpm, float topRpm);
 
-void setTableBin(float array[], int size, float from, float to);
-
 /**
- * @param precision for example '0.1' for one digit fractional part
+ * @param precision for example '0.1' for one digit fractional part. Default to 0.01, two digits.
  */
 template<typename TValue, int TSize>
-void setLinearCurve(TValue (&array)[TSize], float from, float to, float precision) {
+void setLinearCurve(TValue (&array)[TSize], float from, float to, float precision = 0.01f) {
 	for (int i = 0; i < TSize; i++) {
 		float value = interpolateMsg("setLinearCurve", 0, from, TSize - 1, to, i);
 
@@ -176,11 +174,6 @@ void setLinearCurve(TValue (&array)[TSize], float from, float to, float precisio
 		 */
 		array[i] = efiRound(value, precision);
 	}
-}
-
-template<typename TValue, int TSize>
-void setLinearCurve(TValue (&array)[TSize], float from, float to) {
-	setLinearCurve(array, from, to, 0.01f);
 }
 
 template<typename TValue, int TSize>

--- a/unit_tests/afm2mapConverter.cpp
+++ b/unit_tests/afm2mapConverter.cpp
@@ -57,7 +57,7 @@ void printConvertedTable() {
 	printf("\n");
 
 
-	setLinearCurve(PSI_BINS, ASIZE, PSI2KPA(18), PSI2KPA(-14.5), 0.1); // we invert PSI scale since voltage is inverted below
+	setLinearCurve(PSI_BINS, PSI2KPA(18), PSI2KPA(-14.5f), 0.1f); // we invert PSI scale since voltage is inverted below
 	for (int i = 0; i< ASIZE;i++) {
 		printf("%f, ", PSI_BINS[i]);
 	}

--- a/unit_tests/engine_test_helper.cpp
+++ b/unit_tests/engine_test_helper.cpp
@@ -212,8 +212,8 @@ void setupSimpleTestEngineWithMaf(EngineTestHelper *eth, injection_mode_e inject
 	// set cranking mode (it's used by getCurrentInjectionMode())
 	engineConfiguration->crankingInjectionMode = IM_SIMULTANEOUS;
 
-	setArrayValues(config->cltFuelCorrBins, 1);
-	setArrayValues(engineConfiguration->injector.battLagCorr, 0);
+	setArrayValues(config->cltFuelCorrBins, 1.0f);
+	setArrayValues(engineConfiguration->injector.battLagCorr, 0.0f);
 	// this is needed to update injectorLag
 	engine->updateSlowSensors(PASS_ENGINE_PARAMETER_SIGNATURE);
 

--- a/unit_tests/engine_test_helper.cpp
+++ b/unit_tests/engine_test_helper.cpp
@@ -212,8 +212,8 @@ void setupSimpleTestEngineWithMaf(EngineTestHelper *eth, injection_mode_e inject
 	// set cranking mode (it's used by getCurrentInjectionMode())
 	engineConfiguration->crankingInjectionMode = IM_SIMULTANEOUS;
 
-	setArrayValues(config->cltFuelCorrBins, CLT_CURVE_SIZE, 1);
-	setArrayValues(engineConfiguration->injector.battLagCorr, VBAT_INJECTOR_CURVE_SIZE, 0);
+	setArrayValues(config->cltFuelCorrBins, 1);
+	setArrayValues(engineConfiguration->injector.battLagCorr, 0);
 	// this is needed to update injectorLag
 	engine->updateSlowSensors(PASS_ENGINE_PARAMETER_SIGNATURE);
 

--- a/unit_tests/tests/test_fuel_map.cpp
+++ b/unit_tests/tests/test_fuel_map.cpp
@@ -233,7 +233,7 @@ TEST(fuel, testTpsBasedVeDefect799) {
 
 	int mapFrom = 100;
 	// set MAP axis range
-	setLinearCurve(config->veLoadBins, FUEL_LOAD_COUNT, mapFrom, mapFrom + FUEL_LOAD_COUNT - 1, 1);
+	setLinearCurve(config->veLoadBins, mapFrom, mapFrom + FUEL_LOAD_COUNT - 1, 1);
 
 	// RPM does not matter - set table values to match load axis
 	for (int load = 0; load < FUEL_LOAD_COUNT;load++) {
@@ -246,7 +246,7 @@ TEST(fuel, testTpsBasedVeDefect799) {
 	ASSERT_EQ(107, veMap.getValue(2000, 107));
 
 	// set TPS axis range which does not overlap MAP range for this test
-	setLinearCurve(CONFIG(ignitionTpsBins), IGN_TPS_COUNT, 0, 15, 1);
+	setLinearCurve(CONFIG(ignitionTpsBins), 0, 15, 1);
 
 
 	engine->mockMapValue = 107;

--- a/unit_tests/tests/test_trigger_decoder.cpp
+++ b/unit_tests/tests/test_trigger_decoder.cpp
@@ -691,6 +691,12 @@ static void assertInjectors(const char *msg, int value0, int value1) {
 	assertEqualsM4(msg, "inj#1", value1, enginePins.injectors[1].currentLogicValue);
 }
 
+static void setArray(float* p, size_t count, float value) {
+	while (count--) {
+		*p++ = value;
+	}
+}
+
 void doTestFuelSchedulerBug299smallAndMedium(int startUpDelayMs) {
 	printf("*************************************************** testFuelSchedulerBug299 small to medium\r\n");
 
@@ -705,8 +711,9 @@ void doTestFuelSchedulerBug299smallAndMedium(int startUpDelayMs) {
 
 	int engineLoadIndex = findIndex(config->fuelLoadBins, FUEL_LOAD_COUNT, testMafValue);
 	ASSERT_EQ(8, engineLoadIndex);
-	setArrayValues(fuelMap.pointers[engineLoadIndex], 25);
-	setArrayValues(fuelMap.pointers[engineLoadIndex + 1], 25);
+	setArray(fuelMap.pointers[engineLoadIndex], FUEL_RPM_COUNT, 25);
+	setArray(fuelMap.pointers[engineLoadIndex + 1], FUEL_RPM_COUNT, 25);
+	
 
 	engine->periodicFastCallback(PASS_ENGINE_PARAMETER_SIGNATURE);
 	ASSERT_FLOAT_EQ(12.5, engine->injectionDuration) << "fuel#2_0";
@@ -866,8 +873,8 @@ void doTestFuelSchedulerBug299smallAndMedium(int startUpDelayMs) {
 	assertInjectionEvent("#2#", &t->elements[2], 0, 1, 315);
 	assertInjectionEvent("#3#", &t->elements[3], 1, 0, 45 + 90);
 
-	setArrayValues(fuelMap.pointers[engineLoadIndex], 35);
-	setArrayValues(fuelMap.pointers[engineLoadIndex + 1], 35);
+	setArray(fuelMap.pointers[engineLoadIndex], FUEL_RPM_COUNT, 35);
+	setArray(fuelMap.pointers[engineLoadIndex + 1], FUEL_RPM_COUNT, 35);
 	engine->periodicFastCallback(PASS_ENGINE_PARAMETER_SIGNATURE);
 	assertEqualsM("fuel#3", 17.5, engine->injectionDuration);
 	// duty cycle above 75% is a special use-case because 'special' fuel event overlappes the next normal event in batch mode
@@ -957,8 +964,8 @@ TEST(big, testDifferentInjectionModes) {
 	// set fuel map values - extract method?
 	int engineLoadIndex = findIndex(config->fuelLoadBins, FUEL_LOAD_COUNT, testMafValue);
 	ASSERT_EQ(8, engineLoadIndex);
-	setArrayValues(fuelMap.pointers[engineLoadIndex], 40);
-	setArrayValues(fuelMap.pointers[engineLoadIndex + 1], 40);
+	setArray(fuelMap.pointers[engineLoadIndex], FUEL_RPM_COUNT, 40);
+	setArray(fuelMap.pointers[engineLoadIndex + 1], FUEL_RPM_COUNT, 40);
 
 	engine->periodicFastCallback(PASS_ENGINE_PARAMETER_SIGNATURE);
 	assertEqualsM("injectionMode IM_BATCH", (int)IM_BATCH, (int)engineConfiguration->injectionMode);
@@ -988,8 +995,8 @@ TEST(big, testFuelSchedulerBug299smallAndLarge) {
 	// set fuel map values - extract method?
 	int engineLoadIndex = findIndex(config->fuelLoadBins, FUEL_LOAD_COUNT, testMafValue);
 	ASSERT_EQ(8, engineLoadIndex);
-	setArrayValues(fuelMap.pointers[engineLoadIndex], 35);
-	setArrayValues(fuelMap.pointers[engineLoadIndex + 1], 35);
+	setArray(fuelMap.pointers[engineLoadIndex], FUEL_RPM_COUNT, 35);
+	setArray(fuelMap.pointers[engineLoadIndex + 1], FUEL_RPM_COUNT, 35);
 
 	engine->periodicFastCallback(PASS_ENGINE_PARAMETER_SIGNATURE);
 	ASSERT_FLOAT_EQ(17.5, engine->injectionDuration) << "Lfuel#2_1";
@@ -1052,8 +1059,8 @@ TEST(big, testFuelSchedulerBug299smallAndLarge) {
 	eth.executeActions();
 	ASSERT_EQ( 0,  engine->executor.size()) << "Lqs#04";
 
-	setArrayValues(fuelMap.pointers[engineLoadIndex], 4);
-	setArrayValues(fuelMap.pointers[engineLoadIndex + 1], 4);
+	setArray(fuelMap.pointers[engineLoadIndex], FUEL_RPM_COUNT, 4);
+	setArray(fuelMap.pointers[engineLoadIndex + 1], FUEL_RPM_COUNT, 4);
 
 	engine->periodicFastCallback(PASS_ENGINE_PARAMETER_SIGNATURE);
 	ASSERT_EQ( 2,  engine->injectionDuration) << "Lfuel#4";

--- a/unit_tests/tests/test_trigger_decoder.cpp
+++ b/unit_tests/tests/test_trigger_decoder.cpp
@@ -705,8 +705,8 @@ void doTestFuelSchedulerBug299smallAndMedium(int startUpDelayMs) {
 
 	int engineLoadIndex = findIndex(config->fuelLoadBins, FUEL_LOAD_COUNT, testMafValue);
 	ASSERT_EQ(8, engineLoadIndex);
-	setArrayValues(fuelMap.pointers[engineLoadIndex], FUEL_RPM_COUNT, 25);
-	setArrayValues(fuelMap.pointers[engineLoadIndex + 1], FUEL_RPM_COUNT, 25);
+	setArrayValues(fuelMap.pointers[engineLoadIndex], 25);
+	setArrayValues(fuelMap.pointers[engineLoadIndex + 1], 25);
 
 	engine->periodicFastCallback(PASS_ENGINE_PARAMETER_SIGNATURE);
 	ASSERT_FLOAT_EQ(12.5, engine->injectionDuration) << "fuel#2_0";
@@ -866,8 +866,8 @@ void doTestFuelSchedulerBug299smallAndMedium(int startUpDelayMs) {
 	assertInjectionEvent("#2#", &t->elements[2], 0, 1, 315);
 	assertInjectionEvent("#3#", &t->elements[3], 1, 0, 45 + 90);
 
-	setArrayValues(fuelMap.pointers[engineLoadIndex], FUEL_RPM_COUNT, 35);
-	setArrayValues(fuelMap.pointers[engineLoadIndex + 1], FUEL_RPM_COUNT, 35);
+	setArrayValues(fuelMap.pointers[engineLoadIndex], 35);
+	setArrayValues(fuelMap.pointers[engineLoadIndex + 1], 35);
 	engine->periodicFastCallback(PASS_ENGINE_PARAMETER_SIGNATURE);
 	assertEqualsM("fuel#3", 17.5, engine->injectionDuration);
 	// duty cycle above 75% is a special use-case because 'special' fuel event overlappes the next normal event in batch mode
@@ -957,8 +957,8 @@ TEST(big, testDifferentInjectionModes) {
 	// set fuel map values - extract method?
 	int engineLoadIndex = findIndex(config->fuelLoadBins, FUEL_LOAD_COUNT, testMafValue);
 	ASSERT_EQ(8, engineLoadIndex);
-	setArrayValues(fuelMap.pointers[engineLoadIndex], FUEL_RPM_COUNT, 40);
-	setArrayValues(fuelMap.pointers[engineLoadIndex + 1], FUEL_RPM_COUNT, 40);
+	setArrayValues(fuelMap.pointers[engineLoadIndex], 40);
+	setArrayValues(fuelMap.pointers[engineLoadIndex + 1], 40);
 
 	engine->periodicFastCallback(PASS_ENGINE_PARAMETER_SIGNATURE);
 	assertEqualsM("injectionMode IM_BATCH", (int)IM_BATCH, (int)engineConfiguration->injectionMode);
@@ -988,8 +988,8 @@ TEST(big, testFuelSchedulerBug299smallAndLarge) {
 	// set fuel map values - extract method?
 	int engineLoadIndex = findIndex(config->fuelLoadBins, FUEL_LOAD_COUNT, testMafValue);
 	ASSERT_EQ(8, engineLoadIndex);
-	setArrayValues(fuelMap.pointers[engineLoadIndex], FUEL_RPM_COUNT, 35);
-	setArrayValues(fuelMap.pointers[engineLoadIndex + 1], FUEL_RPM_COUNT, 35);
+	setArrayValues(fuelMap.pointers[engineLoadIndex], 35);
+	setArrayValues(fuelMap.pointers[engineLoadIndex + 1], 35);
 
 	engine->periodicFastCallback(PASS_ENGINE_PARAMETER_SIGNATURE);
 	ASSERT_FLOAT_EQ(17.5, engine->injectionDuration) << "Lfuel#2_1";
@@ -1052,8 +1052,8 @@ TEST(big, testFuelSchedulerBug299smallAndLarge) {
 	eth.executeActions();
 	ASSERT_EQ( 0,  engine->executor.size()) << "Lqs#04";
 
-	setArrayValues(fuelMap.pointers[engineLoadIndex], FUEL_RPM_COUNT, 4);
-	setArrayValues(fuelMap.pointers[engineLoadIndex + 1], FUEL_RPM_COUNT, 4);
+	setArrayValues(fuelMap.pointers[engineLoadIndex], 4);
+	setArrayValues(fuelMap.pointers[engineLoadIndex + 1], 4);
 
 	engine->periodicFastCallback(PASS_ENGINE_PARAMETER_SIGNATURE);
 	ASSERT_EQ( 2,  engine->injectionDuration) << "Lfuel#4";


### PR DESCRIPTION
Don't need to pass length - it's an opportunity for a bug.  Use a `TSize` template parameter to bind the length of the passed array.