### PR TITLE
fix display of etb bias

### DIFF
--- a/firmware/tunerstudio/rusefi.input
+++ b/firmware/tunerstudio/rusefi.input
@@ -590,8 +590,8 @@ fileVersion = { @@TS_FILE_VERSION@@ }
 
 	curve = etbTpsBiasCurve, "Electronic TB Bias Curve"
       columnLabel = "TPS", "duty bias"
-      xAxis       =  0, 100, 10
-      yAxis       =  0,  100, 10
+      xAxis       =  0, 50, 11
+      yAxis       =  -40, 40, 9
       xBins       = etbBiasBins, TPSValue
       yBins       = etbBiasValues
       gauge       = TPSGauge


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/568254/80046279-05413180-84bf-11ea-863f-dc76a3056807.png)

Now it's zoomed in on the interesting part, and isn't clipped off the bottom left corner.