### PR TITLE
Debugging for sensor converter functions

### DIFF
--- a/firmware/controllers/sensors/converters/func_chain.h
+++ b/firmware/controllers/sensors/converters/func_chain.h
@@ -24,6 +24,10 @@ protected:
 		// Base case is the identity function
 		return {true, input};
 	}
+
+	void showInfo(Logging* logger, float testInputValue) const {
+		// base case does nothing
+	}
 };
 
 template <typename TFirst, typename... TRest>
@@ -58,6 +62,17 @@ public:
 		return TBase::template get<TGet>();
 	}
 
+	void showInfo(Logging* logger, float testInputValue) const {
+		// Print info about this level
+		m_f.showInfo(logger, testInputValue);
+
+		// If valid, recurse down
+		auto res = m_f.convert(testInputValue);
+		if (res.Valid) {
+			TBase::showInfo(logger, res.Value);
+		}
+	}
+
 private:
 	TFirst m_f;
 };
@@ -75,6 +90,10 @@ public:
 	template <typename TGet>
 	TGet &get() {
 		return m_fs.template get<TGet>();
+	}
+
+	void showInfo(Logging* logger, float testInputValue) const override {
+		m_fs.showInfo(logger, testInputValue);
 	}
 
 private:

--- a/firmware/controllers/sensors/converters/linear_func.cpp
+++ b/firmware/controllers/sensors/converters/linear_func.cpp
@@ -23,7 +23,7 @@ SensorResult LinearFunc::convert(float inputValue) const {
 }
 
 void LinearFunc::showInfo(Logging* logger, float testRawValue) const {
-	scheduleMsg(logger, "    Linear function slope: %f offset: %f min: %f max: %f", m_a, m_b, m_minOutput, m_maxOutput);
+	scheduleMsg(logger, "    Linear function slope: %.2f offset: %.2f min: %.1f max: %.1f", m_a, m_b, m_minOutput, m_maxOutput);
 	const auto [valid, value] = convert(testRawValue);
-	scheduleMsg(logger, "        raw value %f converts to {%d, %f}", testRawValue, valid, value);
+	scheduleMsg(logger, "      raw value %.2f converts to %.2f", testRawValue, value);
 }

--- a/firmware/controllers/sensors/converters/linear_func.cpp
+++ b/firmware/controllers/sensors/converters/linear_func.cpp
@@ -21,3 +21,9 @@ SensorResult LinearFunc::convert(float inputValue) const {
 
 	return {isValid, result};
 }
+
+void LinearFunc::showInfo(Logging* logger, float testRawValue) const {
+	scheduleMsg(logger, "    Linear function slope: %f offset: %f min: %f max: %f", m_a, m_b, m_minOutput, m_maxOutput);
+	const auto [valid, value] = convert(testRawValue);
+	scheduleMsg(logger, "        raw value %f converts to {%d, %f}", testRawValue, valid, value);
+}

--- a/firmware/controllers/sensors/converters/linear_func.h
+++ b/firmware/controllers/sensors/converters/linear_func.h
@@ -10,6 +10,8 @@ public:
 
 	SensorResult convert(float inputValue) const override;
 
+	void showInfo(Logging* logger, float testRawValue) const override;
+
 private:
 	// Linear equation parameters for equation of form
 	// y = ax + b

