### PR TITLE
ignore vbus

### DIFF
--- a/firmware/config/boards/nucleo_f746/board.h
+++ b/firmware/config/boards/nucleo_f746/board.h
@@ -41,6 +41,9 @@
 #define EFI_USB_SERIAL_DM GPIOA_11
 #define EFI_USB_SERIAL_DP GPIOA_12
 
+// Ignore USB VBUS pin (we're never a host, only a device)
+#define BOARD_OTG_NOVBUSSENS TRUE
+
 /*
  * Ethernet PHY type.
  */

--- a/firmware/config/boards/nucleo_f767/board.h
+++ b/firmware/config/boards/nucleo_f767/board.h
@@ -41,6 +41,9 @@
 #define EFI_USB_SERIAL_DM GPIOA_11
 #define EFI_USB_SERIAL_DP GPIOA_12
 
+// Ignore USB VBUS pin (we're never a host, only a device)
+#define BOARD_OTG_NOVBUSSENS TRUE
+
 /*
  * Ethernet PHY type.
  */

--- a/firmware/config/boards/st_stm32f4/board.h
+++ b/firmware/config/boards/st_stm32f4/board.h
@@ -38,6 +38,8 @@
 #define EFI_USB_SERIAL_DM GPIOA_11
 #define EFI_USB_SERIAL_DP GPIOA_12
 
+// Ignore USB VBUS pin (we're never a host, only a device)
+#define BOARD_OTG_NOVBUSSENS TRUE
 
 /*
  * input-floating is the default pin mode. input-output boards should provision appropriate pull-ups/pull-downs.


### PR DESCRIPTION
We don't need vbus (it's a feature for USB OTG), and this can cause issues if that pin is left floating.