### PR TITLE
logging simplification: switch bare functions to member functions

### DIFF
--- a/firmware/console/status_loop.cpp
+++ b/firmware/console/status_loop.cpp
@@ -176,7 +176,7 @@ static systime_t timeOfPreviousPrintVersion = (systime_t) -1;
 #if EFI_PROD_CODE
 static void printOutPin(const char *pinName, brain_pin_e hwPin) {
 	if (hwPin != GPIO_UNASSIGNED) {
-		appendPrintf(&logger, "%s%s%s@%s%s", PROTOCOL_OUTPIN, DELIMETER, pinName, hwPortname(hwPin), DELIMETER);
+		logger.appendPrintf("%s%s%s@%s%s", PROTOCOL_OUTPIN, DELIMETER, pinName, hwPortname(hwPin), DELIMETER);
 	}
 }
 #endif /* EFI_PROD_CODE */

--- a/firmware/controllers/core/error_handling.cpp
+++ b/firmware/controllers/core/error_handling.cpp
@@ -119,7 +119,7 @@ static void printToStream(MemoryStream *stream, const char *fmt, va_list ap) {
 }
 
 static void printWarning(const char *fmt, va_list ap) {
-	resetLogging(&logger); // todo: is 'reset' really needed here?
+	logger.reset(); // todo: is 'reset' really needed here?
 	appendMsgPrefix(&logger);
 
 	logger.append(WARNING_PREFIX);

--- a/firmware/controllers/core/error_handling.cpp
+++ b/firmware/controllers/core/error_handling.cpp
@@ -137,7 +137,7 @@ static void printWarning(const char *fmt, va_list ap) {
 	}
 
 	logger.append(warningBuffer);
-	append(&logger, DELIMETER);
+	logger.append(DELIMETER);
 	scheduleLogging(&logger);
 }
 

