### PR TITLE
remove/comment spammy log prints

### DIFF
--- a/java_console/io/src/main/java/com/rusefi/binaryprotocol/BinaryProtocol.java
+++ b/java_console/io/src/main/java/com/rusefi/binaryprotocol/BinaryProtocol.java
@@ -168,7 +168,6 @@ public class BinaryProtocol {
                 needCompositeLogger = linkManager.getCompositeLogicEnabled();
                 lastLowRpmTime = System.currentTimeMillis();
             } else if (System.currentTimeMillis() - lastLowRpmTime > HIGH_RPM_DELAY * Timeouts.SECOND) {
-                log.info("Time to turn off composite logging");
                 needCompositeLogger = false;
             }
         };

--- a/java_console/io/src/main/java/com/rusefi/binaryprotocol/IncomingDataBuffer.java
+++ b/java_console/io/src/main/java/com/rusefi/binaryprotocol/IncomingDataBuffer.java
@@ -64,8 +64,8 @@ public class IncomingDataBuffer {
             return null;
 
         int packetSize = swap16(getShort());
-        if (log.debugEnabled())
-            log.debug(loggingPrefix + "Got packet size " + packetSize);
+        // if (log.debugEnabled())
+        //     log.debug(loggingPrefix + "Got packet size " + packetSize);
         if (packetSize < 0)
             return null;
         if (!allowLongResponse && packetSize > Math.max(Fields.BLOCKING_FACTOR, Fields.TS_OUTPUT_SIZE) + 10)
@@ -87,8 +87,8 @@ public class IncomingDataBuffer {
             return null;
         }
         onPacketArrived();
-        if (log.debugEnabled())
-            log.trace("packet arrived: " + Arrays.toString(packet) + ": crc OK");
+        // if (log.debugEnabled())
+        //     log.trace("packet arrived: " + Arrays.toString(packet) + ": crc OK");
 
         return packet;
     }
