### PR TITLE
switch ADC to gpt

### DIFF
--- a/firmware/config/boards/kinetis/OS/os/hal/ports/KINETIS/LLD/PITv2/hal_gpt_lld.h
+++ b/firmware/config/boards/kinetis/OS/os/hal/ports/KINETIS/LLD/PITv2/hal_gpt_lld.h
@@ -55,7 +55,7 @@
  * @note    The default is @p TRUE.
  */
 #if !defined(KINETIS_GPT_USE_PIT1) || defined(__DOXYGEN__)
-#define KINETIS_GPT_USE_PIT1                  FALSE
+#define KINETIS_GPT_USE_PIT1                  TRUE
 #endif
 
 /**

--- a/firmware/config/boards/kinetis/efifeatures.h
+++ b/firmware/config/boards/kinetis/efifeatures.h
@@ -253,12 +253,9 @@
 // 168000000/64/16/16 = ~10.25kHz
 
 // todo: warning! these numbers are "tricky"! need to investigate further!
-//168000000/128/65535 = ~20Hz
-#define PWM_FREQ_SLOW 20507   /* PWM clock frequency. */
-#define PWM_PERIOD_SLOW 65535  /* PWM period (in PWM ticks).    */
 //168000000/128/131 = ~10kHz
-#define PWM_FREQ_FAST 20507/*164062*/  /* PWM clock frequency. */
-#define PWM_PERIOD_FAST 131   /* PWM period (in PWM ticks).    */
+#define GPT_FREQ_FAST 20507/*164062*/  /* PWM clock frequency. */
+#define GPT_PERIOD_FAST 131   /* PWM period (in PWM ticks).    */
 
 #define EFI_SPI1_AF 3
 

--- a/firmware/config/boards/kinetis/efifeatures.h
+++ b/firmware/config/boards/kinetis/efifeatures.h
@@ -248,7 +248,7 @@
 // todo: switch to continues ADC conversion for slow ADC?
 // https://github.com/rusefi/rusefi/issues/630
 // todo: switch to continues ADC conversion for fast ADC?
-#define EFI_INTERNAL_FAST_ADC_PWM	&PWMD2
+#define EFI_INTERNAL_FAST_ADC_GPT	&GPTD2
 
 // todo: why 64 SPLL prescaler doesn't work?
 // 168000000/64/128/1025 = ~20Hz

--- a/firmware/config/boards/kinetis/efifeatures.h
+++ b/firmware/config/boards/kinetis/efifeatures.h
@@ -245,8 +245,6 @@
 
 // todo: most of this should become configurable
 
-// todo: switch to continues ADC conversion for slow ADC?
-// https://github.com/rusefi/rusefi/issues/630
 // todo: switch to continues ADC conversion for fast ADC?
 #define EFI_INTERNAL_FAST_ADC_GPT	&GPTD2
 

--- a/firmware/config/boards/kinetis/halconf.h
+++ b/firmware/config/boards/kinetis/halconf.h
@@ -111,7 +111,7 @@
  * @brief   Enables the PWM subsystem.
  */
 #if !defined(HAL_USE_PWM) || defined(__DOXYGEN__)
