### PR TITLE
General purpose PWM: configuration fields

### DIFF
--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -307,7 +307,7 @@ struct gppwm_channel
 	gppwm_channel_e loadAxis;+Selects the load axis to use for the table.;
 	uint8_t[1] pad;
 
-	uint8_t[GPPWM_LOAD_COUNT] loadBins;;"load",      1,     0,   0.0,    250,   2
+	uint8_t[GPPWM_LOAD_COUNT] loadBins;;"load",      1,     0,   0.0,    250,   0
 	uint8_t[GPPWM_RPM_COUNT] rpmBins;;"RPM",  @@RPM_1_BYTE_PACKING_MULT@@,     0,      0.0,   12000.0,   0
 	gppwm_table_t table;
 end_struct

--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -200,6 +200,11 @@ custom pedal_to_tps_t	@@PEDAL_TO_TPS_SIZE@@x@@PEDAL_TO_TPS_SIZE@@ array,   U08, 
 custom iac_pid_mult_t	@@IAC_PID_MULT_SIZE@@x@@IAC_PID_MULT_SIZE@@ array,   U08,   @OFFSET@, [@@IAC_PID_MULT_SIZE@@x@@IAC_PID_MULT_SIZE@@],"%",	   1,     0,     0,  999,    2
 custom boost_table_t	@@BOOST_RPM_COUNT@@x@@BOOST_LOAD_COUNT@@ array,   U08,   @OFFSET@, [@@BOOST_RPM_COUNT@@x@@BOOST_LOAD_COUNT@@],"",    @@LOAD_1_BYTE_PACKING_MULT@@,  0 ,    0,    3000,      0
 
+#define GPPWM_LOAD_COUNT 8
+#define GPPWM_RPM_COUNT 8
+
+custom gppwm_table_t	@@GPPWM_RPM_COUNT@@x@@GPPWM_LOAD_COUNT@@ array, U08, @OFFSET@, [@@GPPWM_RPM_COUNT@@x@@GPPWM_LOAD_COUNT@@], "duty", 1, 0, 0, 100, 0
+
 struct stft_cell_cfg_s
 	int8_t maxAdd;;    "%",        1, 0,  0, 25, 0
 	int8_t maxRemove;; "%",        1, 0, -25, 0, 0
@@ -287,6 +292,25 @@ struct spi_pins
 	brain_pin_e sckPin;
 end_struct
 
+
+#define gppwm_channel_e_enum "None", "TPS", "MAP", "CLT", "IAT"
+custom gppwm_channel_e 1 bits, U08, @OFFSET@, [0:7], @@gppwm_channel_e_enum@@
+
+struct gppwm_channel
+	brain_pin_e pin;+Select a pin to use for PWM or on-off output.;
+	uint8_t dutyIfError;+If an error (with a sensor, etc) is detected, this value is used instead of reading from the table.\nThis should be a safe value for whatever hardware is connected to prevent damage.;"%", 1, 0, 0, 100, 0
+	uint16_t pwmFrequency;+Select a frequency to run PWM at.\nSet this to 0hz to enable on-off mode.;"hz", 1, 0, 0, 500, 0
+
+	uint8_t onAboveDuty;+In on-off mode, turn the output on when the table value is above this duty.;"%", 1, 0, 0, 100, 0
+	uint8_t offBelowDuty;+In on-off mode, turn the output off when the table value is below this duty.;"%", 1, 0, 0, 100, 0
+
+	gppwm_channel_e loadAxis;+Selects the load axis to use for the table.;
+	uint8_t[1] pad;
+
+	uint8_t[GPPWM_LOAD_COUNT] loadBins;;"load",      1,     0,   0.0,    250,   2
+	uint8_t[GPPWM_RPM_COUNT] rpmBins;;"RPM",  @@RPM_1_BYTE_PACKING_MULT@@,     0,      0.0,   12000.0,   0
+	gppwm_table_t table;
+end_struct
 
 custom air_pressure_sensor_type_e 4 bits, U32, @OFFSET@, [0:7]  "Custom", "DENSO183", "MPX4250", "HONDA3BAR", "NEON_2003", "22012AA090", "3 Bar", "MPX4100", "Toyota 89420-02010", "MPX4250A", "INVALID"
 !
