### PR TITLE
Stricter compile options

### DIFF
--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -37,21 +37,19 @@ endif
 
 # Compiler options here.
 ifeq ($(USE_OPT),)
-  USE_OPT = $(EXTRA_PARAMS) $(DEBUG_LEVEL_OPT) $(RFLAGS) -Wno-error=implicit-fallthrough -Wno-error=bool-operation -fomit-frame-pointer -falign-functions=16 -Werror=type-limits -Wno-error=strict-aliasing -Wno-error=attributes
+  USE_OPT = $(EXTRA_PARAMS) $(DEBUG_LEVEL_OPT) $(RFLAGS) -fomit-frame-pointer -falign-functions=16
 endif
-
 
 USE_OPT += $(RUSEFI_OPT)
 
 # C specific options here (added to USE_OPT).
 ifeq ($(USE_COPT),)
-  USE_COPT = -fgnu89-inline -std=gnu99 -Werror-implicit-function-declaration
+  USE_COPT = -fgnu89-inline -std=gnu99 -Wno-error=implicit-fallthrough
 endif
 
 # C++ specific options here (added to USE_OPT).
 ifeq ($(USE_CPPOPT),)
-  # constexpr float expf_taylor_impl probably needs just c++14 but why not go with 17?
-  USE_CPPOPT = -std=c++17 -Wno-register -fno-rtti -fno-threadsafe-statics -fno-exceptions -fno-use-cxa-atexit -Werror=write-strings -Werror=type-limits
+  USE_CPPOPT = -std=c++17 -Wno-register -fno-rtti -fno-threadsafe-statics -fno-exceptions -fno-use-cxa-atexit
 endif
 
 # Enable this if you want the linker to remove unused code and data

--- a/firmware/controllers/core/common_headers.h
+++ b/firmware/controllers/core/common_headers.h
@@ -88,6 +88,8 @@
 #define EXPAND_Engine \
 	    engine_configuration_s *engineConfiguration = engine->engineConfigurationPtr; \
 		persistent_config_s *config = engine->config; \
+		(void)engineConfiguration; \
+		(void)config; \
 		
 
 #ifndef EFI_ACTIVE_CONFIGURATION_IN_FLASH

--- a/firmware/controllers/math/engine_math.cpp
+++ b/firmware/controllers/math/engine_math.cpp
@@ -65,8 +65,8 @@ float getEngineLoadT(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 		}
 		return getMafVoltage(PASS_ENGINE_PARAMETER_SIGNATURE);
 	case LM_SPEED_DENSITY:
-		// SD engine load is used for timing lookup but not for fuel calculation
-		[[fallthrough]]
+		// SD engine load is used for timing lookup but not for fuel calculation,
+		// so fall thru to the MAP case.
 	case LM_MAP:
 		return getMap(PASS_ENGINE_PARAMETER_SIGNATURE);
 	case LM_ALPHA_N:

--- a/firmware/hw_layer/servo.cpp
+++ b/firmware/hw_layer/servo.cpp
@@ -27,18 +27,6 @@ THD_WORKING_AREA(servoThreadStack, UTILITY_THREAD_STACK_SIZE * 3);
 
 static OutputPin pins[SERVO_COUNT];
 
-static int countServos() {
-	int result = 0;
-
-	for (int i = 0; i < SERVO_COUNT; i++) {
-		if (engineConfiguration->servoOutputPins[i] != GPIO_UNASSIGNED) {
-			result++;
-		}
-	}
-	return result;
-
-}
-
 static scheduling_s servoTurnSignalOff;
 
 // todo: extract common 'pin off' callback?

--- a/firmware/rusefi_rules.mk
+++ b/firmware/rusefi_rules.mk
@@ -1,5 +1,5 @@
-RUSEFI_OPT=-Werror -Wno-error=pointer-sign -Wno-error=unused-function -Wno-error=unused-variable -Wno-error=sign-compare -Wno-error=unused-parameter -Werror=missing-field-initializers
+# Warnings-as-errors...
+RUSEFI_OPT = -Werror
 
-RUSEFI_OPT+=-Wno-error=missing-prototypes
-
-RUSEFI_OPT+=-Werror=switch
+# ...except these few
+RUSEFI_OPT += -Wno-error=unused-function -Wno-error=unused-variable -Wno-error=sign-compare -Wno-error=unused-parameter


### PR DESCRIPTION
Turn back on a bunch of warnings-as-errors we had turned off, even though they never happen.