### PR TITLE
DRAFT simplify dequeue logic

### DIFF
--- a/firmware/controllers/system/timer/event_queue.cpp
+++ b/firmware/controllers/system/timer/event_queue.cpp
@@ -165,10 +165,6 @@ int EventQueue::executeAll(efitime_t now) {
 #endif
 	}
 
-#if EFI_UNIT_TEST
-	assertListIsSorted();
-#endif
-
 	return executionCounter;
 }
 

--- a/firmware/controllers/system/timer/event_queue.cpp
+++ b/firmware/controllers/system/timer/event_queue.cpp
@@ -183,7 +183,6 @@ void EventQueue::assertListIsSorted() const {
 	}
 }
 
-
 void EventQueue::setLateDelay(int value) {
 	lateDelay = value;
 }

--- a/firmware/controllers/system/timer/event_queue.cpp
+++ b/firmware/controllers/system/timer/event_queue.cpp
@@ -129,6 +129,8 @@ int EventQueue::executeAll(efitime_t now) {
 #endif
 
 	while (true) {
+		// Read the head every time - a previously executed event could
+		// have inserted something new at the head
 		scheduling_s* current = head;
 
 		// Queue is empty - bail
@@ -136,7 +138,7 @@ int EventQueue::executeAll(efitime_t now) {
 			break;
 		}
 
-		// Only execute events that occured in the past
+		// Only execute events that occured in the past.
 		// The list is sorted, so as soon as we see an event
 		// in the future, we're done.
 		if (current->momentX > now) {
@@ -145,7 +147,7 @@ int EventQueue::executeAll(efitime_t now) {
 
 		executionCounter++;
 
-		// step the head forward and unlink this element
+		// step the head forward, unlink this element, clear scheduled flag
 		head = current->nextScheduling_s;
 		current->nextScheduling_s = nullptr;
 		current->isScheduled = false;
@@ -161,7 +163,8 @@ int EventQueue::executeAll(efitime_t now) {
 		}
 
 #if EFI_UNIT_TEST
-		assertListIsSorted();
+	// (tests only) Ensure we didn't break anything
+	assertListIsSorted();
 #endif
 	}
 

--- a/firmware/controllers/system/timer/event_queue.cpp
+++ b/firmware/controllers/system/timer/event_queue.cpp
@@ -122,72 +122,53 @@ static uint32_t lastEventCallbackDuration;
 int EventQueue::executeAll(efitime_t now) {
 	ScopePerf perf(PE::EventQueueExecuteAll);
 
-
-	scheduling_s * current, *tmp;
-
-	scheduling_s * executionList = nullptr;
-	scheduling_s * lastInExecutionList = nullptr;
-
-	int listIterationCounter = 0;
 	int executionCounter = 0;
-	// we need safe iteration because we are removing elements inside the loop
-	LL_FOREACH_SAFE2(head, current, tmp, nextScheduling_s)
-	{
-		if (++listIterationCounter > QUEUE_LENGTH_LIMIT) {
-			firmwareError(CUSTOM_LIST_LOOP, "Is this list looped?");
-			return false;
-		}
-		if (current->momentX <= now) {
-			executionCounter++;
-			efiAssert(CUSTOM_ERR_ASSERT, head == current, "removing from head", -1);
-			//LL_DELETE(head, current);
-			head = head->nextScheduling_s;
-			if (executionList == NULL) {
-				lastInExecutionList = executionList = current;
-			} else {
-				lastInExecutionList->nextScheduling_s = current;
-				lastInExecutionList = current;
-			}
-			current->nextScheduling_s = nullptr;
-		} else {
-			/**
-			 * The list is sorted. Once we find one action in the future, all the remaining ones
-			 * are also in the future.
-			 */
-			break;
-		}
-	}
+
 #if EFI_UNIT_TEST
 	assertListIsSorted();
 #endif
 
-	/*
-	 * we need safe iteration here because 'callback' might change change 'current->next'
-	 * while re-inserting it into the queue from within the callback
-	 */
-	LL_FOREACH_SAFE2(executionList, current, tmp, nextScheduling_s) {
-		uint32_t before = getTimeNowLowerNt();
+	while (true) {
+		scheduling_s* current = head;
+
+		// Queue is empty - bail
+		if (!current) {
+			break;
+		}
+
+		// Only execute events that occured in the past
+		// The list is sorted, so as soon as we see an event
+		// in the future, we're done.
+		if (current->momentX > now) {
+			break;
+		}
+
+		executionCounter++;
+
+		// step the head forward and unlink this element
+		head = current->nextScheduling_s;
+		current->nextScheduling_s = nullptr;
 		current->isScheduled = false;
-		uint32_t howFarOff = now - current->momentX;
-		maxSchedulingPrecisionLoss = maxI(maxSchedulingPrecisionLoss, howFarOff);
+
 #if EFI_UNIT_TEST
 		printf("QUEUE: execute current=%d param=%d\r\n", (long)current, (long)current->action.getArgument());
 #endif
 
+		// Execute the current element
 		{
 			ScopePerf perf2(PE::EventQueueExecuteCallback);
 			current->action.execute();
 		}
 
-		// even with overflow it's safe to subtract here
-		lastEventCallbackDuration = getTimeNowLowerNt() - before;
-		if (lastEventCallbackDuration > maxEventCallbackDuration)
-			maxEventCallbackDuration = lastEventCallbackDuration;
-		if (lastEventCallbackDuration > 2000) {
-			longScheduling = current;
-// what is this line about?			lastEventCallbackDuration++;
-		}
+#if EFI_UNIT_TEST
+		assertListIsSorted();
+#endif
 	}
+
+#if EFI_UNIT_TEST
+	assertListIsSorted();
+#endif
+
 	return executionCounter;
 }
 
@@ -198,7 +179,6 @@ int EventQueue::size(void) const {
 	return result;
 }
 
-#if EFI_UNIT_TEST
 void EventQueue::assertListIsSorted() const {
 	scheduling_s *current = head;
 	while (current != NULL && current->nextScheduling_s != NULL) {
@@ -206,7 +186,7 @@ void EventQueue::assertListIsSorted() const {
 		current = current->nextScheduling_s;
 	}
 }
-#endif
+
 
 void EventQueue::setLateDelay(int value) {
 	lateDelay = value;


### PR DESCRIPTION
For some reason, dequeuing events from our scheduler queue was a two phase process:
1) move all events that are due to run to their own temporary list
2) execute everything in that list.

I can't come up with a good reason for why we were doing that.

This change simply pops elements off the head one at a time, and executes them, instead of the aforementioned complicated (and slow) logic.

Unit tests pass, but pending testing on real hardware.