### PR TITLE
copyArray helper

### DIFF
--- a/firmware/config/boards/proteus/board_configuration.cpp
+++ b/firmware/config/boards/proteus/board_configuration.cpp
@@ -15,37 +15,43 @@
 
 EXTERN_ENGINE;
 
-static void setInjectorPins() {
-	boardConfiguration->injectionPins[0] = GPIOD_7;
-	boardConfiguration->injectionPins[1] = GPIOG_9;
-	boardConfiguration->injectionPins[2] = GPIOG_10;
-	boardConfiguration->injectionPins[3] = GPIOG_11;
-	boardConfiguration->injectionPins[4] = GPIOG_12;
-	boardConfiguration->injectionPins[5] = GPIOG_13;
-	boardConfiguration->injectionPins[6] = GPIOG_14;
-	boardConfiguration->injectionPins[7] = GPIOB_4;
-	boardConfiguration->injectionPins[8] = GPIOB_5;
-	boardConfiguration->injectionPins[9] = GPIOB_6;
-	boardConfiguration->injectionPins[10] = GPIOB_7;
-	boardConfiguration->injectionPins[11] = GPIOB_8;
+static const brain_pin_e injPins[] = {
+	GPIOD_7,
+	GPIOG_9,
+	GPIOG_10,
+	GPIOG_11,
+	GPIOG_12,
+	GPIOG_13,
+	GPIOG_14,
+	GPIOB_4,
+	GPIOB_5,
+	GPIOB_6,
+	GPIOB_7,
+	GPIOB_8
+};
 
+static const brain_pin_e ignPins[] = {
+	GPIOD_4,
+	GPIOD_3,
+	GPIOC_9,
+	GPIOC_8,
+	GPIOC_7,
+	GPIOG_8,
+	GPIOG_7,
+	GPIOG_6,
+	GPIOG_5,
+	GPIOG_4,
+	GPIOG_3,
+	GPIOG_2,
+};
+
+static void setInjectorPins() {
+	copyArray(boardConfiguration->injectionPins, injPins);
 	boardConfiguration->injectionPinMode = OM_DEFAULT;
 }
 
 static void setIgnitionPins() {
-	boardConfiguration->ignitionPins[0] = GPIOD_4;
-	boardConfiguration->ignitionPins[1] = GPIOD_3;
-	boardConfiguration->ignitionPins[2] = GPIOC_9;
-	boardConfiguration->ignitionPins[3] = GPIOC_8;
-	boardConfiguration->ignitionPins[4] = GPIOC_7;
-	boardConfiguration->ignitionPins[5] = GPIOG_8;
-	boardConfiguration->ignitionPins[6] = GPIOG_7;
-	boardConfiguration->ignitionPins[7] = GPIOG_6;
-	boardConfiguration->ignitionPins[8] = GPIOG_5;
-	boardConfiguration->ignitionPins[9] = GPIOG_4;
-	boardConfiguration->ignitionPins[10] = GPIOG_3;
-	boardConfiguration->ignitionPins[11] = GPIOG_2;
-
+	copyArray(boardConfiguration->ignitionPins, ignPins);
 	boardConfiguration->ignitionPinMode = OM_DEFAULT;
 }
 

--- a/firmware/config/engines/ford_festiva.cpp
+++ b/firmware/config/engines/ford_festiva.cpp
@@ -87,22 +87,28 @@ void setFordEscortGt(DECLARE_CONFIG_PARAMETER_SIGNATURE) {
 	setFuelLoadBin(1.2, 4.4 PASS_CONFIG_PARAMETER_SUFFIX);
 	setFuelRpmBin(800, 7000 PASS_CONFIG_PARAMETER_SUFFIX);
 
-	config->veRpmBins[0] = 800;
-	config->veRpmBins[1] = 1200;
-	config->veRpmBins[2] = 1600;
-	config->veRpmBins[3] = 2000;
-	config->veRpmBins[4] = 2400;
-	config->veRpmBins[5] = 2800;
-	config->veRpmBins[6] = 3200;
-	config->veRpmBins[7] = 3600;
-	config->veRpmBins[8] = 4100;
-	config->veRpmBins[9] = 4500;
-	config->veRpmBins[10] = 4900;
-	config->veRpmBins[11] = 5300;
-	config->veRpmBins[12] = 5700;
-	config->veRpmBins[13] = 6100;
-	config->veRpmBins[14] = 6500;
-	config->veRpmBins[15] = 7000;
+	static const float veRpmBins[] = 
+	{
+		800,
+		1200,
+		1600,
+		2000,
+		2400,
+		2800,
+		3200,
+		3600,
+		4100,
+		4500,
+		4900,
+		5300,
+		5700,
+		6100,
+		6500,
+		7000
+	};
+
+	copyArray(config->veRpmBins, veRpmBins);
+
 
 	copyFuelTable(racingFestivaVeTable, config->veTable);
 
@@ -252,22 +258,28 @@ void setFordEscortGt(DECLARE_CONFIG_PARAMETER_SIGNATURE) {
 	setFsio(1, GPIOD_7, RPM_ABOVE_USER_SETTING_2 PASS_CONFIG_PARAMETER_SUFFIX);
 #endif /* EFI_FSIO */
 
-	config->ignitionRpmBins[0] = 800;
-	config->ignitionRpmBins[1] = 1200;
-	config->ignitionRpmBins[2] = 1600;
-	config->ignitionRpmBins[3] = 2000;
-	config->ignitionRpmBins[4] = 2400;
-	config->ignitionRpmBins[5] = 2800;
-	config->ignitionRpmBins[6] = 3200;
-	config->ignitionRpmBins[7] = 3600;
-	config->ignitionRpmBins[8] = 4100;
-	config->ignitionRpmBins[9] = 4500;
-	config->ignitionRpmBins[10] = 4900;
-	config->ignitionRpmBins[11] = 5300;
-	config->ignitionRpmBins[12] = 5700;
-	config->ignitionRpmBins[13] = 6100;
-	config->ignitionRpmBins[14] = 6500;
-	config->ignitionRpmBins[15] = 7000;
+	static const float ignitionRpmBins[] =
+	{
+		800,
+		1200,
+		1600,
+		2000,
+		2400,
+		2800,
+		3200,
+		3600,
+		4100,
+		4500,
+		4900,
+		5300,
+		5700,
+		6100,
+		6500,
+		7000
+	};
+
+	copyArray(config->ignitionRpmBins, ignitionRpmBins);
+
 #if IGN_LOAD_COUNT == DEFAULT_IGN_LOAD_COUNT
 	copyTimingTable(racingFestivaIgnitionTable, config->ignitionTable);
 #endif

--- a/firmware/controllers/algo/engine_configuration.cpp
+++ b/firmware/controllers/algo/engine_configuration.cpp
@@ -431,20 +431,41 @@ static void setDefaultWarmupIdleCorrection(DECLARE_CONFIG_PARAMETER_SIGNATURE) {
 }
 
 static void setDefaultWarmupFuelEnrichment(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
-	initTemperatureCurve(WARMUP_CLT_EXTRA_FUEL_CURVE, 1.0);
+	static const float bins[] =
+	{
+		-40,
+		-30,
+		-20,
+		-10,
+		0,
+		10,
+		20,
+		30,
+		40,
+		50,
+		60,
+		70
+	};
 
-	setCurveValue(WARMUP_CLT_EXTRA_FUEL_CURVE, -40, 1.50);
-	setCurveValue(WARMUP_CLT_EXTRA_FUEL_CURVE, -30, 1.50);
-	setCurveValue(WARMUP_CLT_EXTRA_FUEL_CURVE, -20, 1.42);
-	setCurveValue(WARMUP_CLT_EXTRA_FUEL_CURVE, -10, 1.36);
-	setCurveValue(WARMUP_CLT_EXTRA_FUEL_CURVE, 0, 1.28);
-	setCurveValue(WARMUP_CLT_EXTRA_FUEL_CURVE, 10, 1.19);
-	setCurveValue(WARMUP_CLT_EXTRA_FUEL_CURVE, 20, 1.12);
-	setCurveValue(WARMUP_CLT_EXTRA_FUEL_CURVE, 30, 1.10);
-	setCurveValue(WARMUP_CLT_EXTRA_FUEL_CURVE, 40, 1.06);
-	setCurveValue(WARMUP_CLT_EXTRA_FUEL_CURVE, 50, 1.06);
-	setCurveValue(WARMUP_CLT_EXTRA_FUEL_CURVE, 60, 1.03);
-	setCurveValue(WARMUP_CLT_EXTRA_FUEL_CURVE, 70, 1.01);
+	copyArrayPartial(config->cltFuelCorrBins, bins);
+
+	static const float values[] =
+	{
+		1.50,
+		1.50,
+		1.42,
+		1.36,
+		1.28,
+		1.19,
+		1.12,
+		1.10,
+		1.06,
+		1.06,
+		1.03,
+		1.01
+	};
+
+	copyArrayPartial(config->cltFuelCorr, values);
 }
 
 static void setDefaultFuelCutParameters(DECLARE_ENGINE_PARAMETER_SIGNATURE) {

--- a/firmware/controllers/algo/engine_configuration.cpp
+++ b/firmware/controllers/algo/engine_configuration.cpp
@@ -444,10 +444,14 @@ static void setDefaultWarmupFuelEnrichment(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 		40,
 		50,
 		60,
-		70
+		70,
+		80,
+		90,
+		100,
+		110
 	};
 
-	copyArrayPartial(config->cltFuelCorrBins, bins);
+	copyArray(config->cltFuelCorrBins, bins);
 
 	static const float values[] =
 	{
@@ -462,10 +466,14 @@ static void setDefaultWarmupFuelEnrichment(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 		1.06,
 		1.06,
 		1.03,
-		1.01
+		1.01,
+		1,
+		1,
+		1,
+		1
 	};
 
-	copyArrayPartial(config->cltFuelCorr, values);
+	copyArray(config->cltFuelCorr, values);
 }
 
 static void setDefaultFuelCutParameters(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
@@ -486,54 +494,64 @@ static void setDefaultCrankingSettings(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 	setLinearCurve(config->cltCrankingCorrBins, CLT_CURVE_RANGE_FROM, 100, 1);
 	setLinearCurve(config->cltCrankingCorr, 1.0, 1.0, 1);
 
-	config->crankingFuelCoef[0] = 2.8; // base cranking fuel adjustment coefficient
-	config->crankingFuelBins[0] = -20; // temperature in C
-	config->crankingFuelCoef[1] = 2.2;
-	config->crankingFuelBins[1] = -10;
-	config->crankingFuelCoef[2] = 1.8;
-	config->crankingFuelBins[2] = 5;
-	config->crankingFuelCoef[3] = 1.5;
-	config->crankingFuelBins[3] = 30;
+	// Cranking temperature compensation
+	static const float crankingCoef[] = {
+		2.8,
+		2.2,
+		1.8,
+		1.5,
+		1.0,
+		1.0,
+		1.0,
+		1.0
+	};
+	copyArray(config->crankingFuelCoef, crankingCoef);
 
-	config->crankingFuelCoef[4] = 1.0;
-	config->crankingFuelBins[4] = 35;
-	config->crankingFuelCoef[5] = 1.0;
-	config->crankingFuelBins[5] = 50;
-	config->crankingFuelCoef[6] = 1.0;
-	config->crankingFuelBins[6] = 65;
-	config->crankingFuelCoef[7] = 1.0;
-	config->crankingFuelBins[7] = 90;
+	// Deg C
+	static const float crankingBins[] = {
+		-20,
+		-10,
+		5,
+		30,
+		35,
+		50,
+		65,
+		90
+	};
+	copyArray(config->crankingFuelBins, crankingBins);
 
-	config->crankingCycleCoef[0] = 1.5;
-	config->crankingCycleBins[0] = 4;
+	// Cranking cycle compensation
 
-	config->crankingCycleCoef[1] = 1.35;
-	config->crankingCycleBins[1] = 8;
+	static const float crankingCycleCoef[] = {
+		1.5,
+		1.35,
+		1.05,
+		0.75,
+		0.5,
+		0.5,
+		0.5,
+		0.5
+	};
+	copyArray(config->crankingCycleCoef, crankingCycleCoef);
 
-	config->crankingCycleCoef[2] = 1.05;
-	config->crankingCycleBins[2] = 12;
+	static const float crankingCycleBins[] = {
+		4,
+		8,
+		12,
+		16,
+		74,
+		75,
+		76,
+		77
+	};
+	copyArray(config->crankingCycleBins, crankingCycleBins);
 
-	config->crankingCycleCoef[3] = 0.75;
-	config->crankingCycleBins[3] = 16;
+	// Cranking ignition timing
+	static const float advanceValues[] = { 0, 0, 0, 0 };
+	copyArray(engineConfiguration->crankingAdvance, advanceValues);
 
-	config->crankingCycleCoef[4] = 0.5;
-	config->crankingCycleBins[4] = 74;
-	config->crankingCycleCoef[5] = 0.5;
-	config->crankingCycleBins[5] = 75;
-	config->crankingCycleCoef[6] = 0.5;
-	config->crankingCycleBins[6] = 76;
-	config->crankingCycleCoef[7] = 0.5;
-	config->crankingCycleBins[7] = 77;
-
-	engineConfiguration->crankingAdvance[0] = 0;
-	engineConfiguration->crankingAdvanceBins[0] = 0;
-	engineConfiguration->crankingAdvance[1] = 0;
-	engineConfiguration->crankingAdvanceBins[1] = 200;
-	engineConfiguration->crankingAdvance[2] = 0;
-	engineConfiguration->crankingAdvanceBins[2] = 400;
-	engineConfiguration->crankingAdvance[3] = 0;
-	engineConfiguration->crankingAdvanceBins[3] = 1000;
-
+	static const float advanceBins[] = { 0, 200, 400, 1000 };
+	copyArray(engineConfiguration->crankingAdvanceBins, advanceBins);
 }
 
 /**
@@ -557,7 +575,6 @@ static void setDefaultIdleSpeedTarget(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 	setCurveValue(engineConfiguration->cltIdleRpmBins, engineConfiguration->cltIdleRpm, CLT_CURVE_SIZE, 90, 900);
 	setCurveValue(engineConfiguration->cltIdleRpmBins, engineConfiguration->cltIdleRpm, CLT_CURVE_SIZE, 100, 1000);
 	setCurveValue(engineConfiguration->cltIdleRpmBins, engineConfiguration->cltIdleRpm, CLT_CURVE_SIZE, 110, 1100);
-
 }
 
 static void setDefaultStepperIdleParameters(DECLARE_ENGINE_PARAMETER_SIGNATURE) {

--- a/firmware/controllers/gauges/malfunction_central.cpp
+++ b/firmware/controllers/gauges/malfunction_central.cpp
@@ -53,8 +53,7 @@ void setError(bool isError, obd_code_e errorCode) {
 
 void getErrorCodes(error_codes_set_s * copy) {
 	copy->count = error_codes_set.count;
-	for (int i = 0; i < copy->count; i++)
-		copy->error_codes[i] = error_codes_set.error_codes[i];
+	copyArray(copy->error_codes, error_codes_set.error_codes);
 }
 
 bool hasErrorCodes(void) {

--- a/firmware/util/containers/cyclic_buffer.h
+++ b/firmware/util/containers/cyclic_buffer.h
@@ -81,9 +81,7 @@ cyclic_buffer<T, maxSize>::cyclic_buffer(const cyclic_buffer& cb) {
 	currentIndex = cb.currentIndex;
 	count = cb.count;
 	size = cb.size;
-	for (int i = 0; i < size; ++i) {
-		elements[i] = cb.elements[i];
-	}
+	copyArray(elements, cb.elements);
 }
 
 template<typename T, size_t maxSize>

--- a/firmware/util/containers/cyclic_buffer.h
+++ b/firmware/util/containers/cyclic_buffer.h
@@ -26,14 +26,6 @@ class cyclic_buffer
   public:
 	cyclic_buffer();
     explicit cyclic_buffer(int size);
-  //cpctor
-    cyclic_buffer(const cyclic_buffer& cb);
-  //dtor
-    ~cyclic_buffer();
-
-  public:
-  //overloaded =operator
-    cyclic_buffer& operator=(const cyclic_buffer& rhCb);
 
   public:
     void add(T value);
@@ -74,31 +66,6 @@ void cyclic_buffer<T, maxSize>::baseC(int size) {
 	memset((void*)&elements, 0, sizeof(elements));
 	setSize(size);
 }
-
-template<typename T, size_t maxSize>
-cyclic_buffer<T, maxSize>::cyclic_buffer(const cyclic_buffer& cb) {
-	//Deep copy the data
-	currentIndex = cb.currentIndex;
-	count = cb.count;
-	size = cb.size;
-	copyArray(elements, cb.elements);
-}
-
-template<typename T, size_t maxSize>
-cyclic_buffer<T, maxSize>::~cyclic_buffer() {
-	//No dynamic allocation - safe to leave
-}
-
-//template<typename T, size_t maxSize>
-//cyclic_buffer& cyclic_buffer<T, maxSize>::operator=(const cyclic_buffer<T, maxSize>& rhCb) {
-//	//Deep copy
-//	currentIndex = rhCb.currentIndex;
-//	count = rhCb.count;
-//	for (int i = 0; i < size; ++i) {
-//		elements[i] = rhCb.elements[i];
-//	}
-//	return *this;
-//}
 
 template<typename T, size_t maxSize>
 void cyclic_buffer<T, maxSize>::add(T value) {

--- a/firmware/util/efilib.h
+++ b/firmware/util/efilib.h
@@ -91,11 +91,34 @@ float expf_taylor(float x);
 namespace efi
 {
 template <typename T, size_t N>
-constexpr size_t size(const T(&)[N])
-{
+constexpr size_t size(const T(&)[N]) {
     return N;
 }
 } // namespace efi
+
+/**
+ * Copies an array from src to dest.  The lengths of the arrays must match.
+ */
+template <typename TElement, size_t N>
+constexpr void copyArray(TElement (&dest)[N], const TElement (&src)[N]) {
+	for (size_t i = 0; i < N; i++) {
+		dest[i] = src[i];
+	}
+}
+
+/**
+ * Copies an array from src to the beginning of dst.  If dst is larger
+ * than src, then only the elements copied from src will be touched.
+ * Any remaining elements at the end will be untouched.
+ */
+template <typename TElement, size_t NSrc, size_t NDest>
+constexpr void copyArrayPartial(TElement (&dest)[NDest], const TElement (&src)[NSrc]) {
+	static_assert(NDest >= NSrc, "Source array must be larger than destination.");
+
+	for (size_t i = 0; i < NSrc; i++) {
+		dest[i] = src[i];
+	}
+}
 
 #endif /* __cplusplus */
 

--- a/firmware/util/math/signal_filtering.c
+++ b/firmware/util/math/signal_filtering.c
@@ -21,8 +21,7 @@ static void addCopyAndSort(SignalFiltering *fs, float value) {
 	fs->values[fs->pointer] = value;
 	fs->pointer = ++fs->pointer == FILTER_SIZE ? 0 : fs->pointer;
 
-	for (int i = 0; i < FILTER_SIZE; i++)
-		fs->sorted[i] = fs->values[i];
+	copyArray(fs->sorted, fs->values);
 
 	for (int i = 0; i < FILTER_SIZE; i++)
 		for (int j = i + 1; j < FILTER_SIZE; j++)


### PR DESCRIPTION
Saves code and data space by storing constant arrays as arrays, then simply copying them in to place instead of hand setting every element.  The new functions are also useful as they guarantee that you can't overrun the destination array.