### PR TITLE
fix expected<T>

### DIFF
--- a/firmware/util/expected.h
+++ b/firmware/util/expected.h
@@ -38,7 +38,7 @@ struct expected {
 	}
 
 	// Easy default value handling
-	constexpr float value_or(TValue valueIfInvalid) const {
+	constexpr TValue value_or(TValue valueIfInvalid) const {
 		return Valid ? Value : valueIfInvalid;
 	}
 


### PR DESCRIPTION
Should return a `TValue`, not a `float`.

Believe it or not, this is related to #1708 