### PR TITLE
reduce crosstalk between tests

### DIFF
--- a/firmware/controllers/engine_cycle/map_averaging.cpp
+++ b/firmware/controllers/engine_cycle/map_averaging.cpp
@@ -350,11 +350,11 @@ float getMap(void) {
 void initMapAveraging(Logging *sharedLogger DECLARE_ENGINE_PARAMETER_SUFFIX) {
 	logger = sharedLogger;
 
+#if !EFI_UNIT_TEST
 #if EFI_SHAFT_POSITION_INPUT
 	addTriggerEventListener(&mapAveragingTriggerCallback, "MAP averaging", engine);
 #endif /* EFI_SHAFT_POSITION_INPUT */
 
-#if !EFI_UNIT_TEST
 	addConsoleAction("faststat", showMapStats);
 #endif /* EFI_UNIT_TEST */
 

--- a/firmware/controllers/engine_cycle/rpm_calculator.cpp
+++ b/firmware/controllers/engine_cycle/rpm_calculator.cpp
@@ -358,7 +358,9 @@ void initRpmCalculator(Logging *sharedLogger DECLARE_ENGINE_PARAMETER_SUFFIX) {
 		return;
 	}
 
+#if !EFI_UNIT_TEST
 	addTriggerEventListener(tdcMarkCallback, "chart TDC mark", engine);
+#endif
 
 	addTriggerEventListener(rpmShaftPositionCallback, "rpm reporter", engine);
 }

--- a/firmware/controllers/system/timer/event_queue.cpp
+++ b/firmware/controllers/system/timer/event_queue.cpp
@@ -209,5 +209,18 @@ scheduling_s *EventQueue::getElementAtIndexForUnitText(int index) {
 }
 
 void EventQueue::clear(void) {
+	// Flush the queue, resetting all scheduling_s as though we'd executed them
+	while(head) {
+		auto x = head;
+		// link next element to head
+		head = x->nextScheduling_s;
+
+		// Reset this element
+		x->momentX = 0;
+		x->isScheduled = false;
+		x->nextScheduling_s = nullptr;
+		x->action = {};
+	}
+
 	head = nullptr;
 }

--- a/unit_tests/global_execution_queue.cpp
+++ b/unit_tests/global_execution_queue.cpp
@@ -10,6 +10,11 @@
 bool_t debugSignalExecutor = false;
 extern bool verboseMode;
 
+TestExecutor::~TestExecutor() {
+	// Flush the queue and reset all scheduling_s at the end of a test's execution
+	clear();
+}
+
 void TestExecutor::scheduleForLater(scheduling_s *scheduling, int delayUs, action_s action) {
 	if (debugSignalExecutor) {
 		printf("scheduleTask %d\r\n", delayUs);

--- a/unit_tests/global_execution_queue.h
+++ b/unit_tests/global_execution_queue.h
@@ -12,6 +12,8 @@
 
 class TestExecutor : public ExecutorInterface {
 public:
+	~TestExecutor();
+
 	void scheduleByTimestamp(scheduling_s *scheduling, efitimeus_t timeUs, action_s action) override;
 	void scheduleByTimestampNt(scheduling_s *scheduling, efitick_t timeNt, action_s action) override;
 	void scheduleForLater(scheduling_s *scheduling, int delayUs, action_s action) override;


### PR DESCRIPTION
Found while debugging #1632, some tests were spilling state in to others via instances of `scheduling_s` that are statically allocated, and therefore used by multiple tests.

This change adds a flush to clean up those leftover instances, then fixes the behavior of the offending events.