### PR TITLE
Gauges for raw sensors

### DIFF
--- a/firmware/console/binary/tunerstudio_configuration.h
+++ b/firmware/console/binary/tunerstudio_configuration.h
@@ -181,7 +181,13 @@ typedef struct {
 	egt_values_s egtValues; // 204
 	scaled_percent throttle2Position;    // 220
 
-	uint8_t unusedAtTheEnd[18]; // we have some unused bytes to allow compatible TS changes
+	scaled_voltage rawTps1Primary;		// 222
+	scaled_voltage rawPpsPrimary;		// 224
+	scaled_voltage rawClt;				// 226
+	scaled_voltage rawIat;				// 228
+	scaled_voltage rawOilPressure;		// 230
+
+	uint8_t unusedAtTheEnd[8]; // we have some unused bytes to allow compatible TS changes
 
 	// Temporary - will remove soon
 	TsDebugChannels* getDebugChannels() {

--- a/firmware/console/status_loop.cpp
+++ b/firmware/console/status_loop.cpp
@@ -723,6 +723,13 @@ void updateTunerStudioState(TunerStudioOutputChannels *tsOutputChannels DECLARE_
 	tsOutputChannels->pedalPosition = pedal.Value;
 	tsOutputChannels->isPedalError = !pedal.Valid;
 
+	// Set raw sensors
+	tsOutputChannels->rawTps1Primary = Sensor::getRaw(SensorType::Tps1);
+	tsOutputChannels->rawPpsPrimary = Sensor::getRaw(SensorType::AcceleratorPedal);
+	tsOutputChannels->rawClt = Sensor::getRaw(SensorType::Clt);
+	tsOutputChannels->rawIat = Sensor::getRaw(SensorType::Iat);
+	tsOutputChannels->rawOilPressure = Sensor::getRaw(SensorType::OilPressure);
+
 	// offset 16
 	tsOutputChannels->massAirFlowVoltage = hasMafSensor() ? getMafVoltage(PASS_ENGINE_PARAMETER_SIGNATURE) : 0;
 

--- a/firmware/tunerstudio/rusefi.input
+++ b/firmware/tunerstudio/rusefi.input
@@ -348,6 +348,11 @@ fileVersion = { @@TS_FILE_VERSION@@ }
 ;
       TPS2Value       = scalar,  S16,    220,        "%",{1/@@PACK_MULT_PERCENT@@},         0
 
+      rawTps1Primary  = scalar,	 U16,    222, "V",{1/@@PACK_MULT_VOLTAGE@@}, 0.0
+      rawPpsPrimary   = scalar,	 U16,    224, "V",{1/@@PACK_MULT_VOLTAGE@@}, 0.0
+      rawClt          = scalar,	 U16,    226, "V",{1/@@PACK_MULT_VOLTAGE@@}, 0.0
+      rawIat          = scalar,	 U16,    228, "V",{1/@@PACK_MULT_VOLTAGE@@}, 0.0
+      rawOilPressure  = scalar,	 U16,    230, "V",{1/@@PACK_MULT_VOLTAGE@@}, 0.0
 
 ;
 ; see TunerStudioOutputChannels struct
@@ -959,6 +964,12 @@ gaugeCategory = Throttle Body (incl. ETB)
    etbErrorGauge      = etb1Error,     @@GAUGE_NAME_ETB_ERROR@@,  "%",    -20,  20,    -10,   -5,    5,    10,  2, 0
    etbDutyCycleGauge  = etb1DutyCycle, @@GAUGE_NAME_ETB_DUTY@@,                 "%",    -100, 100,   -75,   -50,   50,   75,  0, 0
 
+gaugeCategory = Sensors - Raw
+   rawTps1PrimaryGauge  = rawTps1Primary, "Raw TPS 1 Primary", "volts", 0, 5, 0, 0, 5, 5, 3, 0
+   rawPpsPrimaryGauge   = rawPpsPrimary , "Raw Pedal Primary", "volts", 0, 5, 0, 0, 5, 5, 3, 0
+   rawCltGauge          = rawClt        , "Raw CLT",           "volts", 0, 5, 0, 0, 5, 5, 3, 0
+   rawIatGauge          = rawIat        , "Raw IAT",           "volts", 0, 5, 0, 0, 5, 5, 3, 0
+   rawOilPressureGauge  = rawOilPressure, "Raw Oil Pressure",  "volts", 0, 5, 0, 0, 5, 5, 3, 0
 
 [WueAnalyze]
     


### PR DESCRIPTION
Sensors are easier to diagnose when you don't need to get out a multimeter - now we have gauges for them!