--- a/firmware/development/engine_sniffer.cpp
+++ b/firmware/development/engine_sniffer.cpp
@@ -93,7 +93,7 @@ void WaveChart::reset() {
 	counter = 0;
 	startTimeNt = 0;
 	collectingData = false;
-	appendPrintf(&logging, "%s%s", PROTOCOL_ENGINE_SNIFFER, DELIMETER);
+	logging.appendPrintf( "%s%s", PROTOCOL_ENGINE_SNIFFER, DELIMETER);
 }
 
 void WaveChart::startDataCollection() {
@@ -144,8 +144,8 @@ void WaveChart::publishIfFull() {
 }
 
 void WaveChart::publish() {
-	appendPrintf(&logging, DELIMETER);
-	waveChartUsedSize = loggingSize(&logging);
+	logging.appendPrintf( DELIMETER);
+	waveChartUsedSize = logging.loggingSize();
 #if DEBUG_WAVE
 	Logging *l = &chart->logging;
 	scheduleSimpleMsg(&debugLogging, "IT'S TIME", strlen(l->buffer));
@@ -211,20 +211,20 @@ void WaveChart::addEvent3(const char *name, const char * msg) {
 	uint32_t diffNt = nowNt - startTimeNt;
 	uint32_t time100 = NT2US(diffNt / ENGINE_SNIFFER_UNIT_US);
 
-	if (remainingSize(&logging) > 35) {
+	if (logging.remainingSize() > 35) {
 		/**
 		 * printf is a heavy method, append is used here as a performance optimization
 		 */
-		appendFast(&logging, name);
-		appendChar(&logging, CHART_DELIMETER);
-		appendFast(&logging, msg);
-		appendChar(&logging, CHART_DELIMETER);
+		logging.appendFast(name);
+		logging.appendChar(CHART_DELIMETER);
+		logging.appendFast(msg);
+		logging.appendChar(CHART_DELIMETER);
 //		time100 -= startTime100;
 
 		itoa10(timeBuffer, time100);
-		appendFast(&logging, timeBuffer);
-		appendChar(&logging, CHART_DELIMETER);
-		logging.linePointer[0] = 0;
+		logging.appendFast(timeBuffer);
+		logging.appendChar(CHART_DELIMETER);
+		logging.appendChar('\0');
 	}
 	if (!alreadyLocked) {
 		unlockOutputBuffer();

--- a/firmware/development/engine_sniffer.cpp
+++ b/firmware/development/engine_sniffer.cpp
@@ -58,7 +58,7 @@ int waveChartUsedSize;
 //#define DEBUG_WAVE 1
 
 #if DEBUG_WAVE
-static Logging debugLogging;
+static LoggingWithStorage debugLogging("debug");
 #endif /* DEBUG_WAVE */
 
 static LoggingWithStorage logger("wave info");
@@ -76,11 +76,10 @@ static void resetNow(void) {
 }
 #endif
 
-WaveChart::WaveChart() {
+WaveChart::WaveChart() : logging("wave chart", WAVE_LOGGING_BUFFER, sizeof(WAVE_LOGGING_BUFFER)) {
 }
 
 void WaveChart::init() {
-	logging.initLoggingExt("wave chart", WAVE_LOGGING_BUFFER, sizeof(WAVE_LOGGING_BUFFER));
 	isInitialized = true;
 	reset();
 }
@@ -89,7 +88,7 @@ void WaveChart::reset() {
 #if DEBUG_WAVE
 	scheduleSimpleMsg(&debugLogging, "reset while at ", counter);
 #endif /* DEBUG_WAVE */
-	resetLogging(&logging);
+	logging.reset();
 	counter = 0;
 	startTimeNt = 0;
 	collectingData = false;
@@ -239,10 +238,6 @@ void initWaveChart(WaveChart *chart) {
 	chart->init();
 
 	printStatus();
-
-#if DEBUG_WAVE
-	initLoggingExt(&debugLogging, "wave chart debug", &debugLogging.DEFAULT_BUFFER, sizeof(debugLogging.DEFAULT_BUFFER));
-#endif
 
 #if EFI_HISTOGRAMS
 	initHistogram(&engineSnifferHisto, "wave chart");

--- a/firmware/development/logic_analyzer.cpp
+++ b/firmware/development/logic_analyzer.cpp
@@ -171,38 +171,38 @@ static void reportWave(Logging *logging, int index) {
 		float dwellMs = getSignalOnTime(index);
 		float periodMs = getSignalPeriodMs(index);
 
-		appendPrintf(logging, "duty%d%s", index, DELIMETER);
-		appendFloat(logging, 100.0f * dwellMs / periodMs, 2);
-		appendPrintf(logging, "%s", DELIMETER);
+		logging->appendPrintf("duty%d%s", index, DELIMETER);
+		logging->appendFloat(100.0f * dwellMs / periodMs, 2);
+		logging->appendPrintf("%s", DELIMETER);
 
 		/**
 		 * that's the ON time of the LAST signal
 		 */
-		appendPrintf(logging, "dwell%d%s", index, DELIMETER);
-		appendFloat(logging, dwellMs, 2);
-		appendPrintf(logging, "%s", DELIMETER);
+		logging->appendPrintf("dwell%d%s", index, DELIMETER);
+		logging->appendFloat(dwellMs, 2);
+		logging->appendPrintf("%s", DELIMETER);
 
 		/**
 		 * that's the total ON time during the previous engine cycle
 		 */
-		appendPrintf(logging, "total_dwell%d%s", index, DELIMETER);
-		appendFloat(logging, readers[index].prevTotalOnTimeUs / 1000.0f, 2);
-		appendPrintf(logging, "%s", DELIMETER);
+		logging->appendPrintf("total_dwell%d%s", index, DELIMETER);
+		logging->appendFloat(readers[index].prevTotalOnTimeUs / 1000.0f, 2);
+		logging->appendPrintf("%s", DELIMETER);
 
-		appendPrintf(logging, "period%d%s", index, DELIMETER);
-		appendFloat(logging, periodMs, 2);
-		appendPrintf(logging, "%s", DELIMETER);
+		logging->appendPrintf("period%d%s", index, DELIMETER);
+		logging->appendFloat(periodMs, 2);
+		logging->appendPrintf("%s", DELIMETER);
 
 		uint32_t offsetUs = getWaveOffset(index);
 		int rpm = GET_RPM();
 		if (rpm != 0) {
 			float oneDegreeUs = getOneDegreeTimeUs(rpm);
 
-			appendPrintf(logging, "advance%d%s", index, DELIMETER);
+			logging->appendPrintf("advance%d%s", index, DELIMETER);
 			float angle = (offsetUs / oneDegreeUs) - tdcPosition();
 			fixAngle(angle, "waveAn", CUSTOM_ERR_6564);
-			appendFloat(logging, angle, 3);
-			appendPrintf(logging, "%s", DELIMETER);
+			logging->appendFloat(angle, 3);
+			logging->appendPrintf("%s", DELIMETER);
 		}
 	}
 }

--- a/firmware/development/sensor_chart.cpp
+++ b/firmware/development/sensor_chart.cpp
@@ -49,7 +49,7 @@ void scAddData(float angle, float value) {
 			 * data after we have added some data - meaning it's time to flush
 			 */
 			// message terminator
-			appendPrintf(&scLogging, DELIMETER);
+			scLogging.appendPrintf(DELIMETER);
 			// output pending data
 			scheduleLogging(&scLogging);
 			pendingData = false;
@@ -60,11 +60,11 @@ void scAddData(float angle, float value) {
 		pendingData = true;
 		resetLogging(&scLogging);
 		// message header
-		appendPrintf(&scLogging, "%s%s", PROTOCOL_ANALOG_CHART, DELIMETER);
+		scLogging.appendPrintf( "%s%s", PROTOCOL_ANALOG_CHART, DELIMETER);
 	}
 
-	if (remainingSize(&scLogging) > 100) {
-		appendPrintf(&scLogging, "%.2f|%.2f|", angle, value);
+	if (scLogging.remainingSize() > 100) {
+		scLogging.appendPrintf( "%.2f|%.2f|", angle, value);
 	}
 #endif /* EFI_TEXT_LOGGING */
 }

--- a/firmware/development/sensor_chart.cpp
+++ b/firmware/development/sensor_chart.cpp
@@ -58,7 +58,7 @@ void scAddData(float angle, float value) {
 	}
 	if (!pendingData) {
 		pendingData = true;
-		resetLogging(&scLogging);
+		scLogging.reset();
 		// message header
 		scLogging.appendPrintf( "%s%s", PROTOCOL_ANALOG_CHART, DELIMETER);
 	}

--- a/firmware/hw_layer/adc/adc_inputs.cpp
+++ b/firmware/hw_layer/adc/adc_inputs.cpp
@@ -385,10 +385,10 @@ static void printFullAdcReport(Logging *logger) {
 			int pin = getAdcChannelPin(hwIndex);
 
 			int adcValue = getAvgAdcValue(hwIndex, fastAdc.samples, ADC_BUF_DEPTH_FAST, fastAdc.size());
-			appendPrintf(logger, " F ch%d %s%d", index, portname(port), pin);
-			appendPrintf(logger, " ADC%d 12bit=%d", hwIndex, adcValue);
+			logger->appendPrintf(" F ch%d %s%d", index, portname(port), pin);
+			logger->appendPrintf(" ADC%d 12bit=%d", hwIndex, adcValue);
 			float volts = adcToVolts(adcValue);
-			appendPrintf(logger, " v=%.2f", volts);
+			logger->appendPrintf(" v=%.2f", volts);
 
 			appendMsgPostfix(logger);
 			scheduleLogging(logger);
@@ -405,10 +405,10 @@ static void printFullAdcReport(Logging *logger) {
 			int pin = getAdcChannelPin(hwIndex);
 
 			int adcValue = slowAdc.getAdcValueByIndex(index);
-			appendPrintf(logger, " S ch%d %s%d", index, portname(port), pin);
-			appendPrintf(logger, " ADC%d 12bit=%d", hwIndex, adcValue);
+			logger->appendPrintf(" S ch%d %s%d", index, portname(port), pin);
+			logger->appendPrintf(" ADC%d 12bit=%d", hwIndex, adcValue);
 			float volts = adcToVolts(adcValue);
-			appendPrintf(logger, " v=%.2f", volts);
+			logger->appendPrintf(" v=%.2f", volts);
 
 			appendMsgPostfix(logger);
 			scheduleLogging(logger);

--- a/firmware/hw_layer/rtc_helper.cpp
+++ b/firmware/hw_layer/rtc_helper.cpp
@@ -145,7 +145,7 @@ void printDateTime(void) {
 		date_get_tm(&timp);
 
 		appendMsgPrefix(&logger);
-		appendPrintf(&logger, "Current RTC localtime is: %04u-%02u-%02u %02u:%02u:%02u w=%d", timp.tm_year + 1900, timp.tm_mon + 1, timp.tm_mday, timp.tm_hour,
+		logger.appendPrintf( "Current RTC localtime is: %04u-%02u-%02u %02u:%02u:%02u w=%d", timp.tm_year + 1900, timp.tm_mon + 1, timp.tm_mday, timp.tm_hour,
 				timp.tm_min, timp.tm_sec, rtcWorks);
 		appendMsgPostfix(&logger);
 		scheduleLogging(&logger);

--- a/firmware/util/datalogging.cpp
+++ b/firmware/util/datalogging.cpp
@@ -73,26 +73,27 @@ static IntermediateLogging intermediateLogging;
 /**
  * @returns true if data does not fit into this buffer
  */
-static ALWAYS_INLINE bool validateBuffer(Logging *logging, const char *text, uint32_t extraLen) {
-	if (logging->buffer == NULL) {
-		firmwareError(CUSTOM_ERR_LOGGING_NOT_READY, "Logging not initialized: %s", logging->name);
+bool Logging::validateBuffer(const char *text, uint32_t extraLen) {
+	if (!buffer) {
+		firmwareError(CUSTOM_ERR_LOGGING_NOT_READY, "Logging not initialized: %s", name);
 		return true;
 	}
 
-	if (remainingSize(logging) < extraLen + 1) {
+	if (remainingSize() < extraLen + 1) {
 #if EFI_PROD_CODE
 		const char * msg = extraLen > 50 ? "(long)" : text;
-		warning(CUSTOM_LOGGING_BUFFER_OVERFLOW, "output overflow %s %d [%s]", logging->name, extraLen, msg);
+		warning(CUSTOM_LOGGING_BUFFER_OVERFLOW, "output overflow %s %d [%s]", name, extraLen, msg);
 #endif /* EFI_PROD_CODE */
 		return true;
 	}
+
 	return false;
 }
 
 void Logging::append(const char *text) {
 	efiAssertVoid(CUSTOM_APPEND_NULL, text != NULL, "append NULL");
 	uint32_t extraLen = efiStrlen(text);
-	bool isCapacityProblem = validateBuffer(this, text, extraLen);
+	bool isCapacityProblem = validateBuffer(text, extraLen);
 	if (isCapacityProblem) {
 		return;
 	}
@@ -103,20 +104,14 @@ void Logging::append(const char *text) {
 	linePointer += extraLen;
 }
 
-// todo: inline
-void append(Logging *logging, const char *text) {
-	logging->append(text);
-}
-
 /**
  * @note This method if fast because it does not validate much, be sure what you are doing
  */
-void appendFast(Logging *logging, const char *text) {
-	char *s;
-	s = logging->linePointer;
+void Logging::appendFast(const char *text) {
+	char *s = linePointer;
 	while ((*s++ = *text++) != 0)
 		;
-	logging->linePointer = s - 1;
+	linePointer = s - 1;
 }
 
 /**
@@ -138,15 +133,6 @@ void Logging::vappendPrintf(const char *fmt, va_list arg) {
 #endif // EFI_UNIT_TEST
 }
 
-// todo: replace with logging->appendPrintf
-void appendPrintf(Logging *logging, const char *fmt, ...) {
-	efiAssertVoid(CUSTOM_APPEND_STACK, getCurrentRemainingStack() > 128, "lowstck#4");
-	va_list ap;
-	va_start(ap, fmt);
-	logging->vappendPrintf(fmt, ap);
-	va_end(ap);
-}
-
 void Logging::appendPrintf(const char *fmt, ...) {
 #if EFI_UNIT_TEST
 	va_list ap;
@@ -166,7 +152,7 @@ void Logging::initLoggingExt(const char *name, char *buffer, int bufferSize) {
 	this->name = name;
 	this->buffer = buffer;
 	this->bufferSize = bufferSize;
-	resetLogging(this);
+	reset();
 	this->isInitialized = true;
 }
 
@@ -174,7 +160,7 @@ int isInitialized(Logging *logging) {
 	return logging->isInitialized;
 }
 
-void appendFloat(Logging *logging, float value, int precision) {
+void Logging::appendFloat(float value, int precision) {
 	/**
 	 * todo: #1 this implementation is less than perfect
 	 * todo: #2 The only way to avoid double promotion would probably be using *float instead of float
@@ -182,26 +168,26 @@ void appendFloat(Logging *logging, float value, int precision) {
 	 */
 	switch (precision) {
 	case 1:
-		appendPrintf(logging, "%.1f", value);
+		appendPrintf("%.1f", value);
 		break;
 	case 2:
-		appendPrintf(logging, "%.2f", value);
+		appendPrintf("%.2f", value);
 		break;
 	case 3:
-		appendPrintf(logging, "%.3f", value);
+		appendPrintf("%.3f", value);
 		break;
 	case 4:
-		appendPrintf(logging, "%.4f", value);
+		appendPrintf("%.4f", value);
 		break;
 	case 5:
-		appendPrintf(logging, "%.5f", value);
+		appendPrintf("%.5f", value);
 		break;
 	case 6:
-		appendPrintf(logging, "%.6f", value);
+		appendPrintf("%.6f", value);
 		break;
 
 	default:
-		appendPrintf(logging, "%.2f", value);
+		appendPrintf("%.2f", value);
 	}
 }
 
@@ -248,21 +234,21 @@ void printWithLength(char *line) {
 }
 
 void appendMsgPrefix(Logging *logging) {
-	append(logging, PROTOCOL_MSG DELIMETER);
+	logging->append(PROTOCOL_MSG DELIMETER);
 }
 
 void appendMsgPostfix(Logging *logging) {
-	append(logging, DELIMETER);
+	logging->append(DELIMETER);
 }
 
-void resetLogging(Logging *logging) {
-	char *buffer = logging->buffer;
-	if (buffer == NULL) {
-		firmwareError(ERROR_NULL_BUFFER, "Null buffer: %s", logging->name);
+void Logging::reset() {
+	if (!buffer) {
+		firmwareError(ERROR_NULL_BUFFER, "Null buffer: %s", name);
 		return;
 	}
-	logging->linePointer = buffer;
-	logging->linePointer[0] = 0;
+
+	linePointer = buffer;
+	*linePointer = 0;
 }
 
 /**
@@ -279,19 +265,12 @@ void printMsg(Logging *logger, const char *fmt, ...) {
 	logger->vappendPrintf(fmt, ap);
 	va_end(ap);
 
-	append(logger, DELIMETER);
+	logger->append(DELIMETER);
 	printWithLength(logger->buffer);
-	resetLogging(logger);
+	logger->reset();
 }
 
-uint32_t remainingSize(Logging *logging) {
-	return logging->bufferSize - loggingSize(logging);
-}
-
-Logging::Logging() {
-}
-
-Logging::Logging(char const *name, char *buffer, int bufferSize) : Logging() {
+Logging::Logging(char const *name, char *buffer, int bufferSize) {
 #if ! EFI_UNIT_TEST
 	initLoggingExt(name, buffer, bufferSize);
 #else

--- a/firmware/util/datalogging.cpp
+++ b/firmware/util/datalogging.cpp
@@ -179,7 +179,7 @@ static char header[16];
 /**
  * this method should invoked on the main thread only
  */
-void printWithLength(char *line) {
+static void printWithLength(char *line) {
 #if ! EFI_UNIT_TEST
 	int len;
 	char *p;

--- a/firmware/util/datalogging.cpp
+++ b/firmware/util/datalogging.cpp
@@ -74,11 +74,6 @@ static IntermediateLogging intermediateLogging;
  * @returns true if data does not fit into this buffer
  */
 bool Logging::validateBuffer(const char *text, uint32_t extraLen) {
-	if (!buffer) {
-		firmwareError(CUSTOM_ERR_LOGGING_NOT_READY, "Logging not initialized: %s", name);
-		return true;
-	}
-
 	if (remainingSize() < extraLen + 1) {
 #if EFI_PROD_CODE
 		const char * msg = extraLen > 50 ? "(long)" : text;
@@ -146,18 +141,6 @@ void Logging::appendPrintf(const char *fmt, ...) {
 	vappendPrintf(fmt, ap);
 	va_end(ap);
 #endif // EFI_UNIT_TEST
-}
-
-void Logging::initLoggingExt(const char *name, char *buffer, int bufferSize) {
-	this->name = name;
-	this->buffer = buffer;
-	this->bufferSize = bufferSize;
-	reset();
-	this->isInitialized = true;
-}
-
-int isInitialized(Logging *logging) {
-	return logging->isInitialized;
 }
 
 void Logging::appendFloat(float value, int precision) {
@@ -242,11 +225,6 @@ void appendMsgPostfix(Logging *logging) {
 }
 
 void Logging::reset() {
-	if (!buffer) {
-		firmwareError(ERROR_NULL_BUFFER, "Null buffer: %s", name);
-		return;
-	}
-
 	linePointer = buffer;
 	*linePointer = 0;
 }
@@ -270,12 +248,12 @@ void printMsg(Logging *logger, const char *fmt, ...) {
 	logger->reset();
 }
 
-Logging::Logging(char const *name, char *buffer, int bufferSize) {
-#if ! EFI_UNIT_TEST
-	initLoggingExt(name, buffer, bufferSize);
-#else
-	this->buffer = buffer;
-#endif /* ! EFI_UNIT_TEST */
+Logging::Logging(char const *name, char *buffer, int bufferSize)
+	: name(name)
+	, buffer(buffer)
+	, bufferSize(bufferSize)
+{
+	reset();
 }
 
 LoggingWithStorage::LoggingWithStorage(const char *name) : Logging(name, DEFAULT_BUFFER, sizeof(DEFAULT_BUFFER))   {

--- a/firmware/util/datalogging.h
+++ b/firmware/util/datalogging.h
@@ -17,15 +17,39 @@
 // size of buffers?
 class Logging {
 public:
-	Logging();
+	Logging() = delete;
 	Logging(const char *name, char *buffer, int bufferSize);
+
+	void reset();
+
 	void initLoggingExt(const char *name, char *buffer, int bufferSize);
 	void vappendPrintf(const char *fmt, va_list arg);
 	void append(const char *text);
 	void appendFast(const char *text);
 	void appendPrintf(const char *fmt, ...);
+	void appendFloat(float value, int precision);
+
+	/**
+	 * This macro breaks the normal zero=termination constraint, please take care of this outside of this function
+	 */
+	void appendChar(char c) {
+		*linePointer = c;
+		linePointer++;
+	}
+
+	size_t loggingSize() const {
+		return (uintptr_t)linePointer - (uintptr_t)buffer;
+	}
+
+	size_t remainingSize() const {
+		return bufferSize - loggingSize();
+	}
+
+//private:
+	bool validateBuffer(const char *text, uint32_t extraLen);
+
 	const char *name = nullptr;
-	char SMALL_BUFFER[40];
+
 	/**
 	 * Zero-terminated buffer of pending debug message
 	 *
@@ -51,10 +75,6 @@ int isInitialized(Logging *logging);
 
 void initLoggingExt(Logging *logging, const char *name, char *buffer, int bufferSize);
 
-void appendFloat(Logging *logging, float value, int precision);
-
-void resetLogging(Logging *logging);
-
 void appendMsgPrefix(Logging *logging);
 void appendMsgPostfix(Logging *logging);
 
@@ -67,20 +87,7 @@ extern "C"
 #define lockOutputBuffer lockAnyContext
 #define unlockOutputBuffer unlockAnyContext
 
-uint32_t remainingSize(Logging *logging);
-
-#define loggingSize(logging) ((int) (logging)->linePointer - (int) ((logging)->buffer))
-
-
 void printMsg(Logging *logging, const char *fmt, ...);
-void appendPrintf(Logging *logging, const char *fmt, ...);
-void append(Logging *logging, const char *text);
-void appendFast(Logging *logging, const char *text);
-
-/**
- * This macro breaks the normal zero=termination constraint, please take care of this outside of this macro
- */
-#define appendChar(logging, symbol) {(logging)->linePointer[0] = (symbol);(logging)->linePointer++;}
 
 /**
  * this method copies the line into the intermediate buffer for later output by

--- a/firmware/util/datalogging.h
+++ b/firmware/util/datalogging.h
@@ -22,7 +22,6 @@ public:
 
 	void reset();
 
-	void initLoggingExt(const char *name, char *buffer, int bufferSize);
 	void vappendPrintf(const char *fmt, va_list arg);
 	void append(const char *text);
 	void appendFast(const char *text);
@@ -48,21 +47,21 @@ public:
 //private:
 	bool validateBuffer(const char *text, uint32_t extraLen);
 
-	const char *name = nullptr;
+	const char* const name = nullptr;
 
 	/**
 	 * Zero-terminated buffer of pending debug message
 	 *
 	 * Unless a larger external buffer is specified, this is just a pointer to DEFAULT_BUFFER
 	 */
-	char *buffer = nullptr;
+	char* const buffer = nullptr;
+	const int bufferSize = 0;
+
 	/**
 	 * This pointer is always pointing at the position within the buffer into which next
 	 * write operation would append additional data
 	 */
 	char *linePointer = nullptr;
-	int bufferSize = 0;
-	volatile bool isInitialized = false;
 };
 
 class LoggingWithStorage : public Logging {
@@ -70,8 +69,6 @@ public:
 	explicit LoggingWithStorage(const char *name);
 	char DEFAULT_BUFFER[200];
 };
-
-int isInitialized(Logging *logging);
 
 void initLoggingExt(Logging *logging, const char *name, char *buffer, int bufferSize);
 

--- a/firmware/util/datalogging.h
+++ b/firmware/util/datalogging.h
@@ -95,5 +95,3 @@ void scheduleLogging(Logging *logging);
 #ifdef __cplusplus
 }
 #endif /* __cplusplus */
-
-void printWithLength(char *line);

--- a/firmware/util/efilib.cpp
+++ b/firmware/util/efilib.cpp
@@ -314,10 +314,10 @@ void printHistogram(Logging *logging, histogram_s *histogram) {
 
 	resetLogging(logging);
 	appendMsgPrefix(logging);
-	appendPrintf(logging, "histogram %s *", histogram->name);
+	logging.appendPrintf("histogram %s *", histogram->name);
 	for (int i = 0; i < len; i++)
-	appendPrintf(logging, "%d ", report[i]);
-	appendPrintf(logging, "*");
+	logging.appendPrintf("%d ", report[i]);
+	logging.appendPrintf("*");
 	appendMsgPostfix(logging);
 	scheduleLogging(logging);
 #else

--- a/firmware/util/efilib.cpp
+++ b/firmware/util/efilib.cpp
@@ -312,7 +312,7 @@ void printHistogram(Logging *logging, histogram_s *histogram) {
 	int report[5];
 	int len = hsReport(histogram, report);
 
-	resetLogging(logging);
+	logging->reset();
 	appendMsgPrefix(logging);
 	logging.appendPrintf("histogram %s *", histogram->name);
 	for (int i = 0; i < len; i++)

--- a/firmware/util/loggingcentral.cpp
+++ b/firmware/util/loggingcentral.cpp
@@ -82,7 +82,7 @@ void scheduleLogging(Logging *logging) {
 		if (!alreadyLocked) {
 			unlockOutputBuffer();
 		}
-		resetLogging(logging);
+		logging->reset();
 		return;
 	}
 	// memcpy is faster then strcpy because it is not looking for line terminator
@@ -91,7 +91,7 @@ void scheduleLogging(Logging *logging) {
 	if (!alreadyLocked) {
 		unlockOutputBuffer();
 	}
-	resetLogging(logging);
+	logging->reset();
 #endif /* EFI_TEXT_LOGGING */
 }
 
@@ -167,7 +167,7 @@ void scheduleMsg(Logging *logging, const char *format, ...) {
 		return;
 	}
 	int wasLocked = lockAnyContext();
-	resetLogging(logging); // todo: is 'reset' really needed here?
+	logging->reset(); // todo: is 'reset' really needed here?
 	appendMsgPrefix(logging);
 
 	va_list ap;

--- a/simulator/simulator/rusEfiFunctionalTest.cpp
+++ b/simulator/simulator/rusEfiFunctionalTest.cpp
@@ -69,20 +69,20 @@ static void runChprintfTest() {
 
 	{
 		LoggingWithStorage testLogging("test");
-		appendFloat(&testLogging, 1.23, 5);
-		appendFloat(&testLogging, 1.234, 2);
+		testLogging.appendFloat(1.23, 5);
+		testLogging.appendFloat(1.234, 2);
 		assertString(testLogging.buffer, "1.230001.23");
 
 	}
 
 	{
 		LoggingWithStorage testLogging("test");
-		appendFloat(&testLogging, -1.23, 5);
+		testLogging.appendFloat(-1.23, 5);
 		assertString(testLogging.buffer, "-1.23000");
 	}
 	{
 		LoggingWithStorage testLogging("test");
-		appendPrintf(&testLogging, "a%.2fb%fc", -1.2, -3.4);
+		testLogging.appendPrintf( "a%.2fb%fc", -1.2, -3.4);
 		assertString(testLogging.buffer, "a-1.20b-3.400000095c");
 	}
 

--- a/unit_tests/tests/test_accel_enrichment.cpp
+++ b/unit_tests/tests/test_accel_enrichment.cpp
@@ -104,7 +104,7 @@ TEST(fuel, testAccelEnrichmentFractionalTps) {
 		}
 	}
 
-	Logging logger;
+	LoggingWithStorage logger("test");
 	initAccelEnrichment(&logger PASS_ENGINE_PARAMETER_SUFFIX);
 
 	engine->rpmCalculator.setRpmValue(600);

--- a/unit_tests/tests/test_pid_auto.cpp
+++ b/unit_tests/tests/test_pid_auto.cpp
@@ -16,7 +16,7 @@ efitimems_t currentTimeMillis(void) {
 	return mockTimeMs;
 }
 
-Logging logging;
+LoggingWithStorage logging("test");
 
 static float zigZagOffset = 0;
 


### PR DESCRIPTION
Lots of functions of the form `myFunc(Logging* logger)` should actually be members of `Logging`.  This change does that!

Changing the `buffer` member to `const` means that it has to be initialized at construction - so it can't be null! Removing runtime checks in favor of compile-time checks is always great.