### PR TITLE
Finally rename injector_central to bench_test

### DIFF
--- a/firmware/console/binary/tunerstudio.cpp
+++ b/firmware/console/binary/tunerstudio.cpp
@@ -80,7 +80,7 @@
 
 #include <string.h>
 #include "engine_configuration.h"
-#include "injector_central.h"
+#include "bench_test.h"
 #include "svnversion.h"
 #include "loggingcentral.h"
 #include "status_loop.h"

--- a/firmware/controllers/actuators/pwm_tester.cpp
+++ b/firmware/controllers/actuators/pwm_tester.cpp
@@ -21,7 +21,6 @@ static LoggingWithStorage logger;
 static SimplePwm pwmTest[5];
 
 extern OutputPin warningLedPin;
-extern EnginePins enginePins;
 
 EXTERN_ENGINE;
 

--- a/firmware/controllers/algo/engine.cpp
+++ b/firmware/controllers/algo/engine.cpp
@@ -26,7 +26,7 @@
 #include "perf_trace.h"
 
 #if EFI_PROD_CODE
-#include "injector_central.h"
+#include "bench_test.h"
 #else
 #define isRunningBenchTest() true
 #endif /* EFI_PROD_CODE */

--- a/firmware/controllers/bench_test.cpp
+++ b/firmware/controllers/bench_test.cpp
@@ -1,6 +1,6 @@
 /**
- * @file    injector_central.cpp
- * @brief	Utility methods related to fuel injection.
+ * @file    bench_test.cpp
+ * @brief	Utility methods related to bench testing.
  *
  *
  * @date Sep 8, 2013
@@ -27,7 +27,7 @@
 #if !EFI_UNIT_TEST
 
 #include "flash_main.h"
-#include "injector_central.h"
+#include "bench_test.h"
 #include "io_pins.h"
 #include "main_trigger_callback.h"
 #include "engine_configuration.h"
@@ -57,42 +57,8 @@ EXTERN_ENGINE
 static Logging * logger;
 static bool isRunningBench = false;
 
-// todo: move into Engine object?
-// todo: looks like these flags are not currently used? dead functionality? unfinished functionality?
-static int is_injector_enabled[INJECTION_PIN_COUNT];
-
 bool isRunningBenchTest(void) {
 	return isRunningBench;
-}
-
-static void assertCylinderId(int cylinderId, const char *msg) {
-	int isValid = cylinderId >= 1 && cylinderId <= engineConfiguration->specs.cylindersCount;
-	if (!isValid) {
-		// we are here only in case of a fatal issue - at this point it is fine to make some blocking i-o
-		//scheduleSimpleMsg(&logger, "cid=", cylinderId);
-		print("ERROR [%s] cid=%d\r\n", msg, cylinderId);
-		efiAssertVoid(CUSTOM_ERR_6647, false, "Cylinder ID");
-	}
-}
-
-/**
- * @param cylinderId - from 1 to NUMBER_OF_CYLINDERS
- */
-static int isInjectorEnabled(int cylinderId) {
-	assertCylinderId(cylinderId, "isInjectorEnabled");
-	return is_injector_enabled[cylinderId - 1];
-}
-
-static void printInjectorsStatus(void) {
-	for (int id = 1; id <= engineConfiguration->specs.cylindersCount; id++) {
-		scheduleMsg(logger, "injector_%d: %d", id, isInjectorEnabled(id));
-	}
-}
-
-static void setInjectorEnabled(int id, int value) {
-	efiAssertVoid(CUSTOM_ERR_6648, id >= 0 && id < engineConfiguration->specs.cylindersCount, "injector id");
-	is_injector_enabled[id] = value;
-	printInjectorsStatus();
 }
 
 static void runBench(brain_pin_e brainPin, OutputPin *output, float delayMs, float onTimeMs, float offTimeMs,
@@ -337,19 +303,8 @@ void executeTSCommand(uint16_t subsystem, uint16_t index) {
 	}
 }
 
