### PR TITLE
deduplicate ADC pin usage logic

### DIFF
--- a/firmware/hw_layer/AdcConfiguration.h
+++ b/firmware/hw_layer/AdcConfiguration.h
@@ -20,7 +20,7 @@ class AdcDevice {
 public:
 	explicit AdcDevice(ADCConversionGroup* hwConfig);
 	void enableChannel(adc_channel_e hwChannelIndex);
-	void enableChannelAndPin(adc_channel_e hwChannelIndex);
+	void enableChannelAndPin(const char *msg, adc_channel_e hwChannelIndex);
 	adc_channel_e getAdcHardwareIndexByInternalIndex(int index) const;
 	int internalAdcIndexByHardwareIndex[20];
 	bool isHwUsed(adc_channel_e hwChannel) const;


### PR DESCRIPTION
We already keep track of GPIO pin usage - so just recycle that for the ADC.  No need to keep a separate list of ADC pin usage when the only thing we use it for is checking if a pin is already used - `efiSetPadMode` already has that logic.

Bonus: this saves 17*4 = 68 bytes of RAM since now we don't need to keep a table of ADC channel names.