### PR TITLE
Fix #1492

### DIFF
--- a/.github/workflows/build-firmware.yaml
+++ b/.github/workflows/build-firmware.yaml
@@ -99,7 +99,24 @@ jobs:
       working-directory: ./firmware/
       run: make -j4 PROJECT_BOARD=${{matrix.efi-board}} PROJECT_CPU=${{matrix.efi-cpu}} EXTRA_PARAMS="${{matrix.type-extra-params}} ${{matrix.target-extra-params}}" DEBUG_LEVEL_OPT='${{matrix.build-debug-level-opt}}' ${{matrix.extra-options}}
       
-    # The next two steps upload the bin and elf as build artifacts
+    # Get hex2dfu
+    - name: Fetch hex2dfu
+      uses: actions/checkout@v2
+      with:
+        repository: 'rusefi/hex2dfu'
+        path: hex2dfu
+
+    # Build hex2dfu
+    - name: Build hex2dfu
+      working-directory: ./hex2dfu
+      run: gcc hex2dfu.c -o hex2dfu
+
+    # Convert hex to dfu
+    - name: Create DFU file
+      run: ./hex2dfu/hex2dfu -i ./firmware/build/rusefi.hex -o ./firmware/build/rusefi.dfu
+     
+
+    # The next two steps upload the bin, elf, and dfu as build artifacts
     - name: Upload elf
       uses: actions/upload-artifact@v1
       with:
@@ -111,3 +128,9 @@ jobs:
       with:
         name: firmware-${{matrix.build-target}}-${{matrix.build-type}}-bin
         path: ./firmware/build/rusefi.bin
+
+    - name: Upload dfu
+      uses: actions/upload-artifact@v1
+      with:
+        name: firmware-${{matrix.build-target}}-${{matrix.build-type}}-dfu
+        path: ./firmware/build/rusefi.dfu

--- a/firmware/gen_config.bat
+++ b/firmware/gen_config.bat
@@ -1,6 +1,6 @@
 @echo off
 if exist C:\cygwin64 (
- C:\cygwin64\bin\bash.exe gen_config.sh
+ C:\cygwin64\bin\sh.exe gen_config.sh
 ) else (
- if exist C:\cygwin ( C:\cygwin\bin\bash.exe gen_config.sh )
+ if exist C:\cygwin ( C:\cygwin\bin\sh.exe gen_config.sh )
 )

--- a/firmware/gen_config.bat
+++ b/firmware/gen_config.bat
@@ -1,63 +1,6 @@
 @echo off
-rem This batch files reads rusefi_config.txt and produses firmware persistent configuration headers
-rem the storage section of rusefi.ini is updated as well
-
-rm gen_config.log
-rm gen_config_board.log
-
-rem lazy is broken - TS input is not considered a change
-rm build/config.gen
-
-mkdir build
-
-java -DSystemOut.name=gen_config ^
- -Drusefi.generator.lazyfile.enabled=true ^
- -jar ../java_tools/ConfigDefinition.jar ^
- -definition integration\rusefi_config.txt ^
- -romraider integration ^
- -ts_destination tunerstudio ^
- -with_c_defines false ^
- -initialize_to_zero false ^
- -tool gen_config.bat ^
- -c_defines        controllers\generated\rusefi_generated.h ^
- -firing_order controllers/algo/firing_order.h ^
- -c_destination    controllers\generated\engine_configuration_generated_structures.h ^
- -c_fsio_constants controllers\generated\fsio_enums_generated.def ^
- -c_fsio_getters   controllers\generated\fsio_getters.def ^
- -c_fsio_names     controllers\generated\fsio_names.def ^
- -c_fsio_strings   controllers\generated\fsio_strings.def ^
- -java_destination ../java_console/models/src/com/rusefi/config/generated/Fields.java ^
- -romraider_destination ../java_console/rusefi.xml
-
-IF NOT ERRORLEVEL 0 echo ERROR generating
-IF NOT ERRORLEVEL 0 EXIT /B 1
-
-
-rem This would automatically copy latest file to 'dev' TS project
-set ts_path="%HOMEDRIVE%%HOMEPATH%\Documents\TunerStudioProjects"
-echo %ts_path%
-cp tunerstudio/rusefi.ini %ts_path%\dev\projectCfg\mainController.ini
-cp tunerstudio/rusefi_microrusefi.ini %ts_path%\dev_mre\projectCfg\mainController.ini
-
-call gen_config_board microrusefi
-IF NOT ERRORLEVEL 0 echo ERROR generating
-IF NOT ERRORLEVEL 0 EXIT /B 1
-
-call gen_config_board frankenso
-IF NOT ERRORLEVEL 0 echo ERROR generating
-IF NOT ERRORLEVEL 0 EXIT /B 1
-
-call gen_config_board prometheus
-IF NOT ERRORLEVEL 0 echo ERROR generating
-IF NOT ERRORLEVEL 0 EXIT /B 1
-
-call gen_config_board proteus
-IF NOT ERRORLEVEL 0 echo ERROR generating
-IF NOT ERRORLEVEL 0 EXIT /B 1
-
-
-cd config\boards\kinetis\config
-call !gen_config.bat
-pwd
-
-call gen_enum_to_string.bat
+if exist C:\cygwin64 (
+ C:\cygwin64\bin\bash.exe gen_config.sh
+) else (
+ if exist C:\cygwin ( C:\cygwin\bin\bash.exe gen_config.sh )
+)

