### PR TITLE
Simplify fuel math again

### DIFF
--- a/firmware/controllers/engine_cycle/rpm_calculator.cpp
+++ b/firmware/controllers/engine_cycle/rpm_calculator.cpp
@@ -360,7 +360,7 @@ void initRpmCalculator(Logging *sharedLogger DECLARE_ENGINE_PARAMETER_SUFFIX) {
  * The callback would be executed once after the duration of time which
  * it takes the crankshaft to rotate to the specified angle.
  */
-void scheduleByAngle(scheduling_s *timer, efitick_t edgeTimestamp, angle_t angle,
+efitick_t scheduleByAngle(scheduling_s *timer, efitick_t edgeTimestamp, angle_t angle,
 		action_s action DECLARE_ENGINE_PARAMETER_SUFFIX) {
 	float delayUs = ENGINE(rpmCalculator.oneDegreeUs) * angle;
 
@@ -368,6 +368,8 @@ void scheduleByAngle(scheduling_s *timer, efitick_t edgeTimestamp, angle_t angle
 	efitime_t delayedTime = edgeTimestamp + delayNt;
 
 	ENGINE(executor.scheduleByTimestampNt(timer, delayedTime, action));
+
+	return delayedTime;
 }
 
 #else

--- a/firmware/controllers/engine_cycle/rpm_calculator.h
+++ b/firmware/controllers/engine_cycle/rpm_calculator.h
@@ -165,5 +165,5 @@ float getCrankshaftAngleNt(efitick_t timeNt DECLARE_ENGINE_PARAMETER_SUFFIX);
 #define addEngineSnifferEvent(n, msg) {}
 #endif /* EFI_ENGINE_SNIFFER */
 
-void scheduleByAngle(scheduling_s *timer, efitick_t edgeTimestamp, angle_t angle, action_s action DECLARE_ENGINE_PARAMETER_SUFFIX);
+efitick_t scheduleByAngle(scheduling_s *timer, efitick_t edgeTimestamp, angle_t angle, action_s action DECLARE_ENGINE_PARAMETER_SUFFIX);
 


### PR DESCRIPTION
Return the scheduled timestamp from `scheduleByAngle`, so we can schedule something a fixed time after the first event was scheduled. Removes some duplication of `scheduleByAngle`'s logic in the fuel math.