### PR TITLE
cleanup extern mess

### DIFF
--- a/firmware/config/boards/me7_pnp/board_configuration.cpp
+++ b/firmware/config/boards/me7_pnp/board_configuration.cpp
@@ -13,8 +13,7 @@
 #include "engine_configuration.h"
 #include "smart_gpio.h"
 
-EXTERN_ENGINE
-;
+EXTERN_ENGINE;
 
 static void vag_18_Turbo(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 }

--- a/firmware/config/engines/me7pnp.cpp
+++ b/firmware/config/engines/me7pnp.cpp
@@ -14,8 +14,7 @@
 #include "engine_configuration.h"
 #include "smart_gpio.h"
 
-EXTERN_ENGINE
-;
+EXTERN_ENGINE;
 
 void vag_18_Turbo(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 

--- a/firmware/console/binary/bluetooth.cpp
+++ b/firmware/console/binary/bluetooth.cpp
@@ -34,8 +34,7 @@ static thread_reference_t btThreadRef = nullptr; // used by thread suspend/resum
 static LoggingWithStorage btLogger("bluetooth");
 
 
-EXTERN_ENGINE
-;
+EXTERN_ENGINE;
 
 
 // Main communication code

--- a/firmware/console/binary/tunerstudio.cpp
+++ b/firmware/console/binary/tunerstudio.cpp
@@ -103,8 +103,7 @@
 #endif /* EFI_IDLE_CONTROL */
 
 
-EXTERN_ENGINE
-;
+EXTERN_ENGINE;
 
 extern persistent_config_container_s persistentState;
 

--- a/firmware/console/status_loop.cpp
+++ b/firmware/console/status_loop.cpp
@@ -102,7 +102,6 @@ extern WaveChart waveChart;
 
 int warningEnabled = true;
 
-extern bool hasFirmwareErrorFlag;
 extern int maxTriggerReentraint;
 extern uint32_t maxLockedDuration;
 
@@ -172,8 +171,7 @@ static void reportSensorI(Logging *log, const char *caption, const char *units, 
 #endif /* EFI_FILE_LOGGING */
 }
 
-EXTERN_ENGINE
-;
+EXTERN_ENGINE;
 
 static char buf[6];
 

--- a/firmware/controllers/actuators/alternator_controller.cpp
+++ b/firmware/controllers/actuators/alternator_controller.cpp
@@ -30,8 +30,7 @@
 #error "Unexpected OS ACCESS HERE"
 #endif /* HAS_OS_ACCESS */
 
-EXTERN_ENGINE
-;
+EXTERN_ENGINE;
 
 static Logging *logger;
 

--- a/firmware/controllers/actuators/aux_pid.cpp
+++ b/firmware/controllers/actuators/aux_pid.cpp
@@ -25,8 +25,7 @@
 #error "Unexpected OS ACCESS HERE"
 #endif /* HAS_OS_ACCESS */
 
-EXTERN_ENGINE
-;
+EXTERN_ENGINE;
 
 extern fsio8_Map3D_f32t fsioTable1;
 

--- a/firmware/controllers/actuators/idle_thread.cpp
+++ b/firmware/controllers/actuators/idle_thread.cpp
@@ -52,8 +52,7 @@ static StepperMotor iacMotor;
 
 static Logging *logger;
 
-EXTERN_ENGINE
-;
+EXTERN_ENGINE;
 
 static bool shouldResetPid = false;
 // The idea of 'mightResetPid' is to reset PID only once - each time when TPS > idlePidDeactivationTpsThreshold.

--- a/firmware/controllers/algo/accel_enrichment.cpp
+++ b/firmware/controllers/algo/accel_enrichment.cpp
@@ -32,8 +32,7 @@
 #include "tunerstudio_configuration.h"
 #endif /* EFI_TUNER_STUDIO */
 
-EXTERN_ENGINE
-;
+EXTERN_ENGINE;
 
 tps_tps_Map3D_t tpsTpsMap("tpsTps");
 

--- a/firmware/controllers/algo/advance_map.cpp
+++ b/firmware/controllers/algo/advance_map.cpp
@@ -31,8 +31,7 @@
 
 #if EFI_ENGINE_CONTROL
 
-EXTERN_ENGINE
-;
+EXTERN_ENGINE;
 
 static ign_Map3D_t advanceMap("advance");
 // This coeff in ctor parameter is sufficient for int16<->float conversion!

--- a/firmware/controllers/algo/engine.cpp
+++ b/firmware/controllers/algo/engine.cpp
@@ -39,8 +39,7 @@ static TriggerState initState CCM_OPTIONAL;
 
 LoggingWithStorage engineLogger("engine");
 
-EXTERN_ENGINE
-;
+EXTERN_ENGINE;
 
 #if EFI_ENGINE_SNIFFER
 #include "engine_sniffer.h"

--- a/firmware/controllers/algo/engine2.cpp
+++ b/firmware/controllers/algo/engine2.cpp
@@ -28,8 +28,7 @@
 extern fuel_Map3D_t veMap;
 extern afr_Map3D_t afrMap;
 
-EXTERN_ENGINE
-;
+EXTERN_ENGINE;
 
 // this does not look exactly right
 extern LoggingWithStorage engineLogger;

--- a/firmware/controllers/algo/fuel_math.cpp
+++ b/firmware/controllers/algo/fuel_math.cpp
@@ -31,8 +31,7 @@
 #include "speed_density.h"
 #include "perf_trace.h"
 
-EXTERN_ENGINE
-;
+EXTERN_ENGINE;
 
 fuel_Map3D_t fuelMap("fuel");
 static fuel_Map3D_t fuelPhaseMap("fl ph");

--- a/firmware/controllers/algo/launch_control.cpp
+++ b/firmware/controllers/algo/launch_control.cpp
@@ -30,8 +30,7 @@ static Logging *logger;
 extern TunerStudioOutputChannels tsOutputChannels;
 #endif /* EFI_TUNER_STUDIO */
 
-EXTERN_ENGINE
-;
+EXTERN_ENGINE;
 
 static bool getActivateSwitchCondition(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 	switch (engineConfiguration->launchActivationMode) {

--- a/firmware/controllers/bench_test.cpp
+++ b/firmware/controllers/bench_test.cpp
@@ -51,8 +51,7 @@
 
 
 
-EXTERN_ENGINE
-;
+EXTERN_ENGINE;
 
 static Logging * logger;
 static bool isRunningBench = false;

--- a/firmware/controllers/can/obd2.cpp
+++ b/firmware/controllers/can/obd2.cpp
@@ -39,8 +39,7 @@
 #include "fuel_math.h"
 #include "thermistors.h"
 
-EXTERN_ENGINE
-;
+EXTERN_ENGINE;
 
 static LoggingWithStorage logger("obd2");
 

--- a/firmware/controllers/core/error_handling.h
+++ b/firmware/controllers/core/error_handling.h
@@ -31,6 +31,8 @@ typedef uint8_t critical_msg_t[ERROR_BUFFER_SIZE];
  */
 void firmwareError(obd_code_e code, const char *fmt, ...);
 
+extern bool hasFirmwareErrorFlag;
+
 #define hasFirmwareError() hasFirmwareErrorFlag
 
 // todo: rename to getCriticalErrorMessage

--- a/firmware/controllers/core/fsio_impl.cpp
+++ b/firmware/controllers/core/fsio_impl.cpp
@@ -106,8 +106,7 @@ static LEElement * starterRelayDisableLogic;
 static LEElement * mainRelayLogic;
 #endif /* EFI_MAIN_RELAY_CONTROL */
 
-EXTERN_ENGINE
-;
+EXTERN_ENGINE;
 
 static Logging *logger;
 #if EFI_PROD_CODE || EFI_SIMULATOR
@@ -731,9 +730,6 @@ void initFsioImpl(Logging *sharedLogger DECLARE_ENGINE_PARAMETER_SUFFIX) {
 }
 
 #else /* !EFI_FSIO */
-
-EXTERN_ENGINE
-;
 
 // "Limp-mode" implementation for some RAM-limited configs without FSIO
 void runHardcodedFsio(DECLARE_ENGINE_PARAMETER_SIGNATURE) {

--- a/firmware/controllers/core/fsio_impl.cpp
+++ b/firmware/controllers/core/fsio_impl.cpp
@@ -15,6 +15,8 @@
 #include "fsio_impl.h"
 #include "allsensors.h"
 
+EXTERN_ENGINE;
+
 #if EFI_FSIO
 
 #include "os_access.h"
@@ -105,8 +107,6 @@ static LEElement * starterRelayDisableLogic;
 #if EFI_MAIN_RELAY_CONTROL
 static LEElement * mainRelayLogic;
 #endif /* EFI_MAIN_RELAY_CONTROL */
-
-EXTERN_ENGINE;
 
 static Logging *logger;
 #if EFI_PROD_CODE || EFI_SIMULATOR

--- a/firmware/controllers/engine_controller.cpp
+++ b/firmware/controllers/engine_controller.cpp
@@ -102,8 +102,6 @@ EXTERN_ENGINE;
 
 #if !EFI_UNIT_TEST
 
-extern bool hasFirmwareErrorFlag;
-
 static LoggingWithStorage logger("Engine Controller");
 
 /**

--- a/firmware/controllers/engine_cycle/aux_valves.cpp
+++ b/firmware/controllers/engine_cycle/aux_valves.cpp
@@ -19,8 +19,7 @@
 #include "trigger_central.h"
 #include "spark_logic.h"
 
-EXTERN_ENGINE
-;
+EXTERN_ENGINE;
 
 void plainPinTurnOn(AuxActor *current) {
 	NamedOutputPin *output = &enginePins.auxValve[current->valveIndex];

--- a/firmware/controllers/engine_cycle/main_trigger_callback.cpp
+++ b/firmware/controllers/engine_cycle/main_trigger_callback.cpp
@@ -51,9 +51,7 @@
 
 #include "backup_ram.h"
 
-EXTERN_ENGINE
-;
-extern bool hasFirmwareErrorFlag;
+EXTERN_ENGINE;
 
 static const char *prevOutputName = nullptr;
 

--- a/firmware/controllers/engine_cycle/map_averaging.cpp
+++ b/firmware/controllers/engine_cycle/map_averaging.cpp
@@ -93,8 +93,7 @@ static int averagedMapBufIdx = 0;
 // this is 'minimal averaged' MAP within avegaging window
 static float currentPressure = NO_VALUE_YET;
 
-EXTERN_ENGINE
-;
+EXTERN_ENGINE;
 
 /**
  * here we have averaging start and averaging end points for each cylinder

--- a/firmware/controllers/engine_cycle/rpm_calculator.cpp
+++ b/firmware/controllers/engine_cycle/rpm_calculator.cpp
@@ -81,10 +81,7 @@ int RpmCalculator::getRpm(DECLARE_ENGINE_PARAMETER_SIGNATURE) const {
 
 #if EFI_SHAFT_POSITION_INPUT
 
-EXTERN_ENGINE
-;
-
-extern bool hasFirmwareErrorFlag;
+EXTERN_ENGINE;
 
 static Logging * logger;
 

--- a/firmware/controllers/gauges/lcd_controller.cpp
+++ b/firmware/controllers/gauges/lcd_controller.cpp
@@ -42,9 +42,7 @@
 #include "fuel_math.h"
 
 
-EXTERN_ENGINE
-;
-extern bool hasFirmwareErrorFlag;
+EXTERN_ENGINE;
 
 static MenuItem ROOT(NULL, NULL);
 

--- a/firmware/controllers/math/engine_math.cpp
+++ b/firmware/controllers/math/engine_math.cpp
@@ -30,8 +30,7 @@
 #include "advance_map.h"
 #include "config_engine_specs.h"
 
-EXTERN_ENGINE
-;
+EXTERN_ENGINE;
 #if EFI_UNIT_TEST
 extern bool verboseMode;
 #endif /* EFI_UNIT_TEST */

--- a/firmware/controllers/sensors/maf.cpp
+++ b/firmware/controllers/sensors/maf.cpp
@@ -3,8 +3,7 @@
 #include "adc_inputs.h"
 #include "maf.h"
 
-EXTERN_ENGINE
-;
+EXTERN_ENGINE;
 
 /**
  * @return MAF sensor voltage

--- a/firmware/controllers/sensors/stored_value_sensor.h
+++ b/firmware/controllers/sensors/stored_value_sensor.h
@@ -29,7 +29,7 @@
  */
 class StoredValueSensor : public Sensor {
 public:
-	SensorResult get() const final {
+	SensorResult get() const final override {
 		bool valid = m_isValid;
 		float value = m_value;
 

--- a/firmware/controllers/sensors/thermistors.cpp
+++ b/firmware/controllers/sensors/thermistors.cpp
@@ -24,8 +24,7 @@
 #define LIMPING_MODE_CLT_TEMPERATURE 70.0f
 #define NO_CLT_SENSOR_TEMPERATURE 72.0f
 
-EXTERN_ENGINE
-;
+EXTERN_ENGINE;
 
 static Logging *logger = nullptr;
 

--- a/firmware/controllers/settings.cpp
+++ b/firmware/controllers/settings.cpp
@@ -58,8 +58,7 @@ extern WaveChart waveChart;
 static char LOGGING_BUFFER[SETTINGS_LOGGING_BUFFER_SIZE];
 static Logging logger("settings control", LOGGING_BUFFER, sizeof(LOGGING_BUFFER));
 
-EXTERN_ENGINE
-;
+EXTERN_ENGINE;
 
 /*
  static void printIntArray(int array[], int size) {

--- a/firmware/controllers/trigger/trigger_central.cpp
+++ b/firmware/controllers/trigger/trigger_central.cpp
@@ -396,8 +396,7 @@ void TriggerCentral::handleShaftSignal(trigger_event_e signal, efitick_t timesta
 	}
 }
 
-EXTERN_ENGINE
-;
+EXTERN_ENGINE;
 
 static void triggerShapeInfo(void) {
 #if EFI_PROD_CODE || EFI_SIMULATOR

--- a/firmware/controllers/trigger/trigger_decoder.cpp
+++ b/firmware/controllers/trigger/trigger_decoder.cpp
@@ -104,8 +104,7 @@ TriggerStateWithRunningStatistics::TriggerStateWithRunningStatistics() :
 
 #if EFI_SHAFT_POSITION_INPUT
 
-EXTERN_ENGINE
-;
+EXTERN_ENGINE;
 
 #if ! EFI_PROD_CODE
 bool printTriggerDebug = false;

--- a/firmware/controllers/trigger/trigger_emulator_algo.cpp
+++ b/firmware/controllers/trigger/trigger_emulator_algo.cpp
@@ -41,8 +41,7 @@ bool needEvent(const int currentIndex, const int size, MultiChannelStateSequence
 TriggerEmulatorHelper::TriggerEmulatorHelper() {
 }
 
-EXTERN_ENGINE
-;
+EXTERN_ENGINE;
 
 void TriggerEmulatorHelper::handleEmulatorCallback(PwmConfig *state, int stateIndex) {
 	efitick_t stamp = getTimeNowNt();

--- a/firmware/development/engine_emulator.cpp
+++ b/firmware/development/engine_emulator.cpp
@@ -22,8 +22,6 @@
 #include "poten.h"
 #include "trigger_emulator.h"
 
-extern bool hasFirmwareErrorFlag;
-
 static THD_WORKING_AREA(eeThreadStack, UTILITY_THREAD_STACK_SIZE);
 
 #define DIAG_PIN GPIOD_0

--- a/firmware/development/engine_sniffer.cpp
+++ b/firmware/development/engine_sniffer.cpp
@@ -38,8 +38,7 @@
 
 #define CHART_DELIMETER	'!'
 
-EXTERN_ENGINE
-;
+EXTERN_ENGINE;
 extern uint32_t maxLockedDuration;
 
 /**

--- a/firmware/development/logic_analyzer.cpp
+++ b/firmware/development/logic_analyzer.cpp
@@ -37,7 +37,6 @@ EXTERN_ENGINE;
 #if EFI_ENGINE_SNIFFER
 extern WaveChart waveChart;
 #endif /* EFI_ENGINE_SNIFFER */
-extern bool hasFirmwareErrorFlag;
 
 /**
  * Difference between current 1st trigger event and previous 1st trigger event.

--- a/firmware/hw_layer/drivers/can/can_hw.cpp
+++ b/firmware/hw_layer/drivers/can/can_hw.cpp
@@ -22,8 +22,7 @@
 #include "mpu_util.h"
 #include "engine.h"
 
-EXTERN_ENGINE
-;
+EXTERN_ENGINE;
 
 static int canReadCounter = 0;
 static int canWriteOk = 0;

--- a/firmware/hw_layer/hardware.cpp
+++ b/firmware/hw_layer/hardware.cpp
@@ -61,9 +61,7 @@
 #include "flash_main.h"
 #endif
 
-EXTERN_ENGINE
-;
-extern bool hasFirmwareErrorFlag;
+EXTERN_ENGINE;
 
 static mutex_t spiMtx;
 

--- a/firmware/hw_layer/hip9011.cpp
+++ b/firmware/hw_layer/hip9011.cpp
@@ -132,9 +132,7 @@ void Hip9011Hardware::sendCommand(unsigned char command) {
 	spiStartExchangeI(driver, 1, tx_buff, rx_buff);
 }
 
-EXTERN_ENGINE
-;
-
+EXTERN_ENGINE;
 
 static char hipPinNameBuffer[16];
 

--- a/firmware/hw_layer/microsecond_timer.cpp
+++ b/firmware/hw_layer/microsecond_timer.cpp
@@ -61,8 +61,6 @@ static int timerFreezeCounter = 0;
 static volatile int setHwTimerCounter = 0;
 static volatile bool hwStarted = false;
 
-extern bool hasFirmwareErrorFlag;
-
 /**
  * sets the alarm to the specified number of microseconds from now.
  * This function should be invoked under kernel lock which would disable interrupts.

--- a/firmware/hw_layer/sensors/joystick.cpp
+++ b/firmware/hw_layer/sensors/joystick.cpp
@@ -20,8 +20,7 @@
 #include "pin_repository.h"
 #include "digital_input_exti.h"
 
-EXTERN_ENGINE
-;
+EXTERN_ENGINE;
 
 static int joyTotal = 0;
 static int joyCenter;

--- a/firmware/hw_layer/trigger_input_comp.cpp
+++ b/firmware/hw_layer/trigger_input_comp.cpp
@@ -16,11 +16,8 @@
 #include "trigger_input.h"
 #include "digital_input_icu.h"
 
+EXTERN_ENGINE;
 
-extern bool hasFirmwareErrorFlag;
-
-EXTERN_ENGINE
-;
 static Logging *logger;
 
 static volatile int centeredDacValue = 127;

--- a/firmware/hw_layer/trigger_input_exti.cpp
+++ b/firmware/hw_layer/trigger_input_exti.cpp
@@ -21,8 +21,6 @@
 	#error "PAL_USE_CALLBACKS should be enabled to use HAL_TRIGGER_USE_PAL"
 #endif
 
-extern bool hasFirmwareErrorFlag;
-
 static Logging *logger;
 
 EXTERN_ENGINE;

--- a/firmware/hw_layer/trigger_input_icu.cpp
+++ b/firmware/hw_layer/trigger_input_icu.cpp
@@ -24,8 +24,6 @@ int icuFallingCallbackCounter = 0;
 
 EXTERN_ENGINE;
 
-extern bool hasFirmwareErrorFlag;
-
 static Logging *logger;
 
 static void vvtRisingCallback(void *) {

--- a/firmware/hw_layer/vehicle_speed.cpp
+++ b/firmware/hw_layer/vehicle_speed.cpp
@@ -13,8 +13,7 @@
 #include "digital_input_icu.h"
 #include "pin_repository.h"
 
-EXTERN_ENGINE
-;
+EXTERN_ENGINE;
 
 static Logging *logger;
 

--- a/firmware/rusefi.cpp
+++ b/firmware/rusefi.cpp
@@ -137,12 +137,9 @@ bool main_loop_started = false;
 
 static char panicMessage[200];
 
-extern bool hasFirmwareErrorFlag;
-
 static virtual_timer_t resetTimer;
 
-EXTERN_ENGINE
-;
+EXTERN_ENGINE;
 
 // todo: move this into a hw-specific file
 void rebootNow(void) {


### PR DESCRIPTION
- move `extern bool hasFirmwareErrorFlag` to the header, so we don't need it in literally every file
- why did `EXTERN_ENGINE` sometimes have the semicolon on the next line?