-void initInjectorCentral(Logging *sharedLogger) {
+void initBenchTest(Logging *sharedLogger) {
 	logger = sharedLogger;
-
-	for (int i = 0; i < INJECTION_PIN_COUNT; i++) {
-		is_injector_enabled[i] = true;
-	}
-
-	enginePins.startInjectionPins();
-	enginePins.startIgnitionPins();
-	enginePins.startAuxValves();
-
-	printInjectorsStatus();
-	addConsoleActionII("injector", setInjectorEnabled);
 
 	addConsoleAction("fuelpumpbench", fuelPumpBench);
 	addConsoleAction("acrelaybench", acRelayBench);

--- a/firmware/controllers/bench_test.h
+++ b/firmware/controllers/bench_test.h
@@ -1,6 +1,6 @@
 /**
- * @file    injector_central.h
- * @brief	Utility methods related to fuel injection.
+ * @file    bench_test.h
+ * @brief	Utility methods related to bench testing.
  *
  * todo: rename this file
  *
@@ -16,7 +16,7 @@ void fanBench(void);
 void fuelPumpBench(void);
 void acRelayBench(void);
 void milBench(void);
-void initInjectorCentral(Logging *sharedLogger);
+void initBenchTest(Logging *sharedLogger);
 bool isRunningBenchTest(void);
 
 void executeTSCommand(uint16_t subsystem, uint16_t index);

--- a/firmware/controllers/controllers.mk
+++ b/firmware/controllers/controllers.mk
@@ -33,7 +33,7 @@ CONTROLLERS_SRC_CPP = \
 	$(CONTROLLERS_DIR)/engine_cycle/main_trigger_callback.cpp \
 	$(CONTROLLERS_DIR)/engine_cycle/aux_valves.cpp \
 	$(CONTROLLERS_DIR)/flash_main.cpp \
-	$(CONTROLLERS_DIR)/injector_central.cpp \
+	$(CONTROLLERS_DIR)/bench_test.cpp \
 	$(CONTROLLERS_DIR)/can/obd2.cpp \
 	$(CONTROLLERS_DIR)/can/can_verbose.cpp \
 	$(CONTROLLERS_DIR)/can/can_rx.cpp \

--- a/firmware/controllers/core/fsio_impl.cpp
+++ b/firmware/controllers/core/fsio_impl.cpp
@@ -165,7 +165,7 @@ float getEngineValue(le_action_e action DECLARE_ENGINE_PARAMETER_SUFFIX) {
 #include "pin_repository.h"
 #include "pwm_generator.h"
 // todo: that's about bench test mode, wrong header for sure!
-#include "injector_central.h"
+#include "bench_test.h"
 
 static void setFsioAnalogInputPin(const char *indexStr, const char *pinName) {
 // todo: reduce code duplication between all "set pin methods"

--- a/firmware/controllers/core/fsio_impl.cpp
+++ b/firmware/controllers/core/fsio_impl.cpp
@@ -72,8 +72,6 @@ static LENameOrdinalPair leInShutdown(LE_METHOD_IN_SHUTDOWN, "in_shutdown");
 
 #define LE_EVAL_POOL_SIZE 32
 
-extern EnginePins enginePins;
-
 static LECalculator evalCalc;
 static LEElement evalPoolElements[LE_EVAL_POOL_SIZE];
 static LEElementPool evalPool(evalPoolElements, LE_EVAL_POOL_SIZE);
@@ -736,7 +734,6 @@ void initFsioImpl(Logging *sharedLogger DECLARE_ENGINE_PARAMETER_SUFFIX) {
 
 EXTERN_ENGINE
 ;
-extern EnginePins enginePins;
 
 // "Limp-mode" implementation for some RAM-limited configs without FSIO
 void runHardcodedFsio(DECLARE_ENGINE_PARAMETER_SIGNATURE) {

--- a/firmware/controllers/engine_controller.cpp
+++ b/firmware/controllers/engine_controller.cpp
@@ -33,7 +33,7 @@
 #include "main_trigger_callback.h"
 #include "io_pins.h"
 #include "flash_main.h"
-#include "injector_central.h"
+#include "bench_test.h"
 #include "os_util.h"
 #include "engine_math.h"
 #include "allsensors.h"
@@ -604,7 +604,7 @@ void commonInitEngineController(Logging *sharedLogger DECLARE_ENGINE_PARAMETER_S
 
 #if EFI_ENGINE_CONTROL
 	/**
-	 * This has to go after 'initInjectorCentral' in order to
+	 * This has to go after 'enginePins.startPins()' in order to
 	 * properly detect un-assigned output pins
 	 */
 	prepareShapes(PASS_ENGINE_PARAMETER_SIGNATURE);
@@ -666,7 +666,9 @@ void initEngineContoller(Logging *sharedLogger DECLARE_ENGINE_PARAMETER_SUFFIX) 
 	addConsoleAction("analoginfo", printAnalogInfo);
 
 #if EFI_PROD_CODE && EFI_ENGINE_CONTROL
-	initInjectorCentral(sharedLogger);
+	enginePins.startPins();
+
+	initBenchTest(sharedLogger);
 #endif /* EFI_PROD_CODE && EFI_ENGINE_CONTROL */
 
 	commonInitEngineController(sharedLogger);

--- a/firmware/controllers/engine_controller.cpp
+++ b/firmware/controllers/engine_controller.cpp
@@ -103,7 +103,6 @@ EXTERN_ENGINE;
 #if !EFI_UNIT_TEST
 
 extern bool hasFirmwareErrorFlag;
-extern EnginePins enginePins;
 
 static LoggingWithStorage logger("Engine Controller");
 

--- a/firmware/controllers/gauges/lcd_controller.cpp
+++ b/firmware/controllers/gauges/lcd_controller.cpp
@@ -35,7 +35,7 @@
 #include "lcd_menu_tree.h"
 #include "memstreams.h"
 #include "settings.h"
-#include "injector_central.h"
+#include "bench_test.h"
 #include "engine_controller.h"
 #include "mmc_card.h"
 #include "idle_thread.h"

--- a/firmware/controllers/system/efi_gpio.cpp
+++ b/firmware/controllers/system/efi_gpio.cpp
@@ -153,6 +153,12 @@ void EnginePins::unregisterPins() {
 #endif /* EFI_PROD_CODE */
 }
 
+void EnginePins::startPins() {
+	startInjectionPins();
+	startIgnitionPins();
+	startAuxValves();
+}
+
 void EnginePins::reset() {
 	for (int i = 0; i < INJECTION_PIN_COUNT;i++) {
 		injectors[i].reset();

--- a/firmware/controllers/system/efi_gpio.h
+++ b/firmware/controllers/system/efi_gpio.h
@@ -113,6 +113,7 @@ public:
 class EnginePins {
 public:
 	EnginePins();
+	void startPins();
 	void reset();
 	bool stopPins();
 	void unregisterPins();

--- a/firmware/hw_layer/hardware.cpp
+++ b/firmware/hw_layer/hardware.cpp
@@ -18,7 +18,7 @@
 #include "hardware.h"
 #include "rtc_helper.h"
 #include "os_util.h"
-#include "injector_central.h"
+#include "bench_test.h"
 #include "vehicle_speed.h"
 #include "yaw_rate_sensor.h"
 #include "pin_repository.h"

--- a/firmware/hw_layer/hip9011.cpp
+++ b/firmware/hw_layer/hip9011.cpp
@@ -56,7 +56,6 @@
 static NamedOutputPin intHold(PROTOCOL_HIP_NAME);
 
 extern uint32_t lastExecutionCount;
-extern EnginePins enginePins;
 
 uint32_t hipLastExecutionCount;
 

--- a/firmware/hw_layer/io_pins.cpp
+++ b/firmware/hw_layer/io_pins.cpp
@@ -28,8 +28,6 @@ EXTERN_ENGINE;
 
 static LoggingWithStorage logger("io_pins");
 
-extern EnginePins enginePins;
-
 bool efiReadPin(brain_pin_e pin) {
 	if (brain_pin_is_onchip(pin))
 		return palReadPad(getHwPort("readPin", pin), getHwPin("readPin", pin));

--- a/simulator/simulator/rusEfiFunctionalTest.cpp
+++ b/simulator/simulator/rusEfiFunctionalTest.cpp
@@ -22,7 +22,7 @@
 #include "main_trigger_callback.h"
 #include "allsensors.h"
 #include "sensor_chart.h"
-#include "injector_central.h"
+#include "bench_test.h"
 #include "engine.h"
 #include "tunerstudio.h"
 #include "trigger_emulator.h"

--- a/unit_tests/engine_test_helper.cpp
+++ b/unit_tests/engine_test_helper.cpp
@@ -16,7 +16,6 @@
 #include "advance_map.h"
 
 extern int timeNowUs;
-extern EnginePins enginePins;
 extern WarningCodeState unitTestWarningCodeState;
 extern float testMafValue;
 extern float testCltValue;

--- a/unit_tests/engine_test_helper.h
+++ b/unit_tests/engine_test_helper.h
@@ -13,6 +13,8 @@
 #include "main_trigger_callback.h"
 #include "unit_test_framework.h"
 
+extern EnginePins enginePins;
+
 class EngineTestHelperBase
 {
 public:

--- a/unit_tests/tests/test_ignition_scheduling.cpp
+++ b/unit_tests/tests/test_ignition_scheduling.cpp
@@ -8,8 +8,6 @@
 #include "engine_test_helper.h"
 #include "spark_logic.h"
 
-extern EnginePins enginePins;
-
 TEST(ignition, twoCoils) {
 	WITH_ENGINE_TEST_HELPER(BMW_M73_F);
 

--- a/unit_tests/tests/test_trigger_decoder.cpp
+++ b/unit_tests/tests/test_trigger_decoder.cpp
@@ -293,7 +293,6 @@ static void assertREqualsM(const char *msg, void *expected, void *actual) {
 }
 
 extern bool_t debugSignalExecutor;
-extern EnginePins enginePins;
 
 TEST(misc, testRpmCalculator) {
 	printf("*************************************************** testRpmCalculator\r\n");


### PR DESCRIPTION
As alluded to by many comments strewn about the firmware, `injector_central` was completely the wrong name. This change fixes that!

Oh, and get rid of the huge pile of `extern EnginePins enginePins;`