### PR TITLE
Require redundant tps for ETB

### DIFF
--- a/firmware/controllers/actuators/electronic_throttle.cpp
+++ b/firmware/controllers/actuators/electronic_throttle.cpp
@@ -168,6 +168,20 @@ bool EtbController::init(etb_function_e function, DcMotor *motor, pid_s *pidPara
 
 	m_function = function;
 	m_positionSensor = functionToPositionSensor(function);
+
+	// If we are a throttle, require redundant TPS sensor
+	if (function == ETB_Throttle1 || function == ETB_Throttle2) {
+		if (!Sensor::isRedundant(m_positionSensor)) {
+			firmwareError(
+				OBD_Throttle_Position_Sensor_Circuit_Malfunction,
+				"Use of electronic throttle requires %s to be redundant.",
+				Sensor::getSensorName(m_positionSensor)
+			);
+
+			return false;
+		}
+	}
+
 	m_motor = motor;
 	m_pid.initPidClass(pidParameters);
 	m_pedalMap = pedalMap;

--- a/firmware/controllers/sensors/sensor.cpp
+++ b/firmware/controllers/sensors/sensor.cpp
@@ -50,9 +50,10 @@ public:
 		return m_sensor;
 	}
 
-	void setMockValue(float value) {
+	void setMockValue(float value, bool mockRedundant) {
 		m_mockValue = value;
 		m_useMock = true;
+		m_mockRedundant = mockRedundant;
 	}
 
 	void resetMock() {
@@ -131,11 +132,16 @@ public:
 			return sensor->isRedundant();
 		}
 
+		if (m_useMock) {
+			return m_mockRedundant;
+		}
+
 		return false;
 	}
 
 private:
 	bool m_useMock = false;
+	bool m_mockRedundant = false;
 	float m_mockValue;
 	Sensor* m_sensor = nullptr;
 };
@@ -201,11 +207,11 @@ bool Sensor::Register() {
 	return entry ? entry->hasSensor() : false;
 }
 
