### PR TITLE
Shrink output channels, use scaling

### DIFF
--- a/firmware/config/boards/kinetis/config/controllers/algo/rusefi_generated.h
+++ b/firmware/config/boards/kinetis/config/controllers/algo/rusefi_generated.h
@@ -1888,7 +1888,7 @@
 #define triggerSimulatorPins3_offset 738
 #define triggerSimulatorPins3_offset_hex 2e2
 #define TS_FILE_VERSION 20190701
-#define TS_OUTPUT_SIZE 224
+#define TS_OUTPUT_SIZE 220
 #define ts_show_cj125 true
 #define ts_show_egt true
 #define ts_show_etb true

--- a/firmware/config/boards/kinetis/config/controllers/algo/rusefi_generated.h
+++ b/firmware/config/boards/kinetis/config/controllers/algo/rusefi_generated.h
@@ -1888,7 +1888,7 @@
 #define triggerSimulatorPins3_offset 738
 #define triggerSimulatorPins3_offset_hex 2e2
 #define TS_FILE_VERSION 20190701
-#define TS_OUTPUT_SIZE 356
+#define TS_OUTPUT_SIZE 224
 #define ts_show_cj125 true
 #define ts_show_egt true
 #define ts_show_etb true

--- a/firmware/console/binary/tunerstudio_configuration.h
+++ b/firmware/console/binary/tunerstudio_configuration.h
@@ -156,7 +156,7 @@ typedef struct {
 	// TPS/load AE
 	scaled_percent engineLoadDelta; // 76
 	scaled_percent deltaTps; // 78
-	scaled_ms engineLoadAccelExtra; // 80
+	scaled_percent engineLoadAccelExtra; // 80
 	scaled_ms tpsAccelFuel; // 82
 
 	// Ignition

--- a/firmware/console/binary/tunerstudio_configuration.h
+++ b/firmware/console/binary/tunerstudio_configuration.h
@@ -13,6 +13,37 @@
 
 #include "rusefi_types.h"
 
+template <typename T, int num = 1, int denom = 1>
+class scaled_channel {
+private:
+	T m_value;
+
+public:
+	scaled_channel() : m_value(static_cast<T>(0)) { }
+	scaled_channel(float val)
+		: m_value(val * num / denom)
+	{
+	}
+
+	// Allow reading back out as a float (note: this may be lossy!)
+	operator float() const {
+		return m_value * (float)denom / num;
+	}
+};
+
+static_assert(sizeof(scaled_channel<uint8_t>) == 1);
+static_assert(sizeof(scaled_channel<uint16_t>) == 2);
+static_assert(sizeof(scaled_channel<uint32_t>) == 4);
+static_assert(sizeof(scaled_channel<float>) == 4);
+
+using scaled_temperature = scaled_channel<int16_t, 100>;	// +-327 deg C at 0.01 deg resolution
+using scaled_ms = scaled_channel<int16_t, 300>;				// +- 100ms at 0.003ms precision
+using scaled_percent = scaled_channel<int16_t, 100>;		// +-327% at 0.01% resolution
+using scaled_pressure = scaled_channel<uint16_t, 30>;		// 0-2000kPa (~300psi) at 0.03kPa resolution
+using scaled_angle = scaled_channel<int16_t, 50>;			// +-655 degrees at 0.02 degree resolution
+using scaled_voltage = scaled_channel<uint16_t, 1000>;		// 0-65v at 1mV resolution
+using scaled_afr = scaled_channel<uint16_t, 1000>;			// 0-65afr at 0.001 resolution
+
 #define PAGE_COUNT 1
 
 typedef struct {
@@ -24,36 +55,7 @@ typedef struct {
  */
 typedef struct {
 	/* see also [OutputChannels] in rusefi.input */
-	// primary instrument cluster gauges
-	int rpm; // size 4, offset 0
-	/**
-	 * This value is in Celcius - UI would convert into F if needed
-	 */
-	float coolantTemperature; // size 4, offset 4
-	float intakeAirTemperature; // size 4, offset 8
-	float throttlePositon; // size 4, offset 12
-	float massAirFlowVoltage; // size 4, offset 16
-	float airFuelRatio; // size 4, offset 20
-	float engineLoad; // size 4, offset 24
-	float vBatt; // size 4, offset 28
-	short int tpsADC; // size 2, offset 32
-	short int alignment; // size 2, offset 34
-	float baroPressure; // size 4, offset 36
-	float manifoldAirPressure; // size 4, offset 40
-	float crankingFuelMs; // offset 44
-	/**
-	 * This is the raw value we take from the fuel map or base fuel algorithm, before the corrections
-	 */
-	float fuelBase; // 48
-	float tCharge; // 52
-	float ignitionAdvance; // 56
-	float sparkDwell; // 60
-	/**
-	 * this one contains total resulting fuel squirt time, per event
-	 * With all corrections and injector lag. See also baseFuel
-	 */
-	float actualLastInjection; // 64
-	float debugFloatField1;	// 68
+
 	/**
 	 * Yes, I do not really enjoy packing bits into integers but we simply have too many boolean flags and I cannot
 	 * water 4 bytes per traffic - I want gauges to work as fast as possible
@@ -76,107 +78,131 @@ typedef struct {
 	unsigned int brakePedalState : 1; // bit 15. 0 - not pressed, 1 = pressed
 	unsigned int toothLogReady : 1; // bit 16
 	unsigned int acSwitchState : 1; // bit 17. 0 - not pressed, 1 = pressed
-	float vehicleSpeedKph; // 76
-	unsigned int isTpsError : 1; // bit 0, 80
-	unsigned int isCltError : 1; // bit 1
-	unsigned int isMapError : 1; // bit 2
-	unsigned int isIatError : 1; // bit 3
-	unsigned int isAcSwitchEngaged : 1; // bit 4
-	unsigned int isTriggerError : 1; // bit 5
-	unsigned int hasFatalError : 1; // bit 6
-	unsigned int isWarnNow : 1; // bit 7
-	unsigned int unused80b8 : 1; // bit 8
-	unsigned int isKnockChipOk : 1; // bit 9
-	int tsConfigVersion; // 84
-	egt_values_s egtValues; // 88
-	float rpmAcceleration; // 104
-	float massAirFlow; // 108
-	/**
-	 * Current volumetric efficiency
-	 */
-	float veValue; // offset 112
-	/**
-	 * TPS value delta within specified number of cycles
-	 * See tpsAccelFuel
-	 */
-	float deltaTps; // offset 116
-	int triggerErrorsCounter; // offset 120
-	/**
-	 * Engine load delta
-	 */
-	float engineLoadAccelExtra; // offset 124
-	float tpsAccelFuel; // offset 128
-	float baroCorrection; // 132
-	float pedalPosition; // 136
-	/**
-	 * @see coilDutyCycle
-	 */
-	float injectorDutyCycle; // 140
-	int knockCount; // 144
-	float fuelTankLevel; // 148
-	float knockLevel; // 152
+	unsigned int isTpsError : 1; // bit 18
+	unsigned int isCltError : 1; // bit 19
+	unsigned int isMapError : 1; // bit 20
+	unsigned int isIatError : 1; // bit 21
+	unsigned int isAcSwitchEngaged : 1; // bit 22
+	unsigned int isTriggerError : 1; // bit 23
+	unsigned int hasFatalError : 1; // bit 24
+	unsigned int isWarnNow : 1; // bit 25
+	unsigned int unused80b8 : 1; // bit 26
+	unsigned int isKnockChipOk : 1; // bit 27
+
+	// RPM, vss
+	scaled_channel<uint16_t, 4> rpm; // 4
+	scaled_percent rpmAcceleration; // 6
+	scaled_percent speedToRpmRatio; // 8
+	scaled_channel<uint8_t> vehicleSpeedKph; // 10
+	
+	// temperatures
+	scaled_channel<uint8_t> internalMcuTemperature; // offset 11
+	scaled_temperature coolantTemperature;   // offset 12
+	scaled_temperature intakeAirTemperature; // offset 14
+	scaled_temperature auxTemp1;             // offset 16
+	scaled_temperature auxTemp2;             // offset 18
+
+	// throttle, pedal
+	scaled_percent throttlePosition;    // 20
+	scaled_percent pedalPosition;       // 22
+	uint16_t tpsADC;                    // 24
+
+	// air flow/mass measurment
+	scaled_voltage massAirFlowVoltage; // 26
+	scaled_channel<uint16_t, 100> massAirFlow; // 28
+	scaled_pressure manifoldAirPressure; // 30
+	scaled_pressure baroPressure; // 32
+
+	scaled_afr airFuelRatio; // 34
+	scaled_channel<uint16_t, 100> engineLoad; // 36
+
+	scaled_voltage vBatt; // 38
+	scaled_pressure oilPressure; // 40
+	scaled_angle vvtPosition; // 42
+
+	// Fuel math
+	scaled_channel<uint16_t, 1000> chargeAirMass; // 44
+	scaled_ms crankingFuelMs; // 46
+	scaled_afr currentTargetAfr; // 48
+	// This is the raw value we take from the fuel map or base fuel algorithm, before the corrections
+	scaled_ms fuelBase; // 50
+	// Total fuel with CLT, IAT and TPS acceleration without injector lag corrections per cycle, as pulse per cycle
+	scaled_ms fuelRunning; // 52
+	// Actual last injection time - including all compensation and injection mode
+	scaled_ms actualLastInjection; // 54
+	scaled_channel<uint8_t, 2> injectorDutyCycle; // 56
+	scaled_channel<uint8_t, 2> veValue; // 57
+	scaled_angle injectionOffset; // 58
+	scaled_temperature tCharge; // 60
+
+	// Corrections
+	scaled_ms injectorLagMs; // 62
+	scaled_percent iatCorrection; // 64
+	scaled_percent cltCorrection; // 66
+	scaled_percent baroCorrection; // 68
+	scaled_ms fuelPidCorrection; // 70
+
+	// Wall model AE
+	scaled_ms wallFuelAmount; // 72
+	scaled_channel<int16_t, 1000> wallFuelCorrection; // 74
+	
+	// TPS/load AE
+	scaled_percent engineLoadDelta; // 76
+	scaled_percent deltaTps; // 78
+	scaled_ms engineLoadAccelExtra; // 80
+	scaled_ms tpsAccelFuel; // 82
+
+	// Ignition
+	scaled_angle ignitionAdvance; // 84
+	scaled_ms sparkDwell; // 86
+	scaled_percent coilDutyCycle; // 88
+
+	// Idle & ETB
+	scaled_percent idlePosition; // 90
+	scaled_percent etbTarget; // 92
+	scaled_percent etb1DutyCycle; // 94
+	scaled_percent etb1Error; // 96
+
+	// Fuel system
+	scaled_percent fuelTankLevel; // 98
+	float fuelConsumptionPerHour; // 100
+
+	// Knock
+	uint32_t knockCount; // 104
+	float knockLevel; // 108
+
+	// Mode, firmware, protocol, run time
+	uint32_t timeSeconds; // 112
+	uint32_t engineMode; // 116
+	uint32_t firmwareVersion; // 120
+	uint32_t tsConfigVersion; // 124
+
+	// EGT
+	egt_values_s egtValues; // 128
+
+	int16_t accelerationX; // 144
+	int16_t accelerationY; // 148
+
+	// Errors
+	int16_t warningCounter; // 150
+	int triggerErrorsCounter; // 152
 	int totalTriggerErrorCounter; // 156
-	float wallFuelAmount; // 160
-	/**
-	 * multiplier, 1 means no correction, 1.20 means 20% extra
-	 */
-	float iatCorrection; // 164
-	floatms_t wallFuelCorrection; // 168
-	float idlePosition; // 172
-	float currentTargetAfr; // 176
-	float chargeAirMass; // 180
-	/**
-	 * multiplier, 1 means no correction, 1.20 means 20% extra
-	 */
-	float cltCorrection; // 184
-	/**
-	 * Total fuel with CLT, IAT and TPS acceleration without injector lag corrections per cycle,
-	 * as squirt duration.
-	 *
-	 * @see actualLastInjection
-	 */
-	float fuelRunning; // 188
-	int debugIntField1;	// 192
-	float injectorLagMs; // 196
-	float debugFloatField2; // 200
-	float debugFloatField3; // 204
-	float debugFloatField4; // 208
-	float debugFloatField5; // 212
-	int debugIntField2; // 216
-	int debugIntField3; // 220
-	int timeSeconds; // 224
-	float engineLoadDelta; // 228
-	float speedToRpmRatio; // 232
-	int16_t warningCounter; // 236
-	int16_t unused_238;
-	int16_t lastErrorCode; // 240
-	int16_t unused_242;
-	/**
-	 * Microcontroller own internal temperature, C
-	 */
-	float internalMcuTemperature; // 244
-	float vvtPosition; // 248
-	int engineMode; // 252
-	float debugFloatField6; // 256
-	float debugFloatField7; // 260
-	int firmwareVersion; // 264
-	float fuelPidCorrection; // 268
-	/**
-	 * @see injectorDutyCycle
-	 */
-	float coilDutyCycle; // 272
-	int16_t accelerationX; // 276
-	int16_t accelerationY; // 278
-	float oilPressure;	// 280
-	float fuelConsumptionPerHour; // 284
-	float injectionOffset; // 288
-	int16_t debugIntField4; // 292
-	int16_t debugIntField5; // 294
-	int16_t recentErrorCodes[8]; // 298
-	float etbTarget;		// 312
-	float etb1DutyCycle;	// 316
-	float etb1Error;		// 320
-	int unused3[8];
+	int16_t lastErrorCode; // 160
+	int16_t recentErrorCodes[8]; // 162
+
+	// Debug
+	float debugFloatField1; // 180
+	float debugFloatField2;
+	float debugFloatField3;
+	float debugFloatField4;
+	float debugFloatField5;
+	float debugFloatField6;
+	float debugFloatField7;
+	int debugIntField1;
+	int debugIntField2;
+	int debugIntField3;
+	int16_t debugIntField4;
+	int16_t debugIntField5;
 	/* see also [OutputChannels] in rusefi.input */
 } TunerStudioOutputChannels;
 

--- a/firmware/console/binary/tunerstudio_configuration.h
+++ b/firmware/console/binary/tunerstudio_configuration.h
@@ -15,22 +15,27 @@
 
 #include "tunerstudio_debug_struct.h"
 
-template <typename T, int num = 1, int denom = 1>
+// This class lets us transparently store something at a ratio inside an integer type
+// Just use it like a float - you can read and write to it, like this:
+// scaled_channel<uint8_t, 10> myVar;
+// myVar = 2.4f;	// converts to an int, stores 24
+// float x = myVar; // converts back to float, returns 2.4f
+template <typename T, int mult = 1>
 class scaled_channel {
-private:
-	T m_value;
-
 public:
 	scaled_channel() : m_value(static_cast<T>(0)) { }
 	scaled_channel(float val)
-		: m_value(val * num / denom)
+		: m_value(val * mult)
 	{
 	}
 
 	// Allow reading back out as a float (note: this may be lossy!)
 	operator float() const {
-		return m_value * (float)denom / num;
+		return m_value / (float)mult;
 	}
+
+private:
+	T m_value;
 };
 
 static_assert(sizeof(scaled_channel<uint8_t>) == 1);

--- a/firmware/console/binary/tunerstudio_configuration.h
+++ b/firmware/console/binary/tunerstudio_configuration.h
@@ -184,21 +184,15 @@ typedef struct {
 	uint32_t firmwareVersion; // 120
 	uint32_t tsConfigVersion; // 124
 
-	// EGT
-	egt_values_s egtValues; // 128
-
-	int16_t accelerationX; // 144
-	int16_t accelerationY; // 148
-
 	// Errors
-	int16_t warningCounter; // 150
-	int triggerErrorsCounter; // 152
-	int totalTriggerErrorCounter; // 156
-	int16_t lastErrorCode; // 160
-	int16_t recentErrorCodes[8]; // 162
+	int triggerErrorsCounter; // 128
+	int totalTriggerErrorCounter; // 132
+	int16_t warningCounter; // 136
+	int16_t lastErrorCode; // 138
+	int16_t recentErrorCodes[8]; // 140
 
 	// Debug
-	float debugFloatField1; // 180
+	float debugFloatField1; // 156
 	float debugFloatField2;
 	float debugFloatField3;
 	float debugFloatField4;
@@ -209,7 +203,14 @@ typedef struct {
 	int debugIntField2;
 	int debugIntField3;
 	int16_t debugIntField4;
-	int16_t debugIntField5;
+	int16_t debugIntField5; // 198
+
+	// accelerometer
+	int16_t accelerationX; // 200
+	int16_t accelerationY; // 202
+
+	// EGT
+	egt_values_s egtValues; // 204
 
 	// Temporary - will remove soon
 	TsDebugChannels* getDebugChannels() {

--- a/firmware/console/binary/tunerstudio_configuration.h
+++ b/firmware/console/binary/tunerstudio_configuration.h
@@ -13,6 +13,8 @@
 
 #include "rusefi_types.h"
 
+#include "tunerstudio_debug_struct.h"
+
 template <typename T, int num = 1, int denom = 1>
 class scaled_channel {
 private:
@@ -203,6 +205,12 @@ typedef struct {
 	int debugIntField3;
 	int16_t debugIntField4;
 	int16_t debugIntField5;
+
+	// Temporary - will remove soon
+	TsDebugChannels* getDebugChannels() {
+		return reinterpret_cast<TsDebugChannels*>(&debugFloatField1);
+	}
+
 	/* see also [OutputChannels] in rusefi.input */
 } TunerStudioOutputChannels;
 

--- a/firmware/console/binary/tunerstudio_debug_struct.h
+++ b/firmware/console/binary/tunerstudio_debug_struct.h
@@ -1,0 +1,16 @@
+#pragma once
+
+typedef struct {
+	float debugFloatField1; // 180
+	float debugFloatField2;
+	float debugFloatField3;
+	float debugFloatField4;
+	float debugFloatField5;
+	float debugFloatField6;
+	float debugFloatField7;
+	int debugIntField1;
+	int debugIntField2;
+	int debugIntField3;
+	int16_t debugIntField4;
+	int16_t debugIntField5;
+} TsDebugChannels;

--- a/firmware/console/status_loop.cpp
+++ b/firmware/console/status_loop.cpp
@@ -726,7 +726,7 @@ void updateTunerStudioState(TunerStudioOutputChannels *tsOutputChannels DECLARE_
 	// offset 8
 	tsOutputChannels->intakeAirTemperature = intake;
 	// offset 12
-	tsOutputChannels->throttlePositon = tps;
+	tsOutputChannels->throttlePosition = tps;
 	// offset 16
 	tsOutputChannels->massAirFlowVoltage = hasMafSensor() ? getMafVoltage(PASS_ENGINE_PARAMETER_SIGNATURE) : 0;
 
@@ -1021,7 +1021,7 @@ void updateTunerStudioState(TunerStudioOutputChannels *tsOutputChannels DECLARE_
 		break;
 	case DBG_TLE8888:
 #if (BOARD_TLE8888_COUNT > 0)
-		tle8888PostState(tsOutputChannels);
+		//tle8888PostState(tsOutputChannels);
 #endif /* BOARD_TLE8888_COUNT */
 		break;
 	default:

--- a/firmware/console/status_loop.cpp
+++ b/firmware/console/status_loop.cpp
@@ -1021,7 +1021,7 @@ void updateTunerStudioState(TunerStudioOutputChannels *tsOutputChannels DECLARE_
 		break;
 	case DBG_TLE8888:
 #if (BOARD_TLE8888_COUNT > 0)
-		//tle8888PostState(tsOutputChannels);
+		tle8888PostState(tsOutputChannels->getDebugChannels());
 #endif /* BOARD_TLE8888_COUNT */
 		break;
 	default:

--- a/firmware/controllers/generated/rusefi_generated.h
+++ b/firmware/controllers/generated/rusefi_generated.h
@@ -1946,7 +1946,7 @@
 #define triggerSimulatorPins3_offset 738
 #define triggerSimulatorPins3_offset_hex 2e2
 #define TS_FILE_VERSION 20190701
-#define TS_OUTPUT_SIZE 224
+#define TS_OUTPUT_SIZE 220
 #define ts_show_cj125 true
 #define ts_show_egt true
 #define ts_show_etb true

--- a/firmware/controllers/generated/rusefi_generated.h
+++ b/firmware/controllers/generated/rusefi_generated.h
@@ -1946,7 +1946,7 @@
 #define triggerSimulatorPins3_offset 738
 #define triggerSimulatorPins3_offset_hex 2e2
 #define TS_FILE_VERSION 20190701
-#define TS_OUTPUT_SIZE 356
+#define TS_OUTPUT_SIZE 224
 #define ts_show_cj125 true
 #define ts_show_egt true
 #define ts_show_etb true

--- a/firmware/hw_layer/drivers/gpio/tle8888.c
+++ b/firmware/hw_layer/drivers/gpio/tle8888.c
@@ -145,14 +145,14 @@ static const char* tle8888_pin_names[TLE8888_OUTPUTS] = {
 };
 
 #if EFI_TUNER_STUDIO
-void tle8888PostState(TunerStudioOutputChannels *tsOutputChannels) {
-	tsOutputChannels->debugIntField1 = tle8888SpiCounter;
-	tsOutputChannels->debugIntField2 = spiTxb;
-	tsOutputChannels->debugIntField3 = spiRxb;
-	tsOutputChannels->debugIntField4 = initResponsesAccumulator;
-	tsOutputChannels->debugIntField5 = reinitializationCounter;
-	tsOutputChannels->debugFloatField1 = initResponse0;
-	tsOutputChannels->debugFloatField2 = initResponse1;
+void tle8888PostState(TsDebugChannels *debugChannels) {
+	debugChannels->debugIntField1 = tle8888SpiCounter;
+	debugChannels->debugIntField2 = spiTxb;
+	debugChannels->debugIntField3 = spiRxb;
+	debugChannels->debugIntField4 = initResponsesAccumulator;
+	debugChannels->debugIntField5 = reinitializationCounter;
+	debugChannels->debugFloatField1 = initResponse0;
+	debugChannels->debugFloatField2 = initResponse1;
 }
 #endif /* EFI_TUNER_STUDIO */
 

--- a/firmware/hw_layer/drivers/gpio/tle8888.h
+++ b/firmware/hw_layer/drivers/gpio/tle8888.h
@@ -54,8 +54,8 @@ int tle8888_add(unsigned int index, const struct tle8888_config *cfg);
 void requestTLE8888initialization(void);
 
 #if EFI_TUNER_STUDIO
-#include "tunerstudio_configuration.h"
-void tle8888PostState(TunerStudioOutputChannels *tsOutputChannels);
+#include "tunerstudio_debug_struct.h"
+void tle8888PostState(TsDebugChannels *tsDebugChannels);
 #endif /* EFI_TUNER_STUDIO */
 
 #ifdef __cplusplus

--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -68,7 +68,7 @@ struct_no_prefix engine_configuration_s
 #define ETB_BIAS_CURVE_LENGTH 8
 
 ! this is here so that rusEfi console can access it, too
-#define TS_OUTPUT_SIZE 356
+#define TS_OUTPUT_SIZE 224
 
 #define MAP_ANGLE_SIZE 8
 #define MAP_WINDOW_SIZE 8

--- a/firmware/tunerstudio/rusefi.input
+++ b/firmware/tunerstudio/rusefi.input
@@ -292,47 +292,47 @@ fileVersion = { 20190701 }
       firmwareVersion = scalar,  U32,    120,"version_f",    1,         0
       firmwareTsVersion=scalar,  U32,    124,"version_p",    1,         0
 
-; egt
-      egt1            = scalar,  S16,    128,  "deg C",      1,         0
-      egt2            = scalar,  S16,    130,  "deg C",      1,         0
-      egt3            = scalar,  S16,    132,  "deg C",      1,         0
-      egt4            = scalar,  S16,    134,  "deg C",      1,         0
-      egt5            = scalar,  S16,    136,  "deg C",      1,         0
-      egt6            = scalar,  S16,    138,  "deg C",      1,         0
-      egt7            = scalar,  S16,    140,  "deg C",      1,         0
-      egt8            = scalar,  S16,    142,  "deg C",      1,         0
-
-; Accel
-      accelerationX   = scalar,  S16,    144,      "G",        0.01,         0
-      accelerationY   = scalar,  S16,    148,      "G",        0.01,         0
-
 ; Errors
-      warningCounter  = scalar,  U16,    150,  "count",           1,         0
-      triggerErrorsCounter=scalar,U32,   152,"counter",           1,         0
-      ; totalTriggerErrorCounter 156
-      lastErrorCode   = scalar,  U16,    160,  "error",           1,         0
-      recentErrorCode0= scalar,  U16,    162,  "error",           1,         0
-      recentErrorCode1= scalar,  U16,    164,  "error",           1,         0
-      recentErrorCode2= scalar,  U16,    166,  "error",           1,         0
-      recentErrorCode3= scalar,  U16,    168,  "error",           1,         0
-      recentErrorCode4= scalar,  U16,    170,  "error",           1,         0
-      recentErrorCode5= scalar,  U16,    172,  "error",           1,         0
-      recentErrorCode6= scalar,  U16,    174,  "error",           1,         0
-      recentErrorCode7= scalar,  U16,    176,  "error",           1,         0
+      triggerErrorsCounter=scalar,U32,   128,"counter",           1,         0
+      ; totalTriggerErrorCounter 132
+      warningCounter  = scalar,  U16,    136,  "count",           1,         0
+      lastErrorCode   = scalar,  U16,    138,  "error",           1,         0
+      recentErrorCode0= scalar,  U16,    140,  "error",           1,         0
+      recentErrorCode1= scalar,  U16,    142,  "error",           1,         0
+      recentErrorCode2= scalar,  U16,    144,  "error",           1,         0
+      recentErrorCode3= scalar,  U16,    146,  "error",           1,         0
+      recentErrorCode4= scalar,  U16,    148,  "error",           1,         0
+      recentErrorCode5= scalar,  U16,    150,  "error",           1,         0
+      recentErrorCode6= scalar,  U16,    152,  "error",           1,         0
+      recentErrorCode7= scalar,  U16,    154,  "error",           1,         0
 
 ; Debug
-      debugFloatField1= scalar,  F32,    180,    "val",           1,       0.0
-      debugFloatField2= scalar,  F32,    184,    "val",           1,       0.0
-      debugFloatField3= scalar,  F32,    188,    "val",           1,       0.0
-      debugFloatField4= scalar,  F32,    192,    "val",           1,       0.0
-      debugFloatField5= scalar,  F32,    196,    "val",           1,       0.0
-      debugFloatField6= scalar,  F32,    200,    "val",           1,       0.0
-      debugFloatField7= scalar,  F32,    204,    "val",           1,       0.0
-      debugIntField1  = scalar,  S32,    208,    "val",           1,       0.0
-      debugIntField2  = scalar,  S32,    212,    "val",           1,       0.0
-      debugIntField3  = scalar,  S32,    216,    "val",           1,       0.0
-      debugIntField4  = scalar,  S16,    220,    "val",           1,       0.0
-      debugIntField5  = scalar,  S16,    222,    "val",           1,       0.0
+      debugFloatField1= scalar,  F32,    156,    "val",           1,       0.0
+      debugFloatField2= scalar,  F32,    160,    "val",           1,       0.0
+      debugFloatField3= scalar,  F32,    164,    "val",           1,       0.0
+      debugFloatField4= scalar,  F32,    168,    "val",           1,       0.0
+      debugFloatField5= scalar,  F32,    172,    "val",           1,       0.0
+      debugFloatField6= scalar,  F32,    176,    "val",           1,       0.0
+      debugFloatField7= scalar,  F32,    180,    "val",           1,       0.0
+      debugIntField1  = scalar,  S32,    184,    "val",           1,       0.0
+      debugIntField2  = scalar,  S32,    188,    "val",           1,       0.0
+      debugIntField3  = scalar,  S32,    192,    "val",           1,       0.0
+      debugIntField4  = scalar,  S16,    196,    "val",           1,       0.0
+      debugIntField5  = scalar,  S16,    198,    "val",           1,       0.0
+
+; Accel
+      accelerationX   = scalar,  S16,    200,      "G",        0.01,         0
+      accelerationY   = scalar,  S16,    202,      "G",        0.01,         0
+
+; egt
+      egt1            = scalar,  S16,    204,  "deg C",      1,         0
+      egt2            = scalar,  S16,    206,  "deg C",      1,         0
+      egt3            = scalar,  S16,    208,  "deg C",      1,         0
+      egt4            = scalar,  S16,    210,  "deg C",      1,         0
+      egt5            = scalar,  S16,    212,  "deg C",      1,         0
+      egt6            = scalar,  S16,    214,  "deg C",      1,         0
+      egt7            = scalar,  S16,    216,  "deg C",      1,         0
+      egt8            = scalar,  S16,    218,  "deg C",      1,         0
 
 
 ;

--- a/firmware/tunerstudio/rusefi.input
+++ b/firmware/tunerstudio/rusefi.input
@@ -196,111 +196,111 @@ fileVersion = { 20190701 }
 	  ind_isWarnNow    =bits,    U32,      0,  [25:25], "true", "false";
 
 ; RPM, vss
-      RPMValue        = scalar,  U16,      4,    "RPM",    4,   0.00000
-      rpmAcceleration = scalar,  S16,      6,   "dRpm",  100,         0
-      speedToRpmRatio = scalar,  S16,      8,  "value",  100,         0
-      vehicleSpeedKph = scalar,  U16,     10,    "kph",  100,       0.0
+      RPMValue        = scalar,  U16,      4,      "RPM", 0.25,   0.00000
+      rpmAcceleration = scalar,  S16,      6,     "dRpm", 0.01,         0
+      speedToRpmRatio = scalar,  S16,      8,    "value", 0.01,         0
+      vehicleSpeedKph = scalar,  U16,     10,      "kph", 0.01,       0.0
 
 ; temperatures
-     internalMcuTemperature = scalar,S08, 11,  "deg C",    1,         0
+     internalMcuTemperature = scalar,S08, 11,    "deg C",    1,         0
 #if CELSIUS
-      coolant         = scalar,  S16,     12,  "deg C",  100,       0.0
+      coolant         = scalar,  S16,     12,    "deg C", 0.01,       0.0
 #else
-      coolant         = scalar,  S16,     12,  "deg F", {900/5},  17.77777
+      coolant         = scalar,  S16,     12,  "deg F",{9/500},  17.77777
 #endif
 #if CELSIUS
-      intake          = scalar,  S16,     14,  "deg C",  100,       0.0
+      intake          = scalar,  S16,     14,    "deg C", 0.01,       0.0
 #else
-      intake          = scalar,  S16,     14,  "deg F", {900/5},  17.77777
+      intake          = scalar,  S16,     14,  "deg F",{9/500},  17.77777
 #endif
 ; todo: aux1
 ; todo: aux2
       
 
 ; throttle, pedal
-      TPSValue        = scalar,  U16,     20,      "%",  100,         0
-      throttlePedalPosition = scalar,U16, 22,      "%",  100,         0
-      tpsADC          = scalar,  U16,     24,    "ADC",    1,       0.0;
+      TPSValue        = scalar,  U16,     20,        "%", 0.01,         0
+      throttlePedalPosition = scalar,U16, 22,        "%", 0.01,         0
+      tpsADC          = scalar,  U16,     24,      "ADC",    1,       0.0;
 
 ; air flow/mass measurments
-      MAFValue        = scalar,  U16,     26,      "V", 1000,         0
-      massAirFlowValue= scalar,  U16,     28,   "Kg/h",  100,         0
-      MAPValue        = scalar,  U16,     30,    "kPa",   30,       0.0
-      baroPressure    = scalar,  U16,     32,    "kPa",   30,       0.0
-      AFRValue        = scalar,  U16,     34,    "AFR", 1000,       0.0
-      engineLoad      = scalar,  U16,     36,      "%",  100,       0.0 ; Blend of MAP and TPS, depends on algorithm
+      MAFValue        = scalar,  U16,     26,        "V",0.001,         0
+      massAirFlowValue= scalar,  U16,     28,     "Kg/h", 0.01,         0
+      MAPValue        = scalar,  U16,     30,     "kPa",{1/30},       0.0
+      baroPressure    = scalar,  U16,     32,     "kPa",{1/30},       0.0
+      AFRValue        = scalar,  U16,     34,      "AFR",0.001,       0.0
+      engineLoad      = scalar,  U16,     36,        "%", 0.01,       0.0 ; Blend of MAP and TPS, depends on algorithm
 
 ; misc sensors
-      VBatt	          = scalar,	 U16,     38,      "V", 1000,       0.0
-      oilPressure     = scalar,  U16,     40,    "kPa",   30,       0.0
-      vvtPosition     = scalar,  U16,     42,    "deg",   50,         0
+      VBatt           = scalar,	 U16,     38,        "V",0.001,       0.0
+      oilPressure     = scalar,  U16,     40,     "kPa",{1/30},       0.0
+      vvtPosition     = scalar,  U16,     42,      "deg", 0.02,         0
 
       ; 10 bit TPS ADC value (from 0 to 1023 in 5v scale)
       ;tpsADC2         = scalar,  U16,    44,             "ADC",            1,       0.0;
 
 ; fuel math
-      chargeAirMass   = scalar,  U16,     44,      "g", 1000,         0
-      crankingFuelMs  = scalar,  U16,     46,     "ms",  300,       0.0
-      currentTargetAfr= scalar,  U16,     48,  "ratio", 1000,         0
-      baseFuel        = scalar,  U16,     50,     "ms",  300,         0
-      fuelRunning     = scalar,  U16,     52,     "ms",  300,         0
-      actualLastInjection=scalar,U16,     54,     "ms",  300,       0.0
-      injectorDutyCycle=scalar,  U08,     56,      "%",    2,         0
-      veValue         = scalar,  U08,     57,  "ratio",    2,         0
-      injectionOffset = scalar,  S16,     58,    "deg",   50,         0
-      tCharge         = scalar,  U16,     60,  "deg C",  100,       0.0
+      chargeAirMass   = scalar,  U16,     44,        "g",0.001,         0
+      crankingFuelMs  = scalar,  U16,     46,     "ms",{1/300},     0.0
+      currentTargetAfr= scalar,  U16,     48,    "ratio",0.001,         0
+      baseFuel        = scalar,  U16,     50,     "ms",{1/300},       0
+      fuelRunning     = scalar,  U16,     52,     "ms",{1/300},       0
+      actualLastInjection=scalar,U16,     54,     "ms",{1/300},     0.0
+      injectorDutyCycle=scalar,  U08,     56,        "%",  0.5,         0
+      veValue         = scalar,  U08,     57,    "ratio",  0.5,         0
+      injectionOffset = scalar,  S16,     58,      "deg", 0.02,         0
+      tCharge         = scalar,  U16,     60,    "deg C", 0.01,       0.0
 
 ; Corrections
-      injectorLagMs   = scalar,  U16,     62,     "ms",  300,       0.0
-      iatCorrection   = scalar,  U16,     64,      "%",  100,         0
-      cltCorrection   = scalar,  U16,     66,      "%",  100,         0
-      baroCorrection  = scalar,  U16,     68,      "%",  100,         0
-      fuelPidCorrection=scalar,  S16,     70,     "ms",  300,         0
+      injectorLagMs   = scalar,  U16,     62,     "ms",{1/300},       0.0
+      iatCorrection   = scalar,  U16,     64,        "%", 0.01,         0
+      cltCorrection   = scalar,  U16,     66,        "%", 0.01,         0
+      baroCorrection  = scalar,  U16,     68,        "%", 0.01,         0
+      fuelPidCorrection=scalar,  S16,     70,     "ms",{1/300},         0
 
 ; Wall model AE
-      wallFuelAmount  = scalar,  U16,     72,     "ms",  300,         0
-      wallFuelCorrection=scalar, S16,     74,     "ms", 1000,         0
+      wallFuelAmount  = scalar,  U16,     72,     "ms",{1/300},         0
+      wallFuelCorrection=scalar, S16,     74,       "ms",0.001,         0
 
 ; TPS/load AE
-      engineLoadDelta = scalar,  S16,     76,  "value",  100,         0
-      deltaTps        = scalar,  S16,     78,  "ratio",  100,         0
-      engineLoadAccelExtra= scalar,U16,   80,  "value",  300,         0
-      tpsAccelFuel    = scalar,  U16,     82,     "ms",  300,         0
+      engineLoadDelta = scalar,  S16,     76,    "value", 0.01,         0
+      deltaTps        = scalar,  S16,     78,    "ratio", 0.01,         0
+      engineLoadAccelExtra= scalar,U16,   80,  "value",{1/300},         0
+      tpsAccelFuel    = scalar,  U16,     82,     "ms",{1/300},         0
 
 ; Ignition
-      ignitionAdvance = scalar,  U16,     84,    "deg",   50,       0.0
-      sparkDwellValue = scalar,  U16,     86,     "ms",  300,       0.0
-      coilDutyCycle   = scalar,  U16,     88,      "%",  100,         0
+      ignitionAdvance = scalar,  U16,     84,    "deg",   0.02,       0.0
+      sparkDwellValue = scalar,  U16,     86,     "ms",{1/300},       0.0
+      coilDutyCycle   = scalar,  U16,     88,      "%",   0.01,         0
 
 ; Idle & ETB
-      idleAirValvePosition=scalar,S16,    90,      "%",  100,         0
-      etbTarget       = scalar,  S16,     92,      "%",  100,         0
-      etb1DutyCycle   = scalar,  S16,     94,      "%",  100,         0
-      etb1Error       = scalar,  S16,     96,      "%",  100,         0
+      idleAirValvePosition=scalar,S16,    90,      "%",   0.01,         0
+      etbTarget       = scalar,  S16,     92,      "%",   0.01,         0
+      etb1DutyCycle   = scalar,  S16,     94,      "%",   0.01,         0
+      etb1Error       = scalar,  S16,     96,      "%",   0.01,         0
 
 ; Fuel system
-      fuelTankLevel   = scalar,  S16,     98, "amount",  100,         0
-      fuelConsumptionPerHour=scalar,F32, 100,    "kPa",    1,      0.0
+      fuelTankLevel   = scalar,  S16,     98, "amount",   0.01,         0
+      fuelConsumptionPerHour=scalar,F32, 100,    "kPa",      1,      0.0
 
 ; Knock
-      knockCount      = scalar,  U32,    104,"counter",    1,         0
-      knockLevel      = scalar,  F32,    108,  "Volts",    1,         0
+      knockCount      = scalar,  U32,    104,"counter",      1,         0
+      knockLevel      = scalar,  F32,    108,  "Volts",      1,         0
 
 ; Mode, firmware, protocol, run time
-      timeSeconds     = scalar,  U32,    112,    "sec",    1,       0.0
-      engineMode      = scalar,  U32,    116,     "em",    1,       0.0;
-      firmwareVersion = scalar,  U32,    120,"version_f",  1,         0
-      firmwareTsVersion=scalar,  U32,    124,"version_p",  1,         0
+      timeSeconds     = scalar,  U32,    112,    "sec",      1,       0.0
+      engineMode      = scalar,  U32,    116,     "em",      1,       0.0;
+      firmwareVersion = scalar,  U32,    120,"version_f",    1,         0
+      firmwareTsVersion=scalar,  U32,    124,"version_p",    1,         0
 
 ; egt
-      egt1            = scalar,  S16,    128,  "deg C",           1,         0
-      egt2            = scalar,  S16,    130,  "deg C",           1,         0
-      egt3            = scalar,  S16,    132,  "deg C",           1,         0
-      egt4            = scalar,  S16,    134,  "deg C",           1,         0
-      egt5            = scalar,  S16,    136,  "deg C",           1,         0
-      egt6            = scalar,  S16,    138,  "deg C",           1,         0
-      egt7            = scalar,  S16,    140,  "deg C",           1,         0
-      egt8            = scalar,  S16,    142,  "deg C",           1,         0
+      egt1            = scalar,  S16,    128,  "deg C",      1,         0
+      egt2            = scalar,  S16,    130,  "deg C",      1,         0
+      egt3            = scalar,  S16,    132,  "deg C",      1,         0
+      egt4            = scalar,  S16,    134,  "deg C",      1,         0
+      egt5            = scalar,  S16,    136,  "deg C",      1,         0
+      egt6            = scalar,  S16,    138,  "deg C",      1,         0
+      egt7            = scalar,  S16,    140,  "deg C",      1,         0
+      egt8            = scalar,  S16,    142,  "deg C",      1,         0
 
 ; Accel
       accelerationX   = scalar,  S16,    144,      "G",        0.01,         0

--- a/firmware/tunerstudio/rusefi.input
+++ b/firmware/tunerstudio/rusefi.input
@@ -264,7 +264,7 @@ fileVersion = { 20190701 }
 ; TPS/load AE
       engineLoadDelta = scalar,  S16,     76,    "value", 0.01,         0
       deltaTps        = scalar,  S16,     78,    "ratio", 0.01,         0
-      engineLoadAccelExtra= scalar,U16,   80,  "value",{1/300},         0
+      engineLoadAccelExtra=scalar,S16,    80,    "value", 0.01,         0
       tpsAccelFuel    = scalar,  U16,     82,     "ms",{1/300},         0
 
 ; Ignition

--- a/firmware/tunerstudio/rusefi.input
+++ b/firmware/tunerstudio/rusefi.input
@@ -167,136 +167,172 @@ fileVersion = { 20190701 }
 ;
 ; see TunerStudioOutputChannels struct
 ;
-      RPMValue        = scalar,  U32,      0,             "RPM",            1,   0.00000
+
+; Bit flags
+	  hasSdCard       = bits,    U32,      0,    [0:0], "true", "false";
+	  isIgnitionEnabledIndicator=bits,U32, 0,    [1:1], "true", "false";
+	  ind_injection_enabled=bits,U32,      0,    [2:2], "true", "false";
+	  isCylinderCleanupEnabled=bits,U32,   0,    [3:3], "true", "false";
+	  isCylinderCleanupActivated=bits,U32, 0,    [4:4], "true", "false";
+	  ind_fuel_pump   = bits,    U32,      0,    [5:5], "true", "false";
+	  ind_fan         = bits,    U32,      0,    [6:6], "true", "false";
+	  ind_o2_heater   = bits,    U32,      0,    [7:7], "true", "false";
+      ind_check_engine= bits,    U32,      0,    [8:8], "true", "false";
+      needBurn        = bits,    U32,      0,    [9:9], "true", "false";
+      ind_2nd_trigger_en=bits,   U32,      0,  [10:10], "true", "false";
+      clutchUpState    =bits,    U32,      0,  [11:11], "true", "false";
+      clutchDownState  =bits,    U32,      0,  [12:12], "true", "false";
+      knockEverIndicator=bits,   U32,      0,  [13:13], "true", "false";
+      knockNowIndicator=bits,    U32,      0,  [14:14], "true", "false";
+      brakePedalIndicator=bits,  U32,      0,  [15:15], "true", "false";
+      toothLogReady      =bits,  U32,      0,  [16:16], "true", "false";
+      acSwitchIndicator =bits,   U32,      0,  [17:17], "true", "false";
+      ind_tps_error   = bits,    U32,      0,  [18:18], "true", "false";
+      ind_clt_error   = bits,    U32,      0,  [19:19], "true", "false";
+      ind_map_error   = bits,    U32,      0,  [20:21], "true", "false";
+      ind_iat_error   = bits,    U32,      0,  [21:22], "true", "false";
+      ind_isTriggerError = bits, U32,      0,  [23:23], "true", "false";
+      ind_hasFatalError=bits,    U32,      0,  [24:24], "true", "false";
+	  ind_isWarnNow    =bits,    U32,      0,  [25:25], "true", "false";
+
+; RPM, vss
+      RPMValue        = scalar,  U16,      4,    "RPM",    4,   0.00000
+      rpmAcceleration = scalar,  S16,      6,   "dRpm",  100,         0
+      speedToRpmRatio = scalar,  S16,      8,  "value",  100,         0
+      vehicleSpeedKph = scalar,  U16,     10,    "kph",  100,       0.0
+
+; temperatures
+     internalMcuTemperature = scalar,S08, 11,  "deg C",    1,         0
 #if CELSIUS
-      coolant         = scalar,  F32,      4,              "deg C",            1,       0.0
+      coolant         = scalar,  S16,     12,  "deg C",  100,       0.0
 #else
-      coolant         = scalar,  F32,      4,              "deg F",         {9/5},  17.77777
+      coolant         = scalar,  S16,     12,  "deg F", {900/5},  17.77777
 #endif
 #if CELSIUS
-      intake          = scalar,  F32,      8,              "deg C",            1,       0.0
+      intake          = scalar,  S16,     14,  "deg C",  100,       0.0
 #else
-      intake          = scalar,  F32,      8,              "deg F",         {9/5},  17.77777
+      intake          = scalar,  S16,     14,  "deg F", {900/5},  17.77777
 #endif
-      TPSValue        = scalar,  F32,     12,               "%",            1,         0
-      MAFValue        = scalar,  F32,     16,               "V",            1,         0
-      AFRValue       = scalar,  F32,     20,             "AFR",            1,       0.0
-      engineLoad      = scalar,	 F32,     24,	    "%",            1,       0.0 ; Blend of MAP and TPS, depends on algorithm
-      VBatt	          = scalar,	 F32,     28,	            "V",            1,       0.0
+; todo: aux1
+; todo: aux2
+      
+
+; throttle, pedal
+      TPSValue        = scalar,  U16,     20,      "%",  100,         0
+      throttlePedalPosition = scalar,U16, 22,      "%",  100,         0
+      tpsADC          = scalar,  U16,     24,    "ADC",    1,       0.0;
+
+; air flow/mass measurments
+      MAFValue        = scalar,  U16,     26,      "V", 1000,         0
+      massAirFlowValue= scalar,  U16,     28,   "Kg/h",  100,         0
+      MAPValue        = scalar,  U16,     30,    "kPa",   30,       0.0
+      baroPressure    = scalar,  U16,     32,    "kPa",   30,       0.0
+      AFRValue        = scalar,  U16,     34,    "AFR", 1000,       0.0
+      engineLoad      = scalar,  U16,     36,      "%",  100,       0.0 ; Blend of MAP and TPS, depends on algorithm
+
+; misc sensors
+      VBatt	          = scalar,	 U16,     38,      "V", 1000,       0.0
+      oilPressure     = scalar,  U16,     40,    "kPa",   30,       0.0
+      vvtPosition     = scalar,  U16,     42,    "deg",   50,         0
+
       ; 10 bit TPS ADC value (from 0 to 1023 in 5v scale)
-      tpsADC          = scalar,  U16,     32,             "ADC",            1,       0.0;
-      tpsADC2         = scalar,  U16,     34,             "ADC",            1,       0.0;
-      baroPressure    = scalar,  F32,     36,             "pres",           1,       0.0;
-      MAPValue        = scalar,  F32,     40,              "MAP",           1,       0.0;
-	  ; total fuel squirt duration (in MS) per engine cycle according to current CLT
-	  crankingFuelMs  = scalar,  F32,     44,              "ms",            1,       0.0;
-      baseFuel        = scalar,  F32,     48,              "ms",           1,         0
-      tCharge         = scalar,  F32,     52,              "T",             1,       0.0;
-      ignitionAdvance = scalar,  F32,     56,              "deg",           1,       0.0;
-      sparkDwellValue = scalar,  F32,     60,              "ms",           1,       0.0;
-      ; actual total Ms time per engine cycle with all corrections
-      actualLastInjection      = scalar,  F32,     64,              "ms",           1,       0.0;
-      debugFloatField1    = scalar,  F32,  68,            "val",           1,       0.0;
-      
-      hasSdCard       = bits,    U32,     72, [0:0], "true", "false";
-	  isIgnitionEnabledIndicator=bits, U32,     72, [1:1], "true", "false";
-	  ind_injection_enabled=bits,U32,     72, [2:2], "true", "false";
-	  isCylinderCleanupEnabled=bits, U32, 72, [3:3], "true", "false";
-	  isCylinderCleanupActivated=bits,U32,72, [4:4], "true", "false";
-	  ind_fuel_pump   = bits,    U32,     72, [5:5], "true", "false";
-	  ind_fan         = bits,    U32,     72, [6:6], "true", "false";
-	  ind_o2_heater   = bits,    U32,     72, [7:7], "true", "false";
-      ind_check_engine= bits,    U32,     72, [8:8], "true", "false";
-      needBurn        = bits,    U32,     72, [9:9], "true", "false";
-      ind_2nd_trigger_en=bits,   U32,     72, [10:10], "true", "false";
-      clutchUpState    =bits,    U32,     72, [11:11], "true", "false";
-      clutchDownState  =bits,    U32,     72, [12:12], "true", "false";
-      knockEverIndicator=bits,   U32,     72, [13:13], "true", "false";
-      knockNowIndicator=bits,    U32,     72, [14:14], "true", "false";
-      brakePedalIndicator=bits,  U32,     72, [15:15], "true", "false";
-      toothLogReady      =bits,  U32,     72, [16:16], "true", "false";
-      acSwitchIndicator =bits,   U32,     72, [17:17], "true", "false";
-      vehicleSpeedKph = scalar,  F32,     76,        "kph",   1,       0.0;
-      
-      ind_tps_error   = bits,    U32,     80, [0:0], "true", "false";
-      ind_clt_error   = bits,    U32,     80, [1:1], "true", "false";
-      ind_map_error   = bits,    U32,     80, [2:2], "true", "false";
-      ind_iat_error   = bits,    U32,     80, [3:3], "true", "false";
-      ind_isTriggerError = bits, U32,     80, [5:5], "true", "false";
-      ind_hasFatalError=bits,    U32,     80, [6:6], "true", "false";
-      ind_isWarnNow    =bits,    U32,     80, [7:7], "true", "false";
-      firmwareTsVersion = scalar,U32,     84, "version_p",           1,         0
-      egt1            = scalar,  S16,     88, "deg C",           1,         0
-      egt2            = scalar,  S16,     90, "deg C",           1,         0
-      egt3            = scalar,  S16,     92, "deg C",           1,         0
-      egt4            = scalar,  S16,     94, "deg C",           1,         0
-      egt5            = scalar,  S16,     96, "deg C",           1,         0
-      egt6            = scalar,  S16,     98, "deg C",           1,         0
-      egt7            = scalar,  S16,    100, "deg C",           1,         0
-      egt8            = scalar,  S16,    102, "deg C",           1,         0
-      rpmAcceleration = scalar,  F32,    104, "dRpm",         1,         0
-      massAirFlowValue= scalar,  F32,    108, "Kg/h",         1,         0
-      veValue         = scalar,  F32,    112, "ratio",        1,         0
-      deltaTps        = scalar,  F32,    116, "ratio",        1,         0
-      triggerErrorsCounter = scalar, U32,120, "counter",      1,         0
-      engineLoadAccelExtra = scalar,F32, 124, "value",        1,         0
-      tpsAccelFuel    = scalar,  F32,    128, "ms",           1,         0
-      baroCorrection  = scalar,  F32,    132, "%",            1,         0
-      throttlePedalPosition   = scalar,  F32,    136, "%",            1,         0
-      injectorDutyCycle= scalar, F32,    140, "%",            1,         0
-      knockCount      = scalar,  U32,    144, "counter",      1,         0
-      fuelTankLevel   = scalar,  F32,    148, "amount",       1,         0
-      knockLevel      = scalar,  F32,    152, "Volts",        1,         0
+      ;tpsADC2         = scalar,  U16,    44,             "ADC",            1,       0.0;
+
+; fuel math
+      chargeAirMass   = scalar,  U16,     44,      "g", 1000,         0
+      crankingFuelMs  = scalar,  U16,     46,     "ms",  300,       0.0
+      currentTargetAfr= scalar,  U16,     48,  "ratio", 1000,         0
+      baseFuel        = scalar,  U16,     50,     "ms",  300,         0
+      fuelRunning     = scalar,  U16,     52,     "ms",  300,         0
+      actualLastInjection=scalar,U16,     54,     "ms",  300,       0.0
+      injectorDutyCycle=scalar,  U08,     56,      "%",    2,         0
+      veValue         = scalar,  U08,     57,  "ratio",    2,         0
+      injectionOffset = scalar,  S16,     58,    "deg",   50,         0
+      tCharge         = scalar,  U16,     60,  "deg C",  100,       0.0
+
+; Corrections
+      injectorLagMs   = scalar,  U16,     62,     "ms",  300,       0.0
+      iatCorrection   = scalar,  U16,     64,      "%",  100,         0
+      cltCorrection   = scalar,  U16,     66,      "%",  100,         0
+      baroCorrection  = scalar,  U16,     68,      "%",  100,         0
+      fuelPidCorrection=scalar,  S16,     70,     "ms",  300,         0
+
+; Wall model AE
+      wallFuelAmount  = scalar,  U16,     72,     "ms",  300,         0
+      wallFuelCorrection=scalar, S16,     74,     "ms", 1000,         0
+
+; TPS/load AE
+      engineLoadDelta = scalar,  S16,     76,  "value",  100,         0
+      deltaTps        = scalar,  S16,     78,  "ratio",  100,         0
+      engineLoadAccelExtra= scalar,U16,   80,  "value",  300,         0
+      tpsAccelFuel    = scalar,  U16,     82,     "ms",  300,         0
+
+; Ignition
+      ignitionAdvance = scalar,  U16,     84,    "deg",   50,       0.0
+      sparkDwellValue = scalar,  U16,     86,     "ms",  300,       0.0
+      coilDutyCycle   = scalar,  U16,     88,      "%",  100,         0
+
+; Idle & ETB
+      idleAirValvePosition=scalar,S16,    90,      "%",  100,         0
+      etbTarget       = scalar,  S16,     92,      "%",  100,         0
+      etb1DutyCycle   = scalar,  S16,     94,      "%",  100,         0
+      etb1Error       = scalar,  S16,     96,      "%",  100,         0
+
+; Fuel system
+      fuelTankLevel   = scalar,  S16,     98, "amount",  100,         0
+      fuelConsumptionPerHour=scalar,F32, 100,    "kPa",    1,      0.0
+
+; Knock
+      knockCount      = scalar,  U32,    104,"counter",    1,         0
+      knockLevel      = scalar,  F32,    108,  "Volts",    1,         0
+
+; Mode, firmware, protocol, run time
+      timeSeconds     = scalar,  U32,    112,    "sec",    1,       0.0
+      engineMode      = scalar,  U32,    116,     "em",    1,       0.0;
+      firmwareVersion = scalar,  U32,    120,"version_f",  1,         0
+      firmwareTsVersion=scalar,  U32,    124,"version_p",  1,         0
+
+; egt
+      egt1            = scalar,  S16,    128,  "deg C",           1,         0
+      egt2            = scalar,  S16,    130,  "deg C",           1,         0
+      egt3            = scalar,  S16,    132,  "deg C",           1,         0
+      egt4            = scalar,  S16,    134,  "deg C",           1,         0
+      egt5            = scalar,  S16,    136,  "deg C",           1,         0
+      egt6            = scalar,  S16,    138,  "deg C",           1,         0
+      egt7            = scalar,  S16,    140,  "deg C",           1,         0
+      egt8            = scalar,  S16,    142,  "deg C",           1,         0
+
+; Accel
+      accelerationX   = scalar,  S16,    144,      "G",        0.01,         0
+      accelerationY   = scalar,  S16,    148,      "G",        0.01,         0
+
+; Errors
+      warningCounter  = scalar,  U16,    150,  "count",           1,         0
+      triggerErrorsCounter=scalar,U32,   152,"counter",           1,         0
       ; totalTriggerErrorCounter 156
-      wallFuelAmount = scalar, F32,      160, "ms",           1,         0
-      iatCorrection = scalar, F32,       164, "%",            1,         0
-      wallFuelCorrection = scalar, F32,  168, "ms",           1,         0
-      idleAirValvePosition = scalar, F32,     172, "percent",      1,         0
-      currentTargetAfr = scalar, F32,    176, "ratio",      1,         0
-      chargeAirMass = scalar, F32,       180, "g",      1,         0
-      cltCorrection = scalar, F32,       184, "%",            1,         0
-      fuelRunning = scalar, F32,         188, "g",      1,         0
-      debugIntField1    = scalar,  S32,  192, "val",          1,       0.0;
-      injectorLagMs     = scalar,  F32,  196,            "ms",           1,       0.0;
-      debugFloatField2  = scalar,  F32,  200,            "val",           1,       0.0;
-      debugFloatField3  = scalar,  F32,  204,            "val",           1,       0.0;
-      debugFloatField4  = scalar,  F32,  208,            "val",           1,       0.0;
-      debugFloatField5  = scalar,  F32,  212,            "val",           1,       0.0;
-      debugIntField2    = scalar,  S32,   216, "val",          1,       0.0;
-      debugIntField3    = scalar,  S32,   220, "val",          1,       0.0;
-      timeSeconds       = scalar,  U32,   224, "sec",          1,       0.0;
-      engineLoadDelta = scalar,F32, 228, "value",            1,         0
-      speedToRpmRatio = scalar,F32, 232, "value",            1,         0
-      warningCounter = scalar,U16, 236, "count",            1,         0
-      
-      lastErrorCode = scalar,U16, 240, "error",            1,         0
-      
-      internalMcuTemperature = scalar,F32, 244, "C",            1,         0
-      vvtPosition = scalar,F32, 248, "deg",            1,         0
-      engineMode    = scalar,  U32,   252, "em",          1,       0.0;
-      debugFloatField6  = scalar,  F32,  256,            "val",           1,       0.0;
-      debugFloatField7  = scalar,  F32,  260,            "val",           1,       0.0;
-      firmwareVersion = scalar,U32,     264, "version_f",           1,         0
-      fuelPidCorrection        = scalar,  F32,     268,              "ms",           1,         0
-      coilDutyCycle        = scalar,  F32,     272,              "perc",           1,         0
-      accelerationX        = scalar,  S16,     276,              "G",           0.01,         0
-      accelerationY        = scalar,  S16,     278,              "G",           0.01,         0
-      oilPressure	   = scalar,  F32,     280,		 "kPa",			1, 0.0
-      fuelConsumptionPerHour=scalar,  F32,     284,		 "kPa",			1, 0.0
-      injectionOffset       = scalar, F32,     288,              "deg",                 1,     0;
-      debugIntField4    = scalar,  S16,  292, "val",          1,       0.0;
-      debugIntField5    = scalar,  S16,  294, "val",          1,       0.0;
-	  recentErrorCode0 = scalar,U16, 296, "error",            1,         0
-      recentErrorCode1 = scalar,U16, 298, "error",            1,         0
-      recentErrorCode2 = scalar,U16, 300, "error",            1,         0
-      recentErrorCode3 = scalar,U16, 302, "error",            1,         0
-      recentErrorCode4 = scalar,U16, 304, "error",            1,         0
-      recentErrorCode5 = scalar,U16, 306, "error",            1,         0
-      recentErrorCode6 = scalar,U16, 308, "error",            1,         0
-      recentErrorCode7 = scalar,U16, 310, "error",            1,         0
-      etbTarget        = scalar,F32, 312, "%", 1, 0
-      etb1DutyCycle    = scalar,F32, 316, "%", 1, 0
-      etb1Error        = scalar,F32, 320, "%", 1, 0
+      lastErrorCode   = scalar,  U16,    160,  "error",           1,         0
+      recentErrorCode0= scalar,  U16,    162,  "error",           1,         0
+      recentErrorCode1= scalar,  U16,    164,  "error",           1,         0
+      recentErrorCode2= scalar,  U16,    166,  "error",           1,         0
+      recentErrorCode3= scalar,  U16,    168,  "error",           1,         0
+      recentErrorCode4= scalar,  U16,    170,  "error",           1,         0
+      recentErrorCode5= scalar,  U16,    172,  "error",           1,         0
+      recentErrorCode6= scalar,  U16,    174,  "error",           1,         0
+      recentErrorCode7= scalar,  U16,    176,  "error",           1,         0
+
+; Debug
+      debugFloatField1= scalar,  F32,    180,    "val",           1,       0.0
+      debugFloatField2= scalar,  F32,    184,    "val",           1,       0.0
+      debugFloatField3= scalar,  F32,    188,    "val",           1,       0.0
+      debugFloatField4= scalar,  F32,    192,    "val",           1,       0.0
+      debugFloatField5= scalar,  F32,    196,    "val",           1,       0.0
+      debugFloatField6= scalar,  F32,    200,    "val",           1,       0.0
+      debugFloatField7= scalar,  F32,    204,    "val",           1,       0.0
+      debugIntField1  = scalar,  S32,    208,    "val",           1,       0.0
+      debugIntField2  = scalar,  S32,    212,    "val",           1,       0.0
+      debugIntField3  = scalar,  S32,    216,    "val",           1,       0.0
+      debugIntField4  = scalar,  S16,    220,    "val",           1,       0.0
+      debugIntField5  = scalar,  S16,    222,    "val",           1,       0.0
 
 
 ;


### PR DESCRIPTION
- Implement `scaled_channel` which allows a scaled output channel (for example, storing quarter-RPM) to be used as though it was a normal float, even though it's backed by a different type.
- Reorder TS output channels in roughly reverse priority order.  Since rarely used channels are at the end, datalogging can be sped up by reading a contiguous block of channels near the beginning that we actually care about (for example, logging up thru `lastErrorCode`, 140 bytes, updates at 210-215hz while datalogging on a debug build on an stm32f4 over USB.  This previously ran at ~90hz).
- This change reduces total output channel size from 356 to 220 bytes

The modifications to `tle8888.h`/`c` were required because that `tunerstudio_configuration.h` now requires c++, so we inject only the debug channels where we need them in c-land.

This change has been tested by both @960 and myself.  I adjusted tune settings where possible to test channels, and where not possible to test on the bench, I modified the function in `status_loop.cpp` to manually set values, then confirm that they showed as expected in TS.