### PR TITLE
Move all DECLARE_ENGINE_PTR etc to one place

### DIFF
--- a/firmware/console/status_loop.cpp
+++ b/firmware/console/status_loop.cpp
@@ -177,7 +177,7 @@ static void printOutPin(const char *pinName, brain_pin_e hwPin) {
 }
 #endif /* EFI_PROD_CODE */
 
-void printOverallStatus(systime_t nowSeconds) {
+void printOverallStatus(efitimesec_t nowSeconds) {
 #if EFI_ENGINE_SNIFFER
 	waveChart.publishIfFull();
 #endif /* EFI_ENGINE_SNIFFER */

--- a/firmware/console/status_loop.h
+++ b/firmware/console/status_loop.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include "engine.h"
+#include "rusefi_types.h"
 
 void updateDevConsoleState(void);
 void prepareTunerStudioOutputs(void);
@@ -16,4 +16,4 @@ void initStatusLoop(void);
 
 struct Writer;
 void writeLogLine(Writer& buffer);
-void printOverallStatus(systime_t nowSeconds);
+void printOverallStatus(efitimesec_t nowSeconds);

--- a/firmware/controllers/actuators/gppwm/gppwm.h
+++ b/firmware/controllers/actuators/gppwm/gppwm.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "engine.h"
+#include "engine_ptr.h"
 
 void initGpPwm(DECLARE_ENGINE_PARAMETER_SIGNATURE);
 void updateGppwm();

--- a/firmware/controllers/actuators/gppwm/gppwm_channel.h
+++ b/firmware/controllers/actuators/gppwm/gppwm_channel.h
@@ -2,6 +2,9 @@
 
 #include "gppwm.h"
 
+#include "rusefi_types.h"
+
+struct gppwm_channel;
 class OutputPin;
 class SimplePwm;
 class ValueProvider3D;
@@ -16,7 +19,6 @@ public:
 	void setOutput(float result);
 
 private:
-
 	// Store the current state so we can apply hysteresis
 	bool m_state = false;
 

--- a/firmware/controllers/actuators/idle_thread.h
+++ b/firmware/controllers/actuators/idle_thread.h
@@ -8,8 +8,12 @@
 
 #pragma once
 
-#include "engine.h"
+#include "engine_ptr.h"
+#include "rusefi_types.h"
 #include "periodic_task.h"
+
+class Logging;
+class Pid;
 
 class IdleController : public PeriodicTimerController {
 public:
@@ -24,7 +28,7 @@ percent_t getIdlePosition(void);
 void applyIACposition(percent_t position DECLARE_ENGINE_PARAMETER_SUFFIX);
 void setManualIdleValvePosition(int positionPercent);
 
-void startIdleThread(Logging*sharedLogger DECLARE_ENGINE_PARAMETER_SUFFIX);
+void startIdleThread(Logging* sharedLogger DECLARE_ENGINE_PARAMETER_SUFFIX);
 void setDefaultIdleParameters(DECLARE_CONFIG_PARAMETER_SIGNATURE);
 void startIdleBench(void);
 void setIdleDT(int value);

--- a/firmware/controllers/core/common_headers.h
+++ b/firmware/controllers/core/common_headers.h
@@ -27,6 +27,7 @@
 #include "efitime.h"
 
 #ifdef __cplusplus
+#include "engine_ptr.h"
 #include "datalogging.h"
 #include "loggingcentral.h"
 #include "cli_registry.h"
@@ -72,34 +73,6 @@
  */
 #define DISPLAY_SENSOR(x) {}
 #define DISPLAY_IF(x) x
-
-#if EFI_UNIT_TEST
-
-#define DECLARE_ENGINE_PTR                                 \
-	Engine *engine = nullptr;                              \
-	engine_configuration_s *engineConfiguration = nullptr; \
-	persistent_config_s *config = nullptr;
-
-
-#define INJECT_ENGINE_REFERENCE(x)                  \
-	(x)->engine = engine;                           \
-	(x)->engineConfiguration = engineConfiguration; \
-	(x)->config = config;
-
-#else // EFI_UNIT_TEST
-
-#define DECLARE_ENGINE_PTR
-
-#define INJECT_ENGINE_REFERENCE(x) {}
-
-#endif // EFI_UNIT_TEST
-
-#define EXPAND_Engine \
-	    engine_configuration_s *engineConfiguration = engine->engineConfigurationPtr; \
-		persistent_config_s *config = engine->config; \
-		(void)engineConfiguration; \
-		(void)config; \
-		
 
 #ifndef EFI_ACTIVE_CONFIGURATION_IN_FLASH
 // We store a special changeable copy of configuration is RAM, so we can just compare them

--- a/firmware/controllers/core/engine_ptr.h
+++ b/firmware/controllers/core/engine_ptr.h
@@ -2,6 +2,7 @@
 
 #include "efifeatures.h"
 
+#ifdef __cplusplus
 class Engine;
 struct engine_configuration_s;
 struct persistent_config_s;
@@ -62,6 +63,4 @@ struct persistent_config_s;
 		(void)engineConfiguration; \
 		(void)config;
 
-
-
-
+#endif // def __cplusplus

--- a/firmware/controllers/core/engine_ptr.h
+++ b/firmware/controllers/core/engine_ptr.h
@@ -1,0 +1,67 @@
+#pragma once
+
+#include "efifeatures.h"
+
+class Engine;
+struct engine_configuration_s;
+struct persistent_config_s;
+
+#if EFI_UNIT_TEST
+
+	#define DECLARE_ENGINE_PTR                                 \
+		Engine *engine = nullptr;                              \
+		engine_configuration_s *engineConfiguration = nullptr; \
+		persistent_config_s *config = nullptr;
+
+	#define INJECT_ENGINE_REFERENCE(x)                  \
+		(x)->engine = engine;                           \
+		(x)->engineConfiguration = engineConfiguration; \
+		(x)->config = config;
+
+	#define DECLARE_CONFIG_PARAMETER_SIGNATURE engine_configuration_s *engineConfiguration, persistent_config_s *config
+	#define DECLARE_CONFIG_PARAMETER_SUFFIX , DECLARE_CONFIG_PARAMETER_SIGNATURE
+	#define PASS_CONFIG_PARAMETER_SIGNATURE engineConfiguration, config
+	#define PASS_CONFIG_PARAMETER_SUFFIX , PASS_CONFIG_PARAMETER_SIGNATURE
+
+	/**
+	 * @see firmware/global.h for explanation
+	 */
+	#define DECLARE_ENGINE_PARAMETER_SIGNATURE Engine *engine, DECLARE_CONFIG_PARAMETER_SIGNATURE
+	#define DECLARE_ENGINE_PARAMETER_SUFFIX , DECLARE_ENGINE_PARAMETER_SIGNATURE
+	#define PASS_ENGINE_PARAMETER_SIGNATURE engine, PASS_CONFIG_PARAMETER_SIGNATURE
+	#define PASS_ENGINE_PARAMETER_SUFFIX , PASS_ENGINE_PARAMETER_SIGNATURE
+
+#else // EFI_UNIT_TEST
+
+	// These are the non-unit-test (AKA real firmware) noop versions
+
+	#define DECLARE_ENGINE_PTR
+
+	#define INJECT_ENGINE_REFERENCE(x) {}
+
+	// these macro are used when we should not have visibility to 'engine'
+	#define DECLARE_CONFIG_PARAMETER_SIGNATURE void
+	#define DECLARE_CONFIG_PARAMETER_SUFFIX
+	#define PASS_CONFIG_PARAMETER_SIGNATURE
+	#define PASS_CONFIG_PARAMETER_SUFFIX
+
+	// Use this macro to declare a function which only takes magic references
+	#define DECLARE_ENGINE_PARAMETER_SIGNATURE void
+	// Use this version of the macro as the suffix if method has other parameters
+	#define DECLARE_ENGINE_PARAMETER_SUFFIX
+	// Pass this if only magic references are needed
+	#define PASS_ENGINE_PARAMETER_SIGNATURE
+	// Pass this after some other parameters are passed
+	#define PASS_ENGINE_PARAMETER_SUFFIX
+
+#endif // EFI_UNIT_TEST
+
+#define EXPAND_Engine \
+	    engine_configuration_s *engineConfiguration = engine->engineConfigurationPtr; \
+		persistent_config_s *config = engine->config; \
+		(void)engineConfiguration; \
+		(void)config;
+
+
+
+

--- a/firmware/controllers/global_shared.h
+++ b/firmware/controllers/global_shared.h
@@ -29,6 +29,7 @@
  */
 
 #include "global.h"
+#include "engine_ptr.h"
 
 #define EXTERN_ENGINE_CONFIGURATION \
 		extern engine_configuration_s *engineConfiguration; \
@@ -63,25 +64,6 @@
 		extern Engine *engine; \
 		EXTERN_CONFIG \
 		extern EnginePins enginePins \
-
-// See also DECLARE_ENGINE_PTR
-// See also INJECT_ENGINE_REFERENCE
-
-
-// Use this macro to declare a function which only takes magic references
-#define DECLARE_ENGINE_PARAMETER_SIGNATURE void
-// Use this version of the macro as the suffix if method has other parameters
-#define DECLARE_ENGINE_PARAMETER_SUFFIX
-// Pass this if only magic references are needed
-#define PASS_ENGINE_PARAMETER_SIGNATURE
-// Pass this after some other parameters are passed
-#define PASS_ENGINE_PARAMETER_SUFFIX
-
-// these macro are used when we should not have visibility to 'engine'
-#define DECLARE_CONFIG_PARAMETER_SIGNATURE void
-#define DECLARE_CONFIG_PARAMETER_SUFFIX
-#define PASS_CONFIG_PARAMETER_SIGNATURE
-#define PASS_CONFIG_PARAMETER_SUFFIX
 
 #define ENGINE(x) ___engine.x
 

--- a/firmware/development/engine_sniffer.cpp
+++ b/firmware/development/engine_sniffer.cpp
@@ -24,6 +24,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "engine.h"
 #include "global.h"
 #include "os_access.h"
 #include "engine_sniffer.h"

--- a/unit_tests/global.h
+++ b/unit_tests/global.h
@@ -28,11 +28,6 @@ typedef uint32_t ioportmask_t;
 // this is needed by all DECLARE_ENGINE_PARAMETER_* usages
 #include "engine_configuration_generated_structures.h"
 
-#ifdef __cplusplus
-// this is needed by all DECLARE_ENGINE_PARAMETER_* usages
-class Engine;
-#endif /* __cplusplus */
-
 
 #ifdef __cplusplus
 // todo: include it right here? #include "unit_test_framework.h"

--- a/unit_tests/globalaccess.h
+++ b/unit_tests/globalaccess.h
@@ -8,19 +8,7 @@
 #pragma once
 
 #include "global.h"
-
-#define DECLARE_CONFIG_PARAMETER_SIGNATURE engine_configuration_s *engineConfiguration, persistent_config_s *config
-#define DECLARE_CONFIG_PARAMETER_SUFFIX , DECLARE_CONFIG_PARAMETER_SIGNATURE
-#define PASS_CONFIG_PARAMETER_SIGNATURE engineConfiguration, config
-#define PASS_CONFIG_PARAMETER_SUFFIX , PASS_CONFIG_PARAMETER_SIGNATURE
-
-/**
- * @see firmware/global.h for explanation
- */
-#define DECLARE_ENGINE_PARAMETER_SIGNATURE Engine *engine, DECLARE_CONFIG_PARAMETER_SIGNATURE
-#define DECLARE_ENGINE_PARAMETER_SUFFIX , DECLARE_ENGINE_PARAMETER_SIGNATURE
-#define PASS_ENGINE_PARAMETER_SIGNATURE engine, PASS_CONFIG_PARAMETER_SIGNATURE
-#define PASS_ENGINE_PARAMETER_SUFFIX , PASS_ENGINE_PARAMETER_SIGNATURE
+#include "engine_ptr.h"
 
 #define CONFIG(x) engineConfiguration->x
 #define ENGINE(x) engine->x


### PR DESCRIPTION
Consolidate it all to one spot, with associated forward declarations.  This means header files don't need to include the full `engine.h`.  Should help with compile time a bit, in addition to the "which header should I include" problem.