### PR TITLE
read SD card config exactly once

### DIFF
--- a/firmware/hw_layer/mmc_card.cpp
+++ b/firmware/hw_layer/mmc_card.cpp
@@ -51,6 +51,8 @@ static int writeCounter = 0;
 static int totalWritesCounter = 0;
 static int totalSyncCounter = 0;
 
+spi_device_e mmcSpiDevice = SPI_NONE;
+
 #define LOG_INDEX_FILENAME "index.txt"
 
 #define RUSEFI_LOG_PREFIX "re_"
@@ -93,7 +95,6 @@ static SPIConfig ls_spicfg = {
 		.cr2 = 0};
 
 /* MMC/SD over SPI driver configuration.*/
-// don't forget check if STM32_SPI_USE_SPI2 defined and spi has init with correct GPIO in hardware.cpp
 static MMCConfig mmccfg = { NULL, &ls_spicfg, &hs_spicfg };
 
 /**
@@ -141,7 +142,7 @@ static void sdStatistics(void) {
 	printMmcPinout();
 	scheduleMsg(&logger, "SD enabled=%s status=%s", boolToString(CONFIG(isSdCardEnabled)),
 			sdStatus);
-	printSpiConfig(&logger, "SD", CONFIG(sdCardSpiDevice));
+	printSpiConfig(&logger, "SD", mmcSpiDevice);
 	if (isSdCardAlive()) {
 		scheduleMsg(&logger, "filename=%s size=%d", logName, totalLoggedBytes);
 	}
@@ -435,7 +436,7 @@ static THD_FUNCTION(MMCmonThread, arg) {
 	chRegSetThreadName("MMC_Monitor");
 
 	while (true) {
-		// if the SPI device got un-picked somehow, cancel SD card
+				// if the SPI device got un-picked somehow, cancel SD card
 		if (CONFIG(sdCardSpiDevice) == SPI_NONE) {
 			return;
 		}
@@ -481,12 +482,14 @@ void initMmcCard(void) {
 		return;
 	}
 
-	efiAssertVoid(OBD_PCM_Processor_Fault, CONFIG(sdCardSpiDevice) != SPI_NONE, "SD card enabled, but no SPI device configured!");
+	mmcSpiDevice = CONFIG(sdCardSpiDevice);
+
+	efiAssertVoid(OBD_PCM_Processor_Fault, mmcSpiDevice != SPI_NONE, "SD card enabled, but no SPI device configured!");
 
 	// todo: reuse initSpiCs method?
 	hs_spicfg.ssport = ls_spicfg.ssport = getHwPort("mmc", CONFIG(sdCardCsPin));
 	hs_spicfg.sspad = ls_spicfg.sspad = getHwPin("mmc", CONFIG(sdCardCsPin));
-	mmccfg.spip = getSpiDevice(CONFIG(sdCardSpiDevice));
+	mmccfg.spip = getSpiDevice(mmcSpiDevice);
 
 	/**
 	 * FYI: SPI does not work with CCM memory, be sure to have main() stack in RAM, not in CCMRAM
@@ -496,7 +499,7 @@ void initMmcCard(void) {
 	mmcObjectInit(&MMCD1); 						// Initializes an instance.
 	mmcStart(&MMCD1, &mmccfg);
 
-	chThdCreateStatic(mmcThreadStack, sizeof(mmcThreadStack), NORMALPRIO, (tfunc_t)(void*) MMCmonThread, NULL);
+	chThdCreateStatic(mmcThreadStack, sizeof(mmcThreadStack), LOWPRIO, (tfunc_t)(void*) MMCmonThread, NULL);
 
 	addConsoleAction("mountsd", MMCmount);
 	addConsoleAction("umountsd", mmcUnMount);

--- a/firmware/hw_layer/mmc_card.cpp
+++ b/firmware/hw_layer/mmc_card.cpp
@@ -436,7 +436,7 @@ static THD_FUNCTION(MMCmonThread, arg) {
 	chRegSetThreadName("MMC_Monitor");
 
 	while (true) {
-				// if the SPI device got un-picked somehow, cancel SD card
+		// if the SPI device got un-picked somehow, cancel SD card
 		if (CONFIG(sdCardSpiDevice) == SPI_NONE) {
 			return;
 		}

--- a/firmware/hw_layer/mmc_card.h
+++ b/firmware/hw_layer/mmc_card.h
@@ -22,5 +22,6 @@ void readLogFileContent(char *buffer, short fileId, short offset, short length);
 void handleTsR(ts_channel_s *tsChannel, char *input);
 void handleTsW(ts_channel_s *tsChannel, char *input);
 
-#define LOCK_SD_SPI lockSpi(engineConfiguration->sdCardSpiDevice)
-#define UNLOCK_SD_SPI unlockSpi(engineConfiguration->sdCardSpiDevice)
+extern spi_device_e mmcSpiDevice;
+#define LOCK_SD_SPI lockSpi(mmcSpiDevice)
+#define UNLOCK_SD_SPI unlockSpi(mmcSpiDevice)


### PR DESCRIPTION
don't re-read SD card spi device after boot - it could change mid transaction (TS thread could preempt), which will cause disaster (usually multiple-unlock of the same mutex in `UNLOCK_SD_SPI`