### PR TITLE
Remove dead & useless config

### DIFF
--- a/firmware/config/boards/hellen/cypress/config/controllers/algo/auto_generated_enums.cpp
+++ b/firmware/config/boards/hellen/cypress/config/controllers/algo/auto_generated_enums.cpp
@@ -1146,19 +1146,6 @@ case Internal_ForceMyEnumIntSize_maf_sensor:
   }
  return NULL;
 }
-const char *getMass_storage_e(mass_storage_e value){
-switch(value) {
-case Force_4_bytes_size_mass_storage:
-  return "Force_4_bytes_size_mass_storage";
-case MS_ALWAYS:
-  return "MS_ALWAYS";
-case MS_AUTO:
-  return "MS_AUTO";
-case MS_NEVER:
-  return "MS_NEVER";
-  }
- return NULL;
-}
 const char *getOperation_mode_e(operation_mode_e value){
 switch(value) {
 case FOUR_STROKE_CAM_SENSOR:

--- a/firmware/config/boards/hellen/cypress/config/controllers/algo/auto_generated_enums.h
+++ b/firmware/config/boards/hellen/cypress/config/controllers/algo/auto_generated_enums.h
@@ -38,7 +38,6 @@ const char *getInjection_mode_e(injection_mode_e value);
 const char *getLaunchActivationMode_e(launchActivationMode_e value);
 const char *getLog_format_e(log_format_e value);
 const char *getMaf_sensor_type_e(maf_sensor_type_e value);
-const char *getMass_storage_e(mass_storage_e value);
 const char *getOperation_mode_e(operation_mode_e value);
 const char *getPin_input_mode_e(pin_input_mode_e value);
 const char *getPin_mode_e(pin_mode_e value);

--- a/firmware/config/boards/kinetis/config/controllers/algo/auto_generated_enums.cpp
+++ b/firmware/config/boards/kinetis/config/controllers/algo/auto_generated_enums.cpp
@@ -942,19 +942,6 @@ case Internal_ForceMyEnumIntSize_maf_sensor:
   }
  return NULL;
 }