-#define HAL_USE_PWM                 TRUE
+#define HAL_USE_PWM                 FALSE
 #endif
 
 /**

--- a/firmware/config/boards/skeleton/efifeatures.h
+++ b/firmware/config/boards/skeleton/efifeatures.h
@@ -257,7 +257,7 @@
 // todo: switch to continuous ADC conversion for slow ADC?
 // https://github.com/rusefi/rusefi/issues/630
 // todo: switch to continues ADC conversion for fast ADC?
-#define EFI_INTERNAL_FAST_ADC_PWM	&PWMD4
+#define EFI_INTERNAL_FAST_ADC_GPT	&GPTD6
 
 #define EFI_SPI1_AF 5
 

--- a/firmware/config/boards/skeleton/efifeatures.h
+++ b/firmware/config/boards/skeleton/efifeatures.h
@@ -254,8 +254,6 @@
 
 // todo: most of this should become configurable
 
-// todo: switch to continuous ADC conversion for slow ADC?
-// https://github.com/rusefi/rusefi/issues/630
 // todo: switch to continues ADC conversion for fast ADC?
 #define EFI_INTERNAL_FAST_ADC_GPT	&GPTD6
 

--- a/firmware/config/stm32f4ems/efifeatures.h
+++ b/firmware/config/stm32f4ems/efifeatures.h
@@ -287,7 +287,7 @@
 // todo: switch to continues ADC conversion for slow ADC?
 // https://github.com/rusefi/rusefi/issues/630
 // todo: switch to continues ADC conversion for fast ADC?
-#define EFI_INTERNAL_FAST_ADC_PWM	&PWMD4
+#define EFI_INTERNAL_FAST_ADC_GPT	&GPTD6
 
 #define EFI_SPI1_AF 5
 

--- a/firmware/config/stm32f4ems/efifeatures.h
+++ b/firmware/config/stm32f4ems/efifeatures.h
@@ -284,8 +284,6 @@
 
 // todo: most of this should become configurable
 
-// todo: switch to continues ADC conversion for slow ADC?
-// https://github.com/rusefi/rusefi/issues/630
 // todo: switch to continues ADC conversion for fast ADC?
 #define EFI_INTERNAL_FAST_ADC_GPT	&GPTD6
 

--- a/firmware/config/stm32f4ems/halconf.h
+++ b/firmware/config/stm32f4ems/halconf.h
@@ -120,7 +120,7 @@
  * @brief   Enables the PWM subsystem.
  */
 #if !defined(HAL_USE_PWM) || defined(__DOXYGEN__)
-#define HAL_USE_PWM                 TRUE
+#define HAL_USE_PWM                 FALSE
 #endif
 
 /**

--- a/firmware/config/stm32f4ems/mcuconf.h
+++ b/firmware/config/stm32f4ems/mcuconf.h
@@ -272,8 +272,6 @@
 #define STM32_PWM_USE_TIM1                  FALSE
 #define STM32_PWM_USE_TIM2                  FALSE
 #define STM32_PWM_USE_TIM3                  FALSE
-// maybe even swithc this one to software timer?
-// todo: https://github.com/rusefi/rusefi/issues/630 ?
 #define STM32_PWM_USE_TIM4                  FALSE
 #define STM32_PWM_USE_TIM5                  FALSE
 #define STM32_PWM_USE_TIM8                  FALSE

--- a/firmware/config/stm32f4ems/mcuconf.h
+++ b/firmware/config/stm32f4ems/mcuconf.h
@@ -180,7 +180,7 @@
 #define STM32_GPT_USE_TIM3                  FALSE
 #define STM32_GPT_USE_TIM4                  FALSE
 #define STM32_GPT_USE_TIM5                  TRUE
-#define STM32_GPT_USE_TIM6                  FALSE
+#define STM32_GPT_USE_TIM6                  TRUE
 #define STM32_GPT_USE_TIM7                  FALSE
 #define STM32_GPT_USE_TIM8                  FALSE
 #define STM32_GPT_USE_TIM9                  FALSE
@@ -274,7 +274,7 @@
 #define STM32_PWM_USE_TIM3                  FALSE
 // maybe even swithc this one to software timer?
 // todo: https://github.com/rusefi/rusefi/issues/630 ?
-#define STM32_PWM_USE_TIM4                  TRUE
+#define STM32_PWM_USE_TIM4                  FALSE
 #define STM32_PWM_USE_TIM5                  FALSE
 #define STM32_PWM_USE_TIM8                  FALSE
 #define STM32_PWM_USE_TIM9                  FALSE

--- a/firmware/config/stm32f7ems/halconf.h
+++ b/firmware/config/stm32f7ems/halconf.h
@@ -111,7 +111,7 @@
  * @brief   Enables the PWM subsystem.
  */
 #if !defined(HAL_USE_PWM) || defined(__DOXYGEN__)
