### PR TITLE
More Kicad Diff changes

### DIFF
--- a/.github/workflows/gen-diffs.yaml
+++ b/.github/workflows/gen-diffs.yaml
@@ -15,11 +15,11 @@ jobs:
         submodules: recursive
         fetch-depth: 0
 
-    - name: Install ncftp, kicad, and tk bindings
+    - name: Install lftp, kicad, and tk bindings
       run: |
         sudo add-apt-repository ppa:js-reynaud/kicad-5.1
         sudo apt-get update
-        sudo apt-get install ncftp kicad python3-tk
+        sudo apt-get install lftp kicad python3-tk
 
     - name: Get KiCad-Diff
       run: git clone https://github.com/Gasman2014/KiCad-Diff.git

--- a/.github/workflows/gen-diffs.yaml
+++ b/.github/workflows/gen-diffs.yaml
@@ -22,7 +22,7 @@ jobs:
         sudo apt-get install lftp kicad python3-tk
 
     - name: Get KiCad-Diff
-      run: git clone https://github.com/Gasman2014/KiCad-Diff.git
+      run: git clone https://github.com/chuckwagoncomputing/KiCad-Diff.git
 
     - name: Set FTP variables
       run: |

--- a/hardware/generate_diffs.sh
+++ b/hardware/generate_diffs.sh
@@ -13,8 +13,7 @@
 function gendiffs() {
   ../KiCad-Diff/kidiff_linux.py -w -s Git -b $(git rev-parse --short HEAD~1) -a $(git rev-parse --short HEAD) -d :0 $1
   if [ -d $(dirname "$1")/plots ] && [ -n "$RUSEFI_FTP_SERVER" ]; then
-    echo "mkdir diffs/plots_$(basename "$1" .kicad_pcb)" | ncftp -u "$RUSEFI_DOXYGEN_FTP_USER" -p "$RUSEFI_DOXYGEN_FTP_PASS" "$RUSEFI_FTP_SERVER"
-    ncftpput -R -v -u "$RUSEFI_DOXYGEN_FTP_USER" -p "$RUSEFI_DOXYGEN_FTP_PASS" "$RUSEFI_FTP_SERVER" /diffs/plots_$(basename "$1" .kicad_pcb) $(dirname "$1")/plots
+    lftp -u "$RUSEFI_DOXYGEN_FTP_USER","$RUSEFI_DOXYGEN_FTP_PASS" "$RUSEFI_FTP_SERVER" -c "mirror -Re $(dirname "$1")/plots/ /diffs/plots_$(basename "$1" .kicad_pcb); exit"
   fi
 }
 export -f gendiffs

--- a/hardware/generate_diffs.sh
+++ b/hardware/generate_diffs.sh
@@ -10,15 +10,11 @@
 # which contains index.html. Open that in a web browser and you get a nice visual diff of each layer.
 #!/bin/bash
 
-if [ "$1" == "release" ]; then
-  SUFFIX="_release"
-fi
-
 function gendiffs() {
   ../KiCad-Diff/kidiff_linux.py -w -s Git -b $(git rev-parse --short HEAD~1) -a $(git rev-parse --short HEAD) -d :0 $1
   if [ -d $(dirname "$1")/plots ] && [ -n "$RUSEFI_FTP_SERVER" ]; then
     lftp -u "$RUSEFI_DOXYGEN_FTP_USER","$RUSEFI_DOXYGEN_FTP_PASS" "$RUSEFI_FTP_SERVER" -c \
-      "mirror -Re $(dirname "$1")/plots/ /diffs/plots_$(basename "$1" .kicad_pcb)${SUFFIX}; exit"
+      "mirror -Re $(dirname "$1")/plots/ /diffs/plots_$(basename "$1" .kicad_pcb); exit"
   fi
 }
 export -f gendiffs

--- a/hardware/generate_diffs.sh
+++ b/hardware/generate_diffs.sh
@@ -10,10 +10,15 @@
 # which contains index.html. Open that in a web browser and you get a nice visual diff of each layer.
 #!/bin/bash
 
+if [ "$1" == "release" ]; then
+  SUFFIX="_release"
+fi
+
 function gendiffs() {
   ../KiCad-Diff/kidiff_linux.py -w -s Git -b $(git rev-parse --short HEAD~1) -a $(git rev-parse --short HEAD) -d :0 $1
   if [ -d $(dirname "$1")/plots ] && [ -n "$RUSEFI_FTP_SERVER" ]; then
-    lftp -u "$RUSEFI_DOXYGEN_FTP_USER","$RUSEFI_DOXYGEN_FTP_PASS" "$RUSEFI_FTP_SERVER" -c "mirror -Re $(dirname "$1")/plots/ /diffs/plots_$(basename "$1" .kicad_pcb); exit"
+    lftp -u "$RUSEFI_DOXYGEN_FTP_USER","$RUSEFI_DOXYGEN_FTP_PASS" "$RUSEFI_FTP_SERVER" -c \
+      "mirror -Re $(dirname "$1")/plots/ /diffs/plots_$(basename "$1" .kicad_pcb)${SUFFIX}; exit"
   fi
 }
 export -f gendiffs

--- a/hardware/generate_diffs.sh
+++ b/hardware/generate_diffs.sh
@@ -13,7 +13,7 @@
 function gendiffs() {
   ../KiCad-Diff/kidiff_linux.py -w -s Git -b $(git rev-parse --short HEAD~1) -a $(git rev-parse --short HEAD) -d :0 $1
   if [ -d $(dirname "$1")/plots ] && [ -n "$RUSEFI_FTP_SERVER" ]; then
-    lftp -u "$RUSEFI_DOXYGEN_FTP_USER","$RUSEFI_DOXYGEN_FTP_PASS" "$RUSEFI_FTP_SERVER" -c \
+    lftp -u "$RUSEFI_DOXYGEN_FTP_USER","$RUSEFI_DOXYGEN_FTP_PASS" "$RUSEFI_FTP_SERVER" -e \
       "mirror -Re $(dirname "$1")/plots/ /diffs/plots_$(basename "$1" .kicad_pcb); exit"
   fi
 }


### PR DESCRIPTION
Problems:
1: Files were going in a 'plots' subdirectory of plots_<board name>, which was not intended
2: Files from previous changes would remain behind and take up disk space without having a index.html to make them usable.
    With this change, old files are deleted. To make this happen, I switched from ncftp to lftp.
3: If any .kicad_pcb file changed, diffs were generated and uploaded for all .kicad_pcb files. This was an apparent bug in
    KiCad-Diff. I'm using a fork in my own repo for now.