### PR TITLE
clean up some includes

### DIFF
--- a/firmware/controllers/algo/rusefi_enums.h
+++ b/firmware/controllers/algo/rusefi_enums.h
@@ -12,6 +12,7 @@
 
 #include "efifeatures.h"
 #include "obd_error_codes.h"
+#include "rusefi_generated.h"
 // we do not want to start the search for header from current folder so we use brackets here
 // https://stackoverflow.com/questions/21593/what-is-the-difference-between-include-filename-and-include-filename
 #include <rusefi_hw_enums.h>

--- a/firmware/controllers/core/engine_ptr.h
+++ b/firmware/controllers/core/engine_ptr.h
@@ -14,11 +14,15 @@
 
 #ifdef __cplusplus
 class Engine;
+#endif // def __cplusplus
+
+
 struct engine_configuration_s;
 struct persistent_config_s;
 
 #if EFI_UNIT_TEST
 
+#ifdef __cplusplus
 	#define DECLARE_ENGINE_PTR                                 \
 		Engine *engine = nullptr;                              \
 		engine_configuration_s *engineConfiguration = nullptr; \
@@ -44,6 +48,7 @@ struct persistent_config_s;
 
 	#define EXTERN_ENGINE extern EnginePins enginePins; \
 		extern engine_configuration_s & activeConfiguration
+#endif // def __cplusplus
 
 	#define EXTERN_CONFIG
 
@@ -54,6 +59,7 @@ struct persistent_config_s;
 
 	// These are the non-unit-test (AKA real firmware) noop versions
 
+#ifdef __cplusplus
 	#define DECLARE_ENGINE_PTR
 
 	#define INJECT_ENGINE_REFERENCE(x) {}
@@ -72,6 +78,15 @@ struct persistent_config_s;
 	#define PASS_ENGINE_PARAMETER_SIGNATURE
 	// Pass this after some other parameters are passed
 	#define PASS_ENGINE_PARAMETER_SUFFIX
+
+	#define EXTERN_ENGINE \
+			extern Engine ___engine; \
+			extern Engine *engine; \
+			EXTERN_CONFIG \
+			extern EnginePins enginePins \
+
+	#define ENGINE(x) ___engine.x
+#endif // def __cplusplus
 
 	/**
 	 * this macro allows the compiled to figure out the complete static address, that's a performance
@@ -94,18 +109,11 @@ struct persistent_config_s;
 			EXTERN_ENGINE_CONFIGURATION \
 			extern engine_configuration_s & activeConfiguration; \
 
-	#define EXTERN_ENGINE \
-			extern Engine ___engine; \
-			extern Engine *engine; \
-			EXTERN_CONFIG \
-			extern EnginePins enginePins \
-
 	#define EXTERN_ENGINE_CONFIGURATION \
 			extern engine_configuration_s *engineConfiguration; \
 			extern persistent_config_container_s persistentState; \
 			extern persistent_config_s *config;
 
-	#define ENGINE(x) ___engine.x
 
 	#define DEFINE_CONFIG_PARAM(x, y)
 	#define CONFIG_PARAM(x) CONFIG(x)
@@ -118,5 +126,3 @@ struct persistent_config_s;
 		persistent_config_s *config = engine->config; \
 		(void)engineConfiguration; \
 		(void)config;
-
-#endif // def __cplusplus

--- a/firmware/controllers/core/engine_ptr.h
+++ b/firmware/controllers/core/engine_ptr.h
@@ -42,6 +42,14 @@ struct persistent_config_s;
 	#define PASS_ENGINE_PARAMETER_SIGNATURE engine, PASS_CONFIG_PARAMETER_SIGNATURE
 	#define PASS_ENGINE_PARAMETER_SUFFIX , PASS_ENGINE_PARAMETER_SIGNATURE
 
+	#define EXTERN_ENGINE extern EnginePins enginePins; \
+		extern engine_configuration_s & activeConfiguration
+
+	#define EXTERN_CONFIG
+
+	#define DEFINE_CONFIG_PARAM(x, y) , x y
+	#define PASS_CONFIG_PARAM(x) , x
+
 #else // EFI_UNIT_TEST
 
 	// These are the non-unit-test (AKA real firmware) noop versions
@@ -64,6 +72,44 @@ struct persistent_config_s;
 	#define PASS_ENGINE_PARAMETER_SIGNATURE
 	// Pass this after some other parameters are passed
 	#define PASS_ENGINE_PARAMETER_SUFFIX
+
+	/**
+	 * this macro allows the compiled to figure out the complete static address, that's a performance
+	 * optimization which is hopefully useful at least for anything trigger-related
+	 *
+	 * this is related to the fact that for unit tests we prefer to explicitly pass references in method signature thus code covered by
+	 * unit tests would need to use by-reference access. These macro allow us to have faster by-address access in real firmware and by-reference
+	 * access in unit tests
+	 */
+	#define CONFIG(x) persistentState.persistentConfiguration.engineConfiguration.x
+
+	/**
+	 * & is reference in C++ (not C)
+	 * Ref is a pointer that:
+	 *   you access with dot instead of arrow
+	 *   Cannot be null
+	 * This is about EFI_ACTIVE_CONFIGURATION_IN_FLASH
+	 */
+	#define EXTERN_CONFIG \
+			EXTERN_ENGINE_CONFIGURATION \
+			extern engine_configuration_s & activeConfiguration; \
+
+	#define EXTERN_ENGINE \
+			extern Engine ___engine; \
+			extern Engine *engine; \
+			EXTERN_CONFIG \
+			extern EnginePins enginePins \
+
+	#define EXTERN_ENGINE_CONFIGURATION \
+			extern engine_configuration_s *engineConfiguration; \
+			extern persistent_config_container_s persistentState; \
+			extern persistent_config_s *config;
+
+	#define ENGINE(x) ___engine.x
+
+	#define DEFINE_CONFIG_PARAM(x, y)
+	#define CONFIG_PARAM(x) CONFIG(x)
+	#define PASS_CONFIG_PARAM(x)
 
 #endif // EFI_UNIT_TEST
 

