### PR TITLE
ETB Encapsulation & C++ Conventions

### DIFF
--- a/firmware/console/binary/tunerstudio.cpp
+++ b/firmware/console/binary/tunerstudio.cpp
@@ -275,7 +275,7 @@ static const void * getStructAddr(int structId) {
 		return static_cast<trigger_state_s*>(&engine->triggerCentral.triggerState);
 #if EFI_ELECTRONIC_THROTTLE_BODY
 	case LDS_ETB_PID_STATE_INDEX:
-		return static_cast<pid_state_s*>(&etbController[0].etbPid);
+		return etbController[0].getPidState();
 #endif /* EFI_ELECTRONIC_THROTTLE_BODY */
 
 #ifndef EFI_IDLE_CONTROL

--- a/firmware/controllers/actuators/electronic_throttle.cpp
+++ b/firmware/controllers/actuators/electronic_throttle.cpp
@@ -666,6 +666,7 @@ void initElectronicThrottle(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 
 	for (int i = 0 ; i < ETB_COUNT; i++) {
 		etbController[i].init(&etbHardware[i].dcMotor, i, &engineConfiguration->etb);
+		INJECT_ENGINE_REFERENCE(&etbController[i]);
 	}
 
 

--- a/firmware/controllers/actuators/electronic_throttle.cpp
+++ b/firmware/controllers/actuators/electronic_throttle.cpp
@@ -666,7 +666,6 @@ void initElectronicThrottle(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 
 	for (int i = 0 ; i < ETB_COUNT; i++) {
 		etbController[i].init(&etbHardware[i].dcMotor, i, &engineConfiguration->etb);
-		INJECT_ENGINE_REFERENCE(&etbController[i]);
 	}
 
 

--- a/firmware/controllers/actuators/electronic_throttle.h
+++ b/firmware/controllers/actuators/electronic_throttle.h
@@ -11,10 +11,8 @@
 #define DEFAULT_ETB_LOOP_FREQUENCY 200
 #define DEFAULT_ETB_PWM_FREQUENCY 300
 
-#include "globalaccess.h"
+#include "engine.h"
 #include "periodic_task.h"
-#include "pid.h"
-#include "engine_configuration_generated_structures.h"
 
 class DcMotor;
 class Logging;

--- a/firmware/controllers/actuators/electronic_throttle.h
+++ b/firmware/controllers/actuators/electronic_throttle.h
@@ -11,8 +11,10 @@
 #define DEFAULT_ETB_LOOP_FREQUENCY 200
 #define DEFAULT_ETB_PWM_FREQUENCY 300
 
-#include "engine.h"
+#include "globalaccess.h"
 #include "periodic_task.h"
+#include "pid.h"
+#include "engine_configuration_generated_structures.h"
 
 class DcMotor;
 class Logging;

--- a/firmware/controllers/actuators/electronic_throttle.h
+++ b/firmware/controllers/actuators/electronic_throttle.h
@@ -19,7 +19,6 @@ class Logging;
 
 class EtbController final : public PeriodicTimerController {
 public:
-	DECLARE_ENGINE_PTR;
 	void init(DcMotor *motor, int ownIndex, pid_s *pidParameters);
 	void reset();
 

--- a/firmware/controllers/actuators/electronic_throttle.h
+++ b/firmware/controllers/actuators/electronic_throttle.h
@@ -19,6 +19,7 @@ class Logging;
 
 class EtbController final : public PeriodicTimerController {
 public:
+	DECLARE_ENGINE_PTR;
 	void init(DcMotor *motor, int ownIndex, pid_s *pidParameters);
 	void reset();
 

--- a/firmware/controllers/actuators/electronic_throttle.h
+++ b/firmware/controllers/actuators/electronic_throttle.h
@@ -15,20 +15,33 @@
 #include "periodic_task.h"
 
 class DcMotor;
+class Logging;
 
 class EtbController final : public PeriodicTimerController {
 public:
 	DECLARE_ENGINE_PTR;
-	void init(DcMotor *motor, int ownIndex);
+	void init(DcMotor *motor, int ownIndex, pid_s *pidParameters);
+	void reset();
 
+	// PeriodicTimerController implementation
 	int getPeriodMs() override;
 	void PeriodicTask() override;
-	Pid etbPid;
-	bool shouldResetPid = false;
+
+	// Called when the configuration may have changed.  Controller will
+	// reset if necessary.
+	void onConfigurationChange(pid_s* previousConfiguration);
+	
+	// Print this throttle's status.
+	void showStatus(Logging* logger);
+
+	// Used to inspect the internal PID controller's state
+	const pid_state_s* getPidState() const { return &m_pid; };
 
 private:
-	int ownIndex;
-    DcMotor *m_motor;
+	int m_myIndex;
+	DcMotor *m_motor;
+	Pid m_pid;
+	bool m_shouldResetPid = false;
 };
 
 void initElectronicThrottle(DECLARE_ENGINE_PARAMETER_SIGNATURE);


### PR DESCRIPTION
No longer does any logic prod the innards of the ETB controller. Hooray!

~~No longer requires `INJECT_ENGINE_REFERENCE` for `EtbController`!~~ Nope, that was a lie.

Makes naming and conventions more in line with C++ conventions.  That means prefixing member variables with `m_`, and not using `this->` when accessing.

This also fixes the bug that multiple ETBs will overwrite each other's state in the tunerstudio outputs, making the gauges useless.