### PR TITLE
Fix mre vbatt

### DIFF
--- a/firmware/config/boards/microrusefi/board_configuration.cpp
+++ b/firmware/config/boards/microrusefi/board_configuration.cpp
@@ -70,7 +70,7 @@ static void setupVbatt() {
 
 	// set vbatt_divider 8.16
 	// R139=39k high side/R141=10k low side multiplied by above analogInputDividerCoefficient = 8.166666f
-	engineConfiguration->vbattDividerCoeff = (49.0f / 10.0f);
+	engineConfiguration->vbattDividerCoeff = (49.0f / 10.0f) * engineConfiguration->analogInputDividerCoefficient;
 	engineConfiguration->vbattAdcChannel = EFI_ADC_11;
 
 	engineConfiguration->adcVcc = 3.29f;

--- a/firmware/config/boards/microrusefi/board_configuration.cpp
+++ b/firmware/config/boards/microrusefi/board_configuration.cpp
@@ -65,11 +65,11 @@ static void setupVbatt() {
 	engineConfiguration->analogInputDividerCoefficient = 2.5f / 1.5f;
 */
 
-	// 6.8k high side/10k low side = 1.6667 ratio divider
+	// 6.8k high side/10k low side = 1.68 ratio divider
 	engineConfiguration->analogInputDividerCoefficient = 16.8f / 10.0f;
 
-	// set vbatt_divider 8.16
-	// R139=39k high side/R141=10k low side multiplied by above analogInputDividerCoefficient = 8.166666f
+	// set vbatt_divider 8.23
+	// R139=39k high side/R141=10k low side multiplied by above analogInputDividerCoefficient = 8.232f
 	engineConfiguration->vbattDividerCoeff = (49.0f / 10.0f) * engineConfiguration->analogInputDividerCoefficient;
 	engineConfiguration->vbattAdcChannel = EFI_ADC_11;
 


### PR DESCRIPTION
As our friends dexter_lab and RecaroRacer on Slack discovered, the MRE default vbatt divider is configured wrong.  The battery voltage code does NOT use the board's analog divider coefficient, so we have to multiply it in manually.  For some reason that was removed in ca1d44a, and I'm not sure why.