### PR TITLE
avoid float -> int64 conversion

### DIFF
--- a/firmware/controllers/algo/advance_map.cpp
+++ b/firmware/controllers/algo/advance_map.cpp
@@ -250,8 +250,8 @@ size_t getMultiSparkCount(int rpm DECLARE_ENGINE_PARAMETER_SUFFIX) {
 		floatus_t multiDelay = CONFIG(multisparkSparkDuration);
 		floatus_t multiDwell = CONFIG(multisparkDwell);
 
-		ENGINE(engineState.multispark.delay) = US2NT(multiDelay);
-		ENGINE(engineState.multispark.dwell) = US2NT(multiDwell);
+		ENGINE(engineState.multispark.delay) = (uint32_t)USF2NT(multiDelay);
+		ENGINE(engineState.multispark.dwell) = (uint32_t)USF2NT(multiDwell);
 
 		constexpr float usPerDegreeAt1Rpm = 60e6 / 360;
 		floatus_t usPerDegree = usPerDegreeAt1Rpm / rpm;

--- a/firmware/controllers/algo/launch_control.cpp
+++ b/firmware/controllers/algo/launch_control.cpp
@@ -159,7 +159,7 @@ void LaunchControlBase::update() {
 		engine->applyLaunchExtraFuel = false;
 	} else {
 		// If conditions are met...
-		if ((getTimeNowNt() - launchTimer > MS2NT(timeDelay * 1000)) && combinedConditions) {
+		if ((getTimeNowNt() - launchTimer > MSF2NT(timeDelay * 1000)) && combinedConditions) {
 			engine->isLaunchCondition = true;           // ...enable launch!
 			engine->applyLaunchExtraFuel = true;
 		}

--- a/firmware/controllers/engine_cycle/rpm_calculator.cpp
+++ b/firmware/controllers/engine_cycle/rpm_calculator.cpp
@@ -386,7 +386,7 @@ efitick_t scheduleByAngle(scheduling_s *timer, efitick_t edgeTimestamp, angle_t 
 		action_s action DECLARE_ENGINE_PARAMETER_SUFFIX) {
 	float delayUs = ENGINE(rpmCalculator.oneDegreeUs) * angle;
 
-	efitime_t delayNt = US2NT(delayUs);
+	int32_t delayNt = USF2NT(delayUs);
 	efitime_t delayedTime = edgeTimestamp + delayNt;
 
 	ENGINE(executor.scheduleByTimestampNt(timer, delayedTime, action));

--- a/firmware/controllers/system/timer/pwm_generator_logic.cpp
+++ b/firmware/controllers/system/timer/pwm_generator_logic.cpp
@@ -137,7 +137,7 @@ void PwmConfig::setFrequency(float frequency) {
 	/**
 	 * see #handleCycleStart()
 	 */
-	periodNt = US2NT(frequency2periodUs(frequency));
+	periodNt = USF2NT(frequency2periodUs(frequency));
 }
 
 void PwmConfig::stop() {


### PR DESCRIPTION
arm32 doesn't have any native 64b instructions, and that includes conversion from float to 64 bit int.  This is a common conversion we were doing from float -> efitick_t (aka int64_t).  This change avoids that conversion as it's pretty slow to do in software.