-#define HAL_USE_PWM                 TRUE
+#define HAL_USE_PWM                 FALSE
 #endif
 
 /**

--- a/firmware/config/stm32f7ems/mcuconf.h
+++ b/firmware/config/stm32f7ems/mcuconf.h
@@ -201,7 +201,7 @@
 #define STM32_GPT_USE_TIM3                  FALSE
 #define STM32_GPT_USE_TIM4                  FALSE
 #define STM32_GPT_USE_TIM5                  TRUE
-#define STM32_GPT_USE_TIM6                  FALSE
+#define STM32_GPT_USE_TIM6                  TRUE
 #define STM32_GPT_USE_TIM7                  FALSE
 #define STM32_GPT_USE_TIM8                  FALSE
 #define STM32_GPT_USE_TIM9                  FALSE
@@ -283,7 +283,7 @@
 #define STM32_PWM_USE_TIM1                  FALSE
 #define STM32_PWM_USE_TIM2                  FALSE
 #define STM32_PWM_USE_TIM3                  FALSE
-#define STM32_PWM_USE_TIM4                  TRUE
+#define STM32_PWM_USE_TIM4                  FALSE
 #define STM32_PWM_USE_TIM5                  FALSE
 #define STM32_PWM_USE_TIM8                  FALSE
 #define STM32_PWM_USE_TIM9                  FALSE

--- a/firmware/hw_layer/adc_inputs.cpp
+++ b/firmware/hw_layer/adc_inputs.cpp
@@ -76,8 +76,8 @@ AdcDevice::AdcDevice(ADCConversionGroup* hwConfig) {
  */
 // todo: migrate to continues ADC mode? probably not - we cannot afford the callback in
 // todo: continues mode. todo: look into our options
-#define PWM_FREQ_FAST 100000   /* PWM clock frequency. I wonder what does this setting mean?  */
-#define PWM_PERIOD_FAST 10  /* PWM period (in PWM ticks).    */
+#define GPT_FREQ_FAST 100000   /* PWM clock frequency. I wonder what does this setting mean?  */
+#define GPT_PERIOD_FAST 10  /* PWM period (in PWM ticks).    */
 #endif /* PWM_FREQ_FAST PWM_PERIOD_FAST */
 
 // is there a reason to have this configurable at runtime?
@@ -198,13 +198,9 @@ ADC_TwoSamplingDelay_5Cycles,   // cr1
 
 AdcDevice fastAdc(&adcgrpcfg_fast);
 