-/*static*/ void Sensor::setMockValue(SensorType type, float value) {
+/*static*/ void Sensor::setMockValue(SensorType type, float value, bool mockRedundant) {
 	auto entry = getEntryForType(type);
 
 	if (entry) {
-		entry->setMockValue(value);
+		entry->setMockValue(value, mockRedundant);
 	}
 }
 

--- a/firmware/controllers/sensors/sensor.h
+++ b/firmware/controllers/sensors/sensor.h
@@ -105,7 +105,7 @@ public:
 	/*
 	 * Mock a value for a particular sensor.
 	 */
-	static void setMockValue(SensorType type, float value);
+	static void setMockValue(SensorType type, float value, bool mockRedundant = false);
 
 	/*
 	 * Mock a value for a particular sensor.
@@ -127,6 +127,7 @@ public:
 	 * For example, CLT, IAT, Throttle Position 2, etc.
 	 */
 	const char* getSensorName() { return getSensorName(m_type); }
+	static const char* getSensorName(SensorType type);
 
 	// Retrieve the current reading from the sensor.
 	//
@@ -154,8 +155,6 @@ protected:
 	// Protected constructor - only subclasses call this
 	explicit Sensor(SensorType type)
 		: m_type(type) {}
-
-	static const char* getSensorName(SensorType type);
 
 private:
 	const SensorType m_type;

--- a/unit_tests/tests/test_etb.cpp
+++ b/unit_tests/tests/test_etb.cpp
@@ -172,6 +172,15 @@ TEST(etb, initializationNoFunction) {
 	dut.setOutput(0.5f);
 }
 
+TEST(etb, initializationNotRedundantTps) {
+	EtbController dut;
+
+	// Not redundant, should fail upon init
+	Sensor::setMockValue(SensorType::Tps1, 0.0f, false);
+
+	EXPECT_FATAL_ERROR(dut.init(ETB_Throttle1, nullptr, nullptr, nullptr));
+}
+
 TEST(etb, idlePlumbing) {
 	StrictMock<MockEtb> mocks[ETB_COUNT];
 

--- a/unit_tests/tests/test_etb.cpp
+++ b/unit_tests/tests/test_etb.cpp
@@ -120,8 +120,8 @@ TEST(etb, initializationDualThrottle) {
 	Sensor::setMockValue(SensorType::AcceleratorPedal, 0);
 	Sensor::setMockValue(SensorType::AcceleratorPedalPrimary, 0);
 
-	// The presence of a second TPS indicates dual throttle
-	Sensor::setMockValue(SensorType::Tps2, 25.0f);
+	Sensor::setMockValue(SensorType::Tps1, 25.0f, true);
+	Sensor::setMockValue(SensorType::Tps2, 25.0f, true);
 
 	engineConfiguration->etbFunctions[0] = ETB_Throttle1;
 	engineConfiguration->etbFunctions[1] = ETB_Throttle2;
@@ -208,6 +208,9 @@ TEST(etb, testSetpointOnlyPedal) {
 	// Uninitialized ETB must return unexpected (and not deference a null pointer)
 	EXPECT_EQ(etb.getSetpoint(), unexpected);
 
+	// Must have TPS initialized for ETB setup
+	Sensor::setMockValue(SensorType::Tps1, 0.0f, true);
+
 	etb.init(ETB_Throttle1, nullptr, nullptr, &pedalMap);
 
 	// Check endpoints and midpoint
@@ -248,6 +251,9 @@ TEST(etb, setpointIdle) {
 	// Use ETB for idle, but don't give it any range (yet)
 	engineConfiguration->useETBforIdleControl = true;
 	engineConfiguration->etbIdleThrottleRange = 0;
+
+	// Must have TPS initialized for ETB setup
+	Sensor::setMockValue(SensorType::Tps1, 0.0f, true);
 
 	EtbController etb;
 	INJECT_ENGINE_REFERENCE(&etb);
@@ -335,8 +341,8 @@ TEST(etb, setpointWastegateController) {
 
 TEST(etb, etbTpsSensor) {
 	// Throw some distinct values on the TPS sensors so we can identify that we're getting the correct one
-	Sensor::setMockValue(SensorType::Tps1, 25.0f);
-	Sensor::setMockValue(SensorType::Tps2, 75.0f);
+	Sensor::setMockValue(SensorType::Tps1, 25.0f, true);
+	Sensor::setMockValue(SensorType::Tps2, 75.0f, true);
 	Sensor::setMockValue(SensorType::WastegatePosition, 33.0f);
 	Sensor::setMockValue(SensorType::IdlePosition, 66.0f);
 
@@ -388,6 +394,9 @@ TEST(etb, setOutputValid) {
 	WITH_ENGINE_TEST_HELPER(TEST_ENGINE);
 	StrictMock<MockMotor> motor;
 
+	// Must have TPS initialized for ETB setup
+	Sensor::setMockValue(SensorType::Tps1, 0.0f, true);
+
 	EtbController etb;
 	INJECT_ENGINE_REFERENCE(&etb);
 	etb.init(ETB_Throttle1, &motor, nullptr, nullptr);
@@ -403,6 +412,9 @@ TEST(etb, setOutputValid) {
 TEST(etb, setOutputValid2) {
 	WITH_ENGINE_TEST_HELPER(TEST_ENGINE);
 	StrictMock<MockMotor> motor;
+
+	// Must have TPS initialized for ETB setup
+	Sensor::setMockValue(SensorType::Tps1, 0.0f, true);
 
 	EtbController etb;
 	INJECT_ENGINE_REFERENCE(&etb);
@@ -420,6 +432,9 @@ TEST(etb, setOutputOutOfRangeHigh) {
 	WITH_ENGINE_TEST_HELPER(TEST_ENGINE);
 	StrictMock<MockMotor> motor;
 
+	// Must have TPS initialized for ETB setup
+	Sensor::setMockValue(SensorType::Tps1, 0.0f, true);
+
 	EtbController etb;
 	INJECT_ENGINE_REFERENCE(&etb);
 	etb.init(ETB_Throttle1, &motor, nullptr, nullptr);
@@ -436,6 +451,9 @@ TEST(etb, setOutputOutOfRangeLow) {
 	WITH_ENGINE_TEST_HELPER(TEST_ENGINE);
 	StrictMock<MockMotor> motor;
 
+	// Must have TPS initialized for ETB setup
+	Sensor::setMockValue(SensorType::Tps1, 0.0f, true);
+
 	EtbController etb;
 	INJECT_ENGINE_REFERENCE(&etb);
 	etb.init(ETB_Throttle1, &motor, nullptr, nullptr);
@@ -451,6 +469,9 @@ TEST(etb, setOutputOutOfRangeLow) {
 TEST(etb, setOutputPauseControl) {
 	WITH_ENGINE_TEST_HELPER(TEST_ENGINE);
 	StrictMock<MockMotor> motor;
+
+	// Must have TPS initialized for ETB setup
+	Sensor::setMockValue(SensorType::Tps1, 0.0f, true);
 
 	EtbController etb;
 	INJECT_ENGINE_REFERENCE(&etb);
@@ -470,6 +491,9 @@ TEST(etb, closedLoopPid) {
 	pid.pFactor = 5;
 	pid.maxValue = 75;
 	pid.minValue = -60;
+
+	// Must have TPS initialized for ETB setup
+	Sensor::setMockValue(SensorType::Tps1, 0.0f, true);
 
 	EtbController etb;
 	etb.init(ETB_Throttle1, nullptr, &pid, nullptr);


### PR DESCRIPTION
And no, it's not configurable, since it's a safety problem.  It's much easier for us to say "sorry, no, redundant is required" instead of allowing janky setups that aren't a real throttle body.  All real throttle bodies have redundant sensors.