@@ -1245,8 +1269,10 @@ uint8_t[4] unusuedsw;
 
  	custom can_vss_nbc_e 4 bits, U32, @OFFSET@, [0:7], "BMW_e46", "W202"
 	can_vss_nbc_e canVssNbcType;set can_vss X
-	
-	int[464] mainUnusedEnd;
+
+	gppwm_channel[4 iterate] gppwm;
+
+	int[376] mainUnusedEnd;
 
 ! end of engine_configuration_s
 end_struct

--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -293,8 +293,8 @@ struct spi_pins
 end_struct
 
 
-#define gppwm_channel_e_enum "None", "TPS", "MAP", "CLT", "IAT"
-custom gppwm_channel_e 1 bits, U08, @OFFSET@, [0:7], @@gppwm_channel_e_enum@@
+#define gppwm_channel_e_enum "TPS", "MAP", "CLT", "IAT"
+custom gppwm_channel_e 1 bits, U08, @OFFSET@, [0:1], @@gppwm_channel_e_enum@@
 
 struct gppwm_channel
 	brain_pin_e pin;+Select a pin to use for PWM or on-off output.;

--- a/firmware/tunerstudio/rusefi.input
+++ b/firmware/tunerstudio/rusefi.input
@@ -369,6 +369,12 @@ fileVersion = { @@TS_FILE_VERSION@@ }
       time            = { timeNow }
 ;      engineLoad      = { fuleAlgorithm == 0 ? MAF : TPS }
 
+	; These "synthetic" channels provide the Y-axis (load) value for gen purp PWM table's Y axes
+	gppwm1_load = {(gppwm1_loadAxis == 0) ? TPSValue : ((gppwm1_loadAxis == 1) ? MAPValue : ((gppwm1_loadAxis == 2) ? coolant : intake))}
+	gppwm2_load = {(gppwm2_loadAxis == 0) ? TPSValue : ((gppwm2_loadAxis == 1) ? MAPValue : ((gppwm2_loadAxis == 2) ? coolant : intake))}
+	gppwm3_load = {(gppwm3_loadAxis == 0) ? TPSValue : ((gppwm3_loadAxis == 1) ? MAPValue : ((gppwm3_loadAxis == 2) ? coolant : intake))}
+	gppwm4_load = {(gppwm4_loadAxis == 0) ? TPSValue : ((gppwm4_loadAxis == 1) ? MAPValue : ((gppwm4_loadAxis == 2) ? coolant : intake))}
+
 [PcVariables]
     wueAfrTargetOffset = array, S16, [ 16], ":1",   0.1, 0.0, -3.0, 3.0, 1;
     wueAnalRecommend   = array, U08, [ 16], "%",  1.00, 0.0, 100, 255.00, 0
@@ -856,6 +862,30 @@ fileVersion = { @@TS_FILE_VERSION@@ }
       gridOrient  = 250,   0, 340 ; Space 123 rotation of grid in degrees.
       upDownLabel = "(Later)", "(Sooner)"
 
