### PR TITLE
boost fixes

### DIFF
--- a/firmware/controllers/actuators/boost_control.cpp
+++ b/firmware/controllers/actuators/boost_control.cpp
@@ -40,19 +40,10 @@ void BoostController::init(SimplePwm* pwm, const ValueProvider3D* openLoopMap, c
 	m_pid.initPidClass(pidParams);
 }
 
-
-void BoostController::reset() {
-	m_shouldResetPid = true;
-}
-
 void BoostController::onConfigurationChange(pid_s* previousConfiguration) {
 	if (!m_pid.isSame(previousConfiguration)) {
 		m_shouldResetPid = true;
 	}
-}
-
-int BoostController::getPeriodMs() {
-	return GET_PERIOD_LIMITED(&engineConfiguration->boostPid);
 }
 
 expected<float> BoostController::observePlant() const {
@@ -125,7 +116,7 @@ expected<percent_t> BoostController::getClosedLoop(float target, float manifoldP
 		return 0;
 	}
 
-	float closedLoop = m_pid.getOutput(target, manifoldPressure);
+	float closedLoop = m_pid.getOutput(target, manifoldPressure, SLOW_CALLBACK_PERIOD_MS / 1000.0f);
 
 #if EFI_TUNER_STUDIO
 	if (engineConfiguration->debugMode == DBG_BOOST) {
@@ -149,23 +140,29 @@ void BoostController::setOutput(expected<float> output) {
 	setEtbWastegatePosition(percent PASS_ENGINE_PARAMETER_SUFFIX);
 }
 
-void BoostController::PeriodicTask() {
+void BoostController::update() {
 	m_pid.iTermMin = -50;
 	m_pid.iTermMax = 50;
 
-	update();
+	ClosedLoopController::update();
 }
 
-BoostController boostController;
+static BoostController boostController;
+static bool hasInitBoost = false;
+
+void updateBoostControl() {
+	if (hasInitBoost) {
+		boostController.update();
+	}
+}
 
 void setDefaultBoostParameters(DECLARE_CONFIG_PARAMETER_SIGNATURE) {
-	engineConfiguration->boostPwmFrequency = 55;
+	engineConfiguration->boostPwmFrequency = 33;
 	engineConfiguration->boostPid.offset = 0;
 	engineConfiguration->boostPid.pFactor = 0.5;
 	engineConfiguration->boostPid.iFactor = 0.3;
-	engineConfiguration->boostPid.periodMs = 100;
-	engineConfiguration->boostPid.maxValue = 99;
-	engineConfiguration->boostPid.minValue = -99;
+	engineConfiguration->boostPid.maxValue = 20;
+	engineConfiguration->boostPid.minValue = -20;
 	engineConfiguration->boostControlPin = GPIO_UNASSIGNED;
 	engineConfiguration->boostControlPinMode = OM_DEFAULT;
 
@@ -236,7 +233,7 @@ void initBoostCtrl(Logging *sharedLogger DECLARE_ENGINE_PARAMETER_SUFFIX) {
 
 #if !EFI_UNIT_TEST
 	startBoostPin();
-	boostController.Start();
+	hasInitBoost = true;
 #endif
 }
 

--- a/firmware/controllers/actuators/boost_control.cpp
+++ b/firmware/controllers/actuators/boost_control.cpp
@@ -203,12 +203,6 @@ void startBoostPin() {
 #endif /* EFI_UNIT_TEST */
 }
 
-void stopBoostPin() {
-#if !EFI_UNIT_TEST
-	efiSetPadUnused(activeConfiguration.boostControlPin);
-#endif /* EFI_UNIT_TEST */
-}
-
 void onConfigurationChangeBoostCallback(engine_configuration_s *previousConfiguration) {
 	boostController.onConfigurationChange(&previousConfiguration->boostPid);
 }

--- a/firmware/controllers/actuators/boost_control.h
+++ b/firmware/controllers/actuators/boost_control.h
@@ -13,16 +13,12 @@
 
 class SimplePwm;
 
-class BoostController : public ClosedLoopController<float, percent_t>, public PeriodicTimerController {
+class BoostController : public ClosedLoopController<float, percent_t> {
 public:
 	DECLARE_ENGINE_PTR;
 
 	void init(SimplePwm* pmw, const ValueProvider3D* openLoopMap, const ValueProvider3D* closedLoopTargetMap, pid_s* pidParams);
-
-	// PeriodicTimerController implementation
-	int getPeriodMs() override;
-	void PeriodicTask() override;
-	void reset();
+	void update();
 
 	// Called when the configuration may have changed.  Controller will
 	// reset if necessary.
@@ -50,3 +46,5 @@ void startBoostPin();
 void initBoostCtrl(Logging *sharedLogger DECLARE_ENGINE_PARAMETER_SUFFIX);
 void setDefaultBoostParameters(DECLARE_CONFIG_PARAMETER_SIGNATURE);
 void onConfigurationChangeBoostCallback(engine_configuration_s *previousConfiguration);
+
+void updateBoostControl();

--- a/firmware/controllers/actuators/boost_control.h
+++ b/firmware/controllers/actuators/boost_control.h
@@ -47,7 +47,6 @@ private:
 };
 
 void startBoostPin();
-void stopBoostPin();
 void initBoostCtrl(Logging *sharedLogger DECLARE_ENGINE_PARAMETER_SUFFIX);
 void setDefaultBoostParameters(DECLARE_CONFIG_PARAMETER_SIGNATURE);
 void onConfigurationChangeBoostCallback(engine_configuration_s *previousConfiguration);

--- a/firmware/controllers/algo/engine.cpp
+++ b/firmware/controllers/algo/engine.cpp
@@ -33,6 +33,7 @@
 #include "gppwm.h"
 #include "tachometer.h"
 #include "dynoview.h"
+#include "boost_control.h"
 #if EFI_MC33816
  #include "mc33816.h"
 #endif // EFI_MC33816
@@ -192,6 +193,10 @@ void Engine::periodicSlowCallback(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 	updateGppwm();
 
 	updateIdleControl();
+
+#if EFI_BOOST_CONTROL
+	updateBoostControl();
+#endif // EFI_BOOST_CONTROL
 
 	cylinderCleanupControl(PASS_ENGINE_PARAMETER_SIGNATURE);
 

--- a/firmware/hw_layer/hardware.cpp
+++ b/firmware/hw_layer/hardware.cpp
@@ -379,9 +379,6 @@ void applyNewHardwareSettings(void) {
 	stopHD44780_pins();
 #endif /* #if EFI_HD44780_LCD */
 
-#if EFI_BOOST_CONTROL
-	stopBoostPin();
-#endif
 	if (isPinOrModeChanged(clutchUpPin, clutchUpPinMode)) {
 		efiSetPadUnused(activeConfiguration.clutchUpPin);
 	}

--- a/firmware/tunerstudio/rusefi.input
+++ b/firmware/tunerstudio/rusefi.input
@@ -3168,12 +3168,11 @@ cmd_set_engine_type_default					= "@@TS_IO_TEST_COMMAND_char@@\x00\x31\x00\x00"
 ;Boost Closed Loop
 
          dialog = boostPidleft, ""
-            field = "P Gain", 	                        boostPid_pFactor, { isBoostControlEnabled && boostType == 1 }
+            field = "P Gain", 	                         boostPid_pFactor, { isBoostControlEnabled && boostType == 1 }
 	        field = "I Gain",                            boostPid_iFactor, { isBoostControlEnabled && boostType == 1 }
 	        field = "D Gain",                            boostPid_dFactor, { isBoostControlEnabled && boostType == 1 }
-	        field = "Control Period",                    boostPid_periodMs, { isBoostControlEnabled && boostType == 1 }
-	        field = "Min Duty",                          boostPid_minValue, { isBoostControlEnabled && boostType == 1 }
-	        field = "Max Duty",                          boostPid_maxValue, { isBoostControlEnabled && boostType == 1 }
+	        field = "Min adjustment",                 boostPid_minValue, { isBoostControlEnabled && boostType == 1 }
+	        field = "Max adjustment",                 boostPid_maxValue, { isBoostControlEnabled && boostType == 1 }
 
          dialog = boostTableDialog, "", card
                 panel = boostTable2Tbl


### PR DESCRIPTION
- boost control was broken after a config apply since the pin was getting reset but is already a `RegisteredOutputPin`
- call boost control from periodic slow instead of as its own task
- improve boost control default settings
- TS UI cleanup