### PR TITLE
Inject timestamps in to hwHandleShaftSignal

### DIFF
--- a/firmware/controllers/trigger/trigger_central.h
+++ b/firmware/controllers/trigger/trigger_central.h
@@ -26,14 +26,14 @@ class TriggerCentral : public trigger_central_s {
 public:
 	TriggerCentral();
 	void addEventListener(ShaftPositionListener handler, const char *name, Engine *engine);
-	void handleShaftSignal(trigger_event_e signal DECLARE_ENGINE_PARAMETER_SUFFIX);
+	void handleShaftSignal(trigger_event_e signal, efitick_t timestamp DECLARE_ENGINE_PARAMETER_SUFFIX);
 	int getHwEventCounter(int index) const;
 	void resetCounters();
 	void resetAccumSignalData();
 	bool noiseFilter(efitick_t nowNt, trigger_event_e signal DECLARE_ENGINE_PARAMETER_SUFFIX);
 	void validateCamVvtCounters();
 	TriggerStateWithRunningStatistics triggerState;
-	efitick_t nowNt = 0;
+
 	angle_t vvtPosition = 0;
 	/**
 	 * this is similar to TriggerState#startOfCycleNt but with the crank-only sensor magic
@@ -56,8 +56,8 @@ private:
 };
 
 void triggerInfo(void);
-void hwHandleShaftSignal(trigger_event_e signal);
-void hwHandleVvtCamSignal(trigger_value_e front DECLARE_ENGINE_PARAMETER_SUFFIX);
+void hwHandleShaftSignal(trigger_event_e signal, efitick_t timestamp);
+void hwHandleVvtCamSignal(trigger_value_e front, efitick_t timestamp DECLARE_ENGINE_PARAMETER_SUFFIX);
 
 void initTriggerCentral(Logging *sharedLogger);
 void printAllTriggers();

--- a/firmware/controllers/trigger/trigger_emulator_algo.cpp
+++ b/firmware/controllers/trigger/trigger_emulator_algo.cpp
@@ -45,22 +45,24 @@ EXTERN_ENGINE
 ;
 
 void TriggerEmulatorHelper::handleEmulatorCallback(PwmConfig *state, int stateIndex) {
+	efitick_t stamp = getTimeNowNt();
+	
 	// todo: code duplication with TriggerStimulatorHelper::feedSimulatedEvent?
 	MultiChannelStateSequence *multiChannelStateSequence = &state->multiChannelStateSequence;
 
 	if (needEvent(stateIndex, state->phaseCount, &state->multiChannelStateSequence, 0)) {
 		pin_state_t currentValue = multiChannelStateSequence->getChannelState(/*phaseIndex*/0, stateIndex);
-		hwHandleShaftSignal(currentValue ? SHAFT_PRIMARY_RISING : SHAFT_PRIMARY_FALLING);
+		hwHandleShaftSignal(currentValue ? SHAFT_PRIMARY_RISING : SHAFT_PRIMARY_FALLING, stamp);
 	}
 
 	if (needEvent(stateIndex, state->phaseCount, &state->multiChannelStateSequence, 1)) {
 		pin_state_t currentValue = multiChannelStateSequence->getChannelState(/*phaseIndex*/1, stateIndex);
-		hwHandleShaftSignal(currentValue ? SHAFT_SECONDARY_RISING : SHAFT_SECONDARY_FALLING);
+		hwHandleShaftSignal(currentValue ? SHAFT_SECONDARY_RISING : SHAFT_SECONDARY_FALLING, stamp);
 	}
 
 	if (needEvent(stateIndex, state->phaseCount, &state->multiChannelStateSequence, 2)) {
 		pin_state_t currentValue = multiChannelStateSequence->getChannelState(/*phaseIndex*/2, stateIndex);
-		hwHandleShaftSignal(currentValue ? SHAFT_3RD_RISING : SHAFT_3RD_FALLING);
+		hwHandleShaftSignal(currentValue ? SHAFT_3RD_RISING : SHAFT_3RD_FALLING, stamp);
 	}
 
 	//	print("hello %d\r\n", chTimeNow());

