### PR TITLE
two throttles one thread

### DIFF
--- a/firmware/controllers/actuators/electronic_throttle.cpp
+++ b/firmware/controllers/actuators/electronic_throttle.cpp
@@ -395,7 +395,7 @@ void EtbController::setOutput(expected<percent_t> outputValue) {
 	}
 }
 
-void EtbController::update(efitick_t) {
+void EtbController::update() {
 #if EFI_TUNER_STUDIO
 	// Only debug throttle #0
 	if (m_myIndex == 0) {
@@ -484,11 +484,8 @@ void EtbController::autoCalibrateTps() {
  * Since ETB is a safety critical device, we need the hard RTOS guarantee that it will be scheduled over other less important tasks.
  */
 #include "periodic_thread_controller.h"
-struct EtbImpl final : public EtbController, public PeriodicController<512> {
-	EtbImpl() : PeriodicController("ETB", NORMALPRIO + 3, ETB_LOOP_FREQUENCY) {}
-
-	void PeriodicTask(efitick_t nowNt) override {
-
+struct EtbImpl final : public EtbController {
+	void update() override {
 #if EFI_TUNER_STUDIO
 	if (m_isAutocal) {
 		// Don't allow if engine is running!
@@ -547,16 +544,26 @@ struct EtbImpl final : public EtbController, public PeriodicController<512> {
 	}
 #endif /* EFI_TUNER_STUDIO */
 
-		EtbController::update(nowNt);
-	}
-
-	void start() override {
-		Start();
+		EtbController::update();
 	}
 };
 
 // real implementation (we mock for some unit tests)
-EtbImpl etbControllers[ETB_COUNT];
+static EtbImpl etbControllers[ETB_COUNT];
+
+struct EtbThread final : public PeriodicController<512> {
+	EtbThread() : PeriodicController("ETB", NORMALPRIO + 3, ETB_LOOP_FREQUENCY) {}
+
+	void PeriodicTask(efitick_t) override {
+		// Simply update all controllers
+		for (int i = 0 ; i < engine->etbActualCount; i++) {
+			etbControllers[i].update();
+		}
+	}
+};
+
+static EtbThread etbThread;
+
 #endif
 
 static void showEthInfo(void) {
@@ -820,9 +827,9 @@ void doInitElectronicThrottle(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 
 	etbPidReset(PASS_ENGINE_PARAMETER_SIGNATURE);
 
-	for (int i = 0 ; i < engine->etbActualCount; i++) {
-		engine->etbControllers[i]->start();
-	}
+#if !EFI_UNIT_TEST
+	etbThread.Start();
+#endif
 }
 
 void initElectronicThrottle(DECLARE_ENGINE_PARAMETER_SIGNATURE) {

--- a/firmware/controllers/actuators/electronic_throttle.h
+++ b/firmware/controllers/actuators/electronic_throttle.h
@@ -30,7 +30,7 @@ public:
 	virtual void init(SensorType positionSensor, DcMotor *motor, int ownIndex, pid_s *pidParameters, const ValueProvider3D* pedalMap) = 0;
 	virtual void reset() = 0;
 	virtual void setIdlePosition(percent_t pos) = 0;
-	virtual void start() = 0;
+	virtual void update() = 0;
 	virtual void autoCalibrateTps() = 0;
 };
 
@@ -39,9 +39,9 @@ public:
 	void init(SensorType positionSensor, DcMotor *motor, int ownIndex, pid_s *pidParameters, const ValueProvider3D* pedalMap) override;
 	void setIdlePosition(percent_t pos) override;
 	void reset() override;
-	void start() override {}
 
-	void update(efitick_t nowNt);
+	// Update the controller's state: read sensors, send output, etc
+	void update();
 
 	// Called when the configuration may have changed.  Controller will
 	// reset if necessary.

--- a/firmware/controllers/engine_controller.cpp
+++ b/firmware/controllers/engine_controller.cpp
@@ -710,7 +710,7 @@ void initEngineContoller(Logging *sharedLogger DECLARE_ENGINE_PARAMETER_SUFFIX) 
  * UNUSED_SIZE constants.
  */
 #ifndef RAM_UNUSED_SIZE
-#define RAM_UNUSED_SIZE 6100
+#define RAM_UNUSED_SIZE 7500
 #endif
 #ifndef CCM_UNUSED_SIZE
 #define CCM_UNUSED_SIZE 2900

--- a/unit_tests/mocks.h
+++ b/unit_tests/mocks.h
@@ -12,7 +12,7 @@ class MockEtb : public IEtbController {
 public:
 	// IEtbController mocks
 	MOCK_METHOD(void, reset, (), ());
-	MOCK_METHOD(void, start, (), (override));
+	MOCK_METHOD(void, update, (), (override));
 	MOCK_METHOD(void, init, (SensorType positionSensor, DcMotor* motor, int ownIndex, pid_s* pidParameters, const ValueProvider3D* pedalMap), (override));
 	MOCK_METHOD(void, setIdlePosition, (percent_t pos), (override));
 	MOCK_METHOD(void, autoCalibrateTps, (), (override));

--- a/unit_tests/tests/test_etb.cpp
+++ b/unit_tests/tests/test_etb.cpp
@@ -48,7 +48,6 @@ TEST(etb, initializationSingleThrottle) {
 	// Expect mock0 to be init with TPS 1, index 0, and PID params
 	EXPECT_CALL(mocks[0], init(SensorType::Tps1, _, 0, &engineConfiguration->etb, Ne(nullptr)));
 	EXPECT_CALL(mocks[0], reset);
-	EXPECT_CALL(mocks[0], start);
 
 	// We do not expect throttle #2 to be initialized
 
@@ -74,12 +73,10 @@ TEST(etb, initializationDualThrottle) {
 	// Expect mock0 to be init with TPS 1, index 0, and PID params
 	EXPECT_CALL(mocks[0], init(SensorType::Tps1, _, 0, &engineConfiguration->etb, Ne(nullptr)));
 	EXPECT_CALL(mocks[0], reset);
-	EXPECT_CALL(mocks[0], start);
 
 	// Expect mock1 to be init with TPS 2, index 1, and PID params
 	EXPECT_CALL(mocks[1], init(SensorType::Tps2, _, 1, &engineConfiguration->etb, Ne(nullptr)));
 	EXPECT_CALL(mocks[1], reset);
-	EXPECT_CALL(mocks[1], start);
 
 	doInitElectronicThrottle(PASS_ENGINE_PARAMETER_SIGNATURE);
 }
@@ -102,7 +99,6 @@ TEST(etb, initializationDcMotorIdleValveMode) {
 	// Expect mock0 to be init with TPS 2, index 0, and PID params
 	EXPECT_CALL(mocks[0], init(SensorType::Tps2, _, 0, &engineConfiguration->etb, Ne(nullptr)));
 	EXPECT_CALL(mocks[0], reset);
-	EXPECT_CALL(mocks[0], start);
 
 	// We do not expect throttle #2 to be initialized
 


### PR DESCRIPTION
etbs are adults, they can share a single thread between them.  Besides , ChibiOS won't even preempt a thread with the same priority, so they were already sort of running on the same thread.

progress on #1784 