### PR TITLE
remove accelerometer datalog

### DIFF
--- a/firmware/tunerstudio/rusefi.input
+++ b/firmware/tunerstudio/rusefi.input
@@ -978,8 +978,6 @@ gaugeCategory = Throttle Body (incl. ETB)
    entry = coilDutyCycle,	@@GAUGE_NAME_DWELL_DUTY@@,	float,"%.3f"
    entry = currentTargetAfr,@@GAUGE_NAME_TARGET_AFR@@,	float,"%.3f"
 
-   entry = accelerationX,	@@GAUGE_NAME_ACCEL_X@@,	float,"%.2f"
-   entry = accelerationY,	@@GAUGE_NAME_ACCEL_Y@@,	float,"%.2f"
    entry = egt1,	        "EGT1",	float,"%.1f"
    entry = egt2,	        "EGT2",	float,"%.1f"
    entry = egt3,	        "EGT3",	float,"%.1f"


### PR DESCRIPTION
no boards have `EFI_MEMS` enabled - so don't log that field

note: this is part 1.5 in a scheme to allow an f4 to log in excess of 205hz