### PR TITLE
unused fsio ivalue

### DIFF
--- a/firmware/controllers/core/fsio_core.cpp
+++ b/firmware/controllers/core/fsio_core.cpp
@@ -74,7 +74,6 @@ void LEElement::clear() {
 	action = LE_UNDEFINED;
 	next = nullptr;
 	fValue = NAN;
-	iValue = 0;
 }
 
 void LEElement::init(le_action_e action) {

--- a/firmware/controllers/core/fsio_core.h
+++ b/firmware/controllers/core/fsio_core.h
@@ -77,7 +77,6 @@ public:
 
 	le_action_e action;
 	float fValue;
-	int iValue;
 
 	LEElement *next;
 };

--- a/firmware/controllers/core/fsio_impl.cpp
+++ b/firmware/controllers/core/fsio_impl.cpp
@@ -555,7 +555,7 @@ static void showFsio(const char *msg, LEElement *element) {
 	if (msg != NULL)
 		scheduleMsg(logger, "%s:", msg);
 	while (element != NULL) {
-		scheduleMsg(logger, "action %d: fValue=%.2f iValue=%d", element->action, element->fValue, element->iValue);
+		scheduleMsg(logger, "action %d: fValue=%.2f", element->action, element->fValue);
 		element = element->next;
 	}
 	scheduleMsg(logger, "<end>");


### PR DESCRIPTION
Unused member.  Saves about 1200 bytes of RAM.