+	table = gppwm1Tbl, gppwm1Map, "", 1
+		xyLabels = "RPM", ""
+		xBins = gppwm1_rpmBins, RPMValue
+		yBins = gppwm1_loadBins, gppwm1_load
+		zBins = gppwm1_table
+
+	table = gppwm2Tbl, gppwm2Map, "", 1
+		xyLabels = "RPM", ""
+		xBins = gppwm2_rpmBins, RPMValue
+		yBins = gppwm2_loadBins, gppwm2_load
+		zBins = gppwm2_table
+
+	table = gppwm3Tbl, gppwm3Map, "", 1
+		xyLabels = "RPM", ""
+		xBins = gppwm3_rpmBins, RPMValue
+		yBins = gppwm3_loadBins, gppwm3_load
+		zBins = gppwm3_table
+
+	table = gppwm4Tbl, gppwm4Map, "", 1
+		xyLabels = "RPM", ""
+		xBins = gppwm4_rpmBins, RPMValue
+		yBins = gppwm4_loadBins, gppwm4_load
+		zBins = gppwm4_table
+
 [GaugeConfigurations]
 
 gaugeCategory = Sensors - Extra 2
@@ -1294,8 +1324,14 @@ menuDialog = main
 	menu = "&Advanced" 
         subMenu = boostDialog,          "Boost Control"
 		subMenu = boostPidDialog,        "Closed Loop Boost",    { boostType == 1 }
-		subMenu = mc33Dialog,			"GDI Dreams"
-        subMenu = std_separator	
+
+		subMenu = std_separator
+		subMenu = gppwm1, "General Purpose PWM 1"
+		subMenu = gppwm2, "General Purpose PWM 2"
+		subMenu = gppwm3, "General Purpose PWM 3"
+		subMenu = gppwm4, "General Purpose PWM 4"
+
+		subMenu = std_separator
 		subMenu = fsioInputsDialog,        	"FSIO inputs"
 		subMenu = auxPidDialog,				"Aux PID"
 		subMenu = fsioOutputsDialog,        "FSIO outputs"
@@ -1374,6 +1410,7 @@ menuDialog = main
 		# EXPERIMENTAL FEATURES
 		subMenu = parkingLot,				"Experimental/Broken"
 		subMenu = multisparkSettings,		"Multispark", 0, {isIgnitionEnabled == 1}
+		subMenu = mc33Dialog,			"GDI Dreams"
 		subMenu = std_separator
 		
 		subMenu = hipFunction,				"HIP9011 settings (knock sensor) (alpha version)" @@if_ts_show_hip9011
@@ -2912,6 +2949,89 @@ cmd_set_engine_type_default					= "w\x00\x31\x00\x00"
         webHelp = "http://www.rusefi.com/"
         text = "<img src='https://rusefi.com/style/logo_100.gif'>"
 
