### PR TITLE
force a pwm cycle start (skip cycles) if late

### DIFF
--- a/firmware/controllers/system/timer/pwm_generator_logic.h
+++ b/firmware/controllers/system/timer/pwm_generator_logic.h
@@ -110,6 +110,9 @@ private:
 	 * PWM generation is not happening while this value is NAN
 	 */
 	float periodNt;
+
+	// Set if we are very far behind schedule and need to reset back to the beginning of a cycle to find our way
+	bool forceCycleStart = true;
 };
 
 struct hardware_pwm;

--- a/firmware/controllers/system/timer/single_timer_executor.cpp
+++ b/firmware/controllers/system/timer/single_timer_executor.cpp
@@ -123,7 +123,8 @@ void SingleTimerExecutor::executeAllPendingActions() {
 	 * TODO: add a counter & figure out a limit of iterations?
 	 */
 
-	executeCounter = 0;
+	// starts at -1 because do..while will run a minimum of once
+	executeCounter = -1;
 
 	bool didExecute;
 	do {

--- a/firmware/controllers/system/timer/single_timer_executor.cpp
+++ b/firmware/controllers/system/timer/single_timer_executor.cpp
@@ -124,15 +124,19 @@ void SingleTimerExecutor::executeAllPendingActions() {
 	 */
 
 	executeCounter = 0;
+
 	bool didExecute;
 	do {
 		efitick_t nowNt = getTimeNowNt();
 		didExecute = queue.executeOne(nowNt);
-		if (executeCounter++ == 10000) {
-			firmwareError(CUSTOM_ERR_LOCK_ISSUE, "Looks like firmware is really busy");
+
+		// if we're stuck in a loop executing lots of events, panic!
+		if (executeCounter++ == 500) {
+			firmwareError(CUSTOM_ERR_LOCK_ISSUE, "Maximum scheduling run length exceeded - CPU load too high");
 		}
 
 	} while (didExecute);
+
 	maxExecuteCounter = maxI(maxExecuteCounter, executeCounter);
 
 	if (!isLocked()) {
@@ -169,7 +173,7 @@ void initSingleTimerExecutorHardware(void) {
 
 void executorStatistics() {
 	if (engineConfiguration->debugMode == DBG_EXECUTOR) {
-#if EFI_TUNER_STUDIO && EFI_SIGNAL_EXECUTOR_ONE_TIMER
+#if EFI_TUNER_STUDIO
 		tsOutputChannels.debugIntField1 = ___engine.executor.timerCallbackCounter;
 		tsOutputChannels.debugIntField2 = ___engine.executor.executeAllPendingActionsInvocationCounter;
 		tsOutputChannels.debugIntField3 = ___engine.executor.scheduleCounter;


### PR DESCRIPTION
If we're far behind schedule on PWM, skip cycles to catch up instead of executing every single event we missed.  

Trying to catch up will just swamp the scheduler while generating extremely high speed PWM (I measured it at ~50-70khz) that isn't actually doing anything useful.  For example, if you were trying to generate a 60-2 wheel at 6000 rpm, that's 12000 events per second, and if the flash erase + write takes 3 seconds, that leaves you with ~36k events to try and execute once the flash is done, which will be cranked out as fast as the PWM driver can toggle a pin.