### PR TITLE
remove ETB controlPinMode

### DIFF
--- a/firmware/controllers/actuators/dc_motors.cpp
+++ b/firmware/controllers/actuators/dc_motors.cpp
@@ -45,14 +45,13 @@ public:
 	void start(bool useTwoWires, 
 			brain_pin_e pinEnable,
 			// since we have pointer magic here we cannot simply have value parameter
-			const pin_output_mode_e *pinEnableMode,
 			brain_pin_e pinDir1,
 			brain_pin_e pinDir2,
 			ExecutorInterface* executor,
 			int frequency) {
 		dcMotor.setType(useTwoWires ? TwoPinDcMotor::ControlType::PwmDirectionPins : TwoPinDcMotor::ControlType::PwmEnablePin);
 
-		m_pinEnable.initPin("ETB Enable", pinEnable, pinEnableMode);
+		m_pinEnable.initPin("ETB Enable", pinEnable);
 		m_pinDir1.initPin("ETB Dir 1", pinDir1);
 		m_pinDir2.initPin("ETB Dir 2", pinDir2);
 
@@ -92,11 +91,9 @@ DcMotor* initDcMotor(size_t index DECLARE_ENGINE_PARAMETER_SUFFIX)
 	const auto& io = engineConfiguration->etbIo[index];
 	auto& hw = etbHardware[index];
 
-	// controlPinMode is a strange feature - it's simply because I am short on 5v I/O on Frankenso with Miata NB2 test mule
 	hw.start(
 		CONFIG(etb_use_two_wires),
 		io.controlPin1,
-		&io.controlPinMode,
 		io.directionPin1,
 		io.directionPin2,
 		&ENGINE(executor),

--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -525,7 +525,7 @@ struct etb_io
 	brain_pin_e directionPin1;
 	brain_pin_e directionPin2;
 	brain_pin_e controlPin1;
-	pin_output_mode_e controlPinMode;
+	uint8_t pad;
 end_struct
 	
 	idle_hardware_s idle;


### PR DESCRIPTION
Unclear if this was ever actually used, and clearly isn't needed for any board with ETB wired in.