### PR TITLE
Pedal rx shim

### DIFF
--- a/firmware/controllers/can/can_rx.cpp
+++ b/firmware/controllers/can/can_rx.cpp
@@ -35,11 +35,9 @@ void processCanRxMessage(const CANRxFrame& frame, Logging* logger) {
 		// AEM x-series lambda sensor reports in 0.0001 lambda per bit
 		uint16_t lambdaInt = SWAP_UINT16(frame.data16[0]);
 		aemXSeriesLambda = 0.0001f * lambdaInt;
-#if EFI_CANBUS_PEDAL
 	} else if (frame.EID == 0x202) {
-		int16_t pedalScaled = *reinterpret_cast<uint16_t*>(&frame.data8[0]);
+		int16_t pedalScaled = *reinterpret_cast<const uint16_t*>(&frame.data8[0]);
 		canPedal = pedalScaled * 0.01f;
-#endif
 	} else {
 		printPacket(frame, logger);
 		obdOnCanPacketRx(frame);

--- a/firmware/controllers/can/can_rx.cpp
+++ b/firmware/controllers/can/can_rx.cpp
@@ -35,9 +35,11 @@ void processCanRxMessage(const CANRxFrame& frame, Logging* logger) {
 		// AEM x-series lambda sensor reports in 0.0001 lambda per bit
 		uint16_t lambdaInt = SWAP_UINT16(frame.data16[0]);
 		aemXSeriesLambda = 0.0001f * lambdaInt;
+#if EFI_CANBUS_PEDAL
 	} else if (frame.EID == 0x202) {
 		int16_t pedalScaled = *reinterpret_cast<uint16_t*>(&frame.data8[0]);
 		canPedal = pedalScaled * 0.01f;
+#endif
 	} else {
 		printPacket(frame, logger);
 		obdOnCanPacketRx(frame);

--- a/firmware/controllers/can/can_rx.cpp
+++ b/firmware/controllers/can/can_rx.cpp
@@ -26,6 +26,7 @@ static void printPacket(const CANRxFrame& rx, Logging* logger) {
 }
 
 volatile float aemXSeriesLambda = 0;
+volatile float canPedal = 0;
 
 void processCanRxMessage(const CANRxFrame& frame, Logging* logger) {
 	// TODO: if/when we support multiple lambda sensors, sensor N
@@ -34,6 +35,9 @@ void processCanRxMessage(const CANRxFrame& frame, Logging* logger) {
 		// AEM x-series lambda sensor reports in 0.0001 lambda per bit
 		uint16_t lambdaInt = SWAP_UINT16(frame.data16[0]);
 		aemXSeriesLambda = 0.0001f * lambdaInt;
+	} else if (frame.EID == 0x202) {
+		int16_t pedalScaled = *reinterpret_cast<uint16_t*>(&frame.data8[0]);
+		canPedal = pedalScaled * 0.01f;
 	} else {
 		printPacket(frame, logger);
 		obdOnCanPacketRx(frame);

--- a/firmware/controllers/sensors/tps.cpp
+++ b/firmware/controllers/sensors/tps.cpp
@@ -213,7 +213,13 @@ bool hasSecondThrottleBody(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 	return engineConfiguration->tps2_1AdcChannel != EFI_ADC_NONE;
 }
 
+extern float canPedal;
+
 percent_t getPedalPosition(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
+	if (CONFIG(enableCanPedal)) {
+		return canPedal;
+	}
+
 	if (mockPedalPosition != MOCK_UNDEFINED) {
 		return mockPedalPosition;
 	}

--- a/firmware/controllers/sensors/tps.cpp
+++ b/firmware/controllers/sensors/tps.cpp
@@ -216,9 +216,10 @@ bool hasSecondThrottleBody(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 extern float canPedal;
 
 percent_t getPedalPosition(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
-	if (false /*CONFIG(enableCanPedal)*/) {
+#if EFI_CANBUS_PEDAL
 		return canPedal;
-	}
+#endif
+
 
 	if (mockPedalPosition != MOCK_UNDEFINED) {
 		return mockPedalPosition;

--- a/firmware/controllers/sensors/tps.cpp
+++ b/firmware/controllers/sensors/tps.cpp
@@ -216,7 +216,7 @@ bool hasSecondThrottleBody(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 extern float canPedal;
 
 percent_t getPedalPosition(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
-	if (CONFIG(enableCanPedal)) {
+	if (false /*CONFIG(enableCanPedal)*/) {
 		return canPedal;
 	}
 


### PR DESCRIPTION
needs `EFI_CANBUS_PEDAL` set in `efifeatures.h` to enable it, because we REALLY don't want this enabled for somebody who isn't doing something whacky like running a v12 with two ECUs.