### PR TITLE
Allow different length CAN frames

### DIFF
--- a/firmware/hw_layer/drivers/can/can_msg_tx.cpp
+++ b/firmware/hw_layer/drivers/can/can_msg_tx.cpp
@@ -23,11 +23,11 @@ extern LoggingWithStorage sharedLogger;
 	s_device = device;
 }
 
-CanTxMessage::CanTxMessage(uint32_t eid) {
+CanTxMessage::CanTxMessage(uint32_t eid, uint8_t dlc) {
 	m_frame.IDE = CAN_IDE_STD;
 	m_frame.EID = eid;
 	m_frame.RTR = CAN_RTR_DATA;
-	m_frame.DLC = 8;
+	m_frame.DLC = dlc;
 	memset(m_frame.data8, 0, sizeof(m_frame.data8));
 }
 

--- a/firmware/hw_layer/drivers/can/can_msg_tx.h
+++ b/firmware/hw_layer/drivers/can/can_msg_tx.h
@@ -28,7 +28,7 @@ public:
 	/**
 	 * Create a new CAN message, with the specified extended ID.
 	 */
-	CanTxMessage(uint32_t eid);
+	CanTxMessage(uint32_t eid, uint8_t dlc = 8);
 
 	/**
 	 * Destruction of an instance of CanTxMessage will transmit the message over the wire.


### PR DESCRIPTION
Some OEM compat needs different length frames.  Default parameter of 8 to maintain compat with existing stuff.