### PR TITLE
Fix ETB idle hard fault

### DIFF
--- a/firmware/controllers/algo/engine.h
+++ b/firmware/controllers/algo/engine.h
@@ -54,7 +54,7 @@ public:
 	explicit Engine(persistent_config_s *config);
 	Engine();
 
-	IEtbController *etbControllers[ETB_COUNT];
+	IEtbController *etbControllers[ETB_COUNT] = {nullptr};
 
 	cyclic_buffer<int> triggerErrorDetection;
 


### PR DESCRIPTION
Arrays don't get default initialized unless you specifically ask for it.