### PR TITLE
hw: gpio: use unsigned int as pin number inside gpiochip drives

### DIFF
--- a/firmware/hw_layer/drivers/gpio/gpio_ext.h
+++ b/firmware/hw_layer/drivers/gpio/gpio_ext.h
@@ -26,10 +26,11 @@ extern "C"
 #endif /* __cplusplus */
 
 struct gpiochip_ops {
-	int (*setPadMode)(void *data, brain_pin_e pin, int mode);
-	int (*writePad)(void *data, brain_pin_e pin, int value);
-	int (*readPad)(void *data, brain_pin_e pin);
-	int (*getDiag)(void *data, brain_pin_e pin);
+	/* pin argument is pin number within gpio chip, not a global number */
+	int (*setPadMode)(void *data, unsigned int pin, int mode);
+	int (*writePad)(void *data, unsigned int pin, int value);
+	int (*readPad)(void *data, unsigned int pin);
+	int (*getDiag)(void *data, unsigned int pin);
 	int (*init)(void *data);
 	int (*deinit)(void *data);
 };

--- a/firmware/hw_layer/drivers/gpio/mc33810.c
+++ b/firmware/hw_layer/drivers/gpio/mc33810.c
@@ -318,7 +318,7 @@ static THD_FUNCTION(mc33810_driver_thread, p)
 /* Driver exported functions.												*/
 /*==========================================================================*/
 
-int mc33810_writePad(void *data, brain_pin_e pin, int value)
+int mc33810_writePad(void *data, unsigned int pin, int value)
 {
 	struct mc33810_priv *chip;
 
@@ -349,7 +349,7 @@ int mc33810_writePad(void *data, brain_pin_e pin, int value)
 	return 0;
 }
 
-int mc33810_getDiag(void *data, brain_pin_e pin)
+int mc33810_getDiag(void *data, unsigned int pin)
 {
 	int diag;
 

--- a/firmware/hw_layer/drivers/gpio/mc33972.c
+++ b/firmware/hw_layer/drivers/gpio/mc33972.c
@@ -261,7 +261,7 @@ static THD_FUNCTION(mc33972_driver_thread, p)
 /* Driver exported functions.												*/
 /*==========================================================================*/
 
-int mc33972_readPad(void *data, brain_pin_e pin) {
+int mc33972_readPad(void *data, unsigned int pin) {
 	struct mc33972_priv *chip;
 
 	if ((pin >= MC33972_INPUTS) || (data == NULL))
@@ -273,7 +273,7 @@ int mc33972_readPad(void *data, brain_pin_e pin) {
 	return !!(chip->i_state & FLAG_PIN(pin));
 }
 
-int mc33972_getDiag(void *data, brain_pin_e pin) {
+int mc33972_getDiag(void *data, unsigned int pin) {
 	int diag;
 	struct mc33972_priv *chip;
 

--- a/firmware/hw_layer/drivers/gpio/tle6240.c
+++ b/firmware/hw_layer/drivers/gpio/tle6240.c
@@ -376,7 +376,7 @@ static THD_FUNCTION(tle6240_driver_thread, p)
 /* Driver exported functions.												*/
 /*==========================================================================*/
 
-int tle6240_writePad(void *data, brain_pin_e pin, int value)
+int tle6240_writePad(void *data, unsigned int pin, int value)
 {
 	struct tle6240_priv *chip;
 
@@ -409,7 +409,7 @@ int tle6240_writePad(void *data, brain_pin_e pin, int value)
 	return 0;
 }
 
-int tle6240_getDiag(void *data, brain_pin_e pin)
+int tle6240_getDiag(void *data, unsigned int pin)
 {
 	int diag;
 	struct tle6240_priv *chip;

--- a/firmware/hw_layer/drivers/gpio/tle8888.c
+++ b/firmware/hw_layer/drivers/gpio/tle8888.c
@@ -389,7 +389,7 @@ void requestTLE8888initialization(void) {
 /* Driver exported functions.												*/
 /*==========================================================================*/
 
-int tle8888_writePad(void *data, brain_pin_e pin, int value) {
+int tle8888_writePad(void *data, unsigned int pin, int value) {
 
 	if ((pin >= TLE8888_OUTPUTS) || (data == NULL))
 		return -1;


### PR DESCRIPTION
Not brain_pin_e. Drivers like to see pin number within current
chip.