### PR TITLE
always generate default config

### DIFF
--- a/.github/workflows/build-firmware.yaml
+++ b/.github/workflows/build-firmware.yaml
@@ -80,6 +80,10 @@ jobs:
           bash gen_config_board.sh ${{matrix.folder}} ${{matrix.build-target}}
         fi
 
+    - name: Generate Default config
+      working-directory: ./firmware/
+      run: bash gen_config_default.sh
+
     - name: Generate Live Documentation
       working-directory: ./firmware/
       run: bash gen_live_documentation.sh


### PR DESCRIPTION
For some reason gen_config_board.sh doesn't update changes made to TunerStudioOutputChannels.
If someone else who knows more about ConfigDefinition wants to add that to gen_config_board, go ahead, but for now here is a workaround.