-const char *getMass_storage_e(mass_storage_e value){
-switch(value) {
-case Force_4_bytes_size_mass_storage:
-  return "Force_4_bytes_size_mass_storage";
-case MS_ALWAYS:
-  return "MS_ALWAYS";
-case MS_AUTO:
-  return "MS_AUTO";
-case MS_NEVER:
-  return "MS_NEVER";
-  }
- return NULL;
-}
 const char *getOperation_mode_e(operation_mode_e value){
 switch(value) {
 case FOUR_STROKE_CAM_SENSOR:

--- a/firmware/config/boards/kinetis/config/controllers/algo/auto_generated_enums.h
+++ b/firmware/config/boards/kinetis/config/controllers/algo/auto_generated_enums.h
@@ -38,7 +38,6 @@ const char *getInjection_mode_e(injection_mode_e value);
 const char *getLaunchActivationMode_e(launchActivationMode_e value);
 const char *getLog_format_e(log_format_e value);
 const char *getMaf_sensor_type_e(maf_sensor_type_e value);
-const char *getMass_storage_e(mass_storage_e value);
 const char *getOperation_mode_e(operation_mode_e value);
 const char *getPin_input_mode_e(pin_input_mode_e value);
 const char *getPin_mode_e(pin_mode_e value);

--- a/firmware/config/engines/bmw_e34.cpp
+++ b/firmware/config/engines/bmw_e34.cpp
@@ -97,8 +97,6 @@ void setBmwE34(DECLARE_CONFIG_PARAMETER_SIGNATURE) {
 
 	engineConfiguration->malfunctionIndicatorPin = GPIO_UNASSIGNED;
 
-//	bc->isFastAdcEnabled = true;
-
 	engineConfiguration->injectionPinMode = OM_INVERTED;
 	engineConfiguration->injectionPins[0] = GPIOB_8; // #1
 	engineConfiguration->injectionPins[1] = GPIOE_2; // #2

--- a/firmware/config/engines/dodge_neon.cpp
+++ b/firmware/config/engines/dodge_neon.cpp
@@ -358,7 +358,6 @@ void setDodgeNeonNGCEngineConfiguration(DECLARE_CONFIG_PARAMETER_SIGNATURE) {
 	engineConfiguration->clt.adcChannel = EFI_ADC_12;
 
 	engineConfiguration->sensorChartMode = SC_MAP;
-	engineConfiguration->isFastAdcEnabled = true;
 	engineConfiguration->map.sensor.type = MT_DODGE_NEON_2003;
 
 	engineConfiguration->hip9011Gain = 0.3;

--- a/firmware/config/engines/ford_festiva.cpp
+++ b/firmware/config/engines/ford_festiva.cpp
@@ -121,7 +121,6 @@ void setFordEscortGt(DECLARE_CONFIG_PARAMETER_SIGNATURE) {
 	// Denso 195500-2180
 	engineConfiguration->injector.flow = 265;
 
-	engineConfiguration->isFastAdcEnabled = true;
 	engineConfiguration->map.sensor.type = MT_DENSO183;
 	/**
 	 * pin PA4: jumper W47<>W47 - ecu plug 3I

--- a/firmware/config/engines/honda_accord.cpp
+++ b/firmware/config/engines/honda_accord.cpp
@@ -39,7 +39,6 @@ EXTERN_CONFIG;
 
 static void setHondaAccordConfigurationCommon(DECLARE_CONFIG_PARAMETER_SIGNATURE) {
 	engineConfiguration->map.sensor.type = MT_DENSO183;
-	engineConfiguration->isFastAdcEnabled = true;
 
 	// set ignition_mode 0
 	engineConfiguration->ignitionMode = IM_ONE_COIL;

--- a/firmware/config/engines/me7pnp.cpp
+++ b/firmware/config/engines/me7pnp.cpp
@@ -45,7 +45,6 @@ void vag_18_Turbo(DECLARE_CONFIG_PARAMETER_SIGNATURE) {
 
 	//Analog Inputs
 
-	engineConfiguration->isFastAdcEnabled = true;
 	engineConfiguration->map.sensor.type = MT_GM_3_BAR;
 	setCommonNTCSensor(&engineConfiguration->clt, 2700);
 	setCommonNTCSensor(&engineConfiguration->iat, 2700);

--- a/firmware/console/binary/tunerstudio_outputs.h
+++ b/firmware/console/binary/tunerstudio_outputs.h
@@ -59,7 +59,7 @@ typedef struct {
 	unsigned int isO2HeaterOn : 1; // bit 7
 	unsigned int checkEngine : 1; // bit 8
 	unsigned int needBurn : 1; // bit 9
-	unsigned int secondTriggerChannelEnabled : 1; // bit 10
+	unsigned int unusedBit10 : 1; // bit 10
 	unsigned int clutchUpState : 1; // bit 11
 	unsigned int clutchDownState : 1; // bit 12
 	unsigned int knockEverIndicator : 1; // bit 13

--- a/firmware/console/status_loop.cpp
+++ b/firmware/console/status_loop.cpp
@@ -684,7 +684,7 @@ void updateTunerStudioState(TunerStudioOutputChannels *tsOutputChannels DECLARE_
 	tsOutputChannels->isInjectionEnabled = engineConfiguration->isInjectionEnabled;
 	tsOutputChannels->isCylinderCleanupEnabled = engineConfiguration->isCylinderCleanupEnabled;
 	tsOutputChannels->isCylinderCleanupActivated = engine->isCylinderCleanupMode;
-	tsOutputChannels->secondTriggerChannelEnabled = engineConfiguration->secondTriggerChannelEnabled;
+
 #if EFI_VEHICLE_SPEED
 	float vehicleSpeed = getVehicleSpeed();
 	tsOutputChannels->vehicleSpeedKph = vehicleSpeed;

--- a/firmware/controllers/algo/auto_generated_enums.cpp
+++ b/firmware/controllers/algo/auto_generated_enums.cpp
@@ -1080,19 +1080,6 @@ case Internal_ForceMyEnumIntSize_maf_sensor:
   }
  return NULL;
 }
-const char *getMass_storage_e(mass_storage_e value){
-switch(value) {
-case Force_4_bytes_size_mass_storage:
-  return "Force_4_bytes_size_mass_storage";
-case MS_ALWAYS:
-  return "MS_ALWAYS";
-case MS_AUTO:
-  return "MS_AUTO";
-case MS_NEVER:
-  return "MS_NEVER";
-  }
- return NULL;
-}
 const char *getOperation_mode_e(operation_mode_e value){
 switch(value) {
 case FOUR_STROKE_CAM_SENSOR:

--- a/firmware/controllers/algo/auto_generated_enums.h
+++ b/firmware/controllers/algo/auto_generated_enums.h
@@ -38,7 +38,6 @@ const char *getInjection_mode_e(injection_mode_e value);
 const char *getLaunchActivationMode_e(launchActivationMode_e value);
 const char *getLog_format_e(log_format_e value);
 const char *getMaf_sensor_type_e(maf_sensor_type_e value);
-const char *getMass_storage_e(mass_storage_e value);
 const char *getOperation_mode_e(operation_mode_e value);
 const char *getPin_input_mode_e(pin_input_mode_e value);
 const char *getPin_mode_e(pin_mode_e value);

--- a/firmware/controllers/algo/engine_configuration.cpp
+++ b/firmware/controllers/algo/engine_configuration.cpp
@@ -952,8 +952,6 @@ static void setDefaultEngineConfiguration(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 	// performance optimization
 	engineConfiguration->sensorChartMode = SC_OFF;
 
-	engineConfiguration->storageMode = MS_AUTO;
-
 	engineConfiguration->specs.firingOrder = FO_1_3_4_2;
 	engineConfiguration->crankingInjectionMode = IM_SIMULTANEOUS;
 	engineConfiguration->injectionMode = IM_SEQUENTIAL;
@@ -1037,10 +1035,8 @@ static void setDefaultEngineConfiguration(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 	engineConfiguration->isInjectionEnabled = true;
 	engineConfiguration->isIgnitionEnabled = true;
 	engineConfiguration->isCylinderCleanupEnabled = false; // this feature is evil if one does not have TPS, better turn off by default
-	engineConfiguration->secondTriggerChannelEnabled = true;
 
 	engineConfiguration->isMapAveragingEnabled = true;
-	engineConfiguration->isTunerStudioEnabled = true;
 	engineConfiguration->isWaveAnalyzerEnabled = true;
 
 	engineConfiguration->debugMode = DBG_ALTERNATOR_PID;
@@ -1076,10 +1072,7 @@ static void setDefaultEngineConfiguration(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 
 	engineConfiguration->hip9011Gain = 1;
 
-	engineConfiguration->isFastAdcEnabled = true;
 	engineConfiguration->isEngineControlEnabled = true;
-
-	engineConfiguration->isVerboseAlternator = false;
 
 	engineConfiguration->engineLoadAccelLength = 6;
 	engineConfiguration->engineLoadAccelEnrichmentThreshold = 5; // kPa

--- a/firmware/controllers/algo/rusefi_enums.h
+++ b/firmware/controllers/algo/rusefi_enums.h
@@ -660,13 +660,6 @@ typedef enum {
 } can_vss_nbc_e;
 
 typedef enum {
-	MS_AUTO = 0,
-	MS_ALWAYS = 1,
-	MS_NEVER = 2,
-	Force_4_bytes_size_mass_storage = ENUM_32_BITS,
-} mass_storage_e;
-
-typedef enum {
 	ES_BPSX_D1 = 0,
 	/**
 	 * same as innovate LC2

--- a/firmware/controllers/engine_controller.cpp
+++ b/firmware/controllers/engine_controller.cpp
@@ -304,10 +304,6 @@ static void printAnalogChannelInfoExt(const char *name, adc_channel_e hwChannel,
 		return;
 	}
 
-	if (fastAdc.isHwUsed(hwChannel)) {
-		scheduleMsg(&logger, "fast enabled=%s", boolToString(CONFIG(isFastAdcEnabled)));
-	}
-
 	float voltage = adcVoltage * dividerCoeff;
 	scheduleMsg(&logger, "%s ADC%d %s %s adc=%.2f/input=%.2fv/divider=%.2f", name, hwChannel, getAdc_channel_mode_e(getAdcMode(hwChannel)),
 			getPinNameByAdcChannel(name, hwChannel, pinNameBuffer), adcVoltage, voltage, dividerCoeff);
@@ -556,9 +552,7 @@ void commonInitEngineController(Logging *sharedLogger DECLARE_ENGINE_PARAMETER_S
 
 
 #if EFI_TUNER_STUDIO
-	if (engineConfiguration->isTunerStudioEnabled) {
-		startTunerStudioConnectivity();
-	}
+	startTunerStudioConnectivity();
 #endif /* EFI_TUNER_STUDIO */
 
 #if EFI_PROD_CODE || EFI_SIMULATOR

--- a/firmware/controllers/settings.cpp
+++ b/firmware/controllers/settings.cpp
@@ -216,11 +216,9 @@ void printConfiguration(const engine_configuration_s *engineConfiguration) {
 
 	printOutputs(engineConfiguration);
 
-	scheduleMsg(&logger, "map_avg=%s/ts=%s/wa=%s/fastAdc=%s",
+	scheduleMsg(&logger, "map_avg=%s/wa=%s",
 			boolToString(engineConfiguration->isMapAveragingEnabled),
-			boolToString(engineConfiguration->isTunerStudioEnabled),
-			boolToString(engineConfiguration->isWaveAnalyzerEnabled),
-			boolToString(engineConfiguration->isFastAdcEnabled));
+			boolToString(engineConfiguration->isWaveAnalyzerEnabled));
 
 	scheduleMsg(&logger, "isManualSpinningMode=%s/isCylinderCleanupEnabled=%s",
 			boolToString(engineConfiguration->isManualSpinningMode),
@@ -815,9 +813,7 @@ static void setSpiMode(int index, bool mode) {
 }
 
 static void enableOrDisable(const char *param, bool isEnabled) {
-	if (strEqualCaseInsensitive(param, "fastadc")) {
-		engineConfiguration->isFastAdcEnabled = isEnabled;
-	} else if (strEqualCaseInsensitive(param, CMD_TRIGGER_HW_INPUT)) {
+	if (strEqualCaseInsensitive(param, CMD_TRIGGER_HW_INPUT)) {
 		engine->hwTriggerInputEnabled = isEnabled;
 	} else if (strEqualCaseInsensitive(param, "useTLE8888_cranking_hack")) {
 		CONFIG(useTLE8888_cranking_hack) = isEnabled;
@@ -905,8 +901,6 @@ static void enableOrDisable(const char *param, bool isEnabled) {
 		engineConfiguration->isEngineControlEnabled = isEnabled;
 	} else if (strEqualCaseInsensitive(param, "map_avg")) {
 		engineConfiguration->isMapAveragingEnabled = isEnabled;
-	} else if (strEqualCaseInsensitive(param, "tunerstudio")) {
-		engineConfiguration->isTunerStudioEnabled = isEnabled;
 	} else if (strEqualCaseInsensitive(param, "logic_analyzer")) {
 		engineConfiguration->isWaveAnalyzerEnabled = isEnabled;
 	} else if (strEqualCaseInsensitive(param, "manual_spinning")) {

--- a/firmware/hw_layer/adc/adc_inputs.cpp
+++ b/firmware/hw_layer/adc/adc_inputs.cpp
@@ -628,16 +628,14 @@ void initAdcInputs() {
 	// Start the slow ADC thread
 	slowAdcController.Start();
 
-	if (CONFIG(isFastAdcEnabled)) {
-		fastAdc.init();
-		/*
-		 * Initializes the PWM driver.
-		 */
+	fastAdc.init();
+	/*
+		* Initializes the PWM driver.
+		*/
 #if HAL_USE_GPT
-		gptStart(EFI_INTERNAL_FAST_ADC_GPT, &fast_adc_config);
-		gptStartContinuous(EFI_INTERNAL_FAST_ADC_GPT, GPT_PERIOD_FAST);
+	gptStart(EFI_INTERNAL_FAST_ADC_GPT, &fast_adc_config);
+	gptStartContinuous(EFI_INTERNAL_FAST_ADC_GPT, GPT_PERIOD_FAST);
 #endif /* HAL_USE_GPT */
-	}
 
 	addConsoleActionI("adc", (VoidInt) printAdcValue);
 #else

--- a/firmware/hw_layer/mmc_card.cpp
+++ b/firmware/hw_layer/mmc_card.cpp
@@ -397,28 +397,27 @@ static void MMCmount(void) {
 		return;
 	}
 
-//	if (engineConfiguration->storageMode == MS_ALWAYS) {
 #if HAL_USE_USB_MSD
-	  msdObjectInit(&USBMSD1);
+	msdObjectInit(&USBMSD1);
 
 	BaseBlockDevice *bbdp = (BaseBlockDevice*)&MMCD1;
-	  msdStart(&USBMSD1, usb_driver, bbdp, blkbuf, NULL);
+	msdStart(&USBMSD1, usb_driver, bbdp, blkbuf, NULL);
 
-//		  const usb_msd_driver_state_t msd_driver_state = msdInit(ms_usb_driver, bbdp, &UMSD1, USB_MS_DATA_EP, USB_MSD_INTERFACE_NUMBER);
-	//	  UMSD1.chp = NULL;
+	//const usb_msd_driver_state_t msd_driver_state = msdInit(ms_usb_driver, bbdp, &UMSD1, USB_MS_DATA_EP, USB_MSD_INTERFACE_NUMBER);
+	//UMSD1.chp = NULL;
 
-		  /*Disconnect the USB Bus*/
-		  usbDisconnectBus(usb_driver);
-		  chThdSleepMilliseconds(200);
-//
-//		  /*Start the useful functions*/
-//		  msdStart(&UMSD1);
-		  usbStart(usb_driver, &msdusbcfg);
-//
-		  /*Connect the USB Bus*/
-		  usbConnectBus(usb_driver);
+	/*Disconnect the USB Bus*/
+	usbDisconnectBus(usb_driver);
+	chThdSleepMilliseconds(200);
+
+	///*Start the useful functions*/
+	//msdStart(&UMSD1);
+	usbStart(usb_driver, &msdusbcfg);
+
+	/*Connect the USB Bus*/
+	usbConnectBus(usb_driver);
 #endif
-	//}
+
 
 
 	UNLOCK_SD_SPI;

--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -273,9 +273,6 @@ custom debug_mode_e 4 bits,    U32,   @OFFSET@, [0:5], @@debug_mode_e_enum@@
 #define vvt_mode_e_enum "Inactive", "Second half", "2GZ", "Miata NB2", "First half", "Bosch Quick Start", "mode6", "mode7"
 custom vvt_mode_e 4 bits,    U32,   @OFFSET@, [0:2], @@vvt_mode_e_enum@@
 
-#define mass_storage_e_enum "Auto", "Always", "Never", "INVALID"
-custom mass_storage_e 4 bits, U32, @OFFSET@, [0:1], @@mass_storage_e_enum@@
-
 ! At the moment TIM1, TIM2, TIM3 and TIM9 are configured as ICU
 ! todo: as of ChibiOS3, only channels 1 & 2 are allowed to capture input, that's a ChibiOS driver limitation
 ! https://github.com/ChibiOS/ChibiOS-Drivers/blob/master/inc/timcap_driver.h is an alternative driver if channels 3 & 4 really become an issue
@@ -748,7 +745,7 @@ bit is_enabled_spi_1
 bit is_enabled_spi_2
 	bit is_enabled_spi_3
 	bit isSdCardEnabled;enable sd/disable sd
-	bit isFastAdcEnabled
+	bit unused744b4
 	bit isEngineControlEnabled
 	bit isHip9011Enabled
 	bit isVerboseAlternator
@@ -1010,12 +1007,12 @@ custom idle_mode_e 4 bits,    U32,   @OFFSET@, [0:0], "Automatic", "Manual"
 	bit isInjectionEnabled;+Enable fuel injection - This is default off for new projects as a safety feature, set to "true" to enable fuel injection and further injector settings.
 	bit isIgnitionEnabled;+Enable ignition - This is default off for new projects as a safety feature, set to "true" to enable ignition and further ignition settings.
 	bit isCylinderCleanupEnabled;+When enabled if TPS is held above 95% no fuel is injected while cranking to clear excess fuel from the cylinders. 
-	bit secondTriggerChannelEnabled
+	bit unused1476b3
 	bit unusedBit4_1476
 	bit isMapAveragingEnabled
 	bit overrideCrankingIacSetting;+This setting overrides the normal multiplication values that have been set for the idle air control valve during cranking. If this setting is enabled the "IAC multiplier" table in the Cranking settings tab needs to be adjusted appropriately or potentially no IAC opening will occur.
 	bit useSeparateAdvanceForIdle;+This activates a separate ignition timing table for idle conditions, this can help idle stability by using ignition retard and advance either side of the desired idle speed. Extra retard at low idle speeds will prevent stalling and extra advance at high idle speeds can help reduce engine power and slow the idle speed.
-	bit isTunerStudioEnabled
+	bit unused1476b8
 	bit isWaveAnalyzerEnabled
 	bit useSeparateVeForIdle;+This activates a separate fuel table for Idle, this allows fine tuning of the idle fuelling.
 	bit verboseTriggerSynchDetails;+enable trigger_details
@@ -1222,7 +1219,7 @@ float[MAP_ACCEL_TAPER] mapAccelTaperMult;;"mult",      1,     0,   0.0,    300, 
 
 	fsio_pwm_freq_t[AUX_PID_COUNT iterate] auxPidFrequency;
 	int alternatorPwmFrequency;;"Hz",        1,     0,  0,    3000.0,  0
-	mass_storage_e storageMode;
+	int unused2260;;"units", 1, 0, -20, 100, 0
 
 	float[NARROW_BAND_WIDE_BAND_CONVERSION_SIZE] narrowToWideOxygenBins;Narrow Band WBO Approximation;"V",        1,     0,   -10.0,    10.0,  3
 	float[NARROW_BAND_WIDE_BAND_CONVERSION_SIZE] narrowToWideOxygen;;"ratio",      1,     0,      -40.0,    40.0,   2

--- a/firmware/tunerstudio/rusefi.input
+++ b/firmware/tunerstudio/rusefi.input
@@ -170,7 +170,6 @@ enable2ndByteCanID = false
 	  ind_o2_heater   = bits,    U32,      0,    [7:7], "true", "false";
       ind_check_engine= bits,    U32,      0,    [8:8], "true", "false";
       needBurn        = bits,    U32,      0,    [9:9], "true", "false";
-      ind_2nd_trigger_en=bits,   U32,      0,  [10:10], "true", "false";
       clutchUpState    =bits,    U32,      0,  [11:11], "true", "false";
       clutchDownState  =bits,    U32,      0,  [12:12], "true", "false";
       knockEverIndicator=bits,   U32,      0,  [13:13], "true", "false";
@@ -2699,7 +2698,6 @@ cmd_set_engine_type_default					= "@@TS_IO_TEST_COMMAND_char@@\x00\x31\x00\x00"
 		field = "CS Pin",								sdCardCsPin
 		field = "SPI",									sdCardSpiDevice
 		field = "log format",							logFormat
-		field = "Mass Storage",							storageMode
 		field = "Write Period",							sdCardPeriodMs
 	
 	dialog = gpsReceiver, "GPS Receiver" 


### PR DESCRIPTION
This change removes the following config fields:
- `isFastAdcEnabled`: This should be disabled with a `#define` if a board doesn't have this capability.
- `secondTriggerChannelEnabled`: unused, replaced with trigger modes using the proper inputs all by themselves.
- `isTunerStudioEnabled`: this one provides you the potential to "saw off the branch you're sitting on", and lose TS connectivity.  If a board doesn't support TS, just don't define `EFI_TUNER_STUDIO`
- `storageMode`: Unused.