### PR TITLE
use token for sensor listener unsubscribe

### DIFF
--- a/java_console/models/src/main/java/com/rusefi/core/ISensorCentral.java
+++ b/java_console/models/src/main/java/com/rusefi/core/ISensorCentral.java
@@ -7,7 +7,23 @@ package com.rusefi.core;
 public interface ISensorCentral extends ISensorHolder {
     void setAnySensorListener(SensorCentral.SensorListener2 anySensorListener);
 
-    void addListener(Sensor sensor, SensorCentral.SensorListener listener);
+    public class ListenerToken {
+        private ISensorCentral sensorCentralInstance;
+        private Sensor sensor;
+        private SensorCentral.SensorListener listener;
+
+        public ListenerToken(ISensorCentral instance, Sensor sensor, SensorCentral.SensorListener listener) {
+            this.sensorCentralInstance = instance;
+            this.sensor = sensor;
+            this.listener = listener;
+        }
+
+        public void remove() {
+            sensorCentralInstance.removeListener(sensor, listener);
+        }
+    }
+
+    SensorCentral.ListenerToken addListener(Sensor sensor, SensorCentral.SensorListener listener);
 
     void removeListener(Sensor sensor, SensorCentral.SensorListener listener);
 

--- a/java_console/models/src/main/java/com/rusefi/core/SensorCentral.java
+++ b/java_console/models/src/main/java/com/rusefi/core/SensorCentral.java
@@ -62,7 +62,7 @@ public class SensorCentral implements ISensorCentral {
     }
 
     @Override
-    public void addListener(Sensor sensor, SensorListener listener) {
+    public ListenerToken addListener(Sensor sensor, SensorListener listener) {
         List<SensorListener> listeners;
         synchronized (allListeners) {
             listeners = allListeners.get(sensor);
@@ -71,6 +71,8 @@ public class SensorCentral implements ISensorCentral {
             allListeners.put(sensor, listeners);
         }
         listeners.add(listener);
+
+        return new SensorCentral.ListenerToken(this, sensor, listener);
     }
 
     @Override


### PR DESCRIPTION
this change means you can pass a lambda directly to `addListener` instead of having to keep the lambda around yourself, and call `removeListener` with the right parameters.  Just call `listenerToken.remove()` instead.