### PR TITLE
guard against ADC buffer overrun

### DIFF
--- a/firmware/hw_layer/adc/adc_inputs.cpp
+++ b/firmware/hw_layer/adc/adc_inputs.cpp
@@ -346,6 +346,11 @@ bool AdcDevice::isHwUsed(adc_channel_e hwChannelIndex) const {
 }
 
 void AdcDevice::enableChannel(adc_channel_e hwChannel) {
+	if (channelCount >= efi::size(values.adc_data)) {
+		firmwareError(OBD_PCM_Processor_Fault, "Too many ADC channels configured");
+		return;
+	}
+
 	int logicChannel = channelCount++;
 
 	size_t channelAdcIndex = hwChannel - 1;


### PR DESCRIPTION
If too many adc channels got enabled, we'd overrun the buffer and cause a hard fault.  Fail gracefully!