### PR TITLE
switch to single precision constants

### DIFF
--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -40,7 +40,7 @@ endif
 
 # Compiler options here.
 ifeq ($(USE_OPT),)
-  USE_OPT = $(EXTRA_PARAMS) $(DEBUG_LEVEL_OPT) $(RFLAGS) -fomit-frame-pointer -falign-functions=16
+  USE_OPT = $(EXTRA_PARAMS) $(DEBUG_LEVEL_OPT) $(RFLAGS) -fomit-frame-pointer -falign-functions=16 -fsingle-precision-constant
 endif
 
 USE_OPT += $(RUSEFI_OPT)

--- a/unit_tests/Makefile
+++ b/unit_tests/Makefile
@@ -27,6 +27,7 @@ ifeq ($(USE_OPT),)
   USE_OPT += -fprofile-arcs -ftest-coverage
   USE_OPT += -Werror=missing-field-initializers
   USE_OPT += -Wno-unused-parameter -Wno-unused-function
+  USE_OPT += -fsingle-precision-constant
 endif
 
 

--- a/unit_tests/tests/test_pid.cpp
+++ b/unit_tests/tests/test_pid.cpp
@@ -23,21 +23,21 @@ TEST(util, pid) {
 
 	Pid pid(&pidS);
 
-	ASSERT_EQ( 90,  pid.getOutput(14, 12, 0.1)) << "getValue#90";
+	ASSERT_FLOAT_EQ( 90,  pid.getOutput(14, 12, 0.1)) << "getValue#90";
 
 
-	ASSERT_EQ( 10,  pid.getOutput(14, 16, 0.1)) << "getValue#10";
-	ASSERT_EQ(10, pid.getOutput(14, 16, 1));
+	ASSERT_FLOAT_EQ( 10,  pid.getOutput(14, 16, 0.1)) << "getValue#10";
+	ASSERT_FLOAT_EQ(10, pid.getOutput(14, 16, 1));
 
 	pid.updateFactors(29, 0, 0);
-	ASSERT_EQ(10, pid.getOutput(14, 16, 1));
-//	ASSERT_EQ(68, pid.getIntegration());
+	ASSERT_FLOAT_EQ(10, pid.getOutput(14, 16, 1));
+//	ASSERT_FLOAT_EQ(68, pid.getIntegration());
 
-	ASSERT_EQ(10, pid.getOutput(14, 16, 1));
-//	ASSERT_EQ(0, pid.getIntegration());
+	ASSERT_FLOAT_EQ(10, pid.getOutput(14, 16, 1));
+//	ASSERT_FLOAT_EQ(0, pid.getIntegration());
 
-	ASSERT_EQ(10, pid.getOutput(14, 16, 1));
-//	ASSERT_EQ(68, pid.getIntegration());
+	ASSERT_FLOAT_EQ(10, pid.getOutput(14, 16, 1));
+//	ASSERT_FLOAT_EQ(68, pid.getIntegration());
 
 
 
@@ -51,17 +51,17 @@ TEST(util, pid) {
 
 	pid.reset();
 
-	ASSERT_EQ( 50,  pid.getOutput(/*target*/50, /*input*/0)) << "target=50, input=0";
-	ASSERT_EQ( 0,  pid.iTerm) << "target=50, input=0 iTerm";
+	ASSERT_FLOAT_EQ( 50,  pid.getOutput(/*target*/50, /*input*/0)) << "target=50, input=0";
+	ASSERT_FLOAT_EQ( 0,  pid.iTerm) << "target=50, input=0 iTerm";
 
-	ASSERT_EQ( 0,  pid.getOutput(/*target*/50, /*input*/70)) << "target=50, input=70";
-	ASSERT_EQ( 0,  pid.iTerm) << "target=50, input=70 iTerm";
+	ASSERT_FLOAT_EQ( 0,  pid.getOutput(/*target*/50, /*input*/70)) << "target=50, input=70";
+	ASSERT_FLOAT_EQ( 0,  pid.iTerm) << "target=50, input=70 iTerm";
 
-	ASSERT_EQ( 0,  pid.getOutput(/*target*/50, /*input*/70)) << "target=50, input=70 #2";
-	ASSERT_EQ( 0,  pid.iTerm) << "target=50, input=70 iTerm #2";
+	ASSERT_FLOAT_EQ( 0,  pid.getOutput(/*target*/50, /*input*/70)) << "target=50, input=70 #2";
+	ASSERT_FLOAT_EQ( 0,  pid.iTerm) << "target=50, input=70 iTerm #2";
 
-	ASSERT_EQ( 0,  pid.getOutput(/*target*/50, /*input*/50)) << "target=50, input=50";
-	ASSERT_EQ( 0,  pid.iTerm) << "target=50, input=50 iTerm";
+	ASSERT_FLOAT_EQ( 0,  pid.getOutput(/*target*/50, /*input*/50)) << "target=50, input=50";
+	ASSERT_FLOAT_EQ( 0,  pid.iTerm) << "target=50, input=50 iTerm";
 }
 
 static void commonPidTestParameters(pid_s * pidS) {
@@ -77,15 +77,15 @@ static void commonPidTestParameters(pid_s * pidS) {
 static void commonPidTest(Pid *pid) {
 	pid->iTermMax = 45;
 
-	ASSERT_EQ( 12.5,  pid->getOutput(/*target*/50, /*input*/0)) << "target=50, input=0 #0";
-	ASSERT_EQ( 12.5,  pid->getIntegration());
-	ASSERT_EQ( 25  ,  pid->getOutput(/*target*/50, /*input*/0)) << "target=50, input=0 #1";
+	ASSERT_FLOAT_EQ( 12.5,  pid->getOutput(/*target*/50, /*input*/0)) << "target=50, input=0 #0";
+	ASSERT_FLOAT_EQ( 12.5,  pid->getIntegration());
+	ASSERT_FLOAT_EQ( 25  ,  pid->getOutput(/*target*/50, /*input*/0)) << "target=50, input=0 #1";
 
-	ASSERT_EQ( 37.5,  pid->getOutput(/*target*/50, /*input*/0)) << "target=50, input=0 #2";
-	ASSERT_EQ( 37.5,  pid->getIntegration());
+	ASSERT_FLOAT_EQ( 37.5,  pid->getOutput(/*target*/50, /*input*/0)) << "target=50, input=0 #2";
+	ASSERT_FLOAT_EQ( 37.5,  pid->getIntegration());
 
-	ASSERT_EQ( 40.0,  pid->getOutput(/*target*/50, /*input*/0)) << "target=50, input=0 #3";
-	ASSERT_EQ( 45,    pid->getIntegration());
+	ASSERT_FLOAT_EQ( 40.0,  pid->getOutput(/*target*/50, /*input*/0)) << "target=50, input=0 #3";
+	ASSERT_FLOAT_EQ( 45,    pid->getIntegration());
 }
 
 TEST(util, parallelPidLimits) {
@@ -126,12 +126,12 @@ TEST(util, pidIndustrial) {
 
 	float industValue = pid.getOutput(/*target*/1, /*input*/0);
 	// check if the first output is clamped because of large deviative
-	ASSERT_EQ(100.0, industValue);
+	ASSERT_FLOAT_EQ(100.0, industValue);
 
 	// check if all output of the 'zeroed' PidIndustrial (w/o new features) is the same as our "normal" Pid
 	for (int i = 0; i < 10; i++) {
 		float normalValue = pid0.getOutput(1, 0);
-		ASSERT_EQ(normalValue, industValue) << "[" << i << "]";
+		ASSERT_FLOAT_EQ(normalValue, industValue) << "[" << i << "]";
 		industValue = pid.getOutput(1, 0);
 	}
 
@@ -141,11 +141,11 @@ TEST(util, pidIndustrial) {
 	pid.derivativeFilterLoss = 0.01;
 
 	// now the first value is less (and not clipped!) due to the derivative filtering
-	ASSERT_EQ(67.671669f, pid.getOutput(1, 0));
+	ASSERT_FLOAT_EQ(67.671669f, pid.getOutput(1, 0));
 	// here we still have some leftovers of the initial D-term
-	ASSERT_EQ(45.4544487f, pid.getOutput(1, 0));
+	ASSERT_FLOAT_EQ(45.4544487f, pid.getOutput(1, 0));
 	// but the value is quickly fading
-	ASSERT_EQ(30.6446342f, pid.getOutput(1, 0));
+	ASSERT_FLOAT_EQ(30.6446342f, pid.getOutput(1, 0));
 
 	pid.reset();
 
@@ -166,7 +166,7 @@ TEST(util, pidIndustrial) {
 	pid.antiwindupFreq = 0.1;
 
 	// the first value is clipped, and that's when the anti-windup comes into effect
-	ASSERT_EQ(100.0f, pid.getOutput(1, 0));
+	ASSERT_FLOAT_EQ(100.0f, pid.getOutput(1, 0));
 	// it stores a small negative offset in the I-term to avoid it's saturation!
 	ASSERT_NEAR(-0.0455025025f, pid.getIntegration(), EPS4D);
 	// and that's why the second output is smaller then that of normal PID (=1.00999999)


### PR DESCRIPTION
`0.25`: this is a double
`0.25f`: this is a float

Adding this compiler option means these are both actually floats.  We don't have the hardware to process doubles, so it happens instead in software.

For example, the line of code `float instantRpm = (60000000.0 / 360 * US_TO_NT_MULTIPLIER) * angleDiff / time;` compiles to this:

![image](https://user-images.githubusercontent.com/568254/96042981-2017b180-0e23-11eb-911a-c9871357c2ac.png)

Circled are SOFTWARE EMULATED `double` math operations.  Bad! Slow! So much extra code!

With this option added, it now compiles to this:

![image](https://user-images.githubusercontent.com/568254/96043358-afbd6000-0e23-11eb-8c31-ba4c5d7a995a.png)

As a bonus, this saves ~1k of flash space.