### PR TITLE
fix CRC errors

### DIFF
--- a/firmware/console/binary/tunerstudio_io.cpp
+++ b/firmware/console/binary/tunerstudio_io.cpp
@@ -250,12 +250,12 @@ void sr5WriteCrcPacket(ts_channel_s *tsChannel, const uint8_t responseCode, cons
 	}
 
 	// Index 0/1 = packet size (big endian)
-	*(uint16_t *) scratchBuffer = SWAP_UINT16(size + 1);
+	*(uint16_t*)scratchBuffer = SWAP_UINT16(size + 1);
 	// Index 2 = response code
-	*(uint8_t *) (scratchBuffer + 2) = responseCode;
+	scratchBuffer[2] = responseCode;
 
 	// CRC is computed on the responseCode and payload but not length
-	uint32_t crc = crc32((void *) (scratchBuffer + 2), size + 1); // command part of CRC
+	uint32_t crc = crc32(&scratchBuffer[2], size + 1); // command part of CRC
 
 	// Place the CRC at the end
 	*reinterpret_cast<uint32_t*>(&scratchBuffer[size + 3]) = SWAP_UINT32(crc);
@@ -290,6 +290,8 @@ void sr5FlushData(ts_channel_s *tsChannel) {
 #if defined(TS_CAN_DEVICE)
 	UNUSED(tsChannel);
 	canFlushTxStream(&TS_CAN_DEVICE);
+#else
+	UNUSED(tsChannel);
 #endif /* TS_CAN_DEVICE */
 }
 

--- a/firmware/console/binary/tunerstudio_io.cpp
+++ b/firmware/console/binary/tunerstudio_io.cpp
@@ -242,7 +242,7 @@ void sr5WriteCrcPacket(ts_channel_s *tsChannel, const uint8_t responseCode, cons
 	}
 #endif /* TS_CAN_DEVICE */
 
-	auto scratchBuffer = tsChannel->crcReadBuffer;
+	auto scratchBuffer = tsChannel->scratchBuffer;
 
 	// don't transmit a null buffer...
 	if (!buf) {

--- a/firmware/console/binary/tunerstudio_io.cpp
+++ b/firmware/console/binary/tunerstudio_io.cpp
@@ -249,6 +249,9 @@ void sr5WriteCrcPacket(ts_channel_s *tsChannel, const uint8_t responseCode, cons
 		size = 0;
 	}
 
+	// don't transmit too large a buffer
+	efiAssertVoid(OBD_PCM_Processor_Fault, size <= BLOCKING_FACTOR + 7, "sr5WriteCrcPacket tried to transmit too large a packet")
+
 	// If transmitting data, copy it in to place in the scratch buffer
 	if (size) {
 		memcpy(scratchBuffer + 3, buf, size);

--- a/firmware/console/binary/tunerstudio_io.cpp
+++ b/firmware/console/binary/tunerstudio_io.cpp
@@ -253,6 +253,9 @@ void sr5WriteCrcPacket(ts_channel_s *tsChannel, const uint8_t responseCode, cons
 	efiAssertVoid(OBD_PCM_Processor_Fault, size <= BLOCKING_FACTOR + 7, "sr5WriteCrcPacket tried to transmit too large a packet")
 
 	// If transmitting data, copy it in to place in the scratch buffer
+	// We want to prevent the data changing itself (higher priority threads could write
+	// tsOutputChannels) during the CRC computation.  Instead compute the CRC on our
+	// local buffer that nobody else will write.
 	if (size) {
 		memcpy(scratchBuffer + 3, buf, size);
 	}

--- a/firmware/console/binary/tunerstudio_io.cpp
+++ b/firmware/console/binary/tunerstudio_io.cpp
@@ -228,7 +228,7 @@ int sr5ReadData(ts_channel_s *tsChannel, uint8_t * buffer, int size) {
 /**
  * Adds size to the beginning of a packet and a crc32 at the end. Then send the packet.
  */
-void sr5WriteCrcPacket(ts_channel_s *tsChannel, const uint8_t responseCode, const void *buf, const uint16_t size) {
+void sr5WriteCrcPacket(ts_channel_s *tsChannel, const uint8_t responseCode, const void *buf, size_t size) {
 #if defined(TS_CAN_DEVICE) && defined(TS_CAN_DEVICE_SHORT_PACKETS_IN_ONE_FRAME)
 	// a special case for short packets: we can sent them in 1 frame, without CRC & size,
 	// because the CAN protocol is already protected by its own checksum.
@@ -243,6 +243,11 @@ void sr5WriteCrcPacket(ts_channel_s *tsChannel, const uint8_t responseCode, cons
 #endif /* TS_CAN_DEVICE */
 
 	auto scratchBuffer = tsChannel->crcReadBuffer;
+
+	// don't transmit a null buffer...
+	if (!buf) {
+		size = 0;
+	}
 
 	// If transmitting data, copy it in to place in the scratch buffer
 	if (size) {

--- a/firmware/console/binary/tunerstudio_io.h
+++ b/firmware/console/binary/tunerstudio_io.h
@@ -50,7 +50,7 @@ bool stopTsPort(ts_channel_s *tsChannel);
 #define SR5_READ_TIMEOUT TIME_MS2I(1000)
 
 void sr5WriteData(ts_channel_s *tsChannel, const uint8_t * buffer, int size);
-void sr5WriteCrcPacket(ts_channel_s *tsChannel, const uint8_t responseCode, const void *buf, const uint16_t size);
+void sr5WriteCrcPacket(ts_channel_s *tsChannel, const uint8_t responseCode, const void *buf, size_t size);
 void sr5SendResponse(ts_channel_s *tsChannel, ts_response_format_e mode, const uint8_t * buffer, int size);
 void sendOkResponse(ts_channel_s *tsChannel, ts_response_format_e mode);
 int sr5ReadData(ts_channel_s *tsChannel, uint8_t * buffer, int size);

--- a/firmware/console/binary/tunerstudio_io.h
+++ b/firmware/console/binary/tunerstudio_io.h
@@ -29,7 +29,7 @@ struct ts_channel_s {
 	/**
 	 * See 'blockingFactor' in rusefi.ini
 	 */
-	char crcReadBuffer[BLOCKING_FACTOR + 30];
+	char scratchBuffer[BLOCKING_FACTOR + 30];
 
 #if TS_UART_DMA_MODE || PRIMARY_UART_DMA_MODE || TS_UART_MODE
 	UARTDriver *uartp = nullptr;

--- a/firmware/console/binary/tunerstudio_io.h
+++ b/firmware/console/binary/tunerstudio_io.h
@@ -26,7 +26,6 @@ struct ts_channel_s {
 #if ! EFI_UNIT_TEST
 	BaseChannel * channel = nullptr;
 #endif
-	uint8_t writeBuffer[7];	// size(2 bytes) + response(1 byte) + crc32 (4 bytes)
 	/**
 	 * See 'blockingFactor' in rusefi.ini
 	 */


### PR DESCRIPTION
use the `crcReadBuffer` as a transmit buffer as well.  This ensures that we compute the CRC and transmit the same data - there's no opportunity for another thread to preempt and change the data between the CRC calculation and transmission.  This might actually net improve performance - it saves two calls to `sr5WriteData`.

fixes #1943 