### PR TITLE
remove warning message in tune

### DIFF
--- a/firmware/config/boards/kinetis/config/controllers/algo/engine_configuration_generated_structures.h
+++ b/firmware/config/boards/kinetis/config/controllers/algo/engine_configuration_generated_structures.h
@@ -1,4 +1,4 @@
-// this section was generated automatically by rusEfi tool ConfigDefinition.jar based on kineris_gen_config.bat integration/rusefi_config.txt Sun Apr 19 21:16:42 EDT 2020
+// this section was generated automatically by rusEfi tool ConfigDefinition.jar based on kineris_gen_config.bat integration/rusefi_config.txt Wed Apr 22 14:29:10 PDT 2020
 // by class com.rusefi.output.CHeaderConsumer
 // begin
 #ifndef CONFIG_BOARDS_KINETIS_CONFIG_CONTROLLERS_ALGO_ENGINE_CONFIGURATION_GENERATED_STRUCTURES_H
@@ -3048,8 +3048,8 @@ struct engine_configuration_s {
 	/**
 	 * offset 4144
 	 */
-	int mainUnusedEnd[464];
-	/** total size 6000*/
+	int mainUnusedEnd[494];
+	/** total size 6120*/
 };
 
 typedef struct engine_configuration_s engine_configuration_s;
