### PR TITLE
common.h: define MIN and MAX macro only if nod defined yet

### DIFF
--- a/firmware/util/common.h
+++ b/firmware/util/common.h
@@ -22,8 +22,12 @@
 #ifndef COMMON_H_INCLUDED
 #define COMMON_H_INCLUDED
 
+#if !defined(MIN)
 #define MIN(a,b) (((a)<(b))?(a):(b))
+#endif
+#if !defined(MAX)
 #define MAX(a,b) (((a)>(b))?(a):(b))
+#endif
 
 #define CLAMP(x, low, high) ({\
 	__typeof__(x) __x = (x); \


### PR DESCRIPTION
This fix compilation error for Kinetis and Cypress if common.h
is included after platform includes which also defines MIN MAX.