### PR TITLE
Perf trace housekeeping

### DIFF
--- a/firmware/console/binary/tunerstudio.cpp
+++ b/firmware/console/binary/tunerstudio.cpp
@@ -865,7 +865,6 @@ int tunerStudioHandleCrcCommand(ts_channel_s *tsChannel, char *data, int incomin
 		{
 			auto trace = perfTraceGetBuffer();
 			sr5SendResponse(tsChannel, TS_CRC, trace.Buffer, trace.Size);
-
 		}
 
 		break;

--- a/firmware/console/binary/tunerstudio.cpp
+++ b/firmware/console/binary/tunerstudio.cpp
@@ -855,22 +855,21 @@ int tunerStudioHandleCrcCommand(ts_channel_s *tsChannel, char *data, int incomin
 		}
 
 		break;
-	case TS_PERF_TRACE_BEGIN:
+#endif /* EFI_TOOTH_LOGGER */
 #if ENABLE_PERF_TRACE
+	case TS_PERF_TRACE_BEGIN:
 		perfTraceEnable();
 		sendOkResponse(tsChannel, TS_CRC);
-
-#endif /* ENABLE_PERF_TRACE */
 		break;
 	case TS_PERF_TRACE_GET_BUFFER:
 		{
-#if ENABLE_PERF_TRACE
 			auto trace = perfTraceGetBuffer();
 			sr5SendResponse(tsChannel, TS_CRC, trace.Buffer, trace.Size);
-#endif /* ENABLE_PERF_TRACE */
+
 		}
-#endif /* EFI_TOOTH_LOGGER */
+
 		break;
+#endif /* ENABLE_PERF_TRACE */
 	default:
 		tunerStudioError("ERROR: ignoring unexpected command");
 		return false;

--- a/firmware/development/perf_trace.h
+++ b/firmware/development/perf_trace.h
@@ -58,21 +58,9 @@ enum class PE : uint8_t {
 	// please note that the tool requires a comma at the end of last value
 };
 
-void perfEventBegin(PE event, uint8_t data);
-void perfEventEnd(PE event, uint8_t data);
-void perfEventInstantGlobal(PE event, uint8_t data);
-
-inline void perfEventBegin(PE event) {
-	perfEventBegin(event, 0);
-}
-
-inline void perfEventEnd(PE event) {
-	perfEventEnd(event, 0);
-}
-
-inline void perfEventInstantGlobal(PE event) {
-	perfEventInstantGlobal(event, 0);
-}
+void perfEventBegin(PE event, uint8_t data = 0);
+void perfEventEnd(PE event, uint8_t data = 0);
+void perfEventInstantGlobal(PE event, uint8_t data = 0);
 
 // Enable one buffer's worth of perf tracing, and retrieve the buffer size in bytes
 void perfTraceEnable();
@@ -86,6 +74,7 @@ struct TraceBufferResult
 // Retrieve the trace buffer
 const TraceBufferResult perfTraceGetBuffer();
 
+#if ENABLE_PERF_TRACE
 class ScopePerf
 {
 public:
@@ -93,19 +82,24 @@ public:
 
 	ScopePerf(PE event, uint8_t data) : m_event(event), m_data(data)
 	{
-#if ENABLE_PERF_TRACE
 		perfEventBegin(event, data);
-#endif /* ENABLE_PERF_TRACE */
 	}
 
 	~ScopePerf()
 	{
-#if ENABLE_PERF_TRACE
 		perfEventEnd(m_event, m_data);
-#endif /* ENABLE_PERF_TRACE */
 	}
 
 private:
 	const PE m_event;
 	const uint8_t m_data;
 };
+
+#else /* if ENABLE_PERF_TRACE */
+
+struct ScopePerf {
+	ScopePerf(PE event) { (void)event; }
+	ScopePerf(PE event, uint8_t data) { (void)event; (void)data; }
+};
+
+#endif /* ENABLE_PERF_TRACE */


### PR DESCRIPTION
- Use default parameters instead of overloads
- Replace `ScopePerf` implementation when disabled (saves stack space - compiler isn't allowed to rearrange/remove members even if they're unused)