### PR TITLE
Show fatal error text in TS (the right way)

### DIFF
--- a/firmware/console/binary/tunerstudio.cpp
+++ b/firmware/console/binary/tunerstudio.cpp
@@ -469,7 +469,8 @@ static bool isKnownCommand(char command) {
 			|| command == TS_CRC_CHECK_COMMAND
 			|| command == TS_GET_FIRMWARE_VERSION
 			|| command == TS_PERF_TRACE_BEGIN
-			|| command == TS_PERF_TRACE_GET_BUFFER;
+			|| command == TS_PERF_TRACE_GET_BUFFER
+			|| command == TS_GET_CONFIG_ERROR;
 }
 
 // this function runs indefinitely
@@ -845,6 +846,9 @@ int tunerStudioHandleCrcCommand(ts_channel_s *tsChannel, char *data, int incomin
 
 		break;
 #endif /* ENABLE_PERF_TRACE */
+	case TS_GET_CONFIG_ERROR:
+		sr5SendResponse(tsChannel, TS_CRC, reinterpret_cast<const uint8_t*>(getFirmwareError()), strlen(getFirmwareError()));
+		break;
 	default:
 		tunerStudioError("ERROR: ignoring unexpected command");
 		return false;

--- a/firmware/console/binary/tunerstudio_io.h
+++ b/firmware/console/binary/tunerstudio_io.h
@@ -68,6 +68,7 @@ typedef struct {
 #define TS_PAGE_COMMAND 'P' // 0x50
 #define TS_COMMAND_F 'F' // 0x46
 #define TS_GET_FIRMWARE_VERSION 'V' // versionInfo
+#define TS_GET_CONFIG_ERROR 'e' // returns getFirmwareError()
 
 // High speed logger commands
 #define TS_SET_LOGGER_MODE   'l'

--- a/firmware/hw_layer/adc_inputs.cpp
+++ b/firmware/hw_layer/adc_inputs.cpp
@@ -472,7 +472,7 @@ void addChannel(const char *name, adc_channel_e setting, adc_channel_mode_e mode
 
 	if (adcHwChannelEnabled[setting] != ADC_OFF) {
 		getPinNameByAdcChannel(name, setting, errorMsgBuff);
-		firmwareError(CUSTOM_ERR_ADC_USED, "ADC mapping error: input %s for %s already used by %s?", errorMsgBuff, name, adcHwChannelUsage[setting]);
+		firmwareError(CUSTOM_ERR_ADC_USED, "Analog input error: input \"%s\" selected for %s but was already used by %s", errorMsgBuff, name, adcHwChannelUsage[setting]);
 	}
 
 	adcHwChannelUsage[setting] = name;

--- a/firmware/hw_layer/pin_repository.cpp
+++ b/firmware/hw_layer/pin_repository.cpp
@@ -231,7 +231,7 @@ bool brain_pin_markUsed(brain_pin_e brainPin, const char *msg) {
 		 * connected, so the warning is never displayed on the console and that's quite a problem!
 		 */
 //		warning(OBD_PCM_Processor_Fault, "brain pin %d req by %s used by %s", brainPin, msg, getBrainUsedPin(index));
-		firmwareError(CUSTOM_ERR_PIN_ALREADY_USED_1, "brain pin %s req by %s used by %s", hwPortname(brainPin), msg, getBrainUsedPin(index));
+		firmwareError(CUSTOM_ERR_PIN_ALREADY_USED_1, "Pin \"%s\" required by %s but is used by %s", hwPortname(brainPin), msg, getBrainUsedPin(index));
 		return true;
 	}
 

--- a/firmware/tunerstudio/rusefi.input
+++ b/firmware/tunerstudio/rusefi.input
@@ -66,6 +66,7 @@ enable2ndByteCanID = false
 	; we have current pageSize or (pageSize + 8) here?
 	;
    crc32CheckCommand   = "k\x00\x00\x00\x00\x36\xB8"
+   retrieveConfigError = "e"
 
 ;communication settings
    pageActivationDelay = 500 ; Milliseconds delay after burn command. See https://sourceforge.net/p/rusefi/tickets/77/
@@ -939,6 +940,8 @@ gaugeCategory = Throttle Body (incl. ETB)
     indicator = { ind_injection_enabled}, "no injection",   "injection",   red, black, green,   black
     indicator = { ind_isTriggerError}, "ok",      "trg err",       green,  black,  red, black
     
+	; this is an extra so that reading the config error works in TS - you don't even have to show it by default
+	indicator = { ind_hasFatalError }, "Config Error", "Config Error", white, black, red,   black
 
 	; minor info	
     indicator = { ind_fan}, "no fan",   "fan",   white, black, green,   black

--- a/firmware/tunerstudio/rusefi.input
+++ b/firmware/tunerstudio/rusefi.input
@@ -940,7 +940,9 @@ gaugeCategory = Throttle Body (incl. ETB)
     indicator = { ind_injection_enabled}, "no injection",   "injection",   red, black, green,   black
     indicator = { ind_isTriggerError}, "ok",      "trg err",       green,  black,  red, black
     
-	; this is an extra so that reading the config error works in TS - you don't even have to show it by default
+	; this is required so that the "config error" feature works in TS 
+	; don't change this line - TS is looking for an indicator with particular text/styling
+	; you don't even have to show it by default
 	indicator = { ind_hasFatalError }, "Config Error", "Config Error", white, black, red,   black
 
 	; minor info	


### PR DESCRIPTION
Turns out, TS has a feature for this.  It took a little bit of reverse engineering an MS3 ini, but it seems to work well.  Here's what it looks like:

![image](https://user-images.githubusercontent.com/568254/77846418-c7284a80-716a-11ea-8a2e-a76e4e22ce47.png)
