### PR TITLE
ADC: correctly calculate cache invalidate range for STM32F7xxx

### DIFF
--- a/firmware/hw_layer/adc/AdcConfiguration.h
+++ b/firmware/hw_layer/adc/AdcConfiguration.h
@@ -20,7 +20,7 @@ typedef struct {
 
 class AdcDevice {
 public:
-	explicit AdcDevice(ADCConversionGroup* hwConfig, adcsample_t *buf);
+	explicit AdcDevice(ADCConversionGroup* hwConfig, adcsample_t *buf, size_t buf_len);
 	void enableChannel(adc_channel_e hwChannelIndex);
 	void enableChannelAndPin(const char *msg, adc_channel_e hwChannelIndex);
 	adc_channel_e getAdcHardwareIndexByInternalIndex(int index) const;
@@ -34,6 +34,7 @@ public:
 	void invalidateSamplesCache();
 
 	adcsample_t *samples;
+	size_t buf_len;
 
 	int getAdcValueByHwChannel(adc_channel_e hwChannel) const;
 


### PR DESCRIPTION
Bug was introduced in 2312b0ae5755e47b0963586f3ae717537c57da4d when
sample buffer was moved out of class. So sample become adcsample_t*
instead of adcsample_t[] and sizeof returns 4.