--- a/firmware/controllers/sensors/converters/resistance_func.cpp
+++ b/firmware/controllers/sensors/converters/resistance_func.cpp
@@ -29,5 +29,5 @@ SensorResult ResistanceFunc::convert(float raw) const {
 
 void ResistanceFunc::showInfo(Logging* logger, float testInputValue) const {
 	const auto [valid, value] = convert(testInputValue);
-	scheduleMsg(logger, "%.2f volts -> %.1f ohms, with supply voltage %.2f and pullup %.1f.", m_supplyVoltage, m_pullupResistor, testInputValue, value);
+	scheduleMsg(logger, "    %.2f volts -> %.1f ohms, with supply voltage %.2f and pullup %.1f.", testInputValue, value, m_supplyVoltage, m_pullupResistor);
 }

--- a/firmware/controllers/sensors/converters/resistance_func.cpp
+++ b/firmware/controllers/sensors/converters/resistance_func.cpp
@@ -3,6 +3,7 @@
  */
 
 #include "resistance_func.h"
+#include "loggingcentral.h"
 
 void ResistanceFunc::configure(float supplyVoltage, float pullupResistor) {
 	m_pullupResistor = pullupResistor;
@@ -24,4 +25,9 @@ SensorResult ResistanceFunc::convert(float raw) const {
 	float resistance = m_pullupResistor / (m_supplyVoltage / raw - 1);
 
 	return {true, resistance};
+}
+
+void ResistanceFunc::showInfo(Logging* logger, float testInputValue) const {
+	const auto [valid, value] = convert(testInputValue);
+	scheduleMsg(logger, "%.2f volts -> %.1f ohms, with supply voltage %.2f and pullup %.1f.", m_supplyVoltage, m_pullupResistor, testInputValue, value);
 }

--- a/firmware/controllers/sensors/converters/resistance_func.h
+++ b/firmware/controllers/sensors/converters/resistance_func.h
@@ -16,6 +16,8 @@ public:
 
 	SensorResult convert(float inputValue) const override;
 
+	void showInfo(Logging* logger, float testInputValue) const override;
+
 private:
 	float m_supplyVoltage = 5.0f;
 	float m_pullupResistor = 1000.0f;

--- a/firmware/controllers/sensors/converters/sensor_converter_func.h
+++ b/firmware/controllers/sensors/converters/sensor_converter_func.h
@@ -2,6 +2,9 @@
 
 #include "sensor.h"
 
+class Logging;
+
 struct SensorConverter {
 	virtual SensorResult convert(float raw) const = 0;
+	virtual void showInfo(Logging* logger, float testRawValue) const {}
 };

--- a/firmware/controllers/sensors/converters/thermistor_func.h
+++ b/firmware/controllers/sensors/converters/thermistor_func.h
@@ -2,7 +2,7 @@
  * @author Matthew Kennedy, (c) 2019
  * 
  * A function to convert resistance to thermistor temperature (NTC). Uses the
- * Steinhart-Hart equation to prevent having to compute many logarithms at runtime.
+ * Steinhart-Hart equation to avoid having to compute many logarithms at runtime.
  */
 
 #pragma once

--- a/firmware/controllers/sensors/sensor_info_printing.cpp
+++ b/firmware/controllers/sensors/sensor_info_printing.cpp
@@ -10,4 +10,9 @@ void ProxySensor::showInfo(Logging* logger, const char* sensorName) const {
 void FunctionalSensor::showInfo(Logging* logger, const char* sensorName) const {
 	const auto [valid, value] = get();
 	scheduleMsg(logger, "Sensor \"%s\": Raw value: %.2f Valid: %d Converted value %.2f", sensorName, m_rawValue, valid, value);
+
+	// now print out the underlying function's info
+	if (auto func = m_function) {
+		func->showInfo(logger, m_rawValue);
+	}
 }


### PR DESCRIPTION
Looks like this (note new stuff under `TPS 1`):
```
2020-03-30_16_18_33_261: EngineState: confirmation_show_sensors:12
2020-03-30_16_18_33_262: EngineState: Sensor "CLT" is not configured.
2020-03-30_16_18_33_262: EngineState: Sensor "IAT" is not configured.
2020-03-30_16_18_33_262: EngineState: Sensor "Oil Pressure" is not configured.
2020-03-30_16_18_33_263: EngineState: Sensor "TPS 1": Raw value: 0.98 Valid: 1 Converted value -8.16
2020-03-30_16_18_33_388: EngineState:     Linear function slope: 30.44 offset: -38.05 min: -10.0 max: 110.0
2020-03-30_16_18_33_394: EngineState:         raw value 0.98 converts to -8.16
2020-03-30_16_18_33_398: EngineState: Sensor "TPS 1 Primary" is not configured.
2020-03-30_16_18_33_400: EngineState: Sensor "TPS 1 Secondary" is not configured.
2020-03-30_16_18_33_404: EngineState: Sensor "TPS 2" is not configured.
2020-03-30_16_18_33_406: EngineState: Sensor "TPS 2 Primary" is not configured.
2020-03-30_16_18_33_411: EngineState: Sensor "TPS 2 Secondary" is not configured.
2020-03-30_16_18_33_413: EngineState: Sensor "Acc Pedal" is not configured.
2020-03-30_16_18_33_414: EngineState: Sensor "Acc Pedal Primary" is not configured.
2020-03-30_16_18_33_414: EngineState: Sensor "Acc Pedal Secondary" is not configured.
2020-03-30_16_18_33_414: EngineState: Sensor "Driver Acc Intent" proxied from sensor "TPS 1"
```