### PR TITLE
Update to Matt's MAF code for VE table tuning. 

### DIFF
--- a/firmware/controllers/algo/fuel_math.cpp
+++ b/firmware/controllers/algo/fuel_math.cpp
@@ -142,6 +142,7 @@ floatms_t getRunningFuel(floatms_t baseFuel DECLARE_ENGINE_PARAMETER_SUFFIX) {
 /* DISPLAY_ENDIF */
 
 /**
+ * Function block now works to create a standardised load from the cylinder filling as well as tune fuel via VE table. 
  * @return total duration of fuel injection per engine cycle, in milliseconds
  */
 float getRealMafFuel(float airSpeed, int rpm DECLARE_ENGINE_PARAMETER_SUFFIX) {

--- a/firmware/controllers/algo/fuel_math.cpp
+++ b/firmware/controllers/algo/fuel_math.cpp
@@ -151,9 +151,6 @@ float getRealMafFuel(float airSpeed, int rpm DECLARE_ENGINE_PARAMETER_SUFFIX) {
 		return 0;
 	}
 
-	//Calculation of 100% VE air mass in g/rev
-	float StandardAirCharge = CONFIG(specs.displacement) / CONFIG(specs.cylindersCount) * 1.2929; //1 cylinder filling at 1.2929g/L
-
 	// kg/hr -> g/s
 	float gramPerSecond = airSpeed * 1000 / 3600;
 
@@ -167,6 +164,8 @@ float getRealMafFuel(float airSpeed, int rpm DECLARE_ENGINE_PARAMETER_SUFFIX) {
 
 	float cylinderAirmass = airPerRevolution / halfCylCount;
 	
+	//Calculation of 100% VE air mass in g/rev - 1 cylinder filling at 1.2929g/L
+	float StandardAirCharge = CONFIG(specs.displacement) / CONFIG(specs.cylindersCount) * 1.2929; 
 	//Create % load for fuel table using relative naturally aspiratedcylinder filling
 	float airChargeLoad = 100 * cylinderAirmass/StandardAirCharge;
 	

--- a/firmware/controllers/algo/fuel_math.cpp
+++ b/firmware/controllers/algo/fuel_math.cpp
@@ -31,7 +31,7 @@
 #include "speed_density.h"
 #include "perf_trace.h"
 #include "sensor.h"
-#include "config_engine_specs.h"
+
 
 EXTERN_ENGINE;
 
@@ -152,7 +152,7 @@ float getRealMafFuel(float airSpeed, int rpm DECLARE_ENGINE_PARAMETER_SUFFIX) {
 	}
 
 	//Calculation of 100% VE air mass in Kg/h
-	float StandardAirCharge = rpm * get_specs_displacement * 0.000038787;  //- Constant comes from 0.0012929 * 60 / 2 /1000 to convert direct from 2*cc/min to Kg/h
+	float StandardAirCharge = rpm * CONFIG(specs.displacement) * 0.000038787;  //- Constant comes from 0.0012929 * 60 / 2 /1000 to convert direct from 2*cc/min to Kg/h
 
 	// kg/hr -> g/s
 	float gramPerSecond = airSpeed * 1000 / 3600;

--- a/firmware/controllers/algo/fuel_math.cpp
+++ b/firmware/controllers/algo/fuel_math.cpp
@@ -150,12 +150,14 @@ float getRealMafFuel(float airSpeed, int rpm DECLARE_ENGINE_PARAMETER_SUFFIX) {
 		return 0;
 	}
 
+	//Calculation of 100% VE air mass in Kg/h
+	float StandardAirCharge = rpm * get_specs_displacement * 0.000038787;  //- Constant comes from 0.0012929 * 60 / 2 /1000 to convert direct from 2*cc/min to Kg/h
+
 	// kg/hr -> g/s
 	float gramPerSecond = airSpeed * 1000 / 3600;
 
 	// 1/min -> 1/s
 	float revsPerSecond = rpm / 60.0f;
-
 	float airPerRevolution = gramPerSecond / revsPerSecond;
 
 	// Now we have to divide among cylinders - on a 4 stroke, half of the cylinders happen every rev
@@ -163,7 +165,13 @@ float getRealMafFuel(float airSpeed, int rpm DECLARE_ENGINE_PARAMETER_SUFFIX) {
 	float halfCylCount = CONFIG(specs.cylindersCount) / 2.0f;
 
 	float cylinderAirmass = airPerRevolution / halfCylCount;
-	float fuelMassGram = cylinderAirmass / afrMap.getValue(rpm, airSpeed);
+	
+	//Create % load for fuel table using relative naturally aspiratedcylinder filling
+	float airChargeLoad = 100 * cylinderAirmass/StandardAirCharge;
+	
+	//Correct air mass by VE table 
+	float corrCylAirmass = cylinderAirmass * ve2Map.getValue(rpm, airChargeLoad);
+	float fuelMassGram = corrCylAirmass / afrMap.getValue(rpm, airSpeed);
 	float pulseWidthSeconds = fuelMassGram / cc_minute_to_gramm_second(engineConfiguration->injector.flow);
 
 	// Convert to ms

--- a/firmware/controllers/algo/fuel_math.cpp
+++ b/firmware/controllers/algo/fuel_math.cpp
@@ -31,6 +31,7 @@
 #include "speed_density.h"
 #include "perf_trace.h"
 #include "sensor.h"
+#include "config_engine_specs.h"
 
 EXTERN_ENGINE;
 

--- a/firmware/controllers/algo/fuel_math.cpp
+++ b/firmware/controllers/algo/fuel_math.cpp
@@ -150,8 +150,8 @@ float getRealMafFuel(float airSpeed, int rpm DECLARE_ENGINE_PARAMETER_SUFFIX) {
 		return 0;
 	}
 
-	//Calculation of 100% VE air mass in Kg/h
-	float StandardAirCharge = rpm * CONFIG(specs.displacement) * 0.000038787;  //- Constant comes from 0.0012929 * 60 / 2 /1000 to convert direct from 2*cc/min to Kg/h
+	//Calculation of 100% VE air mass in g/rev
+	float StandardAirCharge = CONFIG(specs.displacement) / CONFIG(specs.cylindersCount) * 1.2929; //1 cylinder filling at 1.2929g/L
 
 	// kg/hr -> g/s
 	float gramPerSecond = airSpeed * 1000 / 3600;

--- a/firmware/controllers/algo/fuel_math.cpp
+++ b/firmware/controllers/algo/fuel_math.cpp
@@ -171,7 +171,7 @@ float getRealMafFuel(float airSpeed, int rpm DECLARE_ENGINE_PARAMETER_SUFFIX) {
 	float airChargeLoad = 100 * cylinderAirmass/StandardAirCharge;
 	
 	//Correct air mass by VE table 
-	float corrCylAirmass = cylinderAirmass * ve2Map.getValue(rpm, airChargeLoad);
+	float corrCylAirmass = cylinderAirmass * veMap.getValue(rpm, airChargeLoad);
 	float fuelMassGram = corrCylAirmass / afrMap.getValue(rpm, airSpeed);
 	float pulseWidthSeconds = fuelMassGram / cc_minute_to_gramm_second(engineConfiguration->injector.flow);
 

--- a/firmware/controllers/algo/fuel_math.cpp
+++ b/firmware/controllers/algo/fuel_math.cpp
@@ -170,7 +170,7 @@ float getRealMafFuel(float airSpeed, int rpm DECLARE_ENGINE_PARAMETER_SUFFIX) {
 	float airChargeLoad = 100 * cylinderAirmass/StandardAirCharge;
 	
 	//Correct air mass by VE table 
-	float corrCylAirmass = cylinderAirmass * veMap.getValue(rpm, airChargeLoad);
+	float corrCylAirmass = cylinderAirmass * veMap.getValue(rpm, airChargeLoad) / 100;
 	float fuelMassGram = corrCylAirmass / afrMap.getValue(rpm, airSpeed);
 	float pulseWidthSeconds = fuelMassGram / cc_minute_to_gramm_second(engineConfiguration->injector.flow);
 

--- a/firmware/controllers/algo/fuel_math.cpp
+++ b/firmware/controllers/algo/fuel_math.cpp
@@ -32,12 +32,11 @@
 #include "perf_trace.h"
 #include "sensor.h"
 
-
 EXTERN_ENGINE;
 
 fuel_Map3D_t fuelMap("fuel");
 static fuel_Map3D_t fuelPhaseMap("fl ph");
-extern fuel_Map3D_t ve2Map;
+extern fuel_Map3D_t veMap;
 extern afr_Map3D_t afrMap;
 extern baroCorr_Map3D_t baroCorrMap;
 

--- a/firmware/tunerstudio/rusefi.input
+++ b/firmware/tunerstudio/rusefi.input
@@ -1191,14 +1191,14 @@ menuDialog = main
 		subMenu = std_separator
 
 		# Targets & closed loop
-		subMenu = afrTableTbl,				"Target AFR", 0, {isInjectionEnabled == 1 && fuelAlgorithm == LM_SPEED_DENSITY}
+		subMenu = afrTableTbl,				"Target AFR", 0, {isInjectionEnabled == 1 && (fuelAlgorithm == LM_SPEED_DENSITY || fuelAlgorithm == LM_REAL_MAF)}
 		subMenu = fuelClosedLoopDialog, 	"Closed loop correction", 0, {isInjectionEnabled == 1}
 		subMenu = coastingFuelCutControl, 	"Deceleration fuel cutoff (DFCO)", 0, {isInjectionEnabled == 1}
 		subMenu = std_separator
 
 		# Fuel table/VE
-		subMenu = fuelTableDialog,			"Fuel table", 0, {isInjectionEnabled == 1 && fuelAlgorithm != LM_SPEED_DENSITY}
-		subMenu = veTableDialog,			"VE", 0, {isInjectionEnabled == 1 && fuelAlgorithm == LM_SPEED_DENSITY}
+		subMenu = fuelTableDialog,			"Fuel table", 0, {isInjectionEnabled == 1 && fuelAlgorithm != LM_SPEED_DENSITY && fuelAlgorithm != LM_REAL_MAF}
+		subMenu = veTableDialog,			"VE", 1, {isInjectionEnabled == 1 && (fuelAlgorithm == LM_SPEED_DENSITY || fuelAlgorithm == LM_REAL_MAF)}
 		subMenu = injPhaseTableTbl,         "Injection phase", 0, {isInjectionEnabled == 1}
 		subMenu = std_separator
 

--- a/firmware/tunerstudio/rusefi.input
+++ b/firmware/tunerstudio/rusefi.input
@@ -1198,7 +1198,7 @@ menuDialog = main
 
 		# Fuel table/VE
 		subMenu = fuelTableDialog,			"Fuel table", 0, {isInjectionEnabled == 1 && fuelAlgorithm != LM_SPEED_DENSITY && fuelAlgorithm != LM_REAL_MAF}
-		subMenu = veTableDialog,			"VE", 1, {isInjectionEnabled == 1 && (fuelAlgorithm == LM_SPEED_DENSITY || fuelAlgorithm == LM_REAL_MAF)}
+		subMenu = veTableDialog,			"VE", 0, {isInjectionEnabled == 1 && (fuelAlgorithm == LM_SPEED_DENSITY || fuelAlgorithm == LM_REAL_MAF)}
 		subMenu = injPhaseTableTbl,         "Injection phase", 0, {isInjectionEnabled == 1}
 		subMenu = std_separator
 


### PR DESCRIPTION
PR-ing this now in the spirit of small changes. 
Built upon Matt's last PR to allow the MAF fuelling to be tuned with the VE table. 
MAF air charge fuelling now targets AFR and has correction for air flow inconsistencies like reversion through the MAF. 
Creates a value for "airChargeLoad" which is a standardised VE value and is used as Y axis for the VE table. 
VE table tunes MAF fuel by percentage. 100 = no correction, 80 = 20% less fuel, 120 = 20% more fuel. 
VE table enabled in Tuner studio for LM_REAL_MAF instead of Fuel Table.

Known issues:
Pulse width output is tested ok but does cause the build test to fail due to the change in the maths.
Y axis on VE table does not move in TS, need to change rusefi.input file to solve this for the next PR. 
For now the table works but does not show a live highlight/cursor in TS. 