### PR TITLE
Sync wiki to rusefi_documentation.

### DIFF
--- a/.github/workflows/sync-wiki.yaml
+++ b/.github/workflows/sync-wiki.yaml
@@ -25,5 +25,5 @@ jobs:
       uses: ad-m/github-push-action@master
       with:
         repository: chuckwagoncomputing/rusefi_documentation
-        github_token: ${{ github.token }}
+        github_token: ${{ secrets.ACCESS_TOKEN }}
         branch: master

--- a/.github/workflows/sync-wiki.yaml
+++ b/.github/workflows/sync-wiki.yaml
@@ -1,0 +1,13 @@
+name: Sync Wiki
+
+on: gollum
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Check Out Wiki
+    - uses: actions/checkout@v2
+      with:
+        repository: rusefi/rusefi.wiki

--- a/.github/workflows/sync-wiki.yaml
+++ b/.github/workflows/sync-wiki.yaml
@@ -17,7 +17,7 @@ jobs:
       run: |
         git remote add best-wiki-git https://github.com/rusefi/rusefi.wiki.git
         git fetch best-wiki-git
-	git merge best-wiki-git/master
+        git merge best-wiki-git/master
         git config --local user.email "action@github.com"
         git config --local user.name "GitHub Action"
         git commit -m "Merge changes from wiki" -a

--- a/.github/workflows/sync-wiki.yaml
+++ b/.github/workflows/sync-wiki.yaml
@@ -8,6 +8,6 @@ jobs:
 
     steps:
     - name: Check Out Wiki
-    - uses: actions/checkout@v2
+      uses: actions/checkout@v2
       with:
         repository: rusefi/rusefi.wiki

--- a/.github/workflows/sync-wiki.yaml
+++ b/.github/workflows/sync-wiki.yaml
@@ -17,9 +17,9 @@ jobs:
       run: |
         git remote add best-wiki-git https://github.com/rusefi/rusefi.wiki.git
         git fetch best-wiki-git
-        git merge best-wiki-git/master
         git config --local user.email "action@github.com"
         git config --local user.name "GitHub Action"
+        git merge best-wiki-git/master
         git commit -m "Merge changes from wiki" -a
 
     - name: Push changes

--- a/.github/workflows/sync-wiki.yaml
+++ b/.github/workflows/sync-wiki.yaml
@@ -12,6 +12,7 @@ jobs:
       with:
         fetch-depth: 0
         repository: chuckwagoncomputing/rusefi_documentation
+        persist-credentials: false
 
     - name: Merge
       run: |

--- a/.github/workflows/sync-wiki.yaml
+++ b/.github/workflows/sync-wiki.yaml
@@ -20,7 +20,6 @@ jobs:
         git config --local user.email "action@github.com"
         git config --local user.name "GitHub Action"
         git merge best-wiki-git/master
-        git commit -m "Merge changes from wiki" -a
 
     - name: Push changes
       uses: ad-m/github-push-action@master

--- a/.github/workflows/sync-wiki.yaml
+++ b/.github/workflows/sync-wiki.yaml
@@ -20,9 +20,4 @@ jobs:
         git config --local user.email "action@github.com"
         git config --local user.name "GitHub Action"
         git merge best-wiki-git/master
-
-    - name: Push changes
-      uses: ad-m/github-push-action@master
-      with:
-        github_token: ${{ github.token }}
-        branch: master
+	git push

--- a/.github/workflows/sync-wiki.yaml
+++ b/.github/workflows/sync-wiki.yaml
@@ -20,4 +20,4 @@ jobs:
         git config --local user.email "action@github.com"
         git config --local user.name "GitHub Action"
         git merge best-wiki-git/master
-	git push
+        git push

--- a/.github/workflows/sync-wiki.yaml
+++ b/.github/workflows/sync-wiki.yaml
@@ -20,4 +20,10 @@ jobs:
         git config --local user.email "action@github.com"
         git config --local user.name "GitHub Action"
         git merge best-wiki-git/master
-        git push
+
+    - name: Push changes
+      uses: ad-m/github-push-action@master
+      with:
+        repository: chuckwagoncomputing/rusefi_documentation
+        github_token: ${{ github.token }}
+        branch: master

--- a/.github/workflows/sync-wiki.yaml
+++ b/.github/workflows/sync-wiki.yaml
@@ -7,7 +7,23 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Check Out Wiki
+    - name: Check out docs repo
       uses: actions/checkout@v2
       with:
-        repository: rusefi/rusefi.wiki
+        fetch-depth: 0
+        repository: chuckwagoncomputing/rusefi_documentation
+
+    - name: Merge
+      run: |
+        git remote add best-wiki-git https://github.com/rusefi/rusefi.wiki.git
+        git fetch best-wiki-git
+	git merge best-wiki-git/master
+        git config --local user.email "action@github.com"
+        git config --local user.name "GitHub Action"
+        git commit -m "Merge changes from wiki" -a
+
+    - name: Push changes
+      uses: ad-m/github-push-action@master
+      with:
+        github_token: ${{ github.token }}
+        branch: master

--- a/.github/workflows/sync-wiki.yaml
+++ b/.github/workflows/sync-wiki.yaml
@@ -11,7 +11,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
-        repository: chuckwagoncomputing/rusefi_documentation
+        repository: rusefi/rusefi_documentation
         persist-credentials: false
 
     - name: Merge
@@ -25,6 +25,6 @@ jobs:
     - name: Push changes
       uses: ad-m/github-push-action@master
       with:
-        repository: chuckwagoncomputing/rusefi_documentation
+        repository: rusefi/rusefi_documentation
         github_token: ${{ secrets.ACCESS_TOKEN }}
         branch: master


### PR DESCRIPTION
This requires setting up a Personal Access Token (I think in organization settings?).
Set the token as a Secret for the repository, and call it ACCESS_TOKEN.
This action runs whenever the wiki on this repo is edited, and merges the changes to rusefi_documentation.