### PR TITLE
remove ALWAYS_INLINE

### DIFF
--- a/firmware/controllers/engine_cycle/main_trigger_callback.cpp
+++ b/firmware/controllers/engine_cycle/main_trigger_callback.cpp
@@ -314,7 +314,7 @@ void InjectionEvent::onTriggerTooth(size_t trgEventIndex, int rpm, efitick_t now
 #endif /* EFI_DEFAILED_LOGGING */
 }
 
-static ALWAYS_INLINE void handleFuel(const bool limitedFuel, uint32_t trgEventIndex, int rpm, efitick_t nowNt DECLARE_ENGINE_PARAMETER_SUFFIX) {
+static void handleFuel(const bool limitedFuel, uint32_t trgEventIndex, int rpm, efitick_t nowNt DECLARE_ENGINE_PARAMETER_SUFFIX) {
 	ScopePerf perf(PE::HandleFuel);
 	
 	efiAssertVoid(CUSTOM_STACK_6627, getCurrentRemainingStack() > 128, "lowstck#3");

--- a/firmware/controllers/engine_cycle/spark_logic.cpp
+++ b/firmware/controllers/engine_cycle/spark_logic.cpp
@@ -319,7 +319,7 @@ bool scheduleOrQueue(AngleBasedEvent *event,
 	}
 }
 
-static ALWAYS_INLINE void handleSparkEvent(bool limitedSpark, uint32_t trgEventIndex, IgnitionEvent *event,
+static void handleSparkEvent(bool limitedSpark, uint32_t trgEventIndex, IgnitionEvent *event,
 		int rpm, efitick_t edgeTimestamp DECLARE_ENGINE_PARAMETER_SUFFIX) {
 
 	angle_t sparkAngle = event->sparkAngle;
@@ -421,7 +421,7 @@ void initializeIgnitionActions(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 	list->isReady = true;
 }
 
-static ALWAYS_INLINE void prepareIgnitionSchedule(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
+static void prepareIgnitionSchedule(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 	ScopePerf perf(PE::PrepareIgnitionSchedule);
 	
 	/**

--- a/firmware/controllers/trigger/trigger_central.cpp
+++ b/firmware/controllers/trigger/trigger_central.cpp
@@ -320,7 +320,7 @@ static char shaft_signal_msg_index[15];
 static const bool isUpEvent[6] = { false, true, false, true, false, true };
 static const char *eventId[6] = { PROTOCOL_CRANK1, PROTOCOL_CRANK1, PROTOCOL_CRANK2, PROTOCOL_CRANK2, PROTOCOL_CRANK3, PROTOCOL_CRANK3 };
 
-static ALWAYS_INLINE void reportEventToWaveChart(trigger_event_e ckpSignalType, int index DECLARE_ENGINE_PARAMETER_SUFFIX) {
+static void reportEventToWaveChart(trigger_event_e ckpSignalType, int index DECLARE_ENGINE_PARAMETER_SUFFIX) {
 	if (!ENGINE(isEngineChartEnabled)) { // this is here just as a shortcut so that we avoid engine sniffer as soon as possible
 		return; // engineSnifferRpmThreshold is accounted for inside ENGINE(isEngineChartEnabled)
 	}

--- a/firmware/global.h
+++ b/firmware/global.h
@@ -27,12 +27,9 @@
 #if defined __GNUC__
 // GCC
 #include <sys/types.h>
-#define ALWAYS_INLINE __attribute__((always_inline)) inline
 #else
 // IAR
 typedef unsigned int time_t;
-// todo: what's the IAR option?
-#define ALWAYS_INLINE INLINE
 #endif
 
 #ifdef __cplusplus

--- a/simulator/simulator/global.h
+++ b/simulator/simulator/global.h
@@ -30,8 +30,6 @@
 
 #define US_TO_NT_MULTIPLIER 100
 
-#define ALWAYS_INLINE
-
 #define US2NT(x) (US_TO_NT_MULTIPLIER * (x))
 
 #define NT2US(x) ((x) / US_TO_NT_MULTIPLIER)

--- a/unit_tests/global.h
+++ b/unit_tests/global.h
@@ -58,8 +58,6 @@ void print(const char *fmt, ...);
 #define VCS_VERSION "321"
 #define RUS_EFI_VERSION_TAG "rusEfiVersion"
 
-#define ALWAYS_INLINE INLINE
-
 #define US2NT(x) (US_TO_NT_MULTIPLIER * (x))
 
 #define NT2US(x) ((x) / US_TO_NT_MULTIPLIER)


### PR DESCRIPTION
confirmed that its removal doesn't change the output binary

the functions it'd marked were already getting inlined by the compiler, and these days `inline` is a hint at best, and usually just ignored altogether.