### PR TITLE
improve pin error messages

### DIFF
--- a/firmware/hw_layer/pin_repository.cpp
+++ b/firmware/hw_layer/pin_repository.cpp
@@ -231,7 +231,7 @@ bool brain_pin_markUsed(brain_pin_e brainPin, const char *msg) {
 		 * connected, so the warning is never displayed on the console and that's quite a problem!
 		 */
 //		warning(OBD_PCM_Processor_Fault, "brain pin %d req by %s used by %s", brainPin, msg, getBrainUsedPin(index));
-		firmwareError(CUSTOM_ERR_PIN_ALREADY_USED_1, "Pin \"%s\" required by %s but is used by %s", hwPortname(brainPin), msg, getBrainUsedPin(index));
+		firmwareError(CUSTOM_ERR_PIN_ALREADY_USED_1, "Pin \"%s\" required by \"%s\" but is used by \"%s\"", hwPortname(brainPin), msg, getBrainUsedPin(index));
 		return true;
 	}
 

--- a/firmware/hw_layer/trigger_input.cpp
+++ b/firmware/hw_layer/trigger_input.cpp
@@ -139,14 +139,14 @@ void stopTriggerInputPins(void) {
 void startTriggerInputPins(void) {
 	for (int i = 0; i < TRIGGER_SUPPORTED_CHANNELS; i++) {
 		if (isConfigurationChanged(triggerInputPins[i])) {
-			const char * msg = (i == 0 ? "trigger#1" : (i == 1 ? "trigger#2" : "trigger#3"));
+			const char * msg = (i == 0 ? "Trigger #1" : (i == 1 ? "Trigger #2" : "Trigger #3"));
 			turnOnTriggerInputPin(msg, i, true);
 		}
 	}
 
 	for (int i = 0; i < CAM_INPUTS_COUNT; i++) {
 		if (isConfigurationChanged(camInputs[i])) {
-			turnOnTriggerInputPin("cam", i, false);
+			turnOnTriggerInputPin("Cam", i, false);
 		}
 	}
 

--- a/firmware/hw_layer/trigger_input_icu.cpp
+++ b/firmware/hw_layer/trigger_input_icu.cpp
@@ -89,7 +89,7 @@ int icuTriggerTurnOnInputPin(const char *msg, int index, bool isTriggerShaft) {
 		return -1;
 	}
 
-	digital_input_s* input = startDigitalCapture("trigger", brainPin);
+	digital_input_s* input = startDigitalCapture(msg, brainPin);
 	if (input == NULL) {
 		/* error already reported */
 		return -1;
@@ -108,7 +108,6 @@ int icuTriggerTurnOnInputPin(const char *msg, int index, bool isTriggerShaft) {
 }
 
 void icuTriggerTurnOffInputPin(brain_pin_e brainPin) {
-
 	stopDigitalCapture("trigger", brainPin);
 }
 


### PR DESCRIPTION
This error message isn't very useful:
![image](https://user-images.githubusercontent.com/568254/78391370-16bbab80-759b-11ea-9439-672ffb68094a.png)
Which trigger pin is occupied by what?