### PR TITLE
pass in SD log write length

### DIFF
--- a/firmware/console/status_loop.cpp
+++ b/firmware/console/status_loop.cpp
@@ -374,7 +374,7 @@ void writeLogLine(void) {
 
 	if (isSdCardAlive()) {
 		appendPrintf(&fileLogger, "\r\n");
-		appendToLog(fileLogger.buffer);
+		appendToLog(fileLogger.buffer, strlen(fileLogger.buffer));
 		logFileLineIndex++;
 	}
 #endif /* EFI_FILE_LOGGING */

--- a/firmware/hw_layer/mmc_card.cpp
+++ b/firmware/hw_layer/mmc_card.cpp
@@ -307,7 +307,7 @@ void readLogFileContent(char *buffer, short fileId, short offset, short length) 
 /**
  * @brief Appends specified line to the current log file
  */
-void appendToLog(const char *line) {
+void appendToLog(const char *line, size_t lineLength) {
 	UINT bytesWritten;
 
 	if (!isSdCardAlive()) {
@@ -316,7 +316,7 @@ void appendToLog(const char *line) {
 		errorReported = TRUE;
 		return;
 	}
-	UINT lineLength = strlen(line);
+
 	totalLoggedBytes += lineLength;
 	lockSpi(SPI_NONE);
 	FRESULT err = f_write(&FDLogFile, line, lineLength, &bytesWritten);
@@ -494,7 +494,9 @@ void initMmcCard(void) {
 	chThdCreateStatic(mmcThreadStack, sizeof(mmcThreadStack), LOWPRIO, (tfunc_t)(void*) MMCmonThread, NULL);
 
 	addConsoleAction("mountsd", MMCmount);
-	addConsoleActionS("appendtolog", appendToLog);
+	addConsoleActionS("appendtolog", [](const char* str) {
+		appendToLog(str, strlen(str));
+	});
 	addConsoleAction("umountsd", mmcUnMount);
 	addConsoleActionS("ls", listDirectory);
 	addConsoleActionS("del", removeFile);

--- a/firmware/hw_layer/mmc_card.h
+++ b/firmware/hw_layer/mmc_card.h
@@ -16,7 +16,7 @@ extern "C"
 
 void initMmcCard(void);
 bool isSdCardAlive(void);
-void appendToLog(const char *line);
+void appendToLog(const char *line, size_t length);
 
 void readLogFileContent(char *buffer, short fileId, short offset, short length);
 


### PR DESCRIPTION
Don't assume it's always a string, because in the near future it'll be binary.