### PR TITLE
Fix set date

### DIFF
--- a/.github/workflows/set-date.yaml
+++ b/.github/workflows/set-date.yaml
@@ -14,6 +14,7 @@ on:
 jobs:
   update-date:
     runs-on: ubuntu-latest
+    if: ${{ github.repository == 'rusefi/rusefi' }}
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
This should make it so the set_date workflow only runs on the rusefi/rusefi repo, not forks