### PR TITLE
add isRedundant api for sensors

### DIFF
--- a/firmware/controllers/sensors/redundant_sensor.h
+++ b/firmware/controllers/sensors/redundant_sensor.h
@@ -15,6 +15,11 @@ public:
 
 	SensorResult get() const override;
 
+	bool isRedundant() const override {
+		// This sensor is redundant when not ignoring the second channel
+		return !m_ignoreSecond;
+	}
+
 	void showInfo(Logging* logger, const char* sensorName) const override;
 
 private:

--- a/firmware/controllers/sensors/sensor.cpp
+++ b/firmware/controllers/sensors/sensor.cpp
@@ -118,12 +118,22 @@ public:
 	float getRaw() const {
 		const auto sensor = m_sensor;
 
-		if (m_sensor) {
-			return m_sensor->getRaw();
+		if (sensor) {
+			return sensor->getRaw();
 		}
 
 		// We've exhausted all valid ways to return something - sensor not found.
 		return 0;
+	}
+
+	bool isRedundant() const {
+		const auto sensor = m_sensor;
+
+		if (sensor) {
+			return sensor->isRedundant();
+		}
+
+		return false;
 	}
 
 private:
@@ -179,6 +189,12 @@ bool Sensor::Register() {
 	const auto entry = getEntryForType(type);
 
 	return entry ? entry->getRaw() : 0;
+}
+
+/*static*/ bool Sensor::isRedundant(SensorType type) {
+	const auto entry = getEntryForType(type);
+
+	return entry ? entry->isRedundant() : false;
 }
 
 /*static*/ bool Sensor::hasSensor(SensorType type) {

--- a/firmware/controllers/sensors/sensor.h
+++ b/firmware/controllers/sensors/sensor.h
@@ -93,6 +93,11 @@ public:
 	static float getRaw(SensorType type);
 
 	/*
+	 * Get whether a sensor is redundant (a composite of multiple other sensors that can check consistency between them)
+	 */
+	static bool isRedundant(SensorType type);
+
+	/*
 	 * Query whether there is a sensor of a particular type currently registered.
 	 */
 	static bool hasSensor(SensorType type);
@@ -135,6 +140,14 @@ public:
 	 */
 	virtual float getRaw() const {
 		return 0;
+	}
+
+	/*
+	 * Get whether this sensor is redundant (backed by multiple other sensors)
+	 */
+	virtual bool isRedundant() const {
+		// By default sensors are not redundant
+		return false;
 	}
 
 protected:

--- a/unit_tests/tests/sensor/redundant.cpp
+++ b/unit_tests/tests/sensor/redundant.cpp
@@ -71,6 +71,8 @@ TEST_F(SensorRedundant, SetTwoSensors)
 		auto result = dut.get();
 		EXPECT_TRUE(result.Valid);
 		EXPECT_FLOAT_EQ(result.Value, 25.0f);
+
+		EXPECT_TRUE(dut.isRedundant());
 	}
 }
 
@@ -176,6 +178,8 @@ TEST_F(SensorRedundantIgnoreSecond, OnlyFirst)
 		auto result = dut.get();
 		EXPECT_TRUE(result.Valid);
 		EXPECT_FLOAT_EQ(result.Value, 44.0f);
+
+		EXPECT_FALSE(dut.isRedundant());
 	}
 }
 


### PR DESCRIPTION
Add the ability to check whether a sensor is redunant, so the ETB can require dual TPS sensors later