### PR TITLE
Make stacks smaller

### DIFF
--- a/firmware/config/boards/kinetis/chconf.h
+++ b/firmware/config/boards/kinetis/chconf.h
@@ -44,12 +44,13 @@
  *
  */
 
-#define PORT_IDLE_THREAD_STACK_SIZE     64/*768*//*1024*/
+#define PORT_IDLE_THREAD_STACK_SIZE     32
 
-// rusEfi main processing happens on IRQ so PORT_INT_REQUIRED_STACK has to be pretty large.
-// see also a strange comment about PORT_INT_REQUIRED_STACK in global_shared.h
+// PORT_INT_REQUIRED_STACK is the stack space added to every thread's stack so that even if the thread
+// has used all of its stack space, an interrupt can still occur, and the hardware can push the
+// execution context before switching to the main stack to execute the interrupt.
 // see also http://www.chibios.org/dokuwiki/doku.php?id=chibios:kb:stacks
-#define PORT_INT_REQUIRED_STACK 	512/*768*/
+#define PORT_INT_REQUIRED_STACK 	128
 
 #define CHPRINTF_USE_FLOAT          	TRUE
 

--- a/firmware/config/boards/kinetis/chconf.h
+++ b/firmware/config/boards/kinetis/chconf.h
@@ -46,9 +46,7 @@
 
 #define PORT_IDLE_THREAD_STACK_SIZE     32
 
-// PORT_INT_REQUIRED_STACK is the stack space added to every thread's stack so that even if the thread
-// has used all of its stack space, an interrupt can still occur, and the hardware can push the
-// execution context before switching to the main stack to execute the interrupt.
+// See global_shared.h notes about stack requirements
 // see also http://www.chibios.org/dokuwiki/doku.php?id=chibios:kb:stacks
 #define PORT_INT_REQUIRED_STACK 	128
 

--- a/firmware/config/stm32f4ems/chconf.h
+++ b/firmware/config/stm32f4ems/chconf.h
@@ -41,12 +41,13 @@
  *
  */
 
-#define PORT_IDLE_THREAD_STACK_SIZE     1024
+#define PORT_IDLE_THREAD_STACK_SIZE     32
 
-// rusEfi main processing happens on IRQ so PORT_INT_REQUIRED_STACK has to be pretty large.
-// see also a strange comment about PORT_INT_REQUIRED_STACK in global_shared.h
+// PORT_INT_REQUIRED_STACK is the stack space added to every thread's stack so that even if the thread
+// has used all of its stack space, an interrupt can still occur, and the hardware can push the
+// execution context before switching to the main stack to execute the interrupt.
 // see also http://www.chibios.org/dokuwiki/doku.php?id=chibios:kb:stacks
-#define PORT_INT_REQUIRED_STACK 	768
+#define PORT_INT_REQUIRED_STACK 	128
 
 #define CHPRINTF_USE_FLOAT          	TRUE
 
@@ -605,7 +606,7 @@
  *          tickless mode.
  */
 #if !defined(CH_DBG_THREADS_PROFILING)
-#define CH_DBG_THREADS_PROFILING            FALSE
+#define CH_DBG_THREADS_PROFILING            TRUE
 #endif
 
 /** @} */

--- a/firmware/config/stm32f4ems/chconf.h
+++ b/firmware/config/stm32f4ems/chconf.h
@@ -43,9 +43,7 @@
 
 #define PORT_IDLE_THREAD_STACK_SIZE     32
 
-// PORT_INT_REQUIRED_STACK is the stack space added to every thread's stack so that even if the thread
-// has used all of its stack space, an interrupt can still occur, and the hardware can push the
-// execution context before switching to the main stack to execute the interrupt.
+// See global_shared.h notes about stack requirements
 // see also http://www.chibios.org/dokuwiki/doku.php?id=chibios:kb:stacks
 #define PORT_INT_REQUIRED_STACK 	128
 

--- a/firmware/config/stm32f7ems/chconf.h
+++ b/firmware/config/stm32f7ems/chconf.h
@@ -41,12 +41,13 @@
  *
  */
 
-#define PORT_IDLE_THREAD_STACK_SIZE     1024
+#define PORT_IDLE_THREAD_STACK_SIZE     32
 
