### PR TITLE
switch FSIO from float to expected<float>

### DIFF
--- a/firmware/controllers/core/fsio_core.h
+++ b/firmware/controllers/core/fsio_core.h
@@ -63,6 +63,8 @@ typedef enum {
 
 } le_action_e;
 
+using FsioValue = expected<float>;
+
 class LEElement {
 public:
 	LEElement();
@@ -113,7 +115,7 @@ public:
 	int currentCalculationLogPosition;
 private:
 	void push(le_action_e action, float value);
-	bool processElement(LEElement *element DECLARE_ENGINE_PARAMETER_SUFFIX);
+	FsioValue processElement(LEElement *element DECLARE_ENGINE_PARAMETER_SUFFIX);
 	float pop(le_action_e action);
 	LEElement *first;
 	calc_stack_t stack;

--- a/firmware/controllers/core/fsio_impl.cpp
+++ b/firmware/controllers/core/fsio_impl.cpp
@@ -113,8 +113,8 @@ static LEElement * mainRelayLogic;
 static Logging *logger;
 #if EFI_PROD_CODE || EFI_SIMULATOR
 
-float getEngineValue(le_action_e action DECLARE_ENGINE_PARAMETER_SUFFIX) {
-	efiAssert(CUSTOM_ERR_ASSERT, engine!=NULL, "getLEValue", NAN);
+FsioValue getEngineValue(le_action_e action DECLARE_ENGINE_PARAMETER_SUFFIX) {
+	efiAssert(CUSTOM_ERR_ASSERT, engine!=NULL, "getLEValue", unexpected);
 	switch (action) {
 	case LE_METHOD_FAN:
 		return enginePins.fanRelay.getLogicValue();
@@ -162,7 +162,7 @@ float getEngineValue(le_action_e action DECLARE_ENGINE_PARAMETER_SUFFIX) {
 #include "fsio_getters.def"
 	default:
 		warning(CUSTOM_FSIO_UNEXPECTED, "FSIO ERROR no data for action=%d", action);
-		return NAN;
+		return unexpected;
 	}
 }
 

--- a/firmware/controllers/core/fsio_impl.h
+++ b/firmware/controllers/core/fsio_impl.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "fsio_core.h"
+#include "expected.h"
 #include "engine.h"
 #include "table_helper.h"
 #include "system_fsio.h"
@@ -29,8 +30,8 @@
 typedef Map3D<FSIO_TABLE_8, FSIO_TABLE_8, float, float> fsio8_Map3D_f32t;
 typedef Map3D<FSIO_TABLE_8, FSIO_TABLE_8, uint8_t, float> fsio8_Map3D_u8t;
 
+expected<float> getEngineValue(le_action_e action DECLARE_ENGINE_PARAMETER_SUFFIX);
 
-float getEngineValue(le_action_e action DECLARE_ENGINE_PARAMETER_SUFFIX);
 /**
  * set_fsio_output_pin 7 PE3
  * set_rpn_expression 1 "rpm 0 fsio_setting <"

--- a/unit_tests/tests/test_logic_expression.cpp
+++ b/unit_tests/tests/test_logic_expression.cpp
@@ -15,7 +15,7 @@
 
 #define TEST_POOL_SIZE 256
 
-float getEngineValue(le_action_e action DECLARE_ENGINE_PARAMETER_SUFFIX) {
+FsioValue getEngineValue(le_action_e action DECLARE_ENGINE_PARAMETER_SUFFIX) {
 	switch(action) {
 	case LE_METHOD_FAN:
 		return engine->fsioState.mockFan;
@@ -36,7 +36,7 @@ float getEngineValue(le_action_e action DECLARE_ENGINE_PARAMETER_SUFFIX) {
 #include "fsio_getters.def"
 	default:
 	firmwareError(OBD_PCM_Processor_Fault, "FSIO: No mock value for %d", action);
-		return NAN;
+		return unexpected;
 	}
 }
 


### PR DESCRIPTION
prep for type checking - operations have to be able to fail (ie, return `unexpected`)!