### PR TITLE
either newline at end of mk file either no backslash on last line

### DIFF
--- a/firmware/hw_layer/drivers/drivers.mk
+++ b/firmware/hw_layer/drivers/drivers.mk
@@ -18,4 +18,4 @@ HW_LAYER_DRIVERS = \
 HW_LAYER_DRIVERS_CPP = \
 	$(DRIVERS_DIR)/can/can_hw.cpp \
 	$(DRIVERS_DIR)/can/can_msg_tx.cpp \
-	$(DRIVERS_DIR)/serial/serial_hw.cpp \
+	$(DRIVERS_DIR)/serial/serial_hw.cpp


### PR DESCRIPTION
This fixes following build issue under linux:
make: *** No rule to make target 'build/obj/.cpp cj125.cpp', needed by 'build/obj/ build/obj/cj125.o'.  Stop.
make: *** Waiting for unfinished jobs....

Introduces in 8d35c35035dd7dc5fd3a149d04a5d3f55b6facca