### PR TITLE
remove unneccessary zeroes from TS protocol

### DIFF
--- a/firmware/console/binary/tunerstudio.h
+++ b/firmware/console/binary/tunerstudio.h
@@ -75,14 +75,12 @@ typedef pre_packed struct
 
 	typedef pre_packed struct
 	post_packed {
-		short int page;
 		short int offset;
 		short int count;
 	} TunerStudioWriteChunkRequest;
 
 	typedef pre_packed struct
 		post_packed {
-			short int page;
 			short int offset;
 			short int count;
 		} TunerStudioReadRequest;

--- a/firmware/tunerstudio/rusefi.input
+++ b/firmware/tunerstudio/rusefi.input
@@ -46,16 +46,14 @@ enable2ndByteCanID = false
 
    endianness          = little
    nPages              = 1
-  
 
    pageIdentifier      = "\x00\x00"
-   pageReadCommand     = "@@TS_READ_COMMAND_char@@\x00\x00%2o%2c"
-   burnCommand         = "@@TS_BURN_COMMAND_char@@\x00\x00"
-   pageActivate        = "@@TS_PAGE_COMMAND_char@@\x00\x00"
-   pageValueWrite      = "@@TS_SINGLE_WRITE_COMMAND_char@@\x00\x00%2o%v"
-   pageChunkWrite      = "@@TS_CHUNK_WRITE_COMMAND_char@@\x00\x00%2o%2c%v"
-   ; todo: make this command shorter one day, no need to have all these zeros
-   crc32CheckCommand   = "k\x00\x00\x00\x00\x00\x00"
+   pageReadCommand     = "@@TS_READ_COMMAND_char@@%2o%2c"
+   burnCommand         = "@@TS_BURN_COMMAND_char@@"
+   pageActivate        = "@@TS_PAGE_COMMAND_char@@"
+   pageValueWrite      = "@@TS_SINGLE_WRITE_COMMAND_char@@%2o%v"
+   pageChunkWrite      = "@@TS_CHUNK_WRITE_COMMAND_char@@%2o%2c%v"
+   crc32CheckCommand   = "@@TS_CRC_CHECK_COMMAND@@%2o%2c"
    retrieveConfigError = "e"
 
 ;communication settings

--- a/java_console/io/src/main/java/com/rusefi/binaryprotocol/BinaryProtocol.java
+++ b/java_console/io/src/main/java/com/rusefi/binaryprotocol/BinaryProtocol.java
@@ -362,11 +362,10 @@ public class BinaryProtocol implements BinaryProtocolCommands {
             int remainingSize = image.getSize() - offset;
             int requestSize = Math.min(remainingSize, Fields.BLOCKING_FACTOR);
 
-            byte packet[] = new byte[7];
+            byte packet[] = new byte[5];
             packet[0] = Fields.TS_READ_COMMAND;
-            putShort(packet, 1, 0); // page
-            putShort(packet, 3, swap16(offset));
-            putShort(packet, 5, swap16(requestSize));
+            putShort(packet, 1, swap16(offset));
+            putShort(packet, 3, swap16(requestSize));
 
             byte[] response = executeCommand(packet, "load image offset=" + offset);
 
@@ -408,8 +407,10 @@ public class BinaryProtocol implements BinaryProtocolCommands {
             int crcOfLocallyCachedConfiguration = IoHelper.getCrc32(localCached.getContent());
             log.info(String.format(CONFIGURATION_RUSEFI_BINARY + " Local cache CRC %x\n", crcOfLocallyCachedConfiguration));
 
-            byte packet[] = new byte[7];
+            byte packet[] = new byte[5];
             packet[0] = COMMAND_CRC_CHECK_COMMAND;
+            putShort(packet, 1, swap16(/*offset = */ 0));
+            putShort(packet, 3, swap16(localCached.getSize()));
             byte[] response = executeCommand(packet, "get CRC32");
 
             if (checkResponseCode(response, RESPONSE_OK) && response.length == 5) {
@@ -472,11 +473,10 @@ public class BinaryProtocol implements BinaryProtocolCommands {
 
         isBurnPending = true;
 
-        byte packet[] = new byte[7 + size];
+        byte packet[] = new byte[5 + size];
         packet[0] = COMMAND_CHUNK_WRITE;
-        putShort(packet, 1, 0); // page
-        putShort(packet, 3, swap16(offset));
-        putShort(packet, 5, swap16(size));
+        putShort(packet, 1, swap16(offset));
+        putShort(packet, 3, swap16(size));
 
         System.arraycopy(content, offset, packet, 7, size);
 

--- a/java_console/io/src/main/java/com/rusefi/binaryprotocol/BinaryProtocolCommands.java
+++ b/java_console/io/src/main/java/com/rusefi/binaryprotocol/BinaryProtocolCommands.java
@@ -11,7 +11,6 @@ public interface BinaryProtocolCommands {
     byte RESPONSE_BURN_OK = Fields.TS_RESPONSE_BURN_OK;
     byte RESPONSE_COMMAND_OK = Fields.TS_RESPONSE_COMMAND_OK;
     char COMMAND_PROTOCOL = Fields.TS_COMMAND_F;
-    // todo: make crc32CheckCommand shorted one day later - no need in 6 empty bytes
     char COMMAND_CRC_CHECK_COMMAND = Fields.TS_CRC_CHECK_COMMAND;
     char COMMAND_CHUNK_WRITE = Fields.TS_CHUNK_WRITE_COMMAND;
     char COMMAND_BURN = Fields.TS_BURN_COMMAND;


### PR DESCRIPTION
- remove unused zeroes (that were once page offsets)
- actually send offset/length to the CRC command (so that partial CRCs work)
- remove page parameter from all operations since it isn't used