### PR TITLE
add analog inputs to switches

### DIFF
--- a/firmware/config/boards/proteus/mapping.yaml
+++ b/firmware/config/boards/proteus/mapping.yaml
@@ -56,6 +56,21 @@ switch_inputs:
   GPIOE_13: "Digital 4"
   GPIOE_14: "Digital 5"
   GPIOE_15: "Digital 6"
+  GPIOA_0: "Analog Volt 5"
+  GPIOA_1: "Analog Volt 6"
+  GPIOA_2: "Analog Volt 7"
+  GPIOA_3: "Analog Volt 8"
+  GPIOA_4: "Analog Volt 9"
+  GPIOA_5: "Analog Volt 10"
+  GPIOA_6: "Analog Volt 11"
+  GPIOB_0: "Analog Temp 3"
+  GPIOB_1: "Analog Temp 4"
+  GPIOC_0: "Analog Volt 1"
+  GPIOC_1: "Analog Volt 2"
+  GPIOC_2: "Analog Volt 3"
+  GPIOC_3: "Analog Volt 4"
+  GPIOC_4: "Analog Temp 1"
+  GPIOC_5: "Analog Temp 2"
 
 analog_inputs:
   # PA0

--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -1200,7 +1200,7 @@ int16_t tps2Max;Full throttle#2. tpsMax value as 10 bit ADC value. Not Voltage!\
 	adc_channel_e wastegatePositionSensor;
 	uint8_t[4] unused_former_warmup_target_afr;;"units", 1, 0, -20, 100, 0
 
-	float boostCutPressure;kPa value at which we need to cut fuel and spark, 0 if not enabled;"kPa",        1,     0,    0, 500,     0
+	float boostCutPressure;+MAP value above which fuel is cut in case of overboost.\n0 to disable overboost cut.;"kPa (absolute)",        1,     0,    0, 500,     0
 
 float[MAP_ACCEL_TAPER] mapAccelTaperBins;;"counter",      1,     0,   0.0,    300,   0
 float[MAP_ACCEL_TAPER] mapAccelTaperMult;;"mult",      1,     0,   0.0,    300,   2


### PR DESCRIPTION
No reason the HW can't use analog inputs for switch inputs.