--- a/firmware/gen_config.conf
+++ b/firmware/gen_config.conf
@@ -1,0 +1,18 @@
+-DSystemOut.name=gen_config
+-Drusefi.generator.lazyfile.enabled=true
+-jar ../java_tools/ConfigDefinition.jar
+-definition integration/rusefi_config.txt
+-romraider integration
+-ts_destination tunerstudio
+-with_c_defines false
+-initialize_to_zero false
+-tool gen_config.sh
+-c_defines        controllers/generated/rusefi_generated.h
+-firing_order     controllers/algo/firing_order.h
+-c_destination    controllers/generated/engine_configuration_generated_structures.h
+-c_fsio_constants controllers/generated/fsio_enums_generated.def
+-c_fsio_getters   controllers/generated/fsio_getters.def
+-c_fsio_names     controllers/generated/fsio_names.def
+-c_fsio_strings   controllers/generated/fsio_strings.def
+-java_destination ../java_console/models/src/com/rusefi/config/generated/Fields.java
+-romraider_destination ../java_console/rusefi.xml

--- a/firmware/gen_config.sh
+++ b/firmware/gen_config.sh
@@ -26,13 +26,13 @@ else
 	cp -v tunerstudio/rusefi_microrusefi.ini $TS_PATH/dev_mre/projectCfg/mainController.ini
 fi
 
-./gen_config_board.sh microrusefi
+sh gen_config_board.sh microrusefi
 [ $? -eq 0 ] || (echo "ERROR generating microrusefi"; exit $?)
 
-./gen_config_board.sh frankenso
+sh gen_config_board.sh frankenso
 [ $? -eq 0 ] || (echo "ERROR generating frankenso"; exit $?)
 
-./gen_config_board.sh prometheus
+sh gen_config_board.sh prometheus
 [ $? -eq 0 ] || (echo "ERROR generating prometheus"; exit $?)
 
 #cd config\boards\kinetis\config

--- a/firmware/gen_config.sh
+++ b/firmware/gen_config.sh
@@ -14,24 +14,7 @@ rm build/config.gen
 
 mkdir build
 
-java -DSystemOut.name=gen_config \
-	-Drusefi.generator.lazyfile.enabled=true \
-	-jar ../java_tools/ConfigDefinition.jar \
-	-definition integration/rusefi_config.txt \
-	-romraider integration \
-	-ts_destination tunerstudio \
-	-with_c_defines false \
-	-initialize_to_zero false \
-	-tool gen_config.sh \
-	-c_defines        controllers/generated/rusefi_generated.h \
-	-firing_order 	  controllers/algo/firing_order.h \
-	-c_destination    controllers/generated/engine_configuration_generated_structures.h \
-	-c_fsio_constants controllers/generated/fsio_enums_generated.def \
-	-c_fsio_getters   controllers/generated/fsio_getters.def \
-	-c_fsio_names     controllers/generated/fsio_names.def \
-	-c_fsio_strings   controllers/generated/fsio_strings.def \
-	-java_destination ../java_console/models/src/com/rusefi/config/generated/Fields.java \
-	-romraider_destination ../java_console/rusefi.xml
+java $(< gen_config.conf)
 
 [ $? -eq 0 ] || (echo "ERROR generating"; exit $?)
 


### PR DESCRIPTION
All the parameters to be passed to java are now in gen_config.conf.
gen_config.bat just calls gen_config.sh.
It checks whether C:\cygwin or C:\cygwin64 exists. Are there any situation in which one of these would not be true?