--- a/firmware/hw_layer/trigger_input_comp.cpp
+++ b/firmware/hw_layer/trigger_input_comp.cpp
@@ -55,6 +55,8 @@ static void setHysteresis(COMPDriver *comp, int sign) {
 }
 
 static void comp_shaft_callback(COMPDriver *comp) {
+	efitick_t stamp = getTimeNowNt();
+	
 	uint32_t status = comp_lld_get_status(comp);
 	int isPrimary = (comp == EFI_COMP_PRIMARY_DEVICE);
 	if (!isPrimary && !TRIGGER_WAVEFORM(needSecondTriggerInput)) {
@@ -64,7 +66,7 @@ static void comp_shaft_callback(COMPDriver *comp) {
 	if (status & COMP_IRQ_RISING) {
 		signal = isPrimary ? (engineConfiguration->invertPrimaryTriggerSignal ? SHAFT_PRIMARY_FALLING : SHAFT_PRIMARY_RISING) : 
 			(engineConfiguration->invertSecondaryTriggerSignal ? SHAFT_SECONDARY_FALLING : SHAFT_SECONDARY_RISING);
-		hwHandleShaftSignal(signal);
+		hwHandleShaftSignal(signal, stamp);
 		// shift the threshold down a little bit to avoid false-triggering (threshold hysteresis)
 		setHysteresis(comp, -1);
 	}
@@ -72,7 +74,7 @@ static void comp_shaft_callback(COMPDriver *comp) {
 	if (status & COMP_IRQ_FALLING) {
 		signal = isPrimary ? (engineConfiguration->invertPrimaryTriggerSignal ? SHAFT_PRIMARY_RISING : SHAFT_PRIMARY_FALLING) : 
 			(engineConfiguration->invertSecondaryTriggerSignal ? SHAFT_SECONDARY_RISING : SHAFT_SECONDARY_FALLING);
-		hwHandleShaftSignal(signal);
+		hwHandleShaftSignal(signal, stamp);
 		// shift the threshold up a little bit to avoid false-triggering (threshold hysteresis)
 		setHysteresis(comp, 1);
 	}
@@ -81,10 +83,12 @@ static void comp_shaft_callback(COMPDriver *comp) {
 // todo: add cam support?
 #if 0
 static void comp_cam_callback(COMPDriver *comp) {
+	efitick_t stamp = getTimeNowNt();
+
 	if (isRising) {
-		hwHandleVvtCamSignal(TV_RISE);
+		hwHandleVvtCamSignal(TV_RISE, stamp);
 	} else {
-		hwHandleVvtCamSignal(TV_FALL);
+		hwHandleVvtCamSignal(TV_FALL, stamp);
 	}
 }
 #endif

--- a/firmware/hw_layer/trigger_input_exti.cpp
+++ b/firmware/hw_layer/trigger_input_exti.cpp
@@ -29,7 +29,11 @@ EXTERN_ENGINE;
 static ioline_t primary_line;
 
 static void shaft_callback(void *arg) {
+	// do the time sensitive things as early as possible!
+	efitick_t stamp = getTimeNowNt();
 	ioline_t pal_line = (ioline_t)arg;
+	bool rise = (palReadLine(pal_line) == PAL_HIGH);
+
 	// todo: support for 3rd trigger input channel
 	// todo: start using real event time from HW event, not just software timer?
 	if (hasFirmwareErrorFlag)
@@ -40,7 +44,6 @@ static void shaft_callback(void *arg) {
 		return;
 	}
 
-	bool rise = (palReadLine(pal_line) == PAL_HIGH);
 	trigger_event_e signal;
 	// todo: add support for 3rd channel
 	if (rise) {
@@ -53,18 +56,20 @@ static void shaft_callback(void *arg) {
 					(engineConfiguration->invertSecondaryTriggerSignal ? SHAFT_SECONDARY_RISING : SHAFT_SECONDARY_FALLING);
 	}
 
-	hwHandleShaftSignal(signal);
+	hwHandleShaftSignal(signal, stamp);
 }
 
 static void cam_callback(void *arg) {
+	efitick_t stamp = getTimeNowNt();
+
 	ioline_t pal_line = (ioline_t)arg;
 
 	bool rise = (palReadLine(pal_line) == PAL_HIGH);
 
 	if (rise) {
-		hwHandleVvtCamSignal(TV_RISE);
+		hwHandleVvtCamSignal(TV_RISE, stamp);
 	} else {
-		hwHandleVvtCamSignal(TV_FALL);
+		hwHandleVvtCamSignal(TV_FALL, stamp);
 	}
 }
 

--- a/firmware/hw_layer/trigger_input_icu.cpp
+++ b/firmware/hw_layer/trigger_input_icu.cpp
@@ -28,14 +28,12 @@ extern bool hasFirmwareErrorFlag;
 
 static Logging *logger;
 
-static void vvtWidthCallback(void *arg) {
-    (void)arg;
-	hwHandleVvtCamSignal(TV_RISE);
+static void vvtWidthCallback(void *) {
+	hwHandleVvtCamSignal(TV_RISE, getTimeNowNt());
 }
 
-static void vvtPeriodCallback(void *arg) {
-    (void)arg;
-	hwHandleVvtCamSignal(TV_FALL);
+static void vvtPeriodCallback(void *) {
+	hwHandleVvtCamSignal(TV_FALL, getTimeNowNt());
 }
 
 /**
@@ -43,6 +41,8 @@ static void vvtPeriodCallback(void *arg) {
  * 'width' events happens before the 'period' event
  */
 static void shaftWidthCallback(bool isPrimary) {
+	efitick_t stamp = getTimeNowNt();
+
 	if (!engine->hwTriggerInputEnabled) {
 		return;
 	}
@@ -58,10 +58,12 @@ static void shaftWidthCallback(bool isPrimary) {
 	// todo: add support for 3rd channel
 	trigger_event_e signal = isPrimary ? (engineConfiguration->invertPrimaryTriggerSignal ? SHAFT_PRIMARY_FALLING : SHAFT_PRIMARY_RISING) : (engineConfiguration->invertSecondaryTriggerSignal ? SHAFT_SECONDARY_FALLING : SHAFT_SECONDARY_RISING);
 
-	hwHandleShaftSignal(signal);
+	hwHandleShaftSignal(signal, stamp);
 }
 
 static void shaftPeriodCallback(bool isPrimary) {
+	efitick_t stamp = getTimeNowNt();
+
 	if (!engine->hwTriggerInputEnabled) {
 		return;
 	}
@@ -76,7 +78,7 @@ static void shaftPeriodCallback(bool isPrimary) {
 	//	icucnt_t last_period = icuGetPeriod(icup); so far we are fine with system time
 	trigger_event_e signal =
 			isPrimary ? (engineConfiguration->invertPrimaryTriggerSignal ? SHAFT_PRIMARY_RISING : SHAFT_PRIMARY_FALLING) : (engineConfiguration->invertSecondaryTriggerSignal ? SHAFT_SECONDARY_RISING : SHAFT_SECONDARY_FALLING);
-	hwHandleShaftSignal(signal);
+	hwHandleShaftSignal(signal, stamp);
 }
 
 /*==========================================================================*/

--- a/unit_tests/engine_test_helper.cpp
+++ b/unit_tests/engine_test_helper.cpp
@@ -90,7 +90,7 @@ void EngineTestHelper::fireRise(float delayMs) {
  * fire single RISE front event
  */
 void EngineTestHelper::firePrimaryTriggerRise() {
-	engine.triggerCentral.handleShaftSignal(SHAFT_PRIMARY_RISING, &engine, engine.engineConfigurationPtr, &persistentConfig);
+	engine.triggerCentral.handleShaftSignal(SHAFT_PRIMARY_RISING, getTimeNowNt(), &engine, engine.engineConfigurationPtr, &persistentConfig);
 }
 
 void EngineTestHelper::fireFall(float delayMs) {
@@ -99,7 +99,7 @@ void EngineTestHelper::fireFall(float delayMs) {
 }
 
 void EngineTestHelper::firePrimaryTriggerFall() {
-	engine.triggerCentral.handleShaftSignal(SHAFT_PRIMARY_FALLING, &engine, engine.engineConfigurationPtr, &persistentConfig);
+	engine.triggerCentral.handleShaftSignal(SHAFT_PRIMARY_FALLING, getTimeNowNt(), &engine, engine.engineConfigurationPtr, &persistentConfig);
 }
 
 void EngineTestHelper::fireTriggerEventsWithDuration(float durationMs) {

--- a/unit_tests/tests/test_cam_vtt_input.cpp
+++ b/unit_tests/tests/test_cam_vtt_input.cpp
@@ -105,7 +105,7 @@ TEST(sensors, testCamInput) {
 
 	for (int i = 0; i < 600;i++) {
 		eth.fireRise(50);
-		hwHandleVvtCamSignal(TV_FALL PASS_ENGINE_PARAMETER_SUFFIX);
+		hwHandleVvtCamSignal(TV_FALL, getTimeNowNt() PASS_ENGINE_PARAMETER_SUFFIX);
 	}
 
 	ASSERT_EQ(0,  unitTestWarningCodeState.recentWarnings.getCount()) << "warningCounter#testCamInput #3";

--- a/unit_tests/tests/test_miata_na6_real_cranking.cpp
+++ b/unit_tests/tests/test_miata_na6_real_cranking.cpp
@@ -29,7 +29,7 @@ static void fireTriggerEvent(EngineTestHelper*eth, double timestampS, int channe
 	EXPAND_Engine;
 	timeNowUs = 1000000 * timestampS;
 	printf("MIATANA: posting time=%d event=%d\r\n", timeNowUs, event);
-	engine->triggerCentral.handleShaftSignal(event, engine, engine->engineConfigurationPtr, &eth->persistentConfig);
+	engine->triggerCentral.handleShaftSignal(event, getTimeNowNt(), engine, engine->engineConfigurationPtr, &eth->persistentConfig);
 }
 
 TEST(miataNA6, realCranking) {


### PR DESCRIPTION
Taking the timestamp long after the interrupt has occurred gives an opportunity for not only a fixed offset error (time elapses between interrupt and timestamp), but also jitter.  The more time that elapses without taking the timestamp, the more time other interrupts could occur (or even different execution time due to branches).

The next work is to inject this timestamp all the way down to listeners - most importantly the logic that schedules ignition events, so that ignition timing is referenced to the actual trigger tooth event, not the trigger tooth event plus however long some logic takes to run (source of both offset error and jitter!).