### PR TITLE
Switch TS tables to use new axes

### DIFF
--- a/firmware/controllers/actuators/aux_pid.cpp
+++ b/firmware/controllers/actuators/aux_pid.cpp
@@ -83,7 +83,7 @@ public:
 
 
 			float value = engine->triggerCentral.getVVTPosition();
-			float targetValue = table->getValue(rpm, getEngineLoadT(PASS_ENGINE_PARAMETER_SIGNATURE));
+			float targetValue = table->getValue(rpm, getFuelingLoad(PASS_ENGINE_PARAMETER_SIGNATURE));
 
 			percent_t pwm = auxPid.getOutput(targetValue, value);
 			if (engineConfiguration->isVerboseAuxPid1) {

--- a/firmware/controllers/actuators/idle_thread.cpp
+++ b/firmware/controllers/actuators/idle_thread.cpp
@@ -338,7 +338,7 @@ static percent_t automaticIdleController(float tpsPos DECLARE_ENGINE_PARAMETER_S
 
 	// Apply PID Multiplier if used
 	if (CONFIG(useIacPidMultTable)) {
-		float engineLoad = getEngineLoadT(PASS_ENGINE_PARAMETER_SIGNATURE);
+		float engineLoad = getFuelingLoad(PASS_ENGINE_PARAMETER_SIGNATURE);
 		float multCoef = iacPidMultMap.getValue(rpm / RPM_1_BYTE_PACKING_MULT, engineLoad);
 		// PID can be completely disabled of multCoef==0, or it just works as usual if multCoef==1
 		newValue = interpolateClamped(0.0f, engine->engineState.idle.baseIdlePosition, 1.0f, newValue, multCoef);

--- a/firmware/controllers/algo/fuel_math.cpp
+++ b/firmware/controllers/algo/fuel_math.cpp
@@ -264,17 +264,22 @@ angle_t getInjectionOffset(float rpm DECLARE_ENGINE_PARAMETER_SUFFIX) {
 	if (cisnan(rpm)) {
 		return 0; // error already reported
 	}
-	float engineLoad = getEngineLoadT(PASS_ENGINE_PARAMETER_SIGNATURE);
+
+	float engineLoad = getFuelingLoad(PASS_ENGINE_PARAMETER_SIGNATURE);
+
 	if (cisnan(engineLoad)) {
 		return 0; // error already reported
 	}
+
 	angle_t value = fuelPhaseMap.getValue(rpm, engineLoad);
+
 	if (cisnan(value)) {
 		// we could be here while resetting configuration for example
 		warning(CUSTOM_ERR_6569, "phase map not ready");
 		return 0;
 	}
-	angle_t result =  value + CONFIG(extraInjectionOffset);
+
+	angle_t result = value + CONFIG(extraInjectionOffset);
 	fixAngle(result, "inj offset#2", CUSTOM_ERR_6553);
 	return result;
 }

--- a/firmware/tunerstudio/rusefi.input
+++ b/firmware/tunerstudio/rusefi.input
@@ -840,7 +840,7 @@ enable2ndByteCanID = false
 #if tuneByTPS
       yBins       = ignitionTpsBins,  TPSValue
 #else
-      yBins       = veLoadBins,  MAPValue
+      yBins       = veLoadBins,  fuelingLoad
 #endif
       zBins       = veTable
 ;      gridHeight  = 2.0

--- a/firmware/tunerstudio/rusefi.input
+++ b/firmware/tunerstudio/rusefi.input
@@ -377,7 +377,6 @@ enable2ndByteCanID = false
 
       egoCorrection   = { 100 }
       time            = { timeNow }
-;      engineLoad      = { fuleAlgorithm == 0 ? MAF : TPS }
 
 	; These "synthetic" channels provide the Y-axis (load) value for gen purp PWM table's Y axes
 	gppwm1_load = {(gppwm1_loadAxis == 0) ? TPSValue : ((gppwm1_loadAxis == 1) ? MAPValue : ((gppwm1_loadAxis == 2) ? coolant : intake))}
@@ -773,22 +772,22 @@ enable2ndByteCanID = false
       
    table = fsioTable1Tbl,  fsioTable1Map,  "FSIO Table #1",   1
       xBins       = fsioTable1RpmBins,  RPMValue
-      yBins       = fsioTable1LoadBins,  engineLoad
+      yBins       = fsioTable1LoadBins,  fuelingLoad
       zBins       = fsioTable1
 
    table = fsioTable2Tbl,  fsioTable2Map,  "FSIO Table #2",   1
       xBins       = fsioTable2RpmBins,  RPMValue
-      yBins       = fsioTable2LoadBins,  engineLoad
+      yBins       = fsioTable2LoadBins,  fuelingLoad
       zBins       = fsioTable2
 
    table = fsioTable3Tbl,  fsioTable3Map,  "FSIO Table #3",   1
       xBins       = fsioTable3RpmBins,  RPMValue
-      yBins       = fsioTable3LoadBins,  engineLoad
+      yBins       = fsioTable3LoadBins,  fuelingLoad
       zBins       = fsioTable3
 
    table = fsioTable4Tbl,  fsioTable4Map,  "FSIO Table #4",   1
       xBins       = fsioTable4RpmBins,  RPMValue
-      yBins       = fsioTable4LoadBins,  engineLoad
+      yBins       = fsioTable4LoadBins,  fuelingLoad
       zBins       = fsioTable4
 
    table = baroCorrTbl,  baroCorrMap,  "Baro Correction",   1
@@ -853,7 +852,7 @@ enable2ndByteCanID = false
    		topicHelp = "fuelHelp"
       ;       constant, variable
       xBins       = injPhaseRpmBins,  RPMValue
-      yBins       = injPhaseLoadBins,  engineLoad
+      yBins       = injPhaseLoadBins,  fuelingLoad
       zBins       = injectionPhase
 ;      gridHeight  = 2.0
       gridOrient  = 250,   0, 340 ; Space 123 rotation of grid in degrees.
@@ -872,7 +871,7 @@ enable2ndByteCanID = false
    table = afrTableTbl,  afrTableMap,  "Target AFR Table",   1
       ;       constant, variable
       xBins       = afrRpmBins,  RPMValue
-      yBins       = afrLoadBins,  MAPValue
+      yBins       = afrLoadBins,  fuelingLoad
       zBins       = afrTable
 ;      gridHeight  = 2.0
       gridOrient  = 250,   0, 340 ; Space 123 rotation of grid in degrees.
@@ -881,7 +880,7 @@ enable2ndByteCanID = false
    table = iacPidMultTbl,  iacPidMultMap,  "IAC PID Multiplier Table",   1
       ;       constant, variable
       xBins       = iacPidMultRpmBins,  RPMValue
-      yBins       = iacPidMultLoadBins,  engineLoad
+      yBins       = iacPidMultLoadBins,  fuelingLoad
       zBins       = iacPidMultTable
 ;      gridHeight  = 2.0
       gridOrient  = 250,   0, 340 ; Space 123 rotation of grid in degrees.


### PR DESCRIPTION
Start switching tables over to use the new fuelingLoad channel.