### PR TITLE
Rescale TPS

### DIFF
--- a/firmware/console/status_loop.cpp
+++ b/firmware/console/status_loop.cpp
@@ -735,7 +735,7 @@ void updateTunerStudioState(TunerStudioOutputChannels *tsOutputChannels DECLARE_
 		tsOutputChannels->vBatt = getVBatt(PASS_ENGINE_PARAMETER_SIGNATURE);
 	}
 	// offset 32
-	tsOutputChannels->tpsADC = getTPS12bitAdc(0 PASS_ENGINE_PARAMETER_SUFFIX) / TPS_TS_CONVERSION;
+	tsOutputChannels->tpsADC = getTPS10bitAdc(0 PASS_ENGINE_PARAMETER_SUFFIX);
 	// offset 36
 #if EFI_ANALOG_SENSORS
 	tsOutputChannels->baroPressure = hasBaroSensor() ? getBaroPressure() : 0;

--- a/firmware/controllers/sensors/tps.cpp
+++ b/firmware/controllers/sensors/tps.cpp
@@ -25,7 +25,7 @@ percent_t mockPedalPosition = MOCK_UNDEFINED;
  * this allows unit tests to simulate TPS position
  */
 void setMockTpsAdc(percent_t tpsPosition DECLARE_ENGINE_PARAMETER_SUFFIX) {
-	engine->mockTpsAdcValue = TPS_TS_CONVERSION * tpsPosition;
+	engine->mockTpsAdcValue = tpsPosition;
 }
 
 void setMockTpsValue(percent_t tpsPosition DECLARE_ENGINE_PARAMETER_SUFFIX) {

--- a/firmware/controllers/sensors/tps.cpp
+++ b/firmware/controllers/sensors/tps.cpp
@@ -11,6 +11,9 @@
 
 EXTERN_ENGINE;
 
+// Scaled to 1000 counts = 5.0 volts
+#define TPS_TS_CONVERSION 200
+
 /**
  * set mock_pedal_position X
  * See also directPwmValue
@@ -78,7 +81,7 @@ float getTpsRateOfChange(void) {
  * Return current TPS position based on configured ADC levels, and adc
  *
  * */
-percent_t getTpsValue(int index, int adc DECLARE_ENGINE_PARAMETER_SUFFIX) {
+percent_t getTpsValue(int index, float adc DECLARE_ENGINE_PARAMETER_SUFFIX) {
 
 	DISPLAY_STATE(Engine)
 	DISPLAY_TAG(TPS_SECTION);
@@ -117,8 +120,7 @@ percent_t getTpsValue(int index, int adc DECLARE_ENGINE_PARAMETER_SUFFIX) {
 	int tpsMax = index == 0 ? CONFIG(tpsMax) : CONFIG(tps2Max);
 	int tpsMin = index == 0 ? CONFIG(tpsMin) : CONFIG(tps2Min);
 
-	float result = interpolateMsg("TPS", TPS_TS_CONVERSION * tpsMax, 100,
-			TPS_TS_CONVERSION * tpsMin, 0, adc);
+	float result = interpolateMsg("TPS", tpsMax, 100, tpsMin, 0, adc);
 	if (result < engineConfiguration->tpsErrorDetectionTooLow) {
 #if EFI_PROD_CODE
 		// too much noise with simulator
@@ -149,7 +151,7 @@ float getTPSVoltage(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
  * wants a TPS value.
  * @param index [0, ETB_COUNT)
  */
-int getTPS12bitAdc(int index DECLARE_ENGINE_PARAMETER_SUFFIX) {
+float getTPS10bitAdc(int index DECLARE_ENGINE_PARAMETER_SUFFIX) {
 #if !EFI_PROD_CODE
 	if (engine->mockTpsAdcValue != MOCK_UNDEFINED) {
 		return engine->mockTpsAdcValue;
@@ -160,9 +162,9 @@ int getTPS12bitAdc(int index DECLARE_ENGINE_PARAMETER_SUFFIX) {
 #if EFI_PROD_CODE
 
 	if (index == 0) {
-		return getAdcValue("tps10", engineConfiguration->tps1_1AdcChannel);
+		return convertVoltageTo10bitADC(getVoltageDivided("tps10", engineConfiguration->tps1_1AdcChannel));
 	} else {
-		return getAdcValue("tps20", engineConfiguration->tps2_1AdcChannel);
+		return convertVoltageTo10bitADC(getVoltageDivided("tps20", engineConfiguration->tps2_1AdcChannel));
 	}
 	//	return tpsFastAdc / 4;
 #else
@@ -173,7 +175,7 @@ int getTPS12bitAdc(int index DECLARE_ENGINE_PARAMETER_SUFFIX) {
 void grabTPSIsClosed() {
 #if EFI_PROD_CODE
 	printTPSInfo();
-	engineConfiguration->tpsMin = getTPS10bitAdc();
+	engineConfiguration->tpsMin = getTPS10bitAdc(0);
 	printTPSInfo();
 #endif /* EFI_PROD_CODE */
 }
@@ -181,7 +183,7 @@ void grabTPSIsClosed() {
 void grabTPSIsWideOpen() {
 #if EFI_PROD_CODE
 	printTPSInfo();
-	engineConfiguration->tpsMax = getTPS10bitAdc();
+	engineConfiguration->tpsMax = getTPS10bitAdc(0);
 	printTPSInfo();
 #endif /* EFI_PROD_CODE */
 }
@@ -206,7 +208,7 @@ void grabPedalIsWideOpen() {
  * @brief Position on physical primary TPS
  */
 static percent_t getPrimaryRawTPS(int index DECLARE_ENGINE_PARAMETER_SUFFIX) {
-	int adcValue = getTPS12bitAdc(index PASS_ENGINE_PARAMETER_SUFFIX);
+	float adcValue = getTPS10bitAdc(index PASS_ENGINE_PARAMETER_SUFFIX);
 	percent_t tpsValue = getTpsValue(index, adcValue PASS_ENGINE_PARAMETER_SUFFIX);
 	return tpsValue;
 }
@@ -268,5 +270,5 @@ void setBosch0280750009(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 
 int convertVoltageTo10bitADC(float voltage) {
 	// divided by 2 because of voltage divider, then converted into 10bit ADC value (TunerStudio format)
-	return (int) (voltage / 2 * 1024 / 3.3);
+	return (int) (voltage * TPS_TS_CONVERSION);
 }

--- a/firmware/controllers/sensors/tps.h
+++ b/firmware/controllers/sensors/tps.h
@@ -12,9 +12,6 @@
 #include "global.h"
 #include "engine_configuration.h"
 
-// we have 12 bit precision and TS uses 10 bit precision
-#define TPS_TS_CONVERSION 4
-
 bool hasPedalPositionSensor(DECLARE_ENGINE_PARAMETER_SIGNATURE);
 percent_t getPedalPosition(DECLARE_ENGINE_PARAMETER_SIGNATURE);
 /**
@@ -26,11 +23,10 @@ percent_t getTPS(DECLARE_ENGINE_PARAMETER_SIGNATURE);
 percent_t getTPSWithIndex(int index DECLARE_ENGINE_PARAMETER_SUFFIX);
 bool hasTpsSensor(DECLARE_ENGINE_PARAMETER_SIGNATURE);
 int convertVoltageTo10bitADC(float voltage);
-int getTPS12bitAdc(int index DECLARE_ENGINE_PARAMETER_SUFFIX);
+float getTPS10bitAdc(int index DECLARE_ENGINE_PARAMETER_SUFFIX);
 bool hasSecondThrottleBody(DECLARE_ENGINE_PARAMETER_SIGNATURE);
-#define getTPS10bitAdc() (getTPS12bitAdc(0 PASS_ENGINE_PARAMETER_SUFFIX) / TPS_TS_CONVERSION)
 float getTPSVoltage(DECLARE_ENGINE_PARAMETER_SIGNATURE);
-percent_t getTpsValue(int index, int adc DECLARE_ENGINE_PARAMETER_SUFFIX);
+percent_t getTpsValue(int index, float adc DECLARE_ENGINE_PARAMETER_SUFFIX);
 void setBosch0280750009(DECLARE_ENGINE_PARAMETER_SIGNATURE);
 void setMockTpsAdc(percent_t tpsPosition DECLARE_ENGINE_PARAMETER_SUFFIX);
 void setMockTpsValue(percent_t tpsPosition DECLARE_ENGINE_PARAMETER_SUFFIX);

--- a/firmware/controllers/settings.cpp
+++ b/firmware/controllers/settings.cpp
@@ -426,7 +426,7 @@ void printTPSInfo(void) {
 
 
 #endif /* EFI_PROD_CODE */
-	scheduleMsg(&logger, "current 10bit=%d value=%.2f rate=%.2f", getTPS10bitAdc(), getTPS(PASS_ENGINE_PARAMETER_SIGNATURE),
+	scheduleMsg(&logger, "current 10bit=%d value=%.2f rate=%.2f", (int)getTPS10bitAdc(0), getTPS(PASS_ENGINE_PARAMETER_SIGNATURE),
 			getTpsRateOfChange());
 }
 

--- a/unit_tests/tests/test_sensors.cpp
+++ b/unit_tests/tests/test_sensors.cpp
@@ -34,12 +34,12 @@ TEST(sensors, tps) {
 	engineConfiguration->tpsMax = 193;
 	engineConfiguration->tpsMin = 43;
 
-	ASSERT_NEAR(49.3333, getTpsValue(0, 4 * 117 PASS_ENGINE_PARAMETER_SUFFIX), EPS4D);
+	ASSERT_NEAR(49.3333, getTpsValue(0, 117 PASS_ENGINE_PARAMETER_SUFFIX), EPS4D);
 
 
 	engineConfiguration->tpsMax = 43;
 	engineConfiguration->tpsMin = 193;
-	assertEqualsM("test#2", 50.6667, getTpsValue(0, 4 * 117 PASS_ENGINE_PARAMETER_SUFFIX));
+	assertEqualsM("test#2", 50.6667, getTpsValue(0, 117 PASS_ENGINE_PARAMETER_SUFFIX));
 }
 
 TEST(sensors, testTpsRateOfChange) {


### PR DESCRIPTION
Switch TPS to use 200 "adc counts" per volt, instead of actual ADC counts.  This abstracts the fake ADC counts we give to Tunerstudio away from anything to do with a real ADC.