+	dialog = gppwm1left, ""
+		field = "Pin", gppwm1_pin
+		field = ""
+		field = "Set frequency to 0hz for on-off mode"
+		field = "Frequency", gppwm1_pwmFrequency, {gppwm1_pin != 0}
+		field = ""
+		field = "On above duty", gppwm1_onAboveDuty, {gppwm1_pin != 0 && gppwm1_pwmFrequency == 0}
+		field = "Off below duty", gppwm1_offBelowDuty, {gppwm1_pin != 0 && gppwm1_pwmFrequency == 0}
+		field = "Duty if error", gppwm1_dutyIfError, {gppwm1_pin != 0}
+		field = ""
+		field = "Load Axis", gppwm1_loadAxis, {gppwm1_pin != 0}
+		field = ""
+		field = ""
+		field = ""
+		field = ""
+		field = ""
+
+	dialog = gppwm1, "General Purpose PWM 1", xAxis
+		panel = gppwm1left
+		panel = gppwm1Tbl, {gppwm1_pin != 0}
+
+	dialog = gppwm2left, ""
+		field = "Pin", gppwm2_pin
+		field = ""
+		field = "Set frequency to 0hz for on-off mode"
+		field = "Frequency", gppwm2_pwmFrequency, {gppwm2_pin != 0}
+		field = ""
+		field = "On above duty", gppwm2_onAboveDuty, {gppwm2_pin != 0 && gppwm2_pwmFrequency == 0}
+		field = "Off below duty", gppwm2_offBelowDuty, {gppwm2_pin != 0 && gppwm2_pwmFrequency == 0}
+		field = "Duty if error", gppwm2_dutyIfError, {gppwm2_pin != 0}
+		field = ""
+		field = "Load Axis", gppwm2_loadAxis, {gppwm2_pin != 0}
+		field = ""
+		field = ""
+		field = ""
+		field = ""
+		field = ""
+
+	dialog = gppwm2, "General Purpose PWM 2", xAxis
+		panel = gppwm2left
+		panel = gppwm2Tbl, {gppwm2_pin != 0}
+
+	dialog = gppwm3left, ""
+		field = "Pin", gppwm3_pin
+		field = ""
+		field = "Set frequency to 0hz for on-off mode"
+		field = "Frequency", gppwm3_pwmFrequency, {gppwm3_pin != 0}
+		field = ""
+		field = "On above duty", gppwm3_onAboveDuty, {gppwm3_pin != 0 && gppwm3_pwmFrequency == 0}
+		field = "Off below duty", gppwm3_offBelowDuty, {gppwm3_pin != 0 && gppwm3_pwmFrequency == 0}
+		field = "Duty if error", gppwm3_dutyIfError, {gppwm3_pin != 0}
+		field = ""
+		field = "Load Axis", gppwm3_loadAxis, {gppwm3_pin != 0}
+		field = ""
+		field = ""
+		field = ""
+		field = ""
+		field = ""
+
+	dialog = gppwm3, "General Purpose PWM 3", xAxis
+		panel = gppwm3left
+		panel = gppwm3Tbl, {gppwm3_pin != 0}
+
+	dialog = gppwm4left, ""
+		field = "Pin", gppwm4_pin
+		field = ""
+		field = "Set frequency to 0hz for on-off mode"
+		field = "Frequency", gppwm4_pwmFrequency, {gppwm4_pin != 0}
+		field = ""
+		field = "On above duty", gppwm4_onAboveDuty, {gppwm4_pin != 0 && gppwm4_pwmFrequency == 0}
+		field = "Off below duty", gppwm4_offBelowDuty, {gppwm4_pin != 0 && gppwm4_pwmFrequency == 0}
+		field = "Duty if error", gppwm4_dutyIfError, {gppwm4_pin != 0}
+		field = ""
+		field = "Load Axis", gppwm4_loadAxis, {gppwm4_pin != 0}
+		field = ""
+		field = ""
+		field = ""
+		field = ""
+		field = ""
+
+	dialog = gppwm4, "General Purpose PWM 4", xAxis
+		panel = gppwm4left
+		panel = gppwm4Tbl, {gppwm4_pin != 0}
 
 [Tools]
  ;addTool = toolName, PanelName


### PR DESCRIPTION
Problem: While hugely flexible, FSIO is too complex for the average user. Users require an easy way to configure things that are relatively simple like:
- Vary fuel pump duty cycle with engine load
- Engage/disengage supercharger clutch
- PWM cooling fan control: increase duty as temperature increases
- Automatic transmission line pressure control
- Decrease windshield wiper speed with increasing engine load to emulate old vacuum operated wipers while trying to sneak an EFI'd classic in to a stingy Concours d'Elegance
- Light bulb marked `DANGER TO MANIFOLD` that gets brighter with increasing boost pressure

Solution: After a survey of other ECUs functionality, I came up with this.  I tried to strike a balance between both ease of use, and flexibility to support may different scenarios.  It supports:
- PWM duty lookup from a table, with selectable Y axis (extensible to more channels later)
- Selectable output frequency
- On-off mode with configurable rising/falling thresholds for easy to understand hysteresis, similar to existing fan control
- Fallback duty cycle in case of sensor or table lookup error

Here's what the config UI for one (of four) channels looks like:
![image](https://user-images.githubusercontent.com/568254/80290786-b5e84480-86fc-11ea-8ce8-3eddc16f3c88.png)
