### PR TITLE
Support 4 h-bridges

### DIFF
--- a/firmware/config/boards/kinetis/config/controllers/algo/engine_configuration_generated_structures.h
+++ b/firmware/config/boards/kinetis/config/controllers/algo/engine_configuration_generated_structures.h
@@ -1886,10 +1886,13 @@ struct engine_configuration_s {
 	 * offset 1064
 	 */
 	stft_s stft;
+
+	etb_io etbIo2[2];
+
 	/**
 	 * offset 1088
 	 */
-	int unusedAtOldBoardConfigurationEnd[94];
+	int unusedAtOldBoardConfigurationEnd[92];
 	/**
 	offset 1464 bit 0 */
 	bool vvtDisplayInverted : 1;

--- a/firmware/controllers/actuators/dc_motors.cpp
+++ b/firmware/controllers/actuators/dc_motors.cpp
@@ -101,7 +101,7 @@ const etb_io& getConfigForMotor(size_t index DECLARE_ENGINE_PARAMETER_SUFFIX) {
 }
 
 DcMotor* initDcMotor(size_t index, bool useTwoWires DECLARE_ENGINE_PARAMETER_SUFFIX) {
-	const auto& io = getConfigForMotor(index);
+	const auto& io = getConfigForMotor(index PASS_ENGINE_PARAMETER_SUFFIX);
 	auto& hw = etbHardware[index];
 
 	hw.start(

--- a/firmware/controllers/actuators/dc_motors.cpp
+++ b/firmware/controllers/actuators/dc_motors.cpp
@@ -30,10 +30,8 @@ private:
 	SimplePwm m_pwmDir1;
 	SimplePwm m_pwmDir2;
 
-	SimplePwm etbPwmUp;
-
 public:
-	EtbHardware() : etbPwmUp("etbUp"), dcMotor(&m_pwmEnable, &m_pwmDir1, &m_pwmDir2, &m_disablePin) {}
+	EtbHardware() : dcMotor(&m_pwmEnable, &m_pwmDir1, &m_pwmDir2, &m_disablePin) {}
 
 	TwoPinDcMotor dcMotor;
 	
@@ -45,7 +43,6 @@ public:
 
 	void start(bool useTwoWires, 
 			brain_pin_e pinEnable,
-			// since we have pointer magic here we cannot simply have value parameter
 			brain_pin_e pinDir1,
 			brain_pin_e pinDir2,
 			brain_pin_e pinDisable,
@@ -89,15 +86,26 @@ public:
 	}
 };
 
-static EtbHardware etbHardware[ETB_COUNT];
+static EtbHardware etbHardware[ETB_COUNT * 2];
 
-DcMotor* initDcMotor(size_t index DECLARE_ENGINE_PARAMETER_SUFFIX)
-{
-	const auto& io = engineConfiguration->etbIo[index];
+// We needed more H-bridge configs - so the IO configs are split
+// across two arrays of settings to preserve config compatibility
+const etb_io& getConfigForMotor(size_t index DECLARE_ENGINE_PARAMETER_SUFFIX) {
+	size_t firstSize = efi::size(engineConfiguration->etbIo);
+
+	if (index < firstSize) {
+		return engineConfiguration->etbIo[index];
+	}
+
+	return engineConfiguration->etbIo2[index - firstSize];
+}
+
+DcMotor* initDcMotor(size_t index, bool useTwoWires DECLARE_ENGINE_PARAMETER_SUFFIX) {
+	const auto& io = getConfigForMotor(index);
 	auto& hw = etbHardware[index];
 
 	hw.start(
-		CONFIG(etb_use_two_wires),
+		useTwoWires,
 		io.controlPin1,
 		io.directionPin1,
 		io.directionPin2,

--- a/firmware/controllers/actuators/dc_motors.h
+++ b/firmware/controllers/actuators/dc_motors.h
@@ -13,7 +13,7 @@
 class DcMotor;
 class Logger;
 
-DcMotor* initDcMotor(size_t index DECLARE_ENGINE_PARAMETER_SUFFIX);
+DcMotor* initDcMotor(size_t index, bool useTwoWires DECLARE_ENGINE_PARAMETER_SUFFIX);
 
 // Manual control of motors for use by console commands
 void setDcMotorFrequency(size_t index, int hz);

--- a/firmware/controllers/actuators/electronic_throttle.cpp
+++ b/firmware/controllers/actuators/electronic_throttle.cpp
@@ -682,7 +682,7 @@ void doInitElectronicThrottle(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 	engine->etbActualCount = Sensor::hasSensor(SensorType::Tps2) ? 2 : 1;
 
 	for (int i = 0 ; i < engine->etbActualCount; i++) {
-		auto motor = initDcMotor(i PASS_ENGINE_PARAMETER_SUFFIX);
+		auto motor = initDcMotor(i, CONFIG(etb_use_two_wires) PASS_ENGINE_PARAMETER_SUFFIX);
 
 		// If this motor is actually set up, init the etb
 		if (motor)

--- a/firmware/controllers/actuators/idle_thread.cpp
+++ b/firmware/controllers/actuators/idle_thread.cpp
@@ -595,8 +595,8 @@ void initIdleHardware(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 		StepperHw* hw;
 
 		if (CONFIG(useHbridges)) {
-			auto motorA = initDcMotor(0 PASS_ENGINE_PARAMETER_SUFFIX);
-			auto motorB = initDcMotor(1 PASS_ENGINE_PARAMETER_SUFFIX);
+			auto motorA = initDcMotor(2, /*useTwoWires*/ true PASS_ENGINE_PARAMETER_SUFFIX);
+			auto motorB = initDcMotor(3, /*useTwoWires*/ true PASS_ENGINE_PARAMETER_SUFFIX);
 
 			if (motorA && motorB) {
 				iacHbridgeHw.initialize(

--- a/firmware/controllers/engine_controller.cpp
+++ b/firmware/controllers/engine_controller.cpp
@@ -691,7 +691,7 @@ void initEngineContoller(Logging *sharedLogger DECLARE_ENGINE_PARAMETER_SUFFIX) 
 // help to notice when RAM usage goes up - if a code change adds to RAM usage these variables would fail
 // linking process which is the way to raise the alarm
 #ifndef RAM_UNUSED_SIZE
-#define RAM_UNUSED_SIZE 14300
+#define RAM_UNUSED_SIZE 13600
 #endif
 #ifndef CCM_UNUSED_SIZE
 #define CCM_UNUSED_SIZE 2900

--- a/firmware/controllers/generated/engine_configuration_generated_structures.h
+++ b/firmware/controllers/generated/engine_configuration_generated_structures.h
@@ -1886,10 +1886,13 @@ struct engine_configuration_s {
 	 * offset 1064
 	 */
 	stft_s stft;
+
+	etb_io etbIo2[2];
+
 	/**
 	 * offset 1088
 	 */
-	int unusedAtOldBoardConfigurationEnd[94];
+	int unusedAtOldBoardConfigurationEnd[92];
 	/**
 	offset 1464 bit 0 */
 	bool vvtDisplayInverted : 1;

--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -880,7 +880,9 @@ custom maf_sensor_type_e 4 bits, S32, @OFFSET@, [0:7], @@maf_sensor_type_e_enum@
 
 	stft_s stft
 
-	int[94] unusedAtOldBoardConfigurationEnd;
+	etb_io[ETB_COUNT iterate] etbIo2
+
+	int[92] unusedAtOldBoardConfigurationEnd;
 
 	bit vvtDisplayInverted
 	bit fuelClosedLoopCorrectionEnabled;+Enables lambda sensor closed loop feedback for fuelling.


### PR DESCRIPTION
- Allow DC motor consumer to pick mode (stepper is always 2 pin)
- Add config space for 2 more DC motors
- Remove unused `SimplePwm etbPwmUp`