### PR TITLE
Revamp indicator panel in TS

### DIFF
--- a/firmware/console/status_loop.cpp
+++ b/firmware/console/status_loop.cpp
@@ -721,7 +721,8 @@ void updateTunerStudioState(TunerStudioOutputChannels *tsOutputChannels DECLARE_
 
 	SensorResult pedal = Sensor::get(SensorType::AcceleratorPedal);
 	tsOutputChannels->pedalPosition = pedal.Value;
-	tsOutputChannels->isPedalError = !pedal.Valid;
+	// Only report fail if you have one (many people don't)
+	tsOutputChannels->isPedalError = !pedal.Valid && Sensor::hasSensor(SensorType::AcceleratorPedal);
 
 	// Set raw sensors
 	tsOutputChannels->rawTps1Primary = Sensor::getRaw(SensorType::Tps1);

--- a/firmware/tunerstudio/rusefi.input
+++ b/firmware/tunerstudio/rusefi.input
@@ -1046,7 +1046,7 @@ gaugeCategory = Sensors - Raw
     indicator = { ind_clt_error}, "clt",   "clt error",   white, black, red,   black
     indicator = { ind_iat_error}, "iat",   "iat error",   white, black, red,   black
     indicator = { ind_map_error}, "map",   "map error",   white, black, red,   black
-	indicator = { ind_pedal_error}, "map",   "map error",   white, black, red,   black
+	indicator = { ind_pedal_error}, "pedal",   "pedal error",   white, black, red,   black
 
     indicator = { knockEverIndicator }, "",   "Knock recently",   white, black, red,   black
     indicator = { knockNowIndicator }, "no knock",   "Knock NOW",   white, black, red,   black

--- a/firmware/tunerstudio/rusefi.input
+++ b/firmware/tunerstudio/rusefi.input
@@ -1003,11 +1003,10 @@ gaugeCategory = Sensors - Raw
    ;    1  2  3  4
    ;    5  6  7  8
 
-   ; currently a minimum of 6 gauges must be on the dash, this appears to be an old not needed limitation. next release 1 will work.
    gauge1 = RPMGauge
    gauge2 = CLTGauge
    gauge3 = TPSGauge
-   gauge4 = MAFGauge
+   gauge4 = MAPGauge
    gauge5 = afr1Gauge
    gauge6 = VBattGauge
    gauge7 = dwellGauge

--- a/firmware/tunerstudio/rusefi.input
+++ b/firmware/tunerstudio/rusefi.input
@@ -1016,13 +1016,13 @@ gaugeCategory = Sensors - Raw
 
 ;         =   expression,            off-label,            on-label,            off-bg, off-fg, on-bg, on-fg
 	; important status
-    indicator = { ind_hasFatalError }, "",   "CRITICAL ERROR",   green, black, red,   black
-    indicator = { firmwareTsVersion == fileVersion }, "WRONG VERSION",   "version",   red, black, green,   black
-    indicator = { ind_isWarnNow }, "",   "warn",   green, black, red,   black
-    indicator = { ind_check_engine }, "ok",      "Check engine",       green,  black,  red, black
-    indicator = { isIgnitionEnabledIndicator}, "no ignition",   "ignition",   red, black, green,   black
-    indicator = { ind_injection_enabled}, "no injection",   "injection",   red, black, green,   black
-    indicator = { ind_isTriggerError}, "ok",      "trg err",       green,  black,  red, black
+    indicator = { ind_hasFatalError }, "",   "CRITICAL ERROR",   white, black, red,   black
+    indicator = { firmwareTsVersion == fileVersion }, "WRONG VERSION",   "version ok",   red, black, white,   black
+    indicator = { ind_isWarnNow }, "",   "WARNING",   white, black, yellow,   black
+    indicator = { ind_check_engine }, "",      "Check Engine",       white,  black,  red, black
+    indicator = { isIgnitionEnabledIndicator}, "no ignition",   "ignition",   yellow, black, white,   black
+    indicator = { ind_injection_enabled}, "no injection",   "injection",   yellow, black, white,   black
+    indicator = { ind_isTriggerError}, "trigger ok",      "trigger err",       white,  black,  red, black
     
 	; this is required so that the "config error" feature works in TS 
 	; don't change this line - TS is looking for an indicator with particular text/styling
@@ -1030,15 +1030,15 @@ gaugeCategory = Sensors - Raw
 	indicator = { ind_hasFatalError }, "Config Error", "Config Error", white, black, red,   black
 
 	; minor info	
-    indicator = { ind_fan}, "no fan",   "fan",   white, black, green,   black
-    indicator = { isCylinderCleanupActivated}, "no cyl cleanup",   "cyl cleanup",   white, black, green,   black    
+    indicator = { ind_fan}, "fan off",   "fan on",   white, black, green,   black
+    indicator = { isCylinderCleanupActivated}, "no cyl cleanup",   "cyl cleanup",   white, black, yellow,   black    
     indicator = { needBurn }, "config ok",  "unsaved changes",   white, black, yellow,   black
     indicator = { hasSdCard}, "no SD",   "with SD",   white, black, green,   black
-    indicator = { ind_fuel_pump}, "no pump",   "pump",   white, black, green,   black
+    indicator = { ind_fuel_pump}, "pump off",   "pump on",   white, black, green,   black
     indicator = { clutchUpState }, "clutch",   "cltch Up",   white, black, red,   black
     indicator = { clutchDownState }, "clutch",   "cltch Down",   white, black, yellow,   black
     indicator = { brakePedalIndicator }, "brake",   "brake down",   white, black, red,   black
-    indicator = { acSwitchIndicator }, "AC on",   "AC off",   yellow, black, white,   black
+    indicator = { acSwitchIndicator }, "AC off",   "AC on",   white, black, blue,   white
     
     ; error codes
     indicator = { ind_tps_error}, "tps",   "tps error",   white, black, red,   black


### PR DESCRIPTION
These changes are intended to help improve the "glanceability" of the indicator panel at the bottom of the dash in TS. A ton of indicators of random colors is hard to briefly look at and determine if something is wrong.  A field of all white indicators with a single red one, however, is.

- Things that are "normal" now display white
- Warnings display yellow
- Errors display red
- Things that are on (where on and off are both normal states) display green (fuel pump, fan, etc)

![image](https://user-images.githubusercontent.com/568254/80174043-655ed300-85a6-11ea-964c-4d4f28a1b0e8.png)

Also change pedal position error logic so that we only indicate pedal error when a pedal is configured but failed.  It's a valid configuration to not have a pedal sensor, so don't error in that case.
