### PR TITLE
rename FsioValue to FsioResult

### DIFF
--- a/firmware/controllers/core/fsio_core.cpp
+++ b/firmware/controllers/core/fsio_core.cpp
@@ -140,7 +140,7 @@ void LECalculator::push(le_action_e action, float value) {
 	}
 }
 
-static FsioValue doBinaryBoolean(le_action_e action, float lhs, float rhs) {
+static FsioResult doBinaryBoolean(le_action_e action, float lhs, float rhs) {
 	bool v1 = float2bool(lhs);
 	bool v2 = float2bool(rhs);
 	
@@ -154,7 +154,7 @@ static FsioValue doBinaryBoolean(le_action_e action, float lhs, float rhs) {
 	}
 }
 
-static FsioValue doBinaryNumeric(le_action_e action, float v1, float v2) {
+static FsioResult doBinaryNumeric(le_action_e action, float v1, float v2) {
 	// Process based on the action type
 	switch (action) {
 		case LE_OPERATOR_ADDITION:
@@ -185,7 +185,7 @@ static FsioValue doBinaryNumeric(le_action_e action, float v1, float v2) {
 /**
  * @return true in case of error, false otherwise
  */
-FsioValue LECalculator::processElement(LEElement *element DECLARE_ENGINE_PARAMETER_SUFFIX) {
+FsioResult LECalculator::processElement(LEElement *element DECLARE_ENGINE_PARAMETER_SUFFIX) {
 #if EFI_PROD_CODE
 	efiAssert(CUSTOM_ERR_ASSERT, getCurrentRemainingStack() > 64, "FSIO logic", unexpected);
 #endif
@@ -303,7 +303,7 @@ float LECalculator::getValue(float selfValue DECLARE_ENGINE_PARAMETER_SUFFIX) {
 		if (element->action == LE_METHOD_SELF) {
 			push(element->action, selfValue);
 		} else {
-			FsioValue result = processElement(element PASS_ENGINE_PARAMETER_SUFFIX);
+			FsioResult result = processElement(element PASS_ENGINE_PARAMETER_SUFFIX);
 
 			if (!result) {
 				// error already reported

--- a/firmware/controllers/core/fsio_core.h
+++ b/firmware/controllers/core/fsio_core.h
@@ -64,7 +64,7 @@ typedef enum {
 
 } le_action_e;
 
-using FsioValue = expected<float>;
+using FsioResult = expected<float>;
 
 class LEElement {
 public:
@@ -116,7 +116,7 @@ public:
 	int currentCalculationLogPosition;
 private:
 	void push(le_action_e action, float value);
-	FsioValue processElement(LEElement *element DECLARE_ENGINE_PARAMETER_SUFFIX);
+	FsioResult processElement(LEElement *element DECLARE_ENGINE_PARAMETER_SUFFIX);
 	float pop(le_action_e action);
 	LEElement *first;
 	calc_stack_t stack;

--- a/firmware/controllers/core/fsio_impl.cpp
+++ b/firmware/controllers/core/fsio_impl.cpp
@@ -114,7 +114,7 @@ static LEElement * mainRelayLogic;
 static Logging *logger;
 #if EFI_PROD_CODE || EFI_SIMULATOR
 
-FsioValue getEngineValue(le_action_e action DECLARE_ENGINE_PARAMETER_SUFFIX) {
+FsioResult getEngineValue(le_action_e action DECLARE_ENGINE_PARAMETER_SUFFIX) {
 	efiAssert(CUSTOM_ERR_ASSERT, engine!=NULL, "getLEValue", unexpected);
 	switch (action) {
 	case LE_METHOD_FAN:

--- a/unit_tests/tests/test_logic_expression.cpp
+++ b/unit_tests/tests/test_logic_expression.cpp
@@ -15,7 +15,7 @@
 
 #define TEST_POOL_SIZE 256
 
-FsioValue getEngineValue(le_action_e action DECLARE_ENGINE_PARAMETER_SUFFIX) {
+FsioResult getEngineValue(le_action_e action DECLARE_ENGINE_PARAMETER_SUFFIX) {
 	switch(action) {
 	case LE_METHOD_FAN:
 		return engine->fsioState.mockFan;


### PR DESCRIPTION
related to doing invalid things with fsio, sort of #2058 