### PR TITLE
fix oil pressure sensor

### DIFF
--- a/firmware/controllers/sensors/converters/sensor_converter_func.h
+++ b/firmware/controllers/sensors/converters/sensor_converter_func.h
@@ -5,6 +5,11 @@
 class Logging;
 
 struct SensorConverter {
+	// Trying to copy a converter func by value is almost guaranteed to be a bug - disallow it
+	SensorConverter(const SensorConverter&) = delete;
+	// ...but doing so requires explicitly declaring the default constructor, so do that too.
+	SensorConverter() = default;
+
 	virtual SensorResult convert(float raw) const = 0;
 	virtual void showInfo(Logging* logger, float testRawValue) const {}
 };

--- a/firmware/init/sensor/init_oil_pressure.cpp
+++ b/firmware/init/sensor/init_oil_pressure.cpp
@@ -14,8 +14,7 @@ EXTERN_ENGINE;
 LinearFunc oilpSensorFunc;
 FunctionalSensor oilpSensor(SensorType::OilPressure, /* timeout = */ MS2NT(50));
 
-void configureOilPressure(LinearFunc func, const oil_pressure_config_s& cfg)
-{
+void configureOilPressure(LinearFunc& func, const oil_pressure_config_s& cfg) {
 	float val1 = cfg.value1;
 	float val2 = cfg.value2;
 

--- a/unit_tests/tests/sensor/test_sensor_init.cpp
+++ b/unit_tests/tests/sensor/test_sensor_init.cpp
@@ -108,3 +108,28 @@ TEST(SensorInit, DriverIntentWith) {
 	// Should get the pedal
 	EXPECT_EQ(Sensor::get(SensorType::DriverThrottleIntent).Value, 75);
 }
+
+TEST(SensorInit, OilPressure) {
+	WITH_ENGINE_TEST_HELPER(TEST_ENGINE);
+
+	CONFIG(oilPressure.hwChannel) = EFI_ADC_0;
+	CONFIG(oilPressure.v1) = 1;
+	CONFIG(oilPressure.v2) = 4;
+	CONFIG(oilPressure.value1) = 0;
+	CONFIG(oilPressure.value2) = 1000;
+
+	initOilPressure(PASS_ENGINE_PARAMETER_SIGNATURE);
+
+	// Ensure the sensors were registered
+	auto s = const_cast<Sensor*>(Sensor::getSensorOfType(SensorType::OilPressure));
+	ASSERT_NE(nullptr, s);
+
+	// Test in range
+	EXPECT_POINT_VALID(s, 1.0f, 0.0f);	// minimum
+	EXPECT_POINT_VALID(s, 2.5f, 500.0f);	// mid
+	EXPECT_POINT_VALID(s, 4.0f, 1000.0f) // maximium
+
+	// Test out of range
+	EXPECT_POINT_INVALID(s, 0.0f);
+	EXPECT_POINT_INVALID(s, 5.0f);
+}


### PR DESCRIPTION
- Fix the bug
- Make the bug impossible via the type system: delete the copy constructor
- Add a test that catches the bug