@@ -3060,10 +3060,6 @@ struct persistent_config_s {
 	 * offset 0
 	 */
 	engine_configuration_s engineConfiguration;
-	/**
-	 * offset 6000
-	 */
-	error_message_t warning_message;
 	/**
 	 * offset 6120
 	 */
@@ -3351,4 +3347,4 @@ typedef struct persistent_config_s persistent_config_s;
 
 #endif
 // end
-// this section was generated automatically by rusEfi tool ConfigDefinition.jar based on kineris_gen_config.bat integration/rusefi_config.txt Sun Apr 19 21:16:42 EDT 2020
+// this section was generated automatically by rusEfi tool ConfigDefinition.jar based on kineris_gen_config.bat integration/rusefi_config.txt Wed Apr 22 14:29:10 PDT 2020

--- a/firmware/controllers/core/error_handling.cpp
+++ b/firmware/controllers/core/error_handling.cpp
@@ -107,14 +107,6 @@ static void printWarning(const char *fmt, va_list ap) {
 
 	printToStream(&warningStream, fmt, ap);
 
-#if EFI_TUNER_STUDIO
- #if defined(EFI_NO_CONFIG_WORKING_COPY)
-  memcpy(persistentState.persistentConfiguration.warning_message, warningBuffer, sizeof(warningBuffer));
- #else /* defined(EFI_NO_CONFIG_WORKING_COPY) */
-  memcpy(configWorkingCopy.warning_message, warningBuffer, sizeof(warningBuffer));
- #endif /* defined(EFI_NO_CONFIG_WORKING_COPY) */
-#endif /* EFI_TUNER_STUDIO */
-
 	logger.append(warningBuffer);
 	append(&logger, DELIMETER);
 	scheduleLogging(&logger);

--- a/firmware/controllers/flash_main.cpp
+++ b/firmware/controllers/flash_main.cpp
@@ -150,7 +150,6 @@ persisted_configuration_state_e readConfiguration(Logging * logger) {
 	}
 	// we can only change the state after the CRC check
 	engineConfiguration->byFirmwareVersion = getRusEfiVersion();
-	memset(persistentState.persistentConfiguration.warning_message , 0, ERROR_BUFFER_SIZE);
 	validateConfiguration(PASS_ENGINE_PARAMETER_SIGNATURE);
 	return result;
 }

--- a/firmware/controllers/generated/engine_configuration_generated_structures.h
+++ b/firmware/controllers/generated/engine_configuration_generated_structures.h
@@ -1,4 +1,4 @@
-// this section was generated automatically by rusEfi tool ConfigDefinition.jar based on gen_config.bat integration\rusefi_config.txt Sun Apr 19 21:15:09 EDT 2020
+// this section was generated automatically by rusEfi tool ConfigDefinition.jar based on gen_config.bat integration\rusefi_config.txt Wed Apr 22 14:29:02 PDT 2020
 // by class com.rusefi.output.CHeaderConsumer
 // begin
 #ifndef CONTROLLERS_GENERATED_ENGINE_CONFIGURATION_GENERATED_STRUCTURES_H
@@ -3048,8 +3048,8 @@ struct engine_configuration_s {
 	/**
 	 * offset 4144
 	 */
-	int mainUnusedEnd[464];
-	/** total size 6000*/
+	int mainUnusedEnd[494];
+	/** total size 6120*/
 };
 
 typedef struct engine_configuration_s engine_configuration_s;
@@ -3060,10 +3060,6 @@ struct persistent_config_s {
 	 * offset 0
 	 */
 	engine_configuration_s engineConfiguration;
-	/**
-	 * offset 6000
-	 */
-	error_message_t warning_message;
 	/**
 	 * offset 6120
 	 */
@@ -3351,4 +3347,4 @@ typedef struct persistent_config_s persistent_config_s;
 
 #endif
 // end
-// this section was generated automatically by rusEfi tool ConfigDefinition.jar based on gen_config.bat integration\rusefi_config.txt Sun Apr 19 21:15:09 EDT 2020
+// this section was generated automatically by rusEfi tool ConfigDefinition.jar based on gen_config.bat integration\rusefi_config.txt Wed Apr 22 14:29:02 PDT 2020

--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -1243,14 +1243,12 @@ uint8_t[4] unusuedsw;
  	custom can_vss_nbc_e 4 bits, U32, @OFFSET@, [0:7], "BMW_e46", "W202"
 	can_vss_nbc_e canVssNbcType;set can_vss X
 	
-	int[464] mainUnusedEnd;
+	int[494] mainUnusedEnd;
 
 ! end of engine_configuration_s
 end_struct
 
 engine_configuration_s engineConfiguration;
-
-error_message_t warning_message;
 
 float[AFTERSTART_HOLD_CURVE_SIZE] afterstartCoolantBins;;"C",           1,     0, -100.0,  250.0,   0
 float[AFTERSTART_HOLD_CURVE_SIZE] afterstartHoldTime;;"Seconds",        1,     0,      0,    100,   1

--- a/firmware/tunerstudio/rusefi.input
+++ b/firmware/tunerstudio/rusefi.input
@@ -456,9 +456,6 @@ fileVersion = { @@TS_FILE_VERSION@@ }
      requiresPowerCycle = fsioAdc2
      requiresPowerCycle = fsioAdc3
      requiresPowerCycle = fsioAdc4
-     
-     readOnly = warning_message
-
 
 [CurveEditor]
 ;	xAxis       =  leftValue, rightValue, step
@@ -2480,7 +2477,6 @@ cmd_set_engine_type_default					= "w\x00\x31\x00\x00"
 	dialog = debugging, "Debug"
 		field = "!https://rusefi.com/s/debugmode"
 		field = "Debug mode",							debugMode
-		field = "Warning Text",						warning_message
 
 	
 	dialog = limits, "Limits"


### PR DESCRIPTION
This was causing several issues:
- Every time the ECU reboots, TunerStudio has to do a full read of the configuration (20KB), because the CRC will never match.  If a warning fired in either the previous boot or the current one, the tune (and corresponding CRC) won't match, so it'll have to re-read from the ECU.  This takes ~20 seconds over 115k baud UART, and even longer over Bluetooth, which is not acceptable.
- When TS sends a burn command to the ECU, it then immediately checks the CRC to ensure that the write was successful, and the controller's state matches its internal state.  If a warning has fired since the last full read of the ECU, TS's internal state is now inconsistent with that in the controller, so the CRC check will fail, and TS will display this error message:
![image](https://user-images.githubusercontent.com/568254/80036757-344ba900-84a7-11ea-8bdf-d7d3b3bd267a.png)

Many users (myself included) have been concerned that the display of this message indicated that something went wrong (which technically, it had), when in fact the burn had succeeded fine, but the ECU had changed part of the tune (the warning message) unbeknownst to TunerStudio.