### PR TITLE
TS protocol framing for auto tune/calibration features

### DIFF
--- a/firmware/config/boards/kinetis/config/controllers/algo/rusefi_generated.h
+++ b/firmware/config/boards/kinetis/config/controllers/algo/rusefi_generated.h
@@ -2226,7 +2226,7 @@
 #define triggerSimulatorPins3_offset 738
 #define triggerSimulatorPins3_offset_hex 2e2
 #define TS_FILE_VERSION 20200310
-#define TS_OUTPUT_SIZE 240
+#define TS_OUTPUT_SIZE 244
 #define ts_show_analog_divider true
 #define ts_show_auxserial_pins true
 #define ts_show_can_pins true
@@ -2243,7 +2243,7 @@
 #define ts_show_spi true
 #define ts_show_trigger_comparator true
 #define ts_show_tunerstudio_port true
-#define TS_SIGNATURE "rusEFI v1.2020.3"
+#define TS_SIGNATURE "rusEFI v1.2020.4"
 #define tunerStudioSerialSpeed_offset 728
 #define tunerStudioSerialSpeed_offset_hex 2d8
 #define twoWireBatchIgnition_offset 1476

--- a/firmware/console/binary/tunerstudio_configuration.h
+++ b/firmware/console/binary/tunerstudio_configuration.h
@@ -21,11 +21,11 @@ typedef struct {
 
 enum class TsCalMode : uint8_t {
 	None = 0,
-	Tps1Min = 0,
 	Tps1Max = 1,
-	EtbKp = 2,
-	EtbKi = 3,
-	EtbKd = 4,
+	Tps1Min = 2,
+	EtbKp = 3,
+	EtbKi = 4,
+	EtbKd = 5,
 };
 
 /**

--- a/firmware/console/binary/tunerstudio_configuration.h
+++ b/firmware/console/binary/tunerstudio_configuration.h
@@ -18,6 +18,16 @@ typedef struct {
 	uint16_t values[EGT_CHANNEL_COUNT];
 } egt_values_s;
 
+
+enum class TsCalMode : uint8_t {
+	None = 0,
+	Tps1Min = 0,
+	Tps1Max = 1,
+	EtbKp = 2,
+	EtbKi = 3,
+	EtbKd = 4,
+};
+
 /**
  * At the moment rusEfi does NOT have any code generation around TS output channels, three locations have to be changed manually
  * 1) this TunerStudioOutputChannels firmware version of the structure
@@ -152,15 +162,20 @@ typedef struct {
 	uint32_t firmwareVersion; // 120
 	uint32_t tsConfigVersion; // 124
 
+	// These two fields indicate to TS that we'd like to set a particular field to a particular value
+	float calibrationValue;	// 128
+	TsCalMode calibrationMode; // 132
+	uint8_t padding[3]; // 133-135
+
 	// Errors
-	int totalTriggerErrorCounter; // 128
-	int orderingErrorCounter; // 132
-	int16_t warningCounter; // 136
-	int16_t lastErrorCode; // 138
-	int16_t recentErrorCodes[8]; // 140
+	int totalTriggerErrorCounter; // 136
+	int orderingErrorCounter; // 140
+	int16_t warningCounter; // 144
+	int16_t lastErrorCode; // 146
+	int16_t recentErrorCodes[8]; // 148-162
 
 	// Debug
-	float debugFloatField1; // 156
+	float debugFloatField1; // 164
 	float debugFloatField2;
 	float debugFloatField3;
 	float debugFloatField4;
@@ -171,23 +186,24 @@ typedef struct {
 	int debugIntField2;
 	int debugIntField3;
 	int16_t debugIntField4;
-	int16_t debugIntField5; // 198
+	int16_t debugIntField5; // 206
 
 	// accelerometer
-	int16_t accelerationX; // 200
-	int16_t accelerationY; // 202
+	int16_t accelerationX; // 208
+	int16_t accelerationY; // 210
 
 	// EGT
-	egt_values_s egtValues; // 204
-	scaled_percent throttle2Position;    // 220
+	egt_values_s egtValues; // 212
 
-	scaled_voltage rawTps1Primary;		// 222
-	scaled_voltage rawPpsPrimary;		// 224
-	scaled_voltage rawClt;				// 226
-	scaled_voltage rawIat;				// 228
-	scaled_voltage rawOilPressure;		// 230
+	scaled_percent throttle2Position;    // 228
 
-	uint8_t unusedAtTheEnd[8]; // we have some unused bytes to allow compatible TS changes
+	scaled_voltage rawTps1Primary;		// 230
+	scaled_voltage rawPpsPrimary;		// 232
+	scaled_voltage rawClt;				// 234
+	scaled_voltage rawIat;				// 236
+	scaled_voltage rawOilPressure;		// 238
+
+	uint8_t unusedAtTheEnd[4]; // we have some unused bytes to allow compatible TS changes
 
 	// Temporary - will remove soon
 	TsDebugChannels* getDebugChannels() {

--- a/firmware/console/binary/tunerstudio_configuration.h
+++ b/firmware/console/binary/tunerstudio_configuration.h
@@ -163,6 +163,15 @@ typedef struct {
 	uint32_t tsConfigVersion; // 124
 
 	// These two fields indicate to TS that we'd like to set a particular field to a particular value
+	// We use a maintainConstantValue in TS for each field we'd like to set, like this:
+	//		maintainConstantValue = tpsMax, { (calibrationMode == 1 ) ? calibrationValue : tpsMax }
+	//		maintainConstantValue = tpsMin, { (calibrationMode == 2 ) ? calibrationValue : tpsMin }
+	// When the mode is set to a particular value, TS will copy the calibrationValue in to the specified field.
+	//
+	// With this simple construct, the ECU can send any number of internally computed configuration fields
+	// back to TunerStudio, getting around the problem of setting values on the controller without TS's knowledge.
+	// The ECU simply has to sequentially set a mode/value, wait briefly, then repeat until all the values
+	// it wants to send have been sent.
 	float calibrationValue;	// 128
 	TsCalMode calibrationMode; // 132
 	uint8_t padding[3]; // 133-135

--- a/firmware/controllers/generated/rusefi_generated.h
+++ b/firmware/controllers/generated/rusefi_generated.h
@@ -2226,7 +2226,7 @@
 #define triggerSimulatorPins3_offset 738
 #define triggerSimulatorPins3_offset_hex 2e2
 #define TS_FILE_VERSION 20200310
-#define TS_OUTPUT_SIZE 240
+#define TS_OUTPUT_SIZE 244
 #define ts_show_analog_divider true
 #define ts_show_auxserial_pins true
 #define ts_show_can_pins true
@@ -2243,7 +2243,7 @@
 #define ts_show_spi true
 #define ts_show_trigger_comparator false
 #define ts_show_tunerstudio_port true
-#define TS_SIGNATURE "rusEFI v1.2020.3"
+#define TS_SIGNATURE "rusEFI v1.2020.4"
 #define tunerStudioSerialSpeed_offset 728
 #define tunerStudioSerialSpeed_offset_hex 2d8
 #define twoWireBatchIgnition_offset 1476

--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -23,13 +23,13 @@
 ! type name;comment
 
 
-#define TS_SIGNATURE "rusEFI v1.2020.3"
+#define TS_SIGNATURE "rusEFI v1.2020.4"
 
 !
 ! this is here so that rusEfi console can access it, too
 ! [IMPORTANT] every time TS_OUTPUT_SIZE is changed make sure to increment TS_SIGNATURE above
 !
-#define TS_OUTPUT_SIZE 240
+#define TS_OUTPUT_SIZE 244
 
 !
 ! this is used to confirm that firmware and TunerStudio are using the same rusefi.ini version

--- a/firmware/tunerstudio/rusefi.input
+++ b/firmware/tunerstudio/rusefi.input
@@ -470,6 +470,7 @@ fileVersion = { @@TS_FILE_VERSION@@ }
      
      readOnly = warning_message
 
+
 [CurveEditor]
 ;	xAxis       =  leftValue, rightValue, step
 ;	yAxis       =  bottomValue, topValue, step

--- a/firmware/tunerstudio/rusefi.input
+++ b/firmware/tunerstudio/rusefi.input
@@ -470,13 +470,6 @@ fileVersion = { @@TS_FILE_VERSION@@ }
      
      readOnly = warning_message
 
-	maintainConstantValue = tpsMax, { (calibrationMode == 1 ) ? calibrationValue : tpsMax }
-	maintainConstantValue = tpsMin, { (calibrationMode == 2 ) ? calibrationValue : tpsMin }
-
-	maintainConstantValue = etb_pFactor, { (calibrationMode == 3) ? calibrationValue : etb_pFactor }
-	maintainConstantValue = etb_iFactor, { (calibrationMode == 4) ? calibrationValue : etb_iFactor }
-	maintainConstantValue = etb_dFactor, { (calibrationMode == 5) ? calibrationValue : etb_dFactor }
-
 [CurveEditor]
 ;	xAxis       =  leftValue, rightValue, step
 ;	yAxis       =  bottomValue, topValue, step
@@ -958,6 +951,8 @@ gaugeCategory = Sensors - Basic
 
 gaugeCategory = Sensors - Extra 1
    VSSGauge          = vehicleSpeedKph,     "Vehicle speed",         "kmh",        0,    200,       0,      1,       3,     4,   1,   1
+   accelerationXGauge = accelerationX,       @@GAUGE_NAME_ACCEL_X@@,      "acc",        -11,   11,     1.0,    1.2,      100,    100,   3, 1
+   accelerationYGauge = accelerationY,       @@GAUGE_NAME_ACCEL_Y@@,      "acc",        -11,   11,     1.0,    1.2,      100,    100,   3, 1
    atmPresCGauge     = baroPressure,          "Barometric pressure",       "kPa",        0,   1024,       0,      0,       0,     0,   0,   0
    vvtPositionGauge = vvtPosition, "VVT position", "deg",     0,   100,     0,    0,    720,  720,   0,   0
    internalMcuTemperatureGauge = internalMcuTemperature, @@GAUGE_NAME_ECU_TEMPERATURE@@, "C",     0,   100,     0,    0,    75,  100,   0,   0
@@ -1131,6 +1126,8 @@ gaugeCategory = Sensors - Raw
    entry = coilDutyCycle,	@@GAUGE_NAME_DWELL_DUTY@@,	float,"%.3f"
    entry = currentTargetAfr,@@GAUGE_NAME_TARGET_AFR@@,	float,"%.3f"
 
+   entry = accelerationX,	@@GAUGE_NAME_ACCEL_X@@,	float,"%.2f", { LIS302DLCsPin != 0 }
+   entry = accelerationY,	@@GAUGE_NAME_ACCEL_Y@@,	float,"%.2f", { LIS302DLCsPin != 0 }
    entry = egt1,	        "EGT1",	float,"%.1f", { max31855_cs1 != 0}
    entry = egt2,	        "EGT2",	float,"%.1f", { max31855_cs2 != 0}
    entry = egt3,	        "EGT3",	float,"%.1f", { max31855_cs3 != 0}
@@ -1768,11 +1765,6 @@ cmd_set_engine_type_default					= "w\x00\x31\x00\x00"
 		field = "Throttle2 max value",					tps2Max
 		field = "TPS low value detection threshold",	tpsErrorDetectionTooLow, {tps1_1AdcChannel != 16}
 		field = "TPS high value detection threshold",	tpsErrorDetectionTooHigh, {tps1_1AdcChannel != 16}
-
-		field = "min", tpsMin, 0
-		field = "max", tpsMax, 0
-
-		commandButton = "Autocalibrate ETB TPS", cmd_calibrate_tps_1_closed
 
 	dialog = pedalSensorLeft, "Accelerator pedal"
 		field = "Accelerator position sensor",			throttlePedalPositionAdcChannel

--- a/firmware/tunerstudio/rusefi.input
+++ b/firmware/tunerstudio/rusefi.input
@@ -304,55 +304,60 @@ fileVersion = { @@TS_FILE_VERSION@@ }
       firmwareVersion = scalar,  U32,    120,"version_f",    1,         0
       firmwareTsVersion=scalar,  U32,    124,"version_p",    1,         0
 
+; calibation helpers
+      calibrationValue = scalar, F32, 128, "", 1, 0
+      calibrationMode = scalar, U08, 132, "", 1, 0
+      ; 3 bytes padding1
+
 ; Errors
-      totalTriggerErrorCounter=scalar,U32,   128,"counter",           1,         0
-      ; orderingErrorCounter 132
-      warningCounter  = scalar,  U16,    136,  "count",           1,         0
-      lastErrorCode   = scalar,  U16,    138,  "error",           1,         0
-      recentErrorCode0= scalar,  U16,    140,  "error",           1,         0
-      recentErrorCode1= scalar,  U16,    142,  "error",           1,         0
-      recentErrorCode2= scalar,  U16,    144,  "error",           1,         0
-      recentErrorCode3= scalar,  U16,    146,  "error",           1,         0
-      recentErrorCode4= scalar,  U16,    148,  "error",           1,         0
-      recentErrorCode5= scalar,  U16,    150,  "error",           1,         0
-      recentErrorCode6= scalar,  U16,    152,  "error",           1,         0
-      recentErrorCode7= scalar,  U16,    154,  "error",           1,         0
+      totalTriggerErrorCounter=scalar,U32,   136,"counter",           1,         0
+      ; orderingErrorCounter 140
+      warningCounter  = scalar,  U16,    144,  "count",           1,         0
+      lastErrorCode   = scalar,  U16,    146,  "error",           1,         0
+      recentErrorCode0= scalar,  U16,    148,  "error",           1,         0
+      recentErrorCode1= scalar,  U16,    150,  "error",           1,         0
+      recentErrorCode2= scalar,  U16,    152,  "error",           1,         0
+      recentErrorCode3= scalar,  U16,    154,  "error",           1,         0
+      recentErrorCode4= scalar,  U16,    156,  "error",           1,         0
+      recentErrorCode5= scalar,  U16,    158,  "error",           1,         0
+      recentErrorCode6= scalar,  U16,    160,  "error",           1,         0
+      recentErrorCode7= scalar,  U16,    162,  "error",           1,         0
 
 ; Debug
-      debugFloatField1= scalar,  F32,    156,    "val",           1,       0.0
-      debugFloatField2= scalar,  F32,    160,    "val",           1,       0.0
-      debugFloatField3= scalar,  F32,    164,    "val",           1,       0.0
-      debugFloatField4= scalar,  F32,    168,    "val",           1,       0.0
-      debugFloatField5= scalar,  F32,    172,    "val",           1,       0.0
-      debugFloatField6= scalar,  F32,    176,    "val",           1,       0.0
-      debugFloatField7= scalar,  F32,    180,    "val",           1,       0.0
-      debugIntField1  = scalar,  S32,    184,    "val",           1,       0.0
-      debugIntField2  = scalar,  S32,    188,    "val",           1,       0.0
-      debugIntField3  = scalar,  S32,    192,    "val",           1,       0.0
-      debugIntField4  = scalar,  S16,    196,    "val",           1,       0.0
-      debugIntField5  = scalar,  S16,    198,    "val",           1,       0.0
+      debugFloatField1= scalar,  F32,    164,    "val",           1,       0.0
+      debugFloatField2= scalar,  F32,    168,    "val",           1,       0.0
+      debugFloatField3= scalar,  F32,    172,    "val",           1,       0.0
+      debugFloatField4= scalar,  F32,    176,    "val",           1,       0.0
+      debugFloatField5= scalar,  F32,    180,    "val",           1,       0.0
+      debugFloatField6= scalar,  F32,    184,    "val",           1,       0.0
+      debugFloatField7= scalar,  F32,    188,    "val",           1,       0.0
+      debugIntField1  = scalar,  S32,    192,    "val",           1,       0.0
+      debugIntField2  = scalar,  S32,    196,    "val",           1,       0.0
+      debugIntField3  = scalar,  S32,    200,    "val",           1,       0.0
+      debugIntField4  = scalar,  S16,    204,    "val",           1,       0.0
+      debugIntField5  = scalar,  S16,    206,    "val",           1,       0.0
 
 ; Accel
-      accelerationX   = scalar,  S16,    200,      "G",        0.01,         0
-      accelerationY   = scalar,  S16,    202,      "G",        0.01,         0
+      accelerationX   = scalar,  S16,    208,      "G",        0.01,         0
+      accelerationY   = scalar,  S16,    210,      "G",        0.01,         0
 
 ; egt
-      egt1            = scalar,  S16,    204,  "deg C",      1,         0
-      egt2            = scalar,  S16,    206,  "deg C",      1,         0
-      egt3            = scalar,  S16,    208,  "deg C",      1,         0
-      egt4            = scalar,  S16,    210,  "deg C",      1,         0
-      egt5            = scalar,  S16,    212,  "deg C",      1,         0
-      egt6            = scalar,  S16,    214,  "deg C",      1,         0
-      egt7            = scalar,  S16,    216,  "deg C",      1,         0
-      egt8            = scalar,  S16,    218,  "deg C",      1,         0
-;
-      TPS2Value       = scalar,  S16,    220,        "%",{1/@@PACK_MULT_PERCENT@@},         0
+      egt1            = scalar,  S16,    212,  "deg C",      1,         0
+      egt2            = scalar,  S16,    214,  "deg C",      1,         0
+      egt3            = scalar,  S16,    216,  "deg C",      1,         0
+      egt4            = scalar,  S16,    218,  "deg C",      1,         0
+      egt5            = scalar,  S16,    220,  "deg C",      1,         0
+      egt6            = scalar,  S16,    222,  "deg C",      1,         0
+      egt7            = scalar,  S16,    224,  "deg C",      1,         0
+      egt8            = scalar,  S16,    226,  "deg C",      1,         0
 
-      rawTps1Primary  = scalar,	 U16,    222, "V",{1/@@PACK_MULT_VOLTAGE@@}, 0.0
-      rawPpsPrimary   = scalar,	 U16,    224, "V",{1/@@PACK_MULT_VOLTAGE@@}, 0.0
-      rawClt          = scalar,	 U16,    226, "V",{1/@@PACK_MULT_VOLTAGE@@}, 0.0
-      rawIat          = scalar,	 U16,    228, "V",{1/@@PACK_MULT_VOLTAGE@@}, 0.0
-      rawOilPressure  = scalar,	 U16,    230, "V",{1/@@PACK_MULT_VOLTAGE@@}, 0.0
+      TPS2Value       = scalar,  S16,    228,        "%",{1/@@PACK_MULT_PERCENT@@},         0
+
+      rawTps1Primary  = scalar,	 U16,    230, "V",{1/@@PACK_MULT_VOLTAGE@@}, 0.0
+      rawPpsPrimary   = scalar,	 U16,    232, "V",{1/@@PACK_MULT_VOLTAGE@@}, 0.0
+      rawClt          = scalar,	 U16,    234, "V",{1/@@PACK_MULT_VOLTAGE@@}, 0.0
+      rawIat          = scalar,	 U16,    236, "V",{1/@@PACK_MULT_VOLTAGE@@}, 0.0
+      rawOilPressure  = scalar,	 U16,    238, "V",{1/@@PACK_MULT_VOLTAGE@@}, 0.0
 
 ;
 ; see TunerStudioOutputChannels struct
@@ -465,6 +470,12 @@ fileVersion = { @@TS_FILE_VERSION@@ }
      
      readOnly = warning_message
 
+	maintainConstantValue = tpsMax, { (calibrationMode == 1 ) ? calibrationValue : tpsMax }
+	maintainConstantValue = tpsMin, { (calibrationMode == 2 ) ? calibrationValue : tpsMin }
+
+	maintainConstantValue = etb_pFactor, { (calibrationMode == 3) ? calibrationValue : etb_pFactor }
+	maintainConstantValue = etb_iFactor, { (calibrationMode == 4) ? calibrationValue : etb_iFactor }
+	maintainConstantValue = etb_dFactor, { (calibrationMode == 5) ? calibrationValue : etb_dFactor }
 
 [CurveEditor]
 ;	xAxis       =  leftValue, rightValue, step
@@ -947,8 +958,6 @@ gaugeCategory = Sensors - Basic
 
 gaugeCategory = Sensors - Extra 1
    VSSGauge          = vehicleSpeedKph,     "Vehicle speed",         "kmh",        0,    200,       0,      1,       3,     4,   1,   1
-   accelerationXGauge = accelerationX,       @@GAUGE_NAME_ACCEL_X@@,      "acc",        -11,   11,     1.0,    1.2,      100,    100,   3, 1
-   accelerationYGauge = accelerationY,       @@GAUGE_NAME_ACCEL_Y@@,      "acc",        -11,   11,     1.0,    1.2,      100,    100,   3, 1
    atmPresCGauge     = baroPressure,          "Barometric pressure",       "kPa",        0,   1024,       0,      0,       0,     0,   0,   0
    vvtPositionGauge = vvtPosition, "VVT position", "deg",     0,   100,     0,    0,    720,  720,   0,   0
    internalMcuTemperatureGauge = internalMcuTemperature, @@GAUGE_NAME_ECU_TEMPERATURE@@, "C",     0,   100,     0,    0,    75,  100,   0,   0
@@ -1122,8 +1131,6 @@ gaugeCategory = Sensors - Raw
    entry = coilDutyCycle,	@@GAUGE_NAME_DWELL_DUTY@@,	float,"%.3f"
    entry = currentTargetAfr,@@GAUGE_NAME_TARGET_AFR@@,	float,"%.3f"
 
-   entry = accelerationX,	@@GAUGE_NAME_ACCEL_X@@,	float,"%.2f", { LIS302DLCsPin != 0 }
-   entry = accelerationY,	@@GAUGE_NAME_ACCEL_Y@@,	float,"%.2f", { LIS302DLCsPin != 0 }
    entry = egt1,	        "EGT1",	float,"%.1f", { max31855_cs1 != 0}
    entry = egt2,	        "EGT2",	float,"%.1f", { max31855_cs2 != 0}
    entry = egt3,	        "EGT3",	float,"%.1f", { max31855_cs3 != 0}
@@ -1761,6 +1768,11 @@ cmd_set_engine_type_default					= "w\x00\x31\x00\x00"
 		field = "Throttle2 max value",					tps2Max
 		field = "TPS low value detection threshold",	tpsErrorDetectionTooLow, {tps1_1AdcChannel != 16}
 		field = "TPS high value detection threshold",	tpsErrorDetectionTooHigh, {tps1_1AdcChannel != 16}
+
+		field = "min", tpsMin, 0
+		field = "max", tpsMax, 0
+
+		commandButton = "Autocalibrate ETB TPS", cmd_calibrate_tps_1_closed
 
 	dialog = pedalSensorLeft, "Accelerator pedal"
 		field = "Accelerator position sensor",			throttlePedalPositionAdcChannel


### PR DESCRIPTION
In order for automatic tuning/calibration to provide a great experience, we need some way to exfiltrate data from the ECU back up to TunerStudio, and set it in the configuration.

Here's an example of how this works:
```
maintainConstantValue = tpsMax, { (calibrationMode == 1 ) ? calibrationValue : tpsMax }
maintainConstantValue = tpsMin, { (calibrationMode == 2 ) ? calibrationValue : tpsMin }
```
This line tells TunerStudio:
- when `calibrationMode == 1`, copy the value read in from `calibrationValue` to the configuration field `tpsMax`
- Otherwise just pipe `tpsMax` back in to itself (ie, do nothing)
...and likewise for tpsMin, but for mode `2`.

With this simple construct, the ECU can send any number of internally computed configuration fields back to TunerStudio, getting around the problem of setting values on the controller without TS's knowledge.  The ECU simply has to sequentially set a mode/value, wait briefly, then repeat until all the values it wants to send have been sent.

This change adds the new fields `calibrationMode` and `calibrationValue`.  Because TS will always read these with the mere existence of `maintainConstantValue`, they have to be packed near the existing "important" fields, so as to not hurt update rate and datalogging speed.  As a result, everything after them has to get scooted up by 8 bytes.  In addition, the signature is revved to prevent incompatible protocol problems.