### PR TITLE
Sensor reconfiguration while running

### DIFF
--- a/firmware/controllers/algo/engine_configuration.cpp
+++ b/firmware/controllers/algo/engine_configuration.cpp
@@ -94,6 +94,7 @@
 #endif
 
 #if EFI_PROD_CODE
+#include "init.h"
 #include "hardware.h"
 #include "board.h"
 #endif /* EFI_PROD_CODE */
@@ -179,6 +180,7 @@ void incrementGlobalConfigurationVersion(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
  */
 #if EFI_PROD_CODE
 	applyNewHardwareSettings();
+	reconfigureSensors();
 #endif /* EFI_PROD_CODE */
 	engine->preCalculate(PASS_ENGINE_PARAMETER_SIGNATURE);
 #if EFI_ALTERNATOR_CONTROL

--- a/firmware/init/init.h
+++ b/firmware/init/init.h
@@ -4,5 +4,11 @@
 
 #pragma once
 
+// Call this once at startup to initialize, configure, and subscribe sensors
 void initSensors();
+
+// Call this whenever the configuration may have changed, so any sensors
+// can be reconfigured with the new settings.
+// Note: this may not be necessarily possible for all sensors, so some may
+// do nothing when this is called.
 void reconfigureSensors();

--- a/firmware/init/init.h
+++ b/firmware/init/init.h
@@ -5,3 +5,4 @@
 #pragma once
 
 void initSensors();
+void reconfigureSensors();

--- a/firmware/init/sensor/init_sensors.cpp
+++ b/firmware/init/sensor/init_sensors.cpp
@@ -6,31 +6,31 @@
 #include "init.h"
 #include "sensor.h"
 
+static void initSensorCli();
+
+// Sensor init/config
 void initTps();
 void initOilPressure();
 
-void reconfigureTps();
-void reconfigureOilPressure();
-
-static void initSensorCli();
-
 void initSensors() {
-	// TPS
 	initTps();
-
-	// aux sensors
 	initOilPressure();
 
 	// Init CLI functionality for sensors (mocking)
 	initSensorCli();
 }
 
-static void initSensorCli() {
-	addConsoleActionIF("set_sensor_mock", Sensor::setMockValue);
-	addConsoleAction("reset_sensor_mocks", Sensor::resetAllMocks);
-}
+// Sensor reconfiguration
+void reconfigureTps();
+void reconfigureOilPressure();
 
 void reconfigureSensors() {
 	reconfigureTps();
 	reconfigureOilPressure();
+}
+
+// Mocking/testing helpers
+static void initSensorCli() {
+	addConsoleActionIF("set_sensor_mock", Sensor::setMockValue);
+	addConsoleAction("reset_sensor_mocks", Sensor::resetAllMocks);
 }

--- a/firmware/init/sensor/init_sensors.cpp
+++ b/firmware/init/sensor/init_sensors.cpp
@@ -9,7 +9,10 @@
 void initTps();
 void initOilPressure();
 
-void initSensorCli();
+void reconfigureTps();
+void reconfigureOilPressure();
+
+static void initSensorCli();
 
 void initSensors() {
 	// TPS
@@ -22,7 +25,12 @@ void initSensors() {
 	initSensorCli();
 }
 
-void initSensorCli() {
+static void initSensorCli() {
 	addConsoleActionIF("set_sensor_mock", Sensor::setMockValue);
 	addConsoleAction("reset_sensor_mocks", Sensor::resetAllMocks);
+}
+
+void reconfigureSensors() {
+	reconfigureTps();
+	reconfigureOilPressure();
 }

--- a/firmware/init/sensor/init_tps.cpp
+++ b/firmware/init/sensor/init_tps.cpp
@@ -18,18 +18,22 @@ FunctionalSensor tpsSens1p(SensorType::Tps1, MS2NT(10));
 FunctionalSensor tpsSens2p(SensorType::Tps2, MS2NT(10));
 //FunctionalSensor tpsSens2s(SensorType::Tps2Secondary, MS2NT(10));
 
-static void initTpsFunc(LinearFunc& func, FunctionalSensor& sensor, adc_channel_e channel, float closed, float open) {
-	// Only register if we have a sensor
-	if (channel == EFI_ADC_NONE) {
-		return;
-	}
-
+static void configureTps(LinearFunc& func, float closed, float open) {
 	func.configure(
 		closed / TPS_TS_CONVERSION, 0,
 		open / TPS_TS_CONVERSION, 100, 
 		CONFIG(tpsErrorDetectionTooLow),
 		CONFIG(tpsErrorDetectionTooHigh)
 	);
+}
+
+static void initTpsFunc(LinearFunc& func, FunctionalSensor& sensor, adc_channel_e channel, float closed, float open) {
+	// Only register if we have a sensor
+	if (channel == EFI_ADC_NONE) {
+		return;
+	}
+
+	configureTps(func, closed, open);
 
 	sensor.setFunction(func);
 
@@ -43,4 +47,9 @@ static void initTpsFunc(LinearFunc& func, FunctionalSensor& sensor, adc_channel_
 void initTps() {
 	initTpsFunc(tpsFunc1p, tpsSens1p, CONFIG(tps1_1AdcChannel), CONFIG(tpsMin), CONFIG(tpsMax));
 	initTpsFunc(tpsFunc2p, tpsSens2p, CONFIG(tps2_1AdcChannel), CONFIG(tps2Min), CONFIG(tps2Max));
+}
+
+void reconfigureTps() {
+	configureTps(tpsFunc1p, CONFIG(tpsMin), CONFIG(tpsMax));
+	configureTps(tpsFunc2p, CONFIG(tps2Min), CONFIG(tps2Max));
 }


### PR DESCRIPTION
@960 noted that changing the TPS calibration doesn't take effect until a reboot occurs.  This change reconfigures sensors whenever the configuration changes.