### PR TITLE
Remove sensor reporting loc

### DIFF
--- a/firmware/console/status_loop.cpp
+++ b/firmware/console/status_loop.cpp
@@ -756,7 +756,7 @@ void updateTunerStudioState(TunerStudioOutputChannels *tsOutputChannels DECLARE_
 	tsOutputChannels->rpmAcceleration = engine->rpmCalculator.getRpmAcceleration();
 	// offset 108
 	// For air-interpolated tCharge mode, we calculate a decent massAirFlow approximation, so we can show it to users even without MAF sensor!
-    tsOutputChannels->massAirFlow = getAirFlowGauge(PASS_ENGINE_PARAMETER_SIGNATURE);
+	tsOutputChannels->massAirFlow = getAirFlowGauge(PASS_ENGINE_PARAMETER_SIGNATURE);
 	// offset 116
 	// TPS acceleration
 	tsOutputChannels->deltaTps = engine->tpsAccelEnrichment.getMaxDelta();
@@ -793,14 +793,14 @@ void updateTunerStudioState(TunerStudioOutputChannels *tsOutputChannels DECLARE_
 	tsOutputChannels->firmwareVersion = getRusEfiVersion();
 	// 268
 	tsOutputChannels->fuelPidCorrection = ENGINE(engineState.running.pidCorrection);
-    // 276
-    tsOutputChannels->accelerationX = engine->sensors.accelerometer.x;
-    // 278
-    tsOutputChannels->accelerationY = engine->sensors.accelerometer.y;
+	// 276
+	tsOutputChannels->accelerationX = engine->sensors.accelerometer.x;
+	// 278
+	tsOutputChannels->accelerationY = engine->sensors.accelerometer.y;
 	// 280
 	tsOutputChannels->oilPressure = Sensor::get(SensorType::OilPressure).Value;
-    // 288
-    tsOutputChannels->injectionOffset = engine->engineState.injectionOffset;
+	// 288
+	tsOutputChannels->injectionOffset = engine->engineState.injectionOffset;
 
 	if (hasMapSensor(PASS_ENGINE_PARAMETER_SIGNATURE)) {
 		float mapValue = getMap(PASS_ENGINE_PARAMETER_SIGNATURE);

--- a/firmware/console/status_loop.cpp
+++ b/firmware/console/status_loop.cpp
@@ -797,6 +797,8 @@ void updateTunerStudioState(TunerStudioOutputChannels *tsOutputChannels DECLARE_
     tsOutputChannels->accelerationX = engine->sensors.accelerometer.x;
     // 278
     tsOutputChannels->accelerationY = engine->sensors.accelerometer.y;
+	// 280
+	tsOutputChannels->oilPressure = Sensor::get(SensorType::OilPressure).Value;
     // 288
     tsOutputChannels->injectionOffset = engine->engineState.injectionOffset;
 

--- a/firmware/controllers/sensors/functional_sensor.cpp
+++ b/firmware/controllers/sensors/functional_sensor.cpp
@@ -1,12 +1,6 @@
 #include "functional_sensor.h"
 
 void FunctionalSensor::postRawValue(float inputValue) {
-	// Report the raw value
-	float *rawReportLocation = m_rawReportingLocation;
-	if (rawReportLocation) {
-		*rawReportLocation = inputValue;
-	}
-
 	// If no function is set, this sensor isn't valid.
 	if (!m_function) {
 		invalidate();

--- a/firmware/controllers/sensors/functional_sensor.h
+++ b/firmware/controllers/sensors/functional_sensor.h
@@ -30,17 +30,11 @@ public:
 
 	void postRawValue(float inputValue);
 
-	void setRawReportingLocation(float *rawReportingLocation) {
-		m_rawReportingLocation = rawReportingLocation;
-	}
-
 	void setFunction(SensorConverter& func) {
 		m_function = &func;
 	}
 
 private:
-	float *m_rawReportingLocation = nullptr;
-
 	// Conversion function for this sensor
 	SensorConverter* m_function = nullptr;
 };

--- a/firmware/controllers/sensors/stored_value_sensor.h
+++ b/firmware/controllers/sensors/stored_value_sensor.h
@@ -34,15 +34,11 @@ public:
 		return {valid, value};
 	}
 
-	void setReportingLocation(float *reportLocation) {
-		m_reportingLocation = reportLocation;
-	}
-
 protected:
 	explicit StoredValueSensor(SensorType type)
 		: Sensor(type)
-	//, m_reportingLocation(reportingLocation)
-	{}
+	{
+	}
 
 	// Invalidate the stored value.
 	void invalidate() {
@@ -54,17 +50,9 @@ protected:
 		// Set value before valid - so we don't briefly have the valid bit set on an invalid value
 		m_value = value;
 		m_isValid = true;
-
-		// Report value
-		float *reportLoc = m_reportingLocation;
-		if (reportLoc) {
-			*reportLoc = value;
-		}
 	}
 
 private:
 	bool m_isValid = false;
 	float m_value = 0.0f;
-
-	float *m_reportingLocation = nullptr;
 };

--- a/firmware/init/sensor/init_oil_pressure.cpp
+++ b/firmware/init/sensor/init_oil_pressure.cpp
@@ -33,11 +33,6 @@ void initOilPressure() {
 	oilpSensorFunc.configure(sensorCfg->v1, val1, sensorCfg->v2, val2, /*minOutput*/ -5, greaterOutput);
 	oilpSensor.setFunction(oilpSensorFunc);
 
-#if EFI_TUNER_STUDIO
-	// Tell it to report to its output channel
-	oilpSensor.setReportingLocation(&tsOutputChannels.oilPressure);
-#endif
-
 	// Subscribe the sensor to the ADC
 	AdcSubscription::SubscribeSensor(oilpSensor, channel);
 


### PR DESCRIPTION
I had mixed feelings about doing it this way from the beginning - it's a bit weird to have magical side effects, especially when those side effects mutate state from a huge distance away.

It's easier to reason about what's going on when it's explicitly done (set state in the TS output channels struct).