### PR TITLE
don't use us for pwm calculation

### DIFF
--- a/firmware/controllers/system/timer/pwm_generator_logic.h
+++ b/firmware/controllers/system/timer/pwm_generator_logic.h
@@ -83,7 +83,7 @@ public:
 	// todo: 'outputPins' should be extracted away from here since technically one can want PWM scheduler without actual pin output
 	OutputPin *outputPins[PWM_PHASE_MAX_WAVE_PER_PWM];
 	MultiChannelStateSequence multiChannelStateSequence;
-	efitimeus_t togglePwmState();
+	efitick_t togglePwmState();
 	void stop();
 
 	int dbgNestingLevel;


### PR DESCRIPTION
Seems a little silly to convert nt -> us -> nt, doesn't it?