-#if HAL_USE_PWM
-
-static void pwmpcb_fast(PWMDriver *pwmp) {
-	efiAssertVoid(CUSTOM_ERR_6659, getCurrentRemainingStack()> 32, "lwStAdcFast");
+#if HAL_USE_GPT
+static void fast_adc_callback(GPTDriver*) {
 #if EFI_INTERNAL_ADC
-	(void) pwmp;
-
 	/*
 	 * Starts an asynchronous ADC conversion operation, the conversion
 	 * will be executed in parallel to the current PWM cycle and will
@@ -228,7 +224,7 @@ static void pwmpcb_fast(PWMDriver *pwmp) {
 	fastAdc.conversionCount++;
 #endif /* EFI_INTERNAL_ADC */
 }
-#endif /* HAL_USE_PWM */
+#endif /* HAL_USE_GPT */
 
 float getMCUInternalTemperature(void) {
 #if defined(ADC_CHANNEL_SENSOR)
@@ -269,13 +265,13 @@ int getInternalAdcValue(const char *msg, adc_channel_e hwChannel) {
 	return slowAdc.getAdcValueByHwChannel(hwChannel);
 }
 
-#if HAL_USE_PWM
-static PWMConfig pwmcfg_fast = { PWM_FREQ_FAST, PWM_PERIOD_FAST, pwmpcb_fast, { {
-PWM_OUTPUT_DISABLED, NULL }, { PWM_OUTPUT_DISABLED, NULL }, {
-PWM_OUTPUT_DISABLED, NULL }, { PWM_OUTPUT_DISABLED, NULL } },
-/* HW dependent part.*/
-0, 0 };
-#endif /* HAL_USE_PWM */
+#if HAL_USE_GPT
+static GPTConfig fast_adc_config = {
+	GPT_FREQ_FAST,
+	fast_adc_callback,
+	0, 0
+};
+#endif /* HAL_USE_GPT */
 
 const char * getAdcMode(adc_channel_e hwChannel) {
 	if (slowAdc.isHwUsed(hwChannel)) {
@@ -563,10 +559,10 @@ void initAdcInputs() {
 		/*
 		 * Initializes the PWM driver.
 		 */
-#if HAL_USE_PWM
-		pwmStart(EFI_INTERNAL_FAST_ADC_PWM, &pwmcfg_fast);
-		pwmEnablePeriodicNotification(EFI_INTERNAL_FAST_ADC_PWM);
-#endif /* HAL_USE_PWM */
+#if HAL_USE_GPT
+		gptStart(EFI_INTERNAL_FAST_ADC_GPT, &fast_adc_config);
+		gptStartContinuous(EFI_INTERNAL_FAST_ADC_GPT, GPT_PERIOD_FAST);
+#endif /* HAL_USE_GPT */
 	}
 
 	addConsoleActionI("adc", (VoidInt) printAdcValue);

--- a/firmware/hw_layer/adc_inputs.cpp
+++ b/firmware/hw_layer/adc_inputs.cpp
@@ -69,7 +69,7 @@ AdcDevice::AdcDevice(ADCConversionGroup* hwConfig) {
 	memset(internalAdcIndexByHardwareIndex, 0xFFFFFFFF, sizeof(internalAdcIndexByHardwareIndex));
 }
 
-#if !defined(PWM_FREQ_FAST) || !defined(PWM_PERIOD_FAST)
+#if !defined(GPT_FREQ_FAST) || !defined(GPT_PERIOD_FAST)
 /**
  * 8000 RPM is 133Hz
  * If we want to sample MAP once per 5 degrees we need 133Hz * (360 / 5) = 9576Hz of fast ADC
@@ -78,7 +78,7 @@ AdcDevice::AdcDevice(ADCConversionGroup* hwConfig) {
 // todo: continues mode. todo: look into our options
 #define GPT_FREQ_FAST 100000   /* PWM clock frequency. I wonder what does this setting mean?  */
 #define GPT_PERIOD_FAST 10  /* PWM period (in PWM ticks).    */
-#endif /* PWM_FREQ_FAST PWM_PERIOD_FAST */
+#endif /* GPT_FREQ_FAST GPT_PERIOD_FAST */
 
 // is there a reason to have this configurable at runtime?
 #ifndef ADC_SLOW_DEVICE

--- a/firmware/hw_layer/digital_input_icu.cpp
+++ b/firmware/hw_layer/digital_input_icu.cpp
@@ -150,8 +150,6 @@ icuchannel_t getInputCaptureChannel(brain_pin_e hwPin) {
  * (that's the kind of event you need for shaft position sensor)
  * ChibiOS limitation is that only channels #1 and #2 could be used for input capture
  *
- * TODO: migrate slow ADC to software timer so that TIM8 is also available for input capture
- * todo: https://github.com/rusefi/rusefi/issues/630 ?
  * @return NULL if pin could not be used for ICU
  */
 //Nullable


### PR DESCRIPTION
ADC doesn't need pin outputs, so we can switch it to the basic timer TIM6, where it isn't wasting output pins.  Prep for #1283.