### PR TITLE
fix maf gauge scaling

### DIFF
--- a/firmware/console/binary/tunerstudio_outputs.h
+++ b/firmware/console/binary/tunerstudio_outputs.h
@@ -95,7 +95,7 @@ typedef struct {
 
 	// air flow/mass measurment
 	scaled_voltage massAirFlowVoltage; // 26
-	scaled_channel<uint16_t, 10> massAirFlow; // 28
+	scaled_channel<uint16_t, PACK_MULT_MASS_FLOW> massAirFlow; // 28
 	scaled_pressure manifoldAirPressure; // 30
 	scaled_pressure baroPressure; // 32
 

--- a/firmware/console/binary/tunerstudio_outputs.h
+++ b/firmware/console/binary/tunerstudio_outputs.h
@@ -95,7 +95,7 @@ typedef struct {
 
 	// air flow/mass measurment
 	scaled_voltage massAirFlowVoltage; // 26
-	scaled_channel<uint16_t, 100> massAirFlow; // 28
+	scaled_channel<uint16_t, 10> massAirFlow; // 28
 	scaled_pressure manifoldAirPressure; // 30
 	scaled_pressure baroPressure; // 32
 

--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -152,6 +152,7 @@ struct_no_prefix engine_configuration_s
 #define PACK_MULT_AFR 1000
 #define PACK_MULT_ANGLE 50
 #define PACK_MULT_VOLTAGE 1000
+#define PACK_MULT_MASS_FLOW 10
 #define TPS_1_BYTE_PACKING_MULT 2
 #define LOAD_1_BYTE_PACKING_MULT 2
 #define FSIO_TABLE_8 8

--- a/firmware/tunerstudio/rusefi.input
+++ b/firmware/tunerstudio/rusefi.input
@@ -233,7 +233,7 @@ enable2ndByteCanID = false
 
 ; air flow/mass measurments
       MAFValue        = scalar,  U16,     26,        "V",,{1/@@PACK_MULT_VOLTAGE@@},,         0
-      massAirFlowValue= scalar,  U16,     28,     "Kg/h", 0.1,         0
+      massAirFlowValue= scalar,  U16,     28,     "Kg/h", {1/@@PACK_MULT_MASS_FLOW@@},         0
       MAPValue        = scalar,  U16,     30,     "kPa",{1/@@PACK_MULT_PRESSURE@@},       0.0
       baroPressure    = scalar,  U16,     32,     "kPa",{1/@@PACK_MULT_PRESSURE@@},       0.0
       AFRValue        = scalar,  U16,     34,      "AFR",,{1/@@PACK_MULT_AFR@@},,       0.0

--- a/firmware/tunerstudio/rusefi.input
+++ b/firmware/tunerstudio/rusefi.input
@@ -233,7 +233,7 @@ enable2ndByteCanID = false
 
 ; air flow/mass measurments
       MAFValue        = scalar,  U16,     26,        "V",,{1/@@PACK_MULT_VOLTAGE@@},,         0
-      massAirFlowValue= scalar,  U16,     28,     "Kg/h", 0.01,         0
+      massAirFlowValue= scalar,  U16,     28,     "Kg/h", 0.1,         0
       MAPValue        = scalar,  U16,     30,     "kPa",{1/@@PACK_MULT_PRESSURE@@},       0.0
       baroPressure    = scalar,  U16,     32,     "kPa",{1/@@PACK_MULT_PRESSURE@@},       0.0
       AFRValue        = scalar,  U16,     34,      "AFR",,{1/@@PACK_MULT_AFR@@},,       0.0


### PR DESCRIPTION
Previously only supported up to 655.35kg/h of airflow, which is only about 400hp worth of air.  Now we support 4000hp worth of air!