### PR TITLE
require TPS values to be different

### DIFF
--- a/firmware/controllers/sensors/converters/linear_func.h
+++ b/firmware/controllers/sensors/converters/linear_func.h
@@ -12,6 +12,10 @@ public:
 
 	void showInfo(Logging* logger, float testRawValue) const override;
 
+	float getDivideInput() const {
+		return m_divideInput;
+	}
+
 private:
 	// Linear equation parameters for equation of form
 	// y = ax + b

--- a/firmware/init/sensor/init_tps.cpp
+++ b/firmware/init/sensor/init_tps.cpp
@@ -66,7 +66,8 @@ static bool initTpsFunc(LinearFunc& func, FunctionalSensor& sensor, adc_channel_
 		return false;
 	}
 
-	if (configureTps(func, closed, open, min, max)) {
+	// If the configuration was invalid, don't continues to configure the sensor
+	if (!configureTps(func, closed, open, min, max)) {
 		return;
 	}
 

--- a/firmware/init/sensor/init_tps.cpp
+++ b/firmware/init/sensor/init_tps.cpp
@@ -39,12 +39,25 @@ LinearFunc idlePosFunc(PACK_MULT_VOLTAGE);
 FunctionalSensor wastegateSens(SensorType::WastegatePosition, MS2NT(10));
 FunctionalSensor idlePosSens(SensorType::IdlePosition, MS2NT(10));
 
-static void configureTps(LinearFunc& func, float closed, float open, float min, float max) {
+static bool configureTps(LinearFunc& func, float closed, float open, float min, float max, const char* msg) {
+	float scaledClosed = closed / func.getDivideInput();
+	float scaledOpen = open / func.getDivideInput();
+
+	float split = absF(scaledOpen - scaledClosed);
+
+	// If the voltage for closed vs. open is very near, something is wrong with your calibration
+	if (split < 0.5f) {
+		firmwareError(OBD_Throttle_Position_Sensor_Circuit_Malfunction, "Sensor %s problem: open/closed calibration values are too close together.  Please check your wiring!", msg);
+		return false;
+	}
+
 	func.configure(
 		closed, 0,
 		open, 100, 
 		min, max
 	);
+
+	return true;
 }
 
 static bool initTpsFunc(LinearFunc& func, FunctionalSensor& sensor, adc_channel_e channel, float closed, float open, float min, float max) {
@@ -53,7 +66,9 @@ static bool initTpsFunc(LinearFunc& func, FunctionalSensor& sensor, adc_channel_
 		return false;
 	}
 
-	configureTps(func, closed, open, min, max);
+	if (configureTps(func, closed, open, min, max)) {
+		return;
+	}
 
 	sensor.setFunction(func);
 

--- a/firmware/init/sensor/init_tps.cpp
+++ b/firmware/init/sensor/init_tps.cpp
@@ -67,7 +67,7 @@ static bool initTpsFunc(LinearFunc& func, FunctionalSensor& sensor, adc_channel_
 	}
 
 	// If the configuration was invalid, don't continues to configure the sensor
-	if (!configureTps(func, closed, open, min, max)) {
+	if (!configureTps(func, closed, open, min, max, sensor.getSensorName())) {
 		return;
 	}
 

--- a/firmware/init/sensor/init_tps.cpp
+++ b/firmware/init/sensor/init_tps.cpp
@@ -47,7 +47,7 @@ static bool configureTps(LinearFunc& func, float closed, float open, float min, 
 
 	// If the voltage for closed vs. open is very near, something is wrong with your calibration
 	if (split < 0.5f) {
-		firmwareError(OBD_Throttle_Position_Sensor_Circuit_Malfunction, "Sensor %s problem: open/closed calibration values are too close together.  Please check your wiring!", msg);
+		firmwareError(OBD_Throttle_Position_Sensor_Circuit_Malfunction, "Sensor \"%s\" problem: open/closed calibration values are too close together.  Please check your wiring!", msg);
 		return false;
 	}
 
@@ -68,7 +68,7 @@ static bool initTpsFunc(LinearFunc& func, FunctionalSensor& sensor, adc_channel_
 
 	// If the configuration was invalid, don't continues to configure the sensor
 	if (!configureTps(func, closed, open, min, max, sensor.getSensorName())) {
-		return;
+		return false;
 	}
 
 	sensor.setFunction(func);
@@ -126,14 +126,14 @@ void reconfigureTps(DECLARE_CONFIG_PARAMETER_SIGNATURE) {
 	float min = CONFIG(tpsErrorDetectionTooLow);
 	float max = CONFIG(tpsErrorDetectionTooHigh);
 
-	configureTps(tpsFunc1p, CONFIG(tpsMin), CONFIG(tpsMax), min, max);
-	configureTps(tpsFunc1s, CONFIG(tps1SecondaryMin), CONFIG(tps1SecondaryMax), min, max);
-	configureTps(tpsFunc2p, CONFIG(tps2Min), CONFIG(tps2Max), min, max);
-	configureTps(tpsFunc2s, CONFIG(tps2SecondaryMin), CONFIG(tps2SecondaryMax), min, max);
+	configureTps(tpsFunc1p, CONFIG(tpsMin), CONFIG(tpsMax), min, max, tpsSens1p.getSensorName());
+	configureTps(tpsFunc1s, CONFIG(tps1SecondaryMin), CONFIG(tps1SecondaryMax), min, max, tpsSens1s.getSensorName());
+	configureTps(tpsFunc2p, CONFIG(tps2Min), CONFIG(tps2Max), min, max, tpsSens2p.getSensorName());
+	configureTps(tpsFunc2s, CONFIG(tps2SecondaryMin), CONFIG(tps2SecondaryMax), min, max, tpsSens2s.getSensorName());
 
-	configureTps(pedalFuncPrimary, CONFIG(throttlePedalUpVoltage), CONFIG(throttlePedalWOTVoltage), min, max);
-	configureTps(pedalFuncSecondary, CONFIG(throttlePedalSecondaryUpVoltage), CONFIG(throttlePedalSecondaryWOTVoltage), min, max);
+	configureTps(pedalFuncPrimary, CONFIG(throttlePedalUpVoltage), CONFIG(throttlePedalWOTVoltage), min, max, pedalSensorPrimary.getSensorName());
+	configureTps(pedalFuncSecondary, CONFIG(throttlePedalSecondaryUpVoltage), CONFIG(throttlePedalSecondaryWOTVoltage), min, max, pedalSensorSecondary.getSensorName());
 
-	configureTps(wastegateFunc, CONFIG(wastegatePositionMin), CONFIG(wastegatePositionMax), min, max);
-	configureTps(idlePosFunc, CONFIG(idlePositionMin), CONFIG(idlePositionMax), min, max);
+	configureTps(wastegateFunc, CONFIG(wastegatePositionMin), CONFIG(wastegatePositionMax), min, max, wastegateSens.getSensorName());
+	configureTps(idlePosFunc, CONFIG(idlePositionMin), CONFIG(idlePositionMax), min, max, idlePosSens.getSensorName());
 }

--- a/unit_tests/tests/sensor/test_sensor_init.cpp
+++ b/unit_tests/tests/sensor/test_sensor_init.cpp
@@ -55,13 +55,23 @@ TEST(SensorInit, TpsValuesTooClose) {
 	WITH_ENGINE_TEST_HELPER(TEST_ENGINE);
 
 	// Should fail, 0.49 volts apart
-	CONFIG(tpsMin) = 200;	// 1 volt
+	CONFIG(tpsMin) = 200;	// 1.00 volt
 	CONFIG(tpsMax) = 298;	// 1.49 volts
 	EXPECT_FATAL_ERROR(initTps(PASS_CONFIG_PARAMETER_SIGNATURE));
 
+	// Should fail, -0.49 volts apart
+	CONFIG(tpsMin) = 298;	// 1.49 volt
+	CONFIG(tpsMax) = 200;	// 1.00 volts
+	EXPECT_FATAL_ERROR(initTps(PASS_CONFIG_PARAMETER_SIGNATURE));
+
 	// Should succeed, 0.51 volts apart
-	CONFIG(tpsMin) = 200;	// 1 volt
+	CONFIG(tpsMin) = 200;	// 1.00 volt
 	CONFIG(tpsMax) = 302;	// 1.51 volts
+	EXPECT_NO_FATAL_ERROR(initTps(PASS_CONFIG_PARAMETER_SIGNATURE));
+
+	// Should succeed, -0.51 volts apart
+	CONFIG(tpsMin) = 302;	// 1.51 volt
+	CONFIG(tpsMax) = 200;	// 1.00 volts
 	EXPECT_NO_FATAL_ERROR(initTps(PASS_CONFIG_PARAMETER_SIGNATURE));
 }
 

--- a/unit_tests/tests/sensor/test_sensor_init.cpp
+++ b/unit_tests/tests/sensor/test_sensor_init.cpp
@@ -77,6 +77,14 @@ TEST(SensorInit, TpsValuesTooClose) {
 	CONFIG(tpsMax) = 200;	// 1.00 volts
 	EXPECT_NO_FATAL_ERROR(initTps(PASS_CONFIG_PARAMETER_SIGNATURE));
 	Sensor::resetRegistry();
+
+	// With no pin, it should be ok that they are the same
+	// Should succeed, -0.51 volts apart
+	CONFIG(tps1_1AdcChannel) = ADC_CHANNEL_NONE;
+	CONFIG(tpsMin) = 200;	// 1.00 volt
+	CONFIG(tpsMax) = 200;	// 1.00 volts
+	EXPECT_NO_FATAL_ERROR(initTps(PASS_CONFIG_PARAMETER_SIGNATURE));
+	Sensor::resetRegistry();
 }
 
 TEST(SensorInit, Pedal) {

--- a/unit_tests/tests/sensor/test_sensor_init.cpp
+++ b/unit_tests/tests/sensor/test_sensor_init.cpp
@@ -58,21 +58,25 @@ TEST(SensorInit, TpsValuesTooClose) {
 	CONFIG(tpsMin) = 200;	// 1.00 volt
 	CONFIG(tpsMax) = 298;	// 1.49 volts
 	EXPECT_FATAL_ERROR(initTps(PASS_CONFIG_PARAMETER_SIGNATURE));
+	Sensor::resetRegistry();
 
 	// Should fail, -0.49 volts apart
 	CONFIG(tpsMin) = 298;	// 1.49 volt
 	CONFIG(tpsMax) = 200;	// 1.00 volts
 	EXPECT_FATAL_ERROR(initTps(PASS_CONFIG_PARAMETER_SIGNATURE));
+	Sensor::resetRegistry();
 
 	// Should succeed, 0.51 volts apart
 	CONFIG(tpsMin) = 200;	// 1.00 volt
 	CONFIG(tpsMax) = 302;	// 1.51 volts
 	EXPECT_NO_FATAL_ERROR(initTps(PASS_CONFIG_PARAMETER_SIGNATURE));
+	Sensor::resetRegistry();
 
 	// Should succeed, -0.51 volts apart
 	CONFIG(tpsMin) = 302;	// 1.51 volt
 	CONFIG(tpsMax) = 200;	// 1.00 volts
 	EXPECT_NO_FATAL_ERROR(initTps(PASS_CONFIG_PARAMETER_SIGNATURE));
+	Sensor::resetRegistry();
 }
 
 TEST(SensorInit, Pedal) {

--- a/unit_tests/tests/sensor/test_sensor_init.cpp
+++ b/unit_tests/tests/sensor/test_sensor_init.cpp
@@ -51,6 +51,20 @@ TEST(SensorInit, Tps) {
 	EXPECT_NEAR(50.0f, Sensor::get(SensorType::Tps1).value_or(-1), EPS2D);
 }
 
+TEST(SensorInit, TpsValuesTooClose) {
+	WITH_ENGINE_TEST_HELPER(TEST_ENGINE);
+
+	// Should fail, 0.49 volts apart
+	CONFIG(tpsMin) = 200;	// 1 volt
+	CONFIG(tpsMax) = 298;	// 1.49 volts
+	EXPECT_FATAL_ERROR(initTps(PASS_CONFIG_PARAMETER_SIGNATURE));
+
+	// Should succeed, 0.51 volts apart
+	CONFIG(tpsMin) = 200;	// 1 volt
+	CONFIG(tpsMax) = 302;	// 1.51 volts
+	EXPECT_NO_FATAL_ERROR(initTps(PASS_CONFIG_PARAMETER_SIGNATURE));
+}
+
 TEST(SensorInit, Pedal) {
 	WITH_ENGINE_TEST_HELPER(TEST_ENGINE);
 


### PR DESCRIPTION
warn the user that their wiring may be busted if the TPS values are very close together (aka, auto calibrate didn't work)

progress #1954 part 2