### PR TITLE
Improve tcharge error handling

### DIFF
--- a/firmware/controllers/math/speed_density.cpp
+++ b/firmware/controllers/math/speed_density.cpp
@@ -37,13 +37,26 @@ baroCorr_Map3D_t baroCorrMap("baro");
 //  http://rusefi.com/math/t_charge.html
 /***panel:Charge Temperature*/
 temperature_t getTCharge(int rpm, float tps DECLARE_ENGINE_PARAMETER_SUFFIX) {
-	const auto [cltValid, coolantTemp] = Sensor::get(SensorType::Clt);
-	const auto [iatValid, airTemp] = Sensor::get(SensorType::Iat);
-	
-	if (!cltValid || !iatValid) {
-		warning(CUSTOM_ERR_NAN_TCHARGE, "getTCharge invalid iat/clt");
+	const auto clt = Sensor::get(SensorType::Clt);
+	const auto iat = Sensor::get(SensorType::Iat);
+
+	float airTemp = 0;
+
+	// Without either valid, return 0C.  It's wrong, but it'll pretend to be nice and dense, so at least you won't go lean.
+	if (!iat && !clt) {
+		return 0;
+	} else if (!clt && iat) {
+		// Intake temperature will almost always be colder (richer) than CLT - use that
 		return airTemp;
+	} else if (!iat && clt) {
+		// Without valid intake temperature, assume intake temp is 0C, and interpolate anyway
+		airTemp = 0;
+	} else {
+		// All is well - use real air temp
+		airTemp = iat.Value;
 	}
+
+	float coolantTemp = clt.Value;
 
 	DISPLAY_STATE(Engine)
 


### PR DESCRIPTION
One or both of CLT/IAT sensors could be failed, so we should handle that appropriately, without spamming the log unnecessarily.