@@ -98,7 +98,7 @@ public class IncomingDataBuffer {
     }
 
     public void addData(byte[] freshData) {
-        log.info("IncomingDataBuffer: " + freshData.length + " byte(s) arrived");
+        //log.info("IncomingDataBuffer: " + freshData.length + " byte(s) arrived");
         synchronized (cbb) {
             if (cbb.size() - cbb.length() < freshData.length) {
                 log.error("IncomingDataBuffer: buffer overflow not expected");
@@ -122,7 +122,7 @@ public class IncomingDataBuffer {
      * @return true in case of timeout, false if we have received count of bytes
      */
     public boolean waitForBytes(int timeoutMs, String loggingMessage, long startTimestamp, int count) {
-        log.info(loggingMessage + ": waiting for " + count + " byte(s)");
+        //log.info(loggingMessage + ": waiting for " + count + " byte(s)");
         synchronized (cbb) {
             while (cbb.length() < count) {
                 int timeout = (int) (startTimestamp + timeoutMs - System.currentTimeMillis());

--- a/java_console/io/src/main/java/com/rusefi/io/CommandQueue.java
+++ b/java_console/io/src/main/java/com/rusefi/io/CommandQueue.java
@@ -20,7 +20,7 @@ import static com.devexperts.logging.Logging.getLogging;
  */
 @SuppressWarnings("FieldCanBeLocal")
 public class CommandQueue {
-    private static final Logging log = getLogging(LinkManager.class);
+    private static final Logging log = getLogging(CommandQueue.class);
     public static final String CONFIRMATION_PREFIX = "confirmation_";
     public static final int DEFAULT_TIMEOUT = 500;
     private static final int COMMAND_CONFIRMATION_TIMEOUT = 1000;

--- a/java_console/io/src/main/java/com/rusefi/io/IoStream.java
+++ b/java_console/io/src/main/java/com/rusefi/io/IoStream.java
@@ -69,7 +69,7 @@ public interface IoStream extends WriteStream, Closeable, StreamStatistics {
             packet = IoHelper.makeCrc32Packet(plainPacket);
         }
         // todo: verbose mode printHexBinary(plainPacket))
-        log.debug(getLoggingPrefix() + "Sending packet " + BinaryProtocol.findCommand(plainPacket[0]) + " length=" + plainPacket.length);
+        //log.debug(getLoggingPrefix() + "Sending packet " + BinaryProtocol.findCommand(plainPacket[0]) + " length=" + plainPacket.length);
         write(packet);
         flush();
     }

--- a/java_console/io/src/main/java/com/rusefi/io/LinkManager.java
+++ b/java_console/io/src/main/java/com/rusefi/io/LinkManager.java
@@ -58,7 +58,7 @@ public class LinkManager implements Closeable {
         engineState = new EngineState(new EngineState.EngineStateListenerImpl() {
             @Override
             public void beforeLine(String fullLine) {
-                log.info(fullLine);
+                //log.info(fullLine);
                 HeartBeatListeners.onDataArrived();
             }
         });

--- a/java_console/io/src/main/java/com/rusefi/ui/livedocs/LiveDocsRegistry.java
+++ b/java_console/io/src/main/java/com/rusefi/ui/livedocs/LiveDocsRegistry.java
@@ -27,7 +27,6 @@ public enum LiveDocsRegistry {
     public void refresh(BinaryProtocol binaryProtocol) {
         for (LiveDocHolder holder : liveDocs) {
             boolean visible = holder.isVisible();
-            System.out.println(holder + ": is_visible=" + visible);
             if (visible) {
                 for (LiveDataContext context : holder.getActions().getActions().keySet()) {
                     refresh(binaryProtocol, holder, context);

--- a/java_console/models/src/main/java/com/rusefi/composite/CompositeParser.java
+++ b/java_console/models/src/main/java/com/rusefi/composite/CompositeParser.java
@@ -15,7 +15,6 @@ public class CompositeParser {
     public static List<CompositeEvent> parse(byte[] response) {
         ByteBuffer byteBuffer = ByteBuffer.wrap(response);
         byteBuffer.order(ByteOrder.BIG_ENDIAN);
-        log.info("Got composite length=" + response.length);
         int ptr = 1;
 
         List<CompositeEvent> events = new ArrayList<>();

--- a/java_console/models/src/main/java/com/rusefi/waves/EngineChartParser.java
+++ b/java_console/models/src/main/java/com/rusefi/waves/EngineChartParser.java
@@ -18,7 +18,6 @@ public class EngineChartParser {
     public static EngineChart unpackToMap(String value, Logger logger) {
         if (value == null)
             throw new NullPointerException("value");
-        logger.info(": " + value);
 
         String[] array = value.split(DELI);
 

--- a/java_console/ui/src/main/java/com/rusefi/ui/engine/EngineSnifferPanel.java
+++ b/java_console/ui/src/main/java/com/rusefi/ui/engine/EngineSnifferPanel.java
@@ -57,10 +57,8 @@ public class EngineSnifferPanel {
         @Override
         public Dimension getPreferredSize() {
             Dimension d = chartPanel.getSize();
-//            System.out.println("chartPanel size " + d);
             Dimension s = super.getPreferredSize();
             Dimension dimension = new Dimension((int) (d.width * zoomControl.getZoomProvider().getZoomValue()), s.height);
-//            System.out.println("imagePanel getPreferredSize" + dimension);
             return dimension;
         }
     };
@@ -171,8 +169,6 @@ public class EngineSnifferPanel {
 
         mainPanel.add(chartPanel, BorderLayout.CENTER);
         mainPanel.add(new WarningPanel().getPanel(), BorderLayout.SOUTH);
-
-//        displayChart("wave_chart,crank2!down!192811978!crank2!up!192813389!crank2!down!192813749!crank2!up!192815156!crank2!down!192815512!crank!up!192820764!crank2!up!192825818!crank2!down!192826182!crank2!up!192827610!crank2!down!192827975!crank2!up!192829399!crank2!down!192829757!crank2!up!192831154!crank2!down!192831507!r!187!192834224!crank!down!192834224!crank2!up!192836757!crank2!down!192841994!crank2!up!192843561!crank2!down!192843925!crank2!up!192845334!crank2!down!192845693!crank2!up!192847086!crank2!down!192847439!crank!up!192853135!crank2!up!192857701!crank2!down!192858065!crank2!up!192859491!crank2!down!192859858!crank2!up!192861269!crank2!down!192861626!crank2!up!192863025!crank2!down!192863382!crank2!up!192868647!crank!down!192871268!crank2!down!192872804!crank2!up!192872804!crank!down!192872804!crank!up!192872804!crank2!down!192873898!crank2!up!192875508!crank2!down!192875887!crank2!up!192877357!crank2!down!192877732!crank2!up!192879192!crank2!down!192879565!crank!up!192886293!r!0!194982088!crank!down!194982088!crank2!up!194984699!crank2!down!194990112!crank2!up!194991715!crank2!down!194992085!crank2!up!194993530!crank2!down!194993884!crank2!up!194995292!crank2!down!194995645!crank!up!195001475!crank2!up!195006153!crank2!down!195006515!crank2!up!195007968!crank2!down!195008325!crank2!up!195009773!crank2!down!195010134!crank2!up!195011549!crank2!down!195011901!crank2!up!195017256!crank!down!195019915!crank2!down!195022597!crank2!up!195024189!crank2!down!195024554!crank2!up!195025980!crank2!down!195026329!crank2!up!195027744!crank2!down!195028103!crank!up!195033418!crank2!up!195038542!crank2!down!195038911!crank2!up!195040351!crank2!down!195040722!crank2!up!195042167!crank2!down!195042529!crank2!up!195043934!crank2!down!195044294!r!187!195047060!crank!down!195047060!crank2!up!195049619!crank2!down!195054954!crank2!up!195056549!crank2!down!195056920!crank2!up!195058345!crank2!down!195058703!crank2!up!195060114!crank2!down!195060464!crank!up!195066245!crank2!up!195070882!crank2!down!195071250!crank2!up!195072689!crank2!down!195073054!crank2!up!195074479!,");
     }
 
     private void setPaused(JButton pauseButton, boolean isPaused) {
@@ -216,7 +212,6 @@ public class EngineSnifferPanel {
         for (String imageName : map.getMap().keySet())
             createSecondaryImage(imageName);
 
-
         for (String imageName : images.keySet()) {
             UpDownImage image = images.get(imageName);
             if (image == null)
@@ -230,10 +225,10 @@ public class EngineSnifferPanel {
             EngineReport wr = new EngineReport(list);
             image.setWaveReport(wr, revolutions);
         }
+
         /**
          * this is to fix the UI glitch when images tab shows a tiny square
          */
-        System.out.println("displayChart");
         UiUtils.trueLayout(chartPanel.getParent());
     }
 


### PR DESCRIPTION
printing to stdout is a significant performance sink, especially on windows.  Turning this down/off should make the console a bit snappier, and should speed up hardware CI testing.