### PR TITLE
part of 2217 which may fix 2207

### DIFF
--- a/firmware/controllers/algo/event_registry.h
+++ b/firmware/controllers/algo/event_registry.h
@@ -58,6 +58,9 @@ class FuelSchedule {
 public:
 	FuelSchedule();
 
+	// Call this function if something happens that requires a rebuild, like a change to the trigger pattern
+	void invalidate();
+
 	// Call this every trigger tooth.  It will schedule all required injector events.
 	void onTriggerTooth(size_t toothIndex, int rpm, efitick_t nowNt DECLARE_ENGINE_PARAMETER_SUFFIX);
 
@@ -73,10 +76,7 @@ public:
 	 * injection events, per cylinder
 	 */
 	InjectionEvent elements[MAX_INJECTION_OUTPUT_COUNT];
-	bool isReady;
-
-private:
-	void clear();
+	bool isReady = false;
 };
 
 class AngleBasedEvent {

--- a/firmware/controllers/math/engine_math.cpp
+++ b/firmware/controllers/math/engine_math.cpp
@@ -412,6 +412,9 @@ void prepareOutputSignals(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 	prepareIgnitionPinIndices(CONFIG(ignitionMode) PASS_ENGINE_PARAMETER_SUFFIX);
 
 	TRIGGER_WAVEFORM(prepareShape(&ENGINE(triggerCentral.triggerFormDetails) PASS_ENGINE_PARAMETER_SUFFIX));
+
+	// Fuel schedule may now be completely wrong, force a reset
+	ENGINE(injectionEvents).invalidate();
 }
 
 void setTimingRpmBin(float from, float to DECLARE_CONFIG_PARAMETER_SUFFIX) {

--- a/firmware/controllers/trigger/decoders/trigger_structure.cpp
+++ b/firmware/controllers/trigger/decoders/trigger_structure.cpp
@@ -418,8 +418,13 @@ void findTriggerPosition(TriggerWaveform *triggerShape,
 		return;
 	}
 
-	position->triggerEventIndex = triggerEventIndex;
-	position->angleOffsetFromTriggerEvent = angle - triggerEventAngle;
+	{
+		// This must happen under lock so that the tooth and offset don't get partially read and mismatched
+		chibios_rt::CriticalSectionLocker csl;
+
+		position->triggerEventIndex = triggerEventIndex;
+		position->angleOffsetFromTriggerEvent = angle - triggerEventAngle;
+	}
 }
 
 void TriggerWaveform::prepareShape(TriggerFormDetails *details DECLARE_ENGINE_PARAMETER_SUFFIX) {


### PR DESCRIPTION
maybe helps the 2003 Neon part of #2207

The bug happens when a trigger change occurs that renders the old fueling schedule invalid, potentially referencing teeth that no longer exist.  This change forces a rebuild of the injection schedule after the trigger pattern changes so that injection scheduling can pick up the new trigger shape.