### PR TITLE
Improve unexpected

### DIFF
--- a/firmware/controllers/sensors/converters/linear_func.cpp
+++ b/firmware/controllers/sensors/converters/linear_func.cpp
@@ -19,7 +19,11 @@ SensorResult LinearFunc::convert(float inputValue) const {
 	// Bounds check
 	bool isValid = result <= m_maxOutput && result >= m_minOutput;
 
-	return {isValid, result};
+	if (!isValid) {
+		return unexpected;
+	}
+
+	return result;
 }
 
 void LinearFunc::showInfo(Logging* logger, float testRawValue) const {

--- a/firmware/controllers/sensors/function_pointer_sensor.h
+++ b/firmware/controllers/sensors/function_pointer_sensor.h
@@ -26,7 +26,11 @@ public:
 		// check for NaN
 		bool valid = !(result != result);
 
-		return {valid, result};
+		if (!valid) {
+			return unexpected;
+		}
+
+		return result;
 	}
 
 	void showInfo(Logging* logger, const char* sensorName) const override {}

--- a/firmware/controllers/sensors/redundant_sensor.cpp
+++ b/firmware/controllers/sensors/redundant_sensor.cpp
@@ -26,17 +26,16 @@ SensorResult RedundantSensor::get() const {
 
 	// If either result is invalid, return invalid.
 	if (!result1.Valid || !result2.Valid) {
-		return { false, 0 };
+		return unexpected;
 	}
 
 	// If both are valid, check that they're near one another
 	float delta = absF(result1.Value - result2.Value);
 	if (delta > m_maxDifference) {
-		return { false, 0 };
+		return unexpected;
 	}
 
 	// Both sensors are valid, and their readings are close. All is well.
 	// Return the average
-	float avg = (result1.Value + result2.Value) / 2;
-	return { true, avg };
+	return (result1.Value + result2.Value) / 2;
 }

--- a/firmware/controllers/sensors/sensor.cpp
+++ b/firmware/controllers/sensors/sensor.cpp
@@ -87,7 +87,7 @@ bool Sensor::Register() {
 
 	// Check if this is a valid sensor entry
 	if (!entry) {
-		return {false, 0.0f};
+		return unexpected;
 	}
 
 	// Next check for mock

--- a/firmware/controllers/sensors/stored_value_sensor.h
+++ b/firmware/controllers/sensors/stored_value_sensor.h
@@ -34,11 +34,11 @@ public:
 		float value = m_value;
 
 		if (!valid) {
-			return {false, value};
+			return unexpected;
 		}
 
 		if (getTimeNowNt() - m_timeoutPeriod > m_lastUpdate) {
-			return {false, value};
+			return unexpected;
 		}
 
 		return value;

--- a/firmware/util/expected.h
+++ b/firmware/util/expected.h
@@ -15,12 +15,14 @@
 
 #pragma once
 
+struct unexpected_t {};
+
 template <class TValue>
 struct expected {
 	const bool Valid;
 	const TValue Value;
 
-	constexpr expected(bool valid, TValue value) : Valid(valid), Value(value) {}
+	constexpr expected(const unexpected_t&) : Valid(false), Value{} {}
 
 	// Implicit constructor to convert from TValue (for valid values, so an expected<T> behaves like a T)
 	constexpr expected(TValue validValue)
@@ -40,4 +42,4 @@ struct expected {
 	}
 };
 
-constexpr expected<float> unexpected = {false, 0.0f};
+constexpr unexpected_t unexpected{};

--- a/firmware/util/expected.h
+++ b/firmware/util/expected.h
@@ -22,6 +22,7 @@ struct expected {
 	const bool Valid;
 	const TValue Value;
 
+	// Implicit constructor to construct in the invalid state
 	constexpr expected(const unexpected_t&) : Valid(false), Value{} {}
 
 	// Implicit constructor to convert from TValue (for valid values, so an expected<T> behaves like a T)

--- a/unit_tests/tests/sensor/func_sensor.cpp
+++ b/unit_tests/tests/sensor/func_sensor.cpp
@@ -5,10 +5,11 @@
 
 struct DoublerFunc final : public SensorConverter {
 	SensorResult convert(float input) const {
-		bool valid = input > 0;
-		float value = input * 2;
+		if (input <= 0) {
+			return unexpected;
+		}
 
-		return {valid, value};
+		return input * 2;
 	}
 };
 


### PR DESCRIPTION
This way, `unexpected` isn't locked to only a single templated type, and now works for any `expected<T>`.

Inspiration from [p0323r3](https://github.com/viboes/std-make/blob/master/doc/proposal/expected/p0323r3.pdf).

Plus some consumers I missed the first time around.