### PR TITLE
prevent MMC preemption by TS thread

### DIFF
--- a/firmware/hw_layer/mmc_card.cpp
+++ b/firmware/hw_layer/mmc_card.cpp
@@ -26,7 +26,6 @@
 #include "status_loop.h"
 #include "usb_msd_cfg.h"
 #include "buffered_writer.h"
-#include "os_access.h"
 
 #include "rtc_helper.h"
 


### PR DESCRIPTION
causes a kernel halt if the MMC device changes during an MMC operation, possible when the setting is changed from TS