### PR TITLE
TS cleanup pass

### DIFF
--- a/firmware/config/boards/kinetis/config/controllers/algo/engine_configuration_generated_structures.h
+++ b/firmware/config/boards/kinetis/config/controllers/algo/engine_configuration_generated_structures.h
@@ -1,4 +1,4 @@
-// this section was generated automatically by rusEfi tool ConfigDefinition.jar based on integration/rusefi_config.txt Wed Mar 25 00:28:36 EDT 2020
+// this section was generated automatically by rusEfi tool ConfigDefinition.jar based on integration/rusefi_config.txt Wed Mar 25 17:51:56 PDT 2020
 // by class com.rusefi.output.CHeaderConsumer
 // begin
 #ifndef CONFIG_BOARDS_KINETIS_CONFIG_CONTROLLERS_ALGO_ENGINE_CONFIGURATION_GENERATED_STRUCTURES_H
@@ -278,33 +278,6 @@ struct injector_s {
 
 typedef struct injector_s injector_s;
 
-// start of bi_quard_s
-struct bi_quard_s {
-	/**
-	 * offset 0
-	 */
-	float a0;
-	/**
-	 * offset 4
-	 */
-	float a1;
-	/**
-	 * offset 8
-	 */
-	float a2;
-	/**
-	 * offset 12
-	 */
-	float b1;
-	/**
-	 * offset 16
-	 */
-	float b2;
-	/** total size 20*/
-};
-
-typedef struct bi_quard_s bi_quard_s;
-
 // start of specs_s
 struct specs_s {
 	/**
@@ -578,7 +551,7 @@ struct engine_configuration_s {
 	bool isVerboseAuxPid4 : 1;
 	/**
 	offset 76 bit 9 */
-	bool useBiQuadAnalogFiltering : 1;
+	bool unused76b9 : 1;
 	/**
 	 * Is your UA CJ125 output wired to MCU via resistor divider?
 	offset 76 bit 10 */
@@ -2494,7 +2467,7 @@ struct engine_configuration_s {
 	/**
 	 * offset 2332
 	 */
-	bi_quard_s biQuad;
+	uint8_t unusedOldBiquad[20];
 	/**
 	 * CLT-based timing correction
 	 * offset 2352
@@ -3257,4 +3230,4 @@ typedef struct persistent_config_s persistent_config_s;
 
 #endif
 // end
-// this section was generated automatically by rusEfi tool ConfigDefinition.jar based on integration/rusefi_config.txt Wed Mar 25 00:28:36 EDT 2020
+// this section was generated automatically by rusEfi tool ConfigDefinition.jar based on integration/rusefi_config.txt Wed Mar 25 17:51:56 PDT 2020

--- a/firmware/config/engines/dodge_neon.cpp
+++ b/firmware/config/engines/dodge_neon.cpp
@@ -265,12 +265,6 @@ void setDodgeNeonNGCEngineConfiguration(DECLARE_CONFIG_PARAMETER_SIGNATURE) {
 	engineConfiguration->specs.displacement = 1.996;
 	engineConfiguration->specs.cylindersCount = 4;
 
-	engineConfiguration->biQuad.a0 = 0.0000024635293743901;
-	engineConfiguration->biQuad.a1 = 0.00000492705874878021;
-	engineConfiguration->biQuad.a2 = 0.0000024635293743901;
-	engineConfiguration->biQuad.b1 = -1.9968534854;
-	engineConfiguration->biQuad.b2 = 0.9968633396;
-
 	/**
 	 * 77C
 	 * 1200 rpm

--- a/firmware/controllers/generated/engine_configuration_generated_structures.h
+++ b/firmware/controllers/generated/engine_configuration_generated_structures.h
@@ -1,4 +1,4 @@
-// this section was generated automatically by rusEfi tool ConfigDefinition.jar based on integration\rusefi_config.txt Wed Mar 25 00:28:20 EDT 2020
+// this section was generated automatically by rusEfi tool ConfigDefinition.jar based on integration\rusefi_config.txt Wed Mar 25 17:51:52 PDT 2020
 // by class com.rusefi.output.CHeaderConsumer
 // begin
 #ifndef CONTROLLERS_GENERATED_ENGINE_CONFIGURATION_GENERATED_STRUCTURES_H
@@ -278,33 +278,6 @@ struct injector_s {
 
 typedef struct injector_s injector_s;
 
-// start of bi_quard_s
-struct bi_quard_s {
-	/**
-	 * offset 0
-	 */
-	float a0;
-	/**
-	 * offset 4
-	 */
-	float a1;
-	/**
-	 * offset 8
-	 */
-	float a2;
-	/**
-	 * offset 12
-	 */
-	float b1;
-	/**
-	 * offset 16
-	 */
-	float b2;
-	/** total size 20*/
-};
-
-typedef struct bi_quard_s bi_quard_s;
-
 // start of specs_s
 struct specs_s {
 	/**
@@ -578,7 +551,7 @@ struct engine_configuration_s {
 	bool isVerboseAuxPid4 : 1;
 	/**
 	offset 76 bit 9 */
-	bool useBiQuadAnalogFiltering : 1;
+	bool unused76b9 : 1;
 	/**
 	 * Is your UA CJ125 output wired to MCU via resistor divider?
 	offset 76 bit 10 */
@@ -2494,7 +2467,7 @@ struct engine_configuration_s {
 	/**
 	 * offset 2332
 	 */
-	bi_quard_s biQuad;
+	uint8_t unusedOldBiquad[20];
 	/**
 	 * CLT-based timing correction
 	 * offset 2352
@@ -3257,4 +3230,4 @@ typedef struct persistent_config_s persistent_config_s;
 
 #endif
 // end
-// this section was generated automatically by rusEfi tool ConfigDefinition.jar based on integration\rusefi_config.txt Wed Mar 25 00:28:20 EDT 2020
+// this section was generated automatically by rusEfi tool ConfigDefinition.jar based on integration\rusefi_config.txt Wed Mar 25 17:51:52 PDT 2020

--- a/firmware/hw_layer/adc_inputs.cpp
+++ b/firmware/hw_layer/adc_inputs.cpp
@@ -42,8 +42,6 @@
 #define ADC_BUF_DEPTH_SLOW      8
 #define ADC_BUF_DEPTH_FAST      4
 
-//static Biquad biq[ADC_MAX_CHANNELS_COUNT];
-
 static adc_channel_mode_e adcHwChannelEnabled[HW_MAX_ADC_INDEX];
 static const char * adcHwChannelUsage[HW_MAX_ADC_INDEX];
 

--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -309,14 +309,6 @@ float[VBAT_INJECTOR_CURVE_SIZE] battLagCorr;ms delay between injector open and c
 
 end_struct
 
-struct bi_quard_s
-	float a0;;"v",  1,     0,      -1000,   1000,   9
-	float a1;;"v",  1,     0,      -1000,   1000,   9
-	float a2;;"v",  1,     0,      -1000,   1000,   9
-	float b1;;"v",  1,     0,      -1000,   1000,   9
-	float b2;;"v",  1,     0,      -1000,   1000,   9
-
-end_struct
 
 injector_s injector
 
@@ -330,7 +322,7 @@ bit activateAuxPid3;
 bit isVerboseAuxPid3;
 bit activateAuxPid4;
 bit isVerboseAuxPid4;
-bit useBiQuadAnalogFiltering;
+bit unused76b9;
 bit cj125isUaDivided;+Is your UA CJ125 output wired to MCU via resistor divider?
 bit cj125isLsu49;
 bit etb_use_two_wires;
@@ -1049,7 +1041,7 @@ float[MAP_ACCEL_TAPER] mapAccelTaperMult;;"mult",      1,     0,   0.0,    300, 
 	float[NARROW_BAND_WIDE_BAND_CONVERSION_SIZE] narrowToWideOxygenBins;Narrow Band WBO Approximation;"V",        1,     0,   -10.0,    10.0,  3
 	float[NARROW_BAND_WIDE_BAND_CONVERSION_SIZE] narrowToWideOxygen;;"ratio",      1,     0,      -40.0,    40.0,   2
 	vvt_mode_e vvtMode;set vvt_mode X
-	bi_quard_s biQuad;
+	uint8_t[20] unusedOldBiquad
 	float[CLT_TIMING_CURVE_SIZE] cltTimingBins;CLT-based timing correction;"C",        1,     0,   -100.0,    250.0,  1
 	float[CLT_TIMING_CURVE_SIZE] cltTimingExtra;;"degree",      1,     0,      -400.0,    400.0,   0
 	int nbVvtIndex;;"index",        1,     0,  0,    4.0,  0

--- a/firmware/tunerstudio/rusefi.input
+++ b/firmware/tunerstudio/rusefi.input
@@ -2296,13 +2296,7 @@ cmd_set_engine_type_default					= "w\x00\x31\x00\x00"
 		field = "!ECU reboot needed to apply these settings"
 		field = "Use fixed baro corr from MAP", 		useFixedBaroCorrFromMap
 		field = "Analog divider ratio",					analogInputDividerCoefficient@@if_ts_show_analog_divider
-		field = "Use BiQuad averaging",					useBiQuadAnalogFiltering		
-		field = "Smoothing factor",						slowAdcAlpha, {useBiQuadAnalogFiltering == 0}
-		field = "Bi_Q a0",								biQuad_a0, {useBiQuadAnalogFiltering == 1}
-		field = "Bi_Q a1",								biQuad_a1, {useBiQuadAnalogFiltering == 1}
-		field = "Bi_Q a2",								biQuad_a2, {useBiQuadAnalogFiltering == 1}
-		field = "Bi_Q b1",								biQuad_b1, {useBiQuadAnalogFiltering == 1}
-		field = "Bi_Q b2",								biQuad_b2, {useBiQuadAnalogFiltering == 1}
+		field = "Smoothing factor",						slowAdcAlpha
 
 	dialog = tachSettings, "Tachometer output"
 		field = "!See also dizzySparkOutputPin"

--- a/firmware/tunerstudio/rusefi.input
+++ b/firmware/tunerstudio/rusefi.input
@@ -1165,7 +1165,7 @@ menuDialog = main
 		# Digital outputs
 		subMenu = mainRelay,				"Main relay"
 		subMenu = starterRelay,				"Starter Disable relay"
-		subMenu = fuelPump,					"Fuel rail"
+		subMenu = fuelPump,					"Fuel pump & rail"
 		subMenu = fanSetting,				"Fan"
 		subMenu = tachSettings,				"Tachometer"
 		subMenu = malfunction,				"Check engine light"
@@ -2124,12 +2124,19 @@ cmd_set_engine_type_default					= "w\x00\x31\x00\x00"
 		field = "On temperature",					fanOnTemperature
 		field = "Off temperature",					fanOffTemperature
 
-	dialog = fuelPump, "Fuel Rail"
+	dialog = fuelPumpConfig, "Fuel Pump"
 		field = "Pin",						fuelPumpPin
 		field = "Pin mode",         	        fuelPumpPinMode
 		field = "Prime duration",				startUpFuelPumpDuration
+
+	dialog = fuelRailConfig, "Fuel Rail"
 		field = "Absolute Fuel Pressure",			absoluteFuelPressure
 		field = "Fuel Rail pressure",			fuelRailPressure, {absoluteFuelPressure == 1}
+
+	dialog = fuelPump, ""
+		panel = fuelPumpConfig
+		panel = fuelRailConfig
+
 
 ;			Controller->Actuator Outputs
 	dialog = mainRelay, "Main relay output"

--- a/firmware/util/util.mk
+++ b/firmware/util/util.mk
@@ -15,7 +15,6 @@ UTILSRC_CPP = \
 	$(UTIL_DIR)/math/pid.cpp \
 	$(UTIL_DIR)/math/avg_values.cpp \
 	$(UTIL_DIR)/math/interpolation.cpp \
-	$(UTIL_DIR)/math/biquad.cpp \
 	$(PROJECT_DIR)/util/datalogging.cpp \
 	$(PROJECT_DIR)/util/loggingcentral.cpp \
 	$(PROJECT_DIR)/util/cli_registry.cpp \


### PR DESCRIPTION
Fixes #1222: remove old biquad coefficients from config, they're no longer used.
Fixes #1220: Indicates that it's fuel pump and rail, not just rail