-// rusEfi main processing happens on IRQ so PORT_INT_REQUIRED_STACK has to be pretty large.
-// see also a strange comment about PORT_INT_REQUIRED_STACK in global_shared.h
+// PORT_INT_REQUIRED_STACK is the stack space added to every thread's stack so that even if the thread
+// has used all of its stack space, an interrupt can still occur, and the hardware can push the
+// execution context before switching to the main stack to execute the interrupt.
 // see also http://www.chibios.org/dokuwiki/doku.php?id=chibios:kb:stacks
-#define PORT_INT_REQUIRED_STACK 	768
+#define PORT_INT_REQUIRED_STACK 	128
 
 #define CHPRINTF_USE_FLOAT          	TRUE
 

--- a/firmware/config/stm32f7ems/chconf.h
+++ b/firmware/config/stm32f7ems/chconf.h
@@ -43,9 +43,7 @@
 
 #define PORT_IDLE_THREAD_STACK_SIZE     32
 
-// PORT_INT_REQUIRED_STACK is the stack space added to every thread's stack so that even if the thread
-// has used all of its stack space, an interrupt can still occur, and the hardware can push the
-// execution context before switching to the main stack to execute the interrupt.
+// See global_shared.h notes about stack requirements
 // see also http://www.chibios.org/dokuwiki/doku.php?id=chibios:kb:stacks
 #define PORT_INT_REQUIRED_STACK 	128
 

--- a/firmware/controllers/global_shared.h
+++ b/firmware/controllers/global_shared.h
@@ -13,6 +13,13 @@
 /**
  * The following obscurantism is a hack to reduce stack usage, maybe even a questionable performance
  * optimization.
+ * 
+ * Of note is that interrupts are NOT serviced on the stack of the thread that was running when the
+ * interrupt occurred. The only thing that happens on that thread's stack is that its registers are
+ * pushed (by hardware) when an interrupt occurs, just before swapping the stack pointer out for the
+ * main stack (currently 0x400=1024 bytes), where the ISR actually runs.
+ * 
+ * see also http://www.chibios.org/dokuwiki/doku.php?id=chibios:kb:stacks
  *
  * In the firmware we are using 'extern *Engine' - in the firmware Engine is a signleton
  *

--- a/firmware/controllers/global_shared.h
+++ b/firmware/controllers/global_shared.h
@@ -14,11 +14,6 @@
  * The following obscurantism is a hack to reduce stack usage, maybe even a questionable performance
  * optimization.
  *
- * rusEfi main processing happens on IRQ so PORT_INT_REQUIRED_STACK has to be pretty large. Problem
- * is that PORT_INT_REQUIRED_STACK is included within each user thread stack, thus this large stack multiplies
- * and this consumes a lot of valueable RAM. While forcing the compiler to inline helps to some degree,
- * it would be even better not to waste stack on passing the parameter.
- *
  * In the firmware we are using 'extern *Engine' - in the firmware Engine is a signleton
  *
  * On the other hand, in order to have a meaningful unit test we are passing Engine * engine as a parameter


### PR DESCRIPTION
Excerpt from `ChibiOS/os/common/ports/ARMCMx/chcore_v6m.h`:
```
/**
 * @brief   Per-thread stack overhead for interrupts servicing.
 * @details This constant is used in the calculation of the correct working
 *          area size.
 * @note    In this port this value is conservatively set to 64 because the
 *          function @p chSchDoReschedule() can have a stack frame, especially
 *          with compiler optimizations disabled. The value can be reduced
 *          when compiler optimizations are enabled.
 */
#if !defined(PORT_INT_REQUIRED_STACK)
#define PORT_INT_REQUIRED_STACK         64
#endif
```

Interrupts are NOT serviced on the stack of the thread that was running when the interrupt occurred.  The only thing that happens on that thread's stack is that its registers are pushed (by hardware) when an interrupt occurs, just before swapping the stack pointer out for the main stack (currently 0x400=1024 bytes), where the ISR actually runs.

Likewise, the idle thread actually doesn't do anything, so it shouldn't be so tremendous.

This change saves a lot of RAM.  640 bytes per thread + 960 for the idle thread.