### PR TITLE
don't use standard sprintf/snprintf

### DIFF
--- a/firmware/hw_layer/io_pins.cpp
+++ b/firmware/hw_layer/io_pins.cpp
@@ -11,6 +11,7 @@
 #include "io_pins.h"
 
 #if EFI_PROD_CODE
+#include "os_access.h"
 #include "efi_gpio.h"
 #include "drivers/gpio/gpio_ext.h"
 
@@ -102,10 +103,11 @@ iomode_t getInputMode(pin_input_mode_e mode) {
 }
 
 #if HAL_USE_ICU
+static char icuError[30];
+
 void efiIcuStart(const char *msg, ICUDriver *icup, const ICUConfig *config) {
 	if (icup->state != ICU_STOP && icup->state != ICU_READY) {
-		static char icuError[30];
-		sprintf(icuError, "ICU already used %s", msg);
+		chsnprintf(icuError, sizeof(icuError), "ICU already used %s", msg);
 		firmwareError(CUSTOM_ERR_6679, icuError);
 		return;
 	}

--- a/firmware/hw_layer/pin_repository.cpp
+++ b/firmware/hw_layer/pin_repository.cpp
@@ -101,16 +101,16 @@ static void reportPins(void) {
 
 			/* use autogeneraged helpers here? */
 			if (pin_diag == PIN_OK) {
-				snprintf(pin_error, sizeof(pin_error), "Ok");
+				chsnprintf(pin_error, sizeof(pin_error), "Ok");
 			} else if (pin_diag != PIN_INVALID) {
-				snprintf(pin_error, sizeof(pin_error), "%s%s%s%s%s",
+				chsnprintf(pin_error, sizeof(pin_error), "%s%s%s%s%s",
 					pin_diag & PIN_OPEN ? "open_load " : "",
 					pin_diag & PIN_SHORT_TO_GND ? "short_to_gnd " : "",
 					pin_diag & PIN_SHORT_TO_BAT ? "short_to_bat " : "",
 					pin_diag & PIN_OVERLOAD ? "overload " : "",
 					pin_diag & PIN_DRIVER_OVERTEMP ? "overtemp": "");
 			} else {
-				snprintf(pin_error, sizeof(pin_error), "INVALID");
+				chsnprintf(pin_error, sizeof(pin_error), "INVALID");
 			}
 
 			/* here show all pins, unused too */


### PR DESCRIPTION
This saves 13kb of flash space.

Calling any non-ChibiOS `printf` function will include the full standard library implementation (so then we have two!), which can also format doubles, so it also pulls in huge software support for doubles. Just the function `_dtoa_r` (double-to-alpha, converts a double to a string) was 3.5KB on an optimized build.