### PR TITLE
Fuel ts reorder

### DIFF
--- a/firmware/controllers/bench_test.cpp
+++ b/firmware/controllers/bench_test.cpp
@@ -290,11 +290,13 @@ static void handleCommandX14(uint16_t index) {
 void executeTSCommand(uint16_t subsystem, uint16_t index) {
 	scheduleMsg(logger, "IO test subsystem=%d index=%d", subsystem, index);
 
+	bool running = !ENGINE(rpmCalculator).isStopped();
+
     if (subsystem == 0x11) {
         clearWarnings();
-	} else if (subsystem == 0x12) {
+	} else if (subsystem == 0x12 && !running) {
 		doRunSpark(index, "300", "4", "400", "3");
-	} else if (subsystem == 0x13) {
+	} else if (subsystem == 0x13 && !running) {
 		doRunFuel(index, "300", "4", "400", "3");
 	} else if (subsystem == 0x14) {
 		handleCommandX14(index);

--- a/firmware/tunerstudio/rusefi.input
+++ b/firmware/tunerstudio/rusefi.input
@@ -1196,29 +1196,29 @@ menuDialog = main
 	menu = "Fuel"
 		# basic
 		subMenu = injectionSettings,		"Injection settings"
-		subMenu = injectionDeadTime,		"Injector dead time", 0, {isInjectionEnabled == 1}
 		subMenu = std_separator
 
-		# Targets & closed loop
+		# Air mass model
+		subMenu = veTableDialog,			"VE", 0, {isInjectionEnabled == 1}
+		subMenu = tChargeSettings,			"Charge temperature estimation", 0, {isInjectionEnabled == 1}
+		subMenu = baroCorrTbl,				"Barometric pressure correction", 0, {isInjectionEnabled == 1 && fuelAlgorithm == LM_SPEED_DENSITY}
+		subMenu = std_separator
+
+		# Fuel model
 		subMenu = afrTableTbl,				"Target AFR", 0, {isInjectionEnabled == 1}
 		subMenu = fuelClosedLoopDialog, 	"Closed loop fuel correction", 0, {isInjectionEnabled == 1}
 		subMenu = coastingFuelCutControl, 	"Deceleration fuel cutoff (DFCO)", 0, {isInjectionEnabled == 1}
+		subMenu = cltFuelCorrCurve,			"CLT multiplier", 0, {isInjectionEnabled == 1}
+		subMenu = iatFuelCorrCurve,			"IAT multiplier", 0, {isInjectionEnabled == 1}
 		subMenu = std_separator
 
-		# Fuel table/VE
-		subMenu = veTableDialog,			"VE", 0, {isInjectionEnabled == 1}
+		# Injector model
+		subMenu = injectionDeadTime,		"Injector dead time", 0, {isInjectionEnabled == 1}
 		subMenu = injPhaseTableTbl,         "Injection phase", 0, {isInjectionEnabled == 1}
 		subMenu = std_separator
 
-		# Corrections
-		subMenu = cltFuelCorrCurve,			"CLT multiplier", 0, {isInjectionEnabled == 1}
-		subMenu = iatFuelCorrCurve,			"IAT multiplier", 0, {isInjectionEnabled == 1}
-		subMenu = baroCorrTbl,				"Baro multiplier", 0, {isInjectionEnabled == 1 && fuelAlgorithm == LM_SPEED_DENSITY}
-		subMenu = tChargeSettings,			"tCharge settings", 0, {isInjectionEnabled == 1}
-		subMenu = std_separator
-
 		# Accel enrichment
-		subMenu = AccelEnrich,				"Accel/decel enrichment/enleanment", 0, {isInjectionEnabled == 1}
+		subMenu = AccelEnrich,				"Acceleration enrichment", 0, {isInjectionEnabled == 1}
 		subMenu = tpsTpsAccelTbl, 			"TPS/TPS acceleration extra fuel", 0, {isInjectionEnabled == 1}
 		subMenu = mapAccelTaper,			"Engine load AE taper", 0, {isInjectionEnabled == 1}
 

--- a/firmware/tunerstudio/rusefi.input
+++ b/firmware/tunerstudio/rusefi.input
@@ -526,8 +526,8 @@ enable2ndByteCanID = false
 
 	curve = dwellCorrection, "Dwell time RPM based"
       columnLabel = "RPM", "Dwell"
-      xAxis       =  0, 8000, 10
-      yAxis       =  0,  30, 10
+      xAxis       =  0, 8000, 9
+      yAxis       =  0,  8, 9
       xBins       = sparkDwellRpmBins, RPMValue
       yBins       = sparkDwellValues
       gauge       = RPMGauge
@@ -565,7 +565,7 @@ enable2ndByteCanID = false
 
    curve = iatFuelCorrCurve, "Intake air temperature fuel Multiplier"
       columnLabel = "Coolant", "Multiplier"
-      xAxis       =  -40, 120, 10
+      xAxis       =  -40, 120, 9
       yAxis       =  0,  2, 11
       xBins       = iatFuelCorrBins, intake
       yBins       = iatFuelCorr
@@ -573,15 +573,15 @@ enable2ndByteCanID = false
 	
 	curve = cltTimingCorrCurve, "Warmup timing correction"
       columnLabel = "Coolant", "Extra"
-      xAxis       =  -40, 120, 10
-      yAxis       =  0,  50, 10
+      xAxis       =  -40, 120, 9
+      yAxis       =  0,  20, 9
       xBins       = cltTimingBins, coolant
       yBins       = cltTimingExtra
       gauge       = CLTGauge
 
 	curve = cltFuelCorrCurve, "Warmup fuel manual Multiplier"
       columnLabel = "Coolant", "Multiplier"
-      xAxis       =  -40, 100, 10
+      xAxis       =  -40, 120, 9
       yAxis       =  0,  3, 10
       xBins       = cltFuelCorrBins, coolant
       yBins       = cltFuelCorr
@@ -589,7 +589,7 @@ enable2ndByteCanID = false
 
 	curve = crankingCltCurve, "Cranking Coolant Temperature Multiplier"
       columnLabel = "Coolant", "Multiplier"
-      xAxis       =  -40, 100, 10
+      xAxis       =  -40, 120, 9
       yAxis       =  0,  3, 10
       xBins       = crankingFuelBins, coolant
       yBins       = crankingFuelCoef
@@ -605,7 +605,7 @@ enable2ndByteCanID = false
 
 	curve = crankingTpsCurve, "Cranking TPS Multiplier"
       columnLabel = "TPS", "Multiplier"
-      xAxis       =  0, 100, 10
+      xAxis       =  0, 100, 11
       yAxis       =  0,  3, 10
       xBins       = crankingTpsBins, TPSValue
       yBins       = crankingTpsCoef
@@ -613,8 +613,8 @@ enable2ndByteCanID = false
 
 	curve = crankingDurationCurve, "Cranking Duration Multiplier"
       columnLabel = "Engine Cycle", "Multiplier"
-      xAxis       =  0, 1000, 10
-      yAxis       =  0,  3, 10
+      xAxis       =  0, 50, 11
+      yAxis       =  0,  5, 6
       xBins       = crankingCycleBins
       yBins       = crankingCycleCoef
 
@@ -629,7 +629,7 @@ enable2ndByteCanID = false
 
 	curve = iacCoastingCurve, "Coasting IAC Position for Auto-Idle"
       columnLabel = "Coolant", "Multiplier"
-      xAxis       = -40, 120, 10
+      xAxis       = -40, 120, 9
       yAxis       =  0,  100, 10
       xBins       = iacCoastingBins, coolant
       yBins       = iacCoasting
@@ -637,7 +637,7 @@ enable2ndByteCanID = false
 
 	curve = cltCrankingCurve, "Cranking Idle Air multiplier"
       columnLabel = "Coolant", "Multiplier"
-      xAxis       = -40, 120, 10
+      xAxis       = -40, 120, 9
       yAxis       =  0,  3, 10
       xBins       = cltCrankingCorrBins, coolant
       yBins       = cltCrankingCorr
@@ -645,7 +645,7 @@ enable2ndByteCanID = false
 
 	curve = cltIdleRPMCurve, "Idle Target RPM"
       columnLabel = "Coolant", "RPM"
-      xAxis       = -40, 120, 10
+      xAxis       = -40, 120, 9
       yAxis       =  0, 8000, 10
       xBins       = cltIdleRpmBins, coolant
       yBins       = cltIdleRpm, RPMValue

--- a/firmware/tunerstudio/rusefi.input
+++ b/firmware/tunerstudio/rusefi.input
@@ -550,8 +550,8 @@ enable2ndByteCanID = false
 
    curve = injectorsDeadTime, "Injector dead time"
       columnLabel = "Voltage", "Dead Time"
-      xAxis       =  8, 21, 10
-      yAxis       = -3,  3, 10
+      xAxis       =  8, 16, 5
+      yAxis       = 0, 2, 5
       xBins       = injector_battLagCorrBins, VBatt
       yBins       = injector_battLagCorr
       
@@ -1206,10 +1206,10 @@ menuDialog = main
 
 		# Fuel model
 		subMenu = afrTableTbl,				"Target AFR", 0, {isInjectionEnabled == 1}
-		subMenu = fuelClosedLoopDialog, 	"Closed loop fuel correction", 0, {isInjectionEnabled == 1}
-		subMenu = coastingFuelCutControl, 	"Deceleration fuel cutoff (DFCO)", 0, {isInjectionEnabled == 1}
 		subMenu = cltFuelCorrCurve,			"CLT multiplier", 0, {isInjectionEnabled == 1}
 		subMenu = iatFuelCorrCurve,			"IAT multiplier", 0, {isInjectionEnabled == 1}
+		subMenu = fuelClosedLoopDialog, 	"Closed loop fuel correction", 0, {isInjectionEnabled == 1}
+		subMenu = coastingFuelCutControl, 	"Deceleration fuel cutoff (DFCO)", 0, {isInjectionEnabled == 1}
 		subMenu = std_separator
 
 		# Injector model

--- a/firmware/tunerstudio/rusefi.input
+++ b/firmware/tunerstudio/rusefi.input
@@ -548,13 +548,12 @@ enable2ndByteCanID = false
       yBins       = map_samplingWindow
 	  gauge       = MAPGauge
 
-   curve = injectorsDeadTime, "Injector Dead Time by VBatt"
+   curve = injectorsDeadTime, "Injector dead time"
       columnLabel = "Voltage", "Dead Time"
       xAxis       =  8, 21, 10
       yAxis       = -3,  3, 10
       xBins       = injector_battLagCorrBins, VBatt
       yBins       = injector_battLagCorr
-      gauge       = VBattGauge
       
    curve = mafDecodingCurve, "MAF sensor"
       columnLabel = "Voltage", "kg/hour"
@@ -1195,7 +1194,8 @@ menuDialog = main
 
 	menu = "Fuel"
 		# basic
-		subMenu = injectionSettings,		"Injection settings"
+		subMenu = injectorConfig,			"Injection configuration", 0, {isInjectionEnabled == 1}
+		subMenu = injectionSettings,		"Injection hardware"
 		subMenu = std_separator
 
 		# Air mass model
@@ -1213,7 +1213,6 @@ menuDialog = main
 		subMenu = std_separator
 
 		# Injector model
-		subMenu = injectionDeadTime,		"Injector dead time", 0, {isInjectionEnabled == 1}
 		subMenu = injPhaseTableTbl,         "Injection phase", 0, {isInjectionEnabled == 1}
 		subMenu = std_separator
 
@@ -1425,10 +1424,6 @@ cmd_test_inj9  = "@@TS_IO_TEST_COMMAND_char@@\x00\x13\x00\x09"
 cmd_test_inj10 = "@@TS_IO_TEST_COMMAND_char@@\x00\x13\x00\x0a"
 cmd_test_inj11 = "@@TS_IO_TEST_COMMAND_char@@\x00\x13\x00\x0b"
 cmd_test_inj12 = "@@TS_IO_TEST_COMMAND_char@@\x00\x13\x00\x0c"
-cmd_test_inj13 = "@@TS_IO_TEST_COMMAND_char@@\x00\x13\x00\x0d"
-cmd_test_inj14 = "@@TS_IO_TEST_COMMAND_char@@\x00\x13\x00\x0e"
-cmd_test_inj15 = "@@TS_IO_TEST_COMMAND_char@@\x00\x13\x00\x0f"
-cmd_test_inj16 = "@@TS_IO_TEST_COMMAND_char@@\x00\x13\x00\x10"
 
 cmd_test_fuel_pump           = "@@TS_IO_TEST_COMMAND_char@@\x00\x14\x00\x01"
 cmd_calibrate_tps_1_closed   = "@@TS_IO_TEST_COMMAND_char@@\x00\x14\x00\x02"
@@ -1523,8 +1518,6 @@ cmd_set_engine_type_default					= "@@TS_IO_TEST_COMMAND_char@@\x00\x31\x00\x00"
 		field = "#Batch injection with individual wiring"
 		field = "Two wire batch emulation",				twoWireBatchInjection, {isInjectionEnabled == 1 && injectionMode == 2}
 		field = "Use TPS instead of Load for VE table",	useTPSBasedVeTable, {isInjectionEnabled == 1 && fuelAlgorithm == LM_SPEED_DENSITY}
-		field = "#Enabled for TPS-Based 'VE Autotune Mode' in Project Settings"
-		field = "Use TPS instead of Load for VE table",	useTPSBasedVeTable, {0}
 
 	dialog = ignitionOutputs, "Ignition Outputs"
 		field = "Ignition Pin Mode",         	        ignitionPinMode, {isIgnitionEnabled == 1}
@@ -1612,10 +1605,7 @@ cmd_set_engine_type_default					= "@@TS_IO_TEST_COMMAND_char@@\x00\x31\x00\x00"
 		field = "Injector Flow",			injector_flow, {isInjectionEnabled == 1}
 
 	dialog = injectorOutputSettings, "Injector Outputs",	yAxis
-		field = "!ECU reboot needed to apply these settings"
-		field = "injection Pin Mode",       			injectionPinMode, {isInjectionEnabled == 1}
-		field = "With batched injection without 'Two wire batch emulation'"
-		field = "   fill only first count / 2 values"
+		field = "Use only first half of pins for batch mode"
 		field = "Injection Pin 1",						injectionPins1, {isInjectionEnabled == 1}
 		field = "Injection Pin 2",						injectionPins2, {isInjectionEnabled == 1 && injectionMode != 3 && cylindersCount > 1}
 		field = "Injection Pin 3",						injectionPins3, {isInjectionEnabled == 1 && injectionMode != 3 && cylindersCount > 2}
@@ -1627,19 +1617,41 @@ cmd_set_engine_type_default					= "@@TS_IO_TEST_COMMAND_char@@\x00\x31\x00\x00"
 		field = "Injection Pin 9 ",						injectionPins9, {isInjectionEnabled == 1 && cylindersCount > 8}
 		field = "Injection Pin 10 ",	    			injectionPins10, {isInjectionEnabled == 1 && cylindersCount > 9}
 		field = "Injection Pin 11 ",					injectionPins11, {isInjectionEnabled == 1 && cylindersCount > 10}
-		field = "Injection Pin 12 ",					injectionPins12, {isInjectionEnabled == 1 && cylindersCount > 11}	
-	
-	dialog = injectionBasic, ""
+		field = "Injection Pin 12 ",					injectionPins12, {isInjectionEnabled == 1 && cylindersCount > 11}
+		field = ""
+		field = "injection Pin Mode",       			injectionPinMode, {isInjectionEnabled == 1}
+
+	dialog = testInjectors, "Injector Test"
+		commandButton = "Injector #1", cmd_test_inj1
+		commandButton = "Injector #2", cmd_test_inj2
+		commandButton = "Injector #3", cmd_test_inj3
+		commandButton = "Injector #4", cmd_test_inj4
+		commandButton = "Injector #5", cmd_test_inj5
+		commandButton = "Injector #6", cmd_test_inj6
+		commandButton = "Injector #7", cmd_test_inj7
+		commandButton = "Injector #8", cmd_test_inj8
+		commandButton = "Injector #9", cmd_test_inj9
+		commandButton = "Injector #10", cmd_test_inj10
+		commandButton = "Injector #11", cmd_test_inj11
+		commandButton = "Injector #12", cmd_test_inj12
+
+	dialog = injectionSettingsEast, "", yAxis
+		panel = testInjectors
+		field = ""
+
+	dialog = injectionSettingsWest, "", yAxis
+		panel = injectorOutputSettings
+		field = ""
+
+	dialog = injectionSettings, "", xAxis
+        panel = injectionSettingsWest
+		panel = injectionSettingsEast
+
+	dialog = injectorConfig, "", yAxis
 		topicHelp = "fuelHelp"
 		panel = baseInjection
 		panel = injChars
-
-	dialog = injectionSettings, "", xAxis
-        panel = injectionBasic
-        panel = injectorOutputSettings
-
-	dialog = injectionDeadTime,	"", yAxis
-		panel = injectorsDeadTime,		East
+		panel = injectorsDeadTime
 
 	dialog = ignitionCylExtra, "Ignition Cylinder Extra Timing"
 		field = "Extra cyl #1",                       timing_offset_cylinder1
@@ -2881,17 +2893,7 @@ cmd_set_engine_type_default					= "@@TS_IO_TEST_COMMAND_char@@\x00\x31\x00\x00"
 		commandButton = "Spark #6", cmd_test_spk6
 		commandButton = "Spark #7", cmd_test_spk7
 		commandButton = "Spark #8", cmd_test_spk8
-		
-	dialog = testInjectors, "Fuel"
-		commandButton = "Injector #1", cmd_test_inj1
-		commandButton = "Injector #2", cmd_test_inj2
-		commandButton = "Injector #3", cmd_test_inj3
-		commandButton = "Injector #4", cmd_test_inj4
-		commandButton = "Injector #5", cmd_test_inj5
-		commandButton = "Injector #6", cmd_test_inj6
-		commandButton = "Injector #7", cmd_test_inj7
-		commandButton = "Injector #8", cmd_test_inj8
-		
+
 	dialog = testMisc, "Misc"
 ;		commandButton = "Come To Pit", cmd_call_from_pit
 		commandButton = "Fuel Pump", cmd_test_fuel_pump

--- a/firmware/tunerstudio/rusefi.input
+++ b/firmware/tunerstudio/rusefi.input
@@ -550,7 +550,7 @@ enable2ndByteCanID = false
 
    curve = injectorsDeadTime, "Injector dead time"
       columnLabel = "Voltage", "Dead Time"
-      xAxis       =  8, 16, 5
+      xAxis       =  8, 16, 9
       yAxis       = 0, 2, 5
       xBins       = injector_battLagCorrBins, VBatt
       yBins       = injector_battLagCorr


### PR DESCRIPTION
- make 2d map values more reasonable (ie, avoid crazy decimals from uneven division)
- reorder items in the fueling menu so they group in to:
    - Airflow/airmass
    - Fuel model & corrections
    - Injection settings (currently just injection phase)
    - Enrichments
- Regroup injector hardware, modes, and deadtime in to two dialogs that look like this:

![image](https://user-images.githubusercontent.com/568254/90486074-45bb5f80-e0ed-11ea-90f6-02ce476a1cdf.png)