--- a/firmware/controllers/core/state_sequence.h
+++ b/firmware/controllers/core/state_sequence.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include "global.h"
+#include "rusefi_enums.h"
 
 /**
  * This layer has two primary usages:

--- a/firmware/controllers/global_shared.h
+++ b/firmware/controllers/global_shared.h
@@ -31,49 +31,7 @@
 #include "global.h"
 #include "engine_ptr.h"
 
-#define EXTERN_ENGINE_CONFIGURATION \
-		extern engine_configuration_s *engineConfiguration; \
-		extern persistent_config_container_s persistentState; \
-		extern persistent_config_s *config;
-
-/**
- * this macro allows the compiled to figure out the complete static address, that's a performance
- * optimization which is hopefully useful at least for anything trigger-related
- *
- * this is related to the fact that for unit tests we prefer to explicitly pass references in method signature thus code covered by
- * unit tests would need to use by-reference access. These macro allow us to have faster by-address access in real firmware and by-reference
- * access in unit tests
- */
-#define CONFIG(x) persistentState.persistentConfiguration.engineConfiguration.x
-
-#ifdef __cplusplus
-
-/**
- * & is reference in C++ (not C)
- * Ref is a pointer that:
- *   you access with dot instead of arrow
- *   Cannot be null
- * This is about EFI_ACTIVE_CONFIGURATION_IN_FLASH
- */
-#define EXTERN_CONFIG \
-		EXTERN_ENGINE_CONFIGURATION \
-		extern engine_configuration_s & activeConfiguration; \
-
-#define EXTERN_ENGINE \
-		extern Engine ___engine; \
-		extern Engine *engine; \
-		EXTERN_CONFIG \
-		extern EnginePins enginePins \
-
-#define ENGINE(x) ___engine.x
-
-#define DEFINE_CONFIG_PARAM(x, y)
-#define CONFIG_PARAM(x) CONFIG(x)
-#define PASS_CONFIG_PARAM(x)
-
 #define EXPECTED_REMAINING_STACK 128
-
-#endif /* __cplusplus */
 
 /*
  * Stack debugging

--- a/firmware/controllers/trigger/decoders/trigger_mazda.cpp
+++ b/firmware/controllers/trigger/decoders/trigger_mazda.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "trigger_mazda.h"
+#include "error_handling.h"
 
 void initializeMazdaMiataNaShape(TriggerWaveform *s) {
 	s->initialize(FOUR_STROKE_CAM_SENSOR);

--- a/firmware/controllers/trigger/decoders/trigger_structure.h
+++ b/firmware/controllers/trigger/decoders/trigger_structure.h
@@ -10,8 +10,8 @@
 
 #pragma once
 
+#include "engine_ptr.h"
 #include "state_sequence.h"
-#include "globalaccess.h"
 #include "engine_configuration_generated_structures.h"
 
 #define FOUR_STROKE_ENGINE_CYCLE 720
@@ -74,6 +74,7 @@ class Engine;
 class TriggerState;
 class TriggerFormDetails;
 class TriggerConfiguration;
+class Logging;
 
 // https://github.com/rusefi/rusefi/issues/2010 shows the corner case wheel with huge depth requirement
 #define GAP_TRACKING_LENGTH 18

--- a/firmware/controllers/trigger/decoders/trigger_universal.cpp
+++ b/firmware/controllers/trigger/decoders/trigger_universal.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "trigger_universal.h"
+#include "error_handling.h"
 
 /**
  * @see getCycleDuration

--- a/firmware/controllers/trigger/decoders/trigger_vw.cpp
+++ b/firmware/controllers/trigger/decoders/trigger_vw.cpp
@@ -7,6 +7,7 @@
 
 #include "trigger_vw.h"
 #include "trigger_universal.h"
+#include "error_handling.h"
 
 void setVwConfiguration(TriggerWaveform *s) {
 	efiAssertVoid(CUSTOM_ERR_6660, s != NULL, "TriggerWaveform is NULL");

--- a/unit_tests/global.h
+++ b/unit_tests/global.h
@@ -64,14 +64,6 @@ void print(const char *fmt, ...);
 
 #define CCM_OPTIONAL
 
-#define EXTERN_ENGINE extern EnginePins enginePins; \
-	 extern engine_configuration_s & activeConfiguration
-
-#define EXTERN_CONFIG
-
-#define DEFINE_CONFIG_PARAM(x, y) , x y
-#define PASS_CONFIG_PARAM(x) , x
-
 /**
  * this macro provides references to engine from EngineTestHelper
  */


### PR DESCRIPTION
make better use of `engine_ptr.h` instead of `global.h`