### PR TITLE
Re-shrink stacks

### DIFF
--- a/firmware/config/boards/kinetis/chconf.h
+++ b/firmware/config/boards/kinetis/chconf.h
@@ -48,7 +48,7 @@
 
 // See global_shared.h notes about stack requirements
 // see also http://www.chibios.org/dokuwiki/doku.php?id=chibios:kb:stacks
-#define PORT_INT_REQUIRED_STACK 	400
+#define PORT_INT_REQUIRED_STACK 	128
 
 #define CHPRINTF_USE_FLOAT          	TRUE
 

--- a/firmware/config/stm32f4ems/chconf.h
+++ b/firmware/config/stm32f4ems/chconf.h
@@ -45,7 +45,7 @@
 
 // See global_shared.h notes about stack requirements
 // see also http://www.chibios.org/dokuwiki/doku.php?id=chibios:kb:stacks
-#define PORT_INT_REQUIRED_STACK 	400
+#define PORT_INT_REQUIRED_STACK 	128
 
 #define CHPRINTF_USE_FLOAT          	TRUE
 

--- a/firmware/config/stm32f7ems/chconf.h
+++ b/firmware/config/stm32f7ems/chconf.h
@@ -45,7 +45,7 @@
 
 // See global_shared.h notes about stack requirements
 // see also http://www.chibios.org/dokuwiki/doku.php?id=chibios:kb:stacks
-#define PORT_INT_REQUIRED_STACK 	400
+#define PORT_INT_REQUIRED_STACK 	128
 
 #define CHPRINTF_USE_FLOAT          	TRUE
 

--- a/firmware/controllers/engine_controller.cpp
+++ b/firmware/controllers/engine_controller.cpp
@@ -798,7 +798,7 @@ void initEngineContoller(Logging *sharedLogger DECLARE_ENGINE_PARAMETER_SUFFIX) 
 // help to notice when RAM usage goes up - if a code change adds to RAM usage these variables would fail
 // linking process which is the way to raise the alarm
 #ifndef RAM_UNUSED_SIZE
-#define RAM_UNUSED_SIZE 10000
+#define RAM_UNUSED_SIZE 14000
 #endif
 #ifndef CCM_UNUSED_SIZE
 #define CCM_UNUSED_SIZE 4600

--- a/firmware/hw_layer/servo.cpp
+++ b/firmware/hw_layer/servo.cpp
@@ -20,7 +20,10 @@
 
 EXTERN_ENGINE;
 
-THD_WORKING_AREA(servoThreadStack, UTILITY_THREAD_STACK_SIZE);
+// This thread calls scheduleForLater which eventually could trip the main trigger callback
+// if self stimulation (heh) is enabled, which uses a TON of stack space.
+// So this stack has to be pretty big, unfortunately.
+THD_WORKING_AREA(servoThreadStack, UTILITY_THREAD_STACK_SIZE * 3);
 
 static OutputPin pins[SERVO_COUNT];
 


### PR DESCRIPTION
Finally got a break in to the debugger under the hardware-in-the-loop test conditions that tripped the stack warning.

The problem is that the servo thread directly calls `scheduleForLater`, which could end up executing events off of the queue.  If the ECU is in self-stimulation mode, one of those events could be firing an emulated trigger event, which could then call a relatively deep call hierarchy (`mainTriggerCallback`, etc) that normally runs on the giant (4k) interrupt stack.

Inspection of the caller tree for `doExecute` reveals that the servo is the only time we do this.  Every other call to `doExecute` is made from an interrupt context.

The short term solution is to simply make that one stack big, instead of all stacks. Longer term solution is to do something different for servo control (if we need servo control at all...?), or re-engineer how we do scheduling for events scheduled in the very near future (that we may miss if we set the timer).