### PR TITLE
Fix gpio reinit race condition

### DIFF
--- a/firmware/controllers/actuators/aux_pid.cpp
+++ b/firmware/controllers/actuators/aux_pid.cpp
@@ -132,11 +132,9 @@ void startAuxPins() {
 }
 
 void stopAuxPins() {
-#if EFI_PROD_CODE
 	for (int i = 0;i < AUX_PID_COUNT;i++) {
-		efiSetPadUnused(activeConfiguration.auxPidPins[i]);
+		instances[index].auxOutputPin.unregister();
 	}
-#endif /* EFI_PROD_CODE */
 }
 
 void initAuxPid(Logging *sharedLogger) {

--- a/firmware/controllers/actuators/aux_pid.cpp
+++ b/firmware/controllers/actuators/aux_pid.cpp
@@ -133,7 +133,7 @@ void startAuxPins() {
 
 void stopAuxPins() {
 	for (int i = 0;i < AUX_PID_COUNT;i++) {
-		instances[i].auxOutputPin.unregister();
+		instances[i].auxOutputPin.deInit();
 	}
 }
 

--- a/firmware/controllers/actuators/aux_pid.cpp
+++ b/firmware/controllers/actuators/aux_pid.cpp
@@ -133,7 +133,7 @@ void startAuxPins() {
 
 void stopAuxPins() {
 	for (int i = 0;i < AUX_PID_COUNT;i++) {
-		instances[index].auxOutputPin.unregister();
+		instances[i].auxOutputPin.unregister();
 	}
 }
 

--- a/firmware/controllers/algo/engine.h
+++ b/firmware/controllers/algo/engine.h
@@ -195,12 +195,6 @@ public:
 	 */
 	efitimems64_t callFromPitStopEndTime = 0;
 
-	/**
-	 * This flag indicated a big enough problem that engine control would be
-	 * prohibited if this flag is set to true.
-	 */
-	bool withError = false;
-
 	RpmCalculator rpmCalculator;
 	persistent_config_s *config = nullptr;
 	/**

--- a/firmware/controllers/system/efi_gpio.cpp
+++ b/firmware/controllers/system/efi_gpio.cpp
@@ -468,6 +468,9 @@ void OutputPin::initPin(const char *msg, brain_pin_e brainPin, const pin_output_
 		return;
 	}
 
+	// Enter a critical section so that other threads can't change the pin state out from underneath us
+	chibios_rt::CriticalSectionLocker csl;
+
 	// Check that this OutputPin isn't already assigned to another pin (reinit is allowed to change mode)
 	// To avoid this error, call unregister() first
 	if (this->brainPin != GPIO_UNASSIGNED && this->brainPin != brainPin) {
@@ -510,9 +513,6 @@ void OutputPin::initPin(const char *msg, brain_pin_e brainPin, const pin_output_
 		}
 	#endif
 #endif // briefly leave the include guard because we need to set default state in tests
-
-	// Enter a critical section so that other threads can't change the pin state out from underneath us
-	chibios_rt::CriticalSectionLocker csl;
 
 	this->brainPin = brainPin;
 

--- a/firmware/controllers/system/efi_gpio.cpp
+++ b/firmware/controllers/system/efi_gpio.cpp
@@ -471,7 +471,7 @@ void OutputPin::initPin(const char *msg, brain_pin_e brainPin, const pin_output_
 	// Check that this OutputPin isn't already assigned to another pin (reinit is allowed to change mode)
 	// To avoid this error, call unregister() first
 	if (this->brainPin != GPIO_UNASSIGNED && this->brainPin != brainPin) {
-		firmwareError(CUSTOM_OBD_PIN_CONFLICT, "outputPin [%s] already assigned to %x %d, cannot reassign without unregister first", this->port, this->pin);
+		firmwareError(CUSTOM_OBD_PIN_CONFLICT, "outputPin [%s] already assigned, cannot reassign without unregister first", msg);
 		return;
 	}
 

--- a/firmware/controllers/system/efi_gpio.cpp
+++ b/firmware/controllers/system/efi_gpio.cpp
@@ -9,6 +9,7 @@
 #include "global.h"
 #include "engine.h"
 #include "efi_gpio.h"
+#include "os_access.h"
 #include "drivers/gpio/gpio_ext.h"
 #include "perf_trace.h"
 #include "engine_controller.h"
@@ -515,6 +516,9 @@ void OutputPin::initPin(const char *msg, brain_pin_e brainPin, const pin_output_
 	#endif
 
 #endif // briefly leave the include guard because we need to set default state in tests
+
+	// Enter a critical section so that other threads can't change the pin state out from underneath us
+	chibios_rt::CriticalSectionLocker csl;
 
 	this->brainPin = brainPin;
 

--- a/firmware/controllers/system/efi_gpio.cpp
+++ b/firmware/controllers/system/efi_gpio.cpp
@@ -189,15 +189,13 @@ void EnginePins::unregisterPins() {
 	for (int i = 0;i < FSIO_COMMAND_COUNT;i++) {
 		unregisterOutputIfPinChanged(fsioOutputs[i], fsioOutputPins[i]);
 	}
-
+#endif /* EFI_PROD_CODE */
 
 	RegisteredOutputPin * pin = registeredOutputHead;
 	while (pin != nullptr) {
 		pin->unregister();
 		pin = pin->next;
 	}
-
-#endif /* EFI_PROD_CODE */
 }
 
 void EnginePins::debug() {

--- a/firmware/controllers/system/efi_gpio.cpp
+++ b/firmware/controllers/system/efi_gpio.cpp
@@ -92,7 +92,7 @@ void RegisteredOutputPin::init(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 
 void RegisteredOutputPin::unregister() {
 	if (isPinConfigurationChanged()) {
-		OutputPin::unregister();
+		OutputPin::deInit();
 	}
 }
 
@@ -148,13 +148,13 @@ EnginePins::EnginePins() :
 #if EFI_PROD_CODE
 #define unregisterOutputIfPinChanged(output, pin) {                                \
 	if (isConfigurationChanged(pin)) {                                             \
-		(output).unregister();                        \
+		(output).deInit();                        \
 	}                                                                              \
 }
 
 #define unregisterOutputIfPinOrModeChanged(output, pin, mode) {                    \
 	if (isPinOrModeChanged(pin, mode)) {                                           \
-		(output).unregister();                        \
+		(output).deInit();                        \
 	}                                                                              \
 }
 
@@ -472,7 +472,7 @@ void OutputPin::initPin(const char *msg, brain_pin_e brainPin, const pin_output_
 	chibios_rt::CriticalSectionLocker csl;
 
 	// Check that this OutputPin isn't already assigned to another pin (reinit is allowed to change mode)
-	// To avoid this error, call unregister() first
+	// To avoid this error, call deInit() first
 	if (this->brainPin != GPIO_UNASSIGNED && this->brainPin != brainPin) {
 		firmwareError(CUSTOM_OBD_PIN_CONFLICT, "outputPin [%s] already assigned, cannot reassign without unregister first", msg);
 		return;
@@ -538,14 +538,14 @@ void OutputPin::initPin(const char *msg, brain_pin_e brainPin, const pin_output_
 			// if the pin was set to logical 1, then set an error and disable the pin so that things don't catch fire
 			if (logicalValue) {
 				firmwareError(OBD_PCM_Processor_Fault, "%s: startup pin state %s actual value=%d logical value=%d mode=%s", msg, hwPortname(brainPin), actualValue, logicalValue, getPin_output_mode_e(*outputMode));
-				OutputPin::unregister();
+				OutputPin::deInit();
 			}
 		}
 	}
 #endif /* EFI_GPIO_HARDWARE */
 }
 
-void OutputPin::unregister() {
+void OutputPin::deInit() {
 	// Unregister under lock - we don't want other threads mucking with the pin while we're trying to turn it off
 	chibios_rt::CriticalSectionLocker csl;
 

--- a/firmware/controllers/system/efi_gpio.cpp
+++ b/firmware/controllers/system/efi_gpio.cpp
@@ -463,7 +463,6 @@ void OutputPin::initPin(const char *msg, brain_pin_e brainPin) {
 }
 
 void OutputPin::initPin(const char *msg, brain_pin_e brainPin, const pin_output_mode_e *outputMode) {
-#if EFI_GPIO_HARDWARE && EFI_PROD_CODE
 	if (brainPin == GPIO_UNASSIGNED)
 		return;
 
@@ -475,6 +474,8 @@ void OutputPin::initPin(const char *msg, brain_pin_e brainPin, const pin_output_
 				);
 		return;
 	}
+
+#if EFI_GPIO_HARDWARE && EFI_PROD_CODE
 	iomode_t mode = (*outputMode == OM_DEFAULT || *outputMode == OM_INVERTED) ?
 		PAL_MODE_OUTPUT_PUSHPULL : PAL_MODE_OUTPUT_OPENDRAIN;
 
@@ -514,7 +515,6 @@ void OutputPin::initPin(const char *msg, brain_pin_e brainPin, const pin_output_
 			this->ext = true;
 		}
 	#endif
-
 #endif // briefly leave the include guard because we need to set default state in tests
 
 	// Enter a critical section so that other threads can't change the pin state out from underneath us

--- a/firmware/controllers/system/efi_gpio.h
+++ b/firmware/controllers/system/efi_gpio.h
@@ -51,7 +51,7 @@ public:
 	/**
 	 * dissociates pin from this output and un-registers it in pin repository
 	 */
-	virtual void unregister();
+	void deInit();
 
 	bool isInitialized();
 
@@ -141,7 +141,7 @@ class RegisteredOutputPin : public virtual OutputPin {
 public:
 	RegisteredOutputPin(const char *registrationName, short pinOffset, short pinModeOffset);
 	void init(DECLARE_ENGINE_PARAMETER_SIGNATURE);
-	void unregister() override;
+	void unregister();
 	RegisteredOutputPin *next;
 	const char *registrationName;
 private:

--- a/firmware/controllers/system/efi_gpio.h
+++ b/firmware/controllers/system/efi_gpio.h
@@ -69,7 +69,7 @@ public:
 
 #if (EFI_GPIO_HARDWARE && (BOARD_EXT_GPIOCHIPS > 0))
 	/* used for external pins */
-	bool ext;
+	bool ext = false;
 #endif /* EFI_GPIO_HARDWARE */
 
 	int8_t currentLogicValue = INITIAL_PIN_STATE;
@@ -83,7 +83,7 @@ private:
 	void setOnchipValue(int electricalValue);
 
 	// 4 byte pointer is a bit of a memory waste here
-	const pin_output_mode_e *modePtr;
+	const pin_output_mode_e *modePtr = nullptr;
 };
 
 /**

--- a/firmware/controllers/system/efi_gpio.h
+++ b/firmware/controllers/system/efi_gpio.h
@@ -60,12 +60,12 @@ public:
 	void toggle();
 	bool getLogicValue() const;
 
-	brain_pin_e brainPin = GPIO_UNASSIGNED;
-
 #if EFI_GPIO_HARDWARE
 	ioportid_t port = 0;
 	uint8_t pin = 0;
 #endif /* EFI_GPIO_HARDWARE */
+
+	brain_pin_e brainPin = GPIO_UNASSIGNED;
 
 #if (EFI_GPIO_HARDWARE && (BOARD_EXT_GPIOCHIPS > 0))
 	/* used for external pins */

--- a/firmware/controllers/system/efi_gpio.h
+++ b/firmware/controllers/system/efi_gpio.h
@@ -47,10 +47,11 @@ public:
 	 * same as above, with DEFAULT_OUTPUT mode
 	 */
 	void initPin(const char *msg, brain_pin_e brainPin);
+
 	/**
 	 * dissociates pin from this output and un-registers it in pin repository
 	 */
-	void unregisterOutput(brain_pin_e oldPin);
+	virtual void unregister();
 
 	bool isInitialized();
 
@@ -59,6 +60,7 @@ public:
 	void toggle();
 	bool getLogicValue() const;
 
+	brain_pin_e brainPin;
 
 #if EFI_GPIO_HARDWARE
 	ioportid_t port = 0;
@@ -67,11 +69,7 @@ public:
 
 #if (EFI_GPIO_HARDWARE && (BOARD_EXT_GPIOCHIPS > 0))
 	/* used for external pins */
-	brain_pin_e brainPin;
 	bool ext;
-#elif EFI_SIMULATOR || EFI_UNIT_TEST
-	// used for setMockState
-	brain_pin_e brainPin;
 #endif /* EFI_GPIO_HARDWARE */
 
 	int8_t currentLogicValue = INITIAL_PIN_STATE;
@@ -143,7 +141,7 @@ class RegisteredOutputPin : public virtual OutputPin {
 public:
 	RegisteredOutputPin(const char *registrationName, short pinOffset, short pinModeOffset);
 	void init(DECLARE_ENGINE_PARAMETER_SIGNATURE);
-	void unregister();
+	void unregister() override;
 	RegisteredOutputPin *next;
 	const char *registrationName;
 private:

--- a/firmware/controllers/system/efi_gpio.h
+++ b/firmware/controllers/system/efi_gpio.h
@@ -60,7 +60,7 @@ public:
 	void toggle();
 	bool getLogicValue() const;
 
-	brain_pin_e brainPin;
+	brain_pin_e brainPin = GPIO_UNASSIGNED;
 
 #if EFI_GPIO_HARDWARE
 	ioportid_t port = 0;

--- a/firmware/controllers/trigger/trigger_emulator_algo.cpp
+++ b/firmware/controllers/trigger/trigger_emulator_algo.cpp
@@ -222,7 +222,7 @@ void startTriggerEmulatorPins() {
 
 void stopTriggerEmulatorPins() {
 	for (size_t i = 0; i < efi::size(emulatorOutputs); i++) {
-		triggerSignal.outputPins[i]->unregister();
+		triggerSignal.outputPins[i]->deInit();
 	}
 }
 

--- a/firmware/controllers/trigger/trigger_emulator_algo.cpp
+++ b/firmware/controllers/trigger/trigger_emulator_algo.cpp
@@ -222,12 +222,7 @@ void startTriggerEmulatorPins() {
 
 void stopTriggerEmulatorPins() {
 	for (size_t i = 0; i < efi::size(emulatorOutputs); i++) {
-		brain_pin_e brainPin = activeConfiguration.triggerSimulatorPins[i];
-		if (brainPin != GPIO_UNASSIGNED) {
-#if EFI_PROD_CODE
-			efiSetPadUnused(brainPin);
-#endif // EFI_PROD_CODE
-		}
+		triggerSignal.outputPins[i]->unregister();
 	}
 }
 

--- a/firmware/hw_layer/sensors/hip9011.cpp
+++ b/firmware/hw_layer/sensors/hip9011.cpp
@@ -385,10 +385,8 @@ static msg_t hipThread(void *arg) {
 }
 
 void stopHip9001_pins() {
-#if EFI_PROD_CODE
-	efiSetPadUnused(activeConfiguration.hip9011IntHoldPin);
-	efiSetPadUnused(activeConfiguration.hip9011CsPin);
-#endif /* EFI_PROD_CODE */
+	intHold.unregister();
+	enginePins.hipCs.unregister();
 }
 
 void startHip9001_pins() {

--- a/firmware/hw_layer/sensors/hip9011.cpp
+++ b/firmware/hw_layer/sensors/hip9011.cpp
@@ -385,8 +385,8 @@ static msg_t hipThread(void *arg) {
 }
 
 void stopHip9001_pins() {
-	intHold.unregister();
-	enginePins.hipCs.unregister();
+	intHold.deInit();
+	enginePins.hipCs.deInit();
 }
 
 void startHip9001_pins() {

--- a/unit_tests/engine_test_helper.cpp
+++ b/unit_tests/engine_test_helper.cpp
@@ -51,6 +51,7 @@ EngineTestHelper::EngineTestHelper(engine_type_e engineType, configuration_callb
 	memset(&activeConfiguration, 0, sizeof(activeConfiguration));
 
 	enginePins.reset();
+	enginePins.unregisterPins();
 
 	persistent_config_s *config = &persistentConfig;
 	Engine *engine = &this->engine;
@@ -99,6 +100,8 @@ EngineTestHelper::~EngineTestHelper() {
 	writeEvents(filePath.str().c_str());
 
 	// Cleanup
+	enginePins.reset();
+	enginePins.unregisterPins();
 	Sensor::resetRegistry();
 	memset(mockPinStates, 0, sizeof(mockPinStates));
 }


### PR DESCRIPTION
Bug: if you un-initialize a pin, setValue will still work! If you initialize pin A, then set it to "none", then initialize the same pin elsewhere, both users will be able to call setValue and set the same pin!  This causes a problem in particular when reinitializing a pin that's set by a higher priority thread, like the hardware trigger emulator does.

This PR fixes both possibilities:
- Only do the hardware set if `brainPin != GPIO_UNASSIGNED`, which is now always set by `initPin`, and always cleared by `unregister`.
- Guard pin init and de-init with a critical section so that other threads couldn't even set the pin if they tried