### PR TITLE
Check for sd buffer overrun

### DIFF
--- a/firmware/console/binary_log/binary_logging.h
+++ b/firmware/console/binary_log/binary_logging.h
@@ -1,4 +1,4 @@
 #include <cstddef>
 
-void writeHeader(char* buffer);
+size_t writeHeader(char* buffer);
 size_t writeBlock(char* buffer);

--- a/firmware/console/status_loop.cpp
+++ b/firmware/console/status_loop.cpp
@@ -119,7 +119,7 @@ static void setWarningEnabled(int value) {
 
 #if EFI_FILE_LOGGING
 // this one needs to be in main ram so that SD card SPI DMA works fine
-static char sdLogBuffer[2300] MAIN_RAM;
+static char sdLogBuffer[2200] MAIN_RAM;
 static uint64_t binaryLogCount = 0;
 
 #endif /* EFI_FILE_LOGGING */

--- a/firmware/console/status_loop.cpp
+++ b/firmware/console/status_loop.cpp
@@ -147,15 +147,15 @@ void writeLogLine() {
 	if (!main_loop_started)
 		return;
 
-	size_t length = efi::size(sdLogBuffer);
-
+	size_t length;
 	if (binaryLogCount == 0) {
-		memset(sdLogBuffer, 0xAA, length);
-		writeHeader(sdLogBuffer);
+		length = writeHeader(sdLogBuffer);
 	} else {
 		updateTunerStudioState(&tsOutputChannels);
 		length = writeBlock(sdLogBuffer);
 	}
+
+	efiAssertVoid(OBD_PCM_Processor_Fault, length <= efi::size(sdLogBuffer), "SD log buffer overflow");
 
 	appendToLog(sdLogBuffer, length);
 


### PR DESCRIPTION
also write the actual header length, instead of assuming it fits in 2k

fixes #1864