### PR TITLE
update biquad filter default

### DIFF
--- a/firmware/util/math/biquad.cpp
+++ b/firmware/util/math/biquad.cpp
@@ -49,7 +49,6 @@ void Biquad::configureLowpass(float samplingFrequency, float cutoffFrequency, fl
 	float K = getK(samplingFrequency, cutoffFrequency);
 	float norm = getNorm(K, Q);
 
-	norm = 1 / (1 + K / Q + K * K);
 	a0 = K * K * norm;
 	a1 = 2 * a0;
 	a2 = a0;

--- a/firmware/util/math/biquad.h
+++ b/firmware/util/math/biquad.h
@@ -17,8 +17,9 @@ public:
 
 	void configureBandpass(float samplingFrequency, float centerFrequency, float Q);
 
-	// Default Q = 1/sqrt(2) = 0.707 gives a maximally flat passband without any overshoot near the cutoff (ie, Butterworth)
-	void configureLowpass(float samplingFrequency, float cutoffFrequency, float Q = 0.707f);
+	// Default Q = 0.54, which is the maximum quality factor without time domain overshoot
+	// note that it is less than the maximally flat (frequency domain) Q=0.707, which gives some overshoot
+	void configureLowpass(float samplingFrequency, float cutoffFrequency, float Q = 0.54f);
 
 private:
 	float a0, a1, a2, b1, b2;


### PR DESCRIPTION
Q = 0.707 was actually causing overshoot on step responses, but 0.54 won't.

Also removes a line of code that was a duplicate of the previous line.