### PR TITLE
introduce vehicle acceleration in TS

### DIFF
--- a/firmware/console/binary/tunerstudio_outputs.h
+++ b/firmware/console/binary/tunerstudio_outputs.h
@@ -259,7 +259,9 @@ typedef struct {
 	scaled_lambda targetLambda; // 280
 	scaled_afr airFuelRatio; // 282
 
-	uint8_t unusedAtTheEnd[4]; // we have some unused bytes to allow compatible TS changes
+	scaled_ms VssAcceleration; //284
+	//288
+	uint8_t unusedAtTheEnd[2]; // we have some unused bytes to allow compatible TS changes
 
 	// Temporary - will remove soon
 	TsDebugChannels* getDebugChannels() {

--- a/firmware/tunerstudio/rusefi.input
+++ b/firmware/tunerstudio/rusefi.input
@@ -1055,6 +1055,9 @@ gaugeCategory = Knock
    knock7Gauge = knock7, "Knock Cyl 7", "dBv", -60, 10, -60, -60, 10, 10, 0, 0
    knock8Gauge = knock8, "Knock Cyl 8", "dBv", -60, 10, -60, -60, 10, 10, 0, 0
 
+gaugeCategory = DynoView
+	accelGauge = VssAcceleration, "Vehicle acceleration",    "m/s2",       -10,   10,      -6,     -4,      4,    6,   2,   2
+
 [WueAnalyze]
     
 ;                    wueCurveName, afrTempCompensationCurve, lambdaTargetTableName, lambdaChannel, coolantTempChannel, egoCorrectionChannel, wueChannel, activeCondition

--- a/firmware/tunerstudio/rusefi.input
+++ b/firmware/tunerstudio/rusefi.input
@@ -384,6 +384,7 @@ enable2ndByteCanID = false
 	highFuelPressure      = scalar,  S16,     278, "bar", {1/@@PACK_MULT_HIGH_PRESSURE@@}, 0
 	targetLambda     = scalar,  U16,     280,      "",{1/@@PACK_MULT_LAMBDA@@},       0.0
 	AFRValue        = scalar,  U16,     282,      "AFR",{1/@@PACK_MULT_AFR@@},       0.0
+	VssAcceleration = scalar,  U16,     284,      "m/s2" {1/@@PACK_MULT_MS@@}, 0.0
 
 ;
 ; see TunerStudioOutputChannels struct
@@ -1285,6 +1286,8 @@ gaugeCategory = Knock
    entry = knock6, "Knock 6", int, "%d"
    entry = knock7, "Knock 7", int, "%d"
    entry = knock8, "Knock 8", int, "%d"
+
+   entry = VssAcceleration, "Accel", float, "%.3f"
 
 ;     tpsADC          = U16,    "ADC",
 ;     alignmet        = U16,    "al",


### PR DESCRIPTION
added new field to send out Vehicle acceleration based on Vss.
I did not create a new scaled type, i reused the scaled_ms -> we use the same scaling.