### PR TITLE
add settings to log debug & errors list

### DIFF
--- a/firmware/tunerstudio/rusefi.input
+++ b/firmware/tunerstudio/rusefi.input
@@ -318,6 +318,10 @@ fileVersion = { 20190701 }
     wueAfrTargetOffset = array, S16, [ 16], ":1",   0.1, 0.0, -3.0, 3.0, 1;
     wueAnalRecommend   = array, U08, [ 16], "%",  1.00, 0.0, 100, 255.00, 0
 
+; These are inverted (false = "Yes") so that they default to enabled
+	enableLogDebugChannels = bits, U08, [0:0], "Yes", "No"
+	enableLogErrorList = bits, U08, [0:0], "Yes", "No"
+
 [ConstantsExtensions]
     defaultValue = wueAfrTargetOffset, -1.5 -1.4 -1.15 -0.95 -0.775 -0.65 -0.5625 -0.5 -0.4375 -0.375 -0.3125 -0.25 -0.1875 -0.125 -0.0625 0
 
@@ -1009,54 +1013,54 @@ gaugeCategory = Throttle Body (incl. ETB)
 ; is there a way to log parameter?   entry = debugMode,   "debugMode",int,"%d"
 ; Alternator_PID: alternator duty cycle
 ; DBG_TPS_ACCEL: from TPS 
-   entry = debugFloatField1,   @@GAUGE_NAME_DEBUG_F1@@,float,"%.4f"
+   entry = debugFloatField1,   @@GAUGE_NAME_DEBUG_F1@@,float,"%.4f", { !enableLogDebugChannels }
 
 ; Alternator_PID: current integration term
 ; DBG_TPS_ACCEL: to TPS
-   entry = debugFloatField2,   @@GAUGE_NAME_DEBUG_F2@@,float,"%.4f"
+   entry = debugFloatField2,   @@GAUGE_NAME_DEBUG_F2@@,float,"%.4f", { !enableLogDebugChannels }
    
 ; Alternator_PID: previous error
 ; DBG_TPS_ACCEL: tps<>tps table value
-   entry = debugFloatField3,   @@GAUGE_NAME_DEBUG_F3@@,float,"%.4f"
+   entry = debugFloatField3,   @@GAUGE_NAME_DEBUG_F3@@,float,"%.4f", { !enableLogDebugChannels }
    
 ; Alternator_PID: I setting
 ; DBG_TPS_ACCEL: extra fuel   
-   entry = debugFloatField4,   @@GAUGE_NAME_DEBUG_F4@@,float,"%.4f"
+   entry = debugFloatField4,   @@GAUGE_NAME_DEBUG_F4@@,float,"%.4f", { !enableLogDebugChannels }
 
 ; Alternator_PID: D setting
-   entry = debugFloatField5,   @@GAUGE_NAME_DEBUG_F5@@,float,"%.4f"
+   entry = debugFloatField5,   @@GAUGE_NAME_DEBUG_F5@@,float,"%.4f", { !enableLogDebugChannels }
 
 ; Alternator_PID: dTerm
-   entry = debugFloatField6,   @@GAUGE_NAME_DEBUG_F6@@,float,"%.4f"
+   entry = debugFloatField6,   @@GAUGE_NAME_DEBUG_F6@@,float,"%.4f", { !enableLogDebugChannels }
    
-   entry = debugFloatField7,   @@GAUGE_NAME_DEBUG_F7@@,float,"%.4f"
+   entry = debugFloatField7,   @@GAUGE_NAME_DEBUG_F7@@,float,"%.4f", { !enableLogDebugChannels }
 
 
 ; Alternator_PID: P setting
-   entry = debugIntField1,   @@GAUGE_NAME_DEBUG_I1@@,int,"%d"
+   entry = debugIntField1,   @@GAUGE_NAME_DEBUG_I1@@,int,"%d", { !enableLogDebugChannels }
 
 ; Alternator_PID: offset setting
-   entry = debugIntField2,   @@GAUGE_NAME_DEBUG_I2@@,int,"%d"
+   entry = debugIntField2,   @@GAUGE_NAME_DEBUG_I2@@,int,"%d", { !enableLogDebugChannels }
    
 ; Alternator_PID: PID reset counter   
-   entry = debugIntField3,   @@GAUGE_NAME_DEBUG_I3@@,int,"%d"
+   entry = debugIntField3,   @@GAUGE_NAME_DEBUG_I3@@,int,"%d", { !enableLogDebugChannels }
 
-   entry = debugIntField4,   @@GAUGE_NAME_DEBUG_I4@@,int,"%d"
+   entry = debugIntField4,   @@GAUGE_NAME_DEBUG_I4@@,int,"%d", { !enableLogDebugChannels }
 
-   entry = debugIntField5,   @@GAUGE_NAME_DEBUG_I5@@,int,"%d"
-   
-      
+   entry = debugIntField5,   @@GAUGE_NAME_DEBUG_I5@@,int,"%d", { !enableLogDebugChannels }
+
+
    entry = engineMode,   "Engine Mode",int,"%d"
    entry = warningCounter,   @@GAUGE_NAME_WARNING_COUNTER@@,int,"%d"
    entry = lastErrorCode,   @@GAUGE_NAME_WARNING_LAST@@,int,"%d"
-   entry = recentErrorCode0,   "error 0",int,"%d"
-   entry = recentErrorCode1,   "error 1",int,"%d"
-   entry = recentErrorCode2,   "error 2",int,"%d"
-   entry = recentErrorCode3,   "error 3",int,"%d"
-   entry = recentErrorCode4,   "error 4",int,"%d"
-   entry = recentErrorCode5,   "error 5",int,"%d"
-   entry = recentErrorCode6,   "error 6",int,"%d"
-   entry = recentErrorCode7,   "error 7",int,"%d"
+   entry = recentErrorCode0,   "error 0",int,"%d", { !enableLogErrorList }
+   entry = recentErrorCode1,   "error 1",int,"%d", { !enableLogErrorList }
+   entry = recentErrorCode2,   "error 2",int,"%d", { !enableLogErrorList }
+   entry = recentErrorCode3,   "error 3",int,"%d", { !enableLogErrorList }
+   entry = recentErrorCode4,   "error 4",int,"%d", { !enableLogErrorList }
+   entry = recentErrorCode5,   "error 5",int,"%d", { !enableLogErrorList }
+   entry = recentErrorCode6,   "error 6",int,"%d", { !enableLogErrorList }
+   entry = recentErrorCode7,   "error 7",int,"%d", { !enableLogErrorList }
    entry = internalMcuTemperature,   @@GAUGE_NAME_CPU_TEMP@@,float,"%.2f"
    
    entry = tCharge, "tCharge",float,"%.3f"
@@ -1232,6 +1236,7 @@ menuDialog = main
 
 	menu = "&Controller"
 		subMenu = ecuStimulator,			"ECU stimulator"
+		subMenu = datalogSettings,			"Datalogging"
 		subMenu = ioTest,					"Bench test"
 		subMenu = engineTypeDialog,			"Popular vehicles"
 		subMenu = std_separator
@@ -2605,6 +2610,11 @@ cmd_set_engine_type_default					= "w\x00\x31\x00\x00"
 	    field = "Logic input channel 4", 				logicAnalyzerPins4
 		field = ""
 	    field = "Engine chart size", 					engineChartSize
+
+	dialog = datalogSettings, "Datalogging Settings"
+		field = "#Disabling optional logging may increase update rate!"
+		field = "Log debug channels",					enableLogDebugChannels
+		field = "Log recent errors list",				enableLogErrorList
 
 				;			Racing Features->Launch Control
 	dialog = smLaunchControl, "Launch Control Settings NOT WORKING"


### PR DESCRIPTION
Add settings to TunerStudio to manually disable logging debug channels & the error list.  These new settings default to "Yes".  That means that unless a user intentionally goes to change the setting, the default behavior **does not change**.

The new settings are normal fields, but only stored in `CurrentTune.msq` without being sent at all to the ECU (in the `[PcVariables]` section of the ini).