### PR TITLE
iBOM improvements

### DIFF
--- a/.github/workflows/gen-docs.yaml
+++ b/.github/workflows/gen-docs.yaml
@@ -18,7 +18,7 @@ jobs:
       run: |
         sudo add-apt-repository ppa:kicad/kicad-5.1-releases
         sudo apt-get update
-        sudo apt-get install ncftp kicad doxygen
+        sudo apt-get install ncftp kicad doxygen xvfb
 
     - name: Set FTP variables
       env:

--- a/.github/workflows/gen-docs.yaml
+++ b/.github/workflows/gen-docs.yaml
@@ -14,11 +14,11 @@ jobs:
         submodules: recursive
         fetch-depth: 0
 
-    - name: Install ncftp, kicad, xvfb, and doxygen
+    - name: Install ncftp, kicad, and doxygen
       run: |
         sudo add-apt-repository ppa:kicad/kicad-5.1-releases
         sudo apt-get update
-        sudo apt-get install ncftp kicad doxygen xvfb
+        sudo apt-get install ncftp kicad doxygen
 
     - name: Set FTP variables
       env:
@@ -32,4 +32,4 @@ jobs:
         fi
 
     - name: Generate documentation
-      run: xvfb-run bash ./misc/jenkins/generate_doxygen/gen_upload_docs.sh
+      run: bash ./misc/jenkins/generate_doxygen/gen_upload_docs.sh

--- a/.github/workflows/gen-docs.yaml
+++ b/.github/workflows/gen-docs.yaml
@@ -16,7 +16,7 @@ jobs:
 
     - name: Install ncftp, kicad, xvfb, and doxygen
       run: |
-        sudo add-apt-repository ppa:js-reynaud/kicad-5.1
+        sudo add-apt-repository ppa:kicad/kicad-5.1-releases
         sudo apt-get update
         sudo apt-get install ncftp kicad doxygen xvfb
 

--- a/.github/workflows/gen-docs.yaml
+++ b/.github/workflows/gen-docs.yaml
@@ -18,11 +18,12 @@ jobs:
       run: |
         sudo add-apt-repository ppa:kicad/kicad-5.1-releases
         sudo apt-get update
-        sudo apt-get install ncftp kicad doxygen xvfb
+        sudo apt-get install ncftp kicad doxygen
 
     - name: Set FTP variables
       env:
         ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
+        INTERACTIVE_HTML_BOM_NO_DISPLAY: 'true'
       run: |
         if [ "${{github.event_name}}" = "push" ] && [ "${{github.ref}}" = "refs/heads/master" ]; then
           echo "::set-env name=RUSEFI_FTP_SERVER::${{secrets.RUSEFI_FTP_SERVER}}";

--- a/hardware/frankenso/sym-lib-table
+++ b/hardware/frankenso/sym-lib-table
@@ -4,4 +4,5 @@
   (lib (name rusEFI_ITEAD)(type Legacy)(uri ${KIPRJMOD}/../rusefi_lib/itead_hc-0X_bluetooth.lib)(options "")(descr ""))
   (lib (name rusEFI_Older)(type Legacy)(uri ${KIPRJMOD}/../rusefi_lib/KICAD_Older_Version.lib)(options "")(descr ""))
   (lib (name rusEFI_Polo)(type Legacy)(uri ${KIPRJMOD}/../rusefi_lib/Pololu_DRV8880.lib)(options "")(descr ""))
+  (lib (name frankenso-rescue)(type Legacy)(uri ${KIPRJMOD}/frankenso-rescue.lib)(options "")(descr ""))
 )

--- a/hardware/frankenso/sym-lib-table
+++ b/hardware/frankenso/sym-lib-table
@@ -4,5 +4,4 @@
   (lib (name rusEFI_ITEAD)(type Legacy)(uri ${KIPRJMOD}/../rusefi_lib/itead_hc-0X_bluetooth.lib)(options "")(descr ""))
   (lib (name rusEFI_Older)(type Legacy)(uri ${KIPRJMOD}/../rusefi_lib/KICAD_Older_Version.lib)(options "")(descr ""))
   (lib (name rusEFI_Polo)(type Legacy)(uri ${KIPRJMOD}/../rusefi_lib/Pololu_DRV8880.lib)(options "")(descr ""))
-  (lib (name frankenso-rescue)(type Legacy)(uri ${KIPRJMOD}/frankenso-rescue.lib)(options "")(descr ""))
 )

--- a/misc/jenkins/InteractiveHtmlBom/run.sh
+++ b/misc/jenkins/InteractiveHtmlBom/run.sh
@@ -8,7 +8,7 @@ pwd
 [ -e hardware/frankenso/frankenso.kicad_pcb ] || { echo "hardware/frankenso/frankenso.kicad_pcb not found. Was this invoked from wrong folder?"; exit -1; }
 
 for f in $(ls hardware/*/*.kicad_pcb); do
-  if ls $(dirname $f)/$(basename $f .kicad_pcb).net; then
+  if ls $(dirname $f)/$(basename $f .kicad_pcb).net 2>/dev/null; then
     $IBOM_CMD --netlist-file $(ls $(dirname $f)/$(basename $f .kicad_pcb).net) $f
   else
     $IBOM_CMD $f

--- a/misc/jenkins/InteractiveHtmlBom/run.sh
+++ b/misc/jenkins/InteractiveHtmlBom/run.sh
@@ -9,8 +9,8 @@ pwd
 
 for f in $(ls hardware/*/*.kicad_pcb); do
   if ls $(dirname $f)/$(basename $f .kicad_pcb).net 2>/dev/null; then
-    $IBOM_CMD --netlist-file $(ls $(dirname $f)/$(basename $f .kicad_pcb).net) $f
+    $IBOM_CMD --include-nets --include-tracks --netlist-file $(ls $(dirname $f)/$(basename $f .kicad_pcb).net) $f
   else
-    $IBOM_CMD $f
+    $IBOM_CMD --include-nets --include-tracks $f
   fi
 done

--- a/misc/jenkins/InteractiveHtmlBom/run.sh
+++ b/misc/jenkins/InteractiveHtmlBom/run.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 INTERACTIVE_HTML_BOM_NO_DISPLAY="true"
-IBOM_CMD="python3 hardware/InteractiveHtmlBom/InteractiveHtmlBom/generate_interactive_bom.py --no-browser --name-format \"%f_latest\" --dest-dir ../ibom"
+IBOM_CMD="python3 hardware/InteractiveHtmlBom/InteractiveHtmlBom/generate_interactive_bom.py --no-browser --name-format \"%f_latest\" --dest-dir ../ibom --include-nets"
 echo "IBOM_CMD=$IBOM_CMD"
 
 pwd
@@ -9,8 +9,8 @@ pwd
 
 for f in $(ls hardware/*/*.kicad_pcb); do
   if ls $(dirname $f)/$(basename $f .kicad_pcb).net 2>/dev/null; then
-    $IBOM_CMD --include-nets --include-tracks --netlist-file $(ls $(dirname $f)/$(basename $f .kicad_pcb).net) $f
+    $IBOM_CMD --netlist-file $(ls $(dirname $f)/$(basename $f .kicad_pcb).net) $f
   else
-    $IBOM_CMD --include-nets --include-tracks $f
+    $IBOM_CMD $f
   fi
 done

--- a/misc/jenkins/InteractiveHtmlBom/run.sh
+++ b/misc/jenkins/InteractiveHtmlBom/run.sh
@@ -7,12 +7,10 @@ echo "IBOM_CMD=$IBOM_CMD"
 pwd
 [ -e hardware/frankenso/frankenso.kicad_pcb ] || { echo "hardware/frankenso/frankenso.kicad_pcb not found. Was this invoked from wrong folder?"; exit -1; }
 
-$IBOM_CMD hardware/Common_Rail_MC33816/Common_Rail_MC33816.kicad_pcb
-$IBOM_CMD hardware/brain_board/brain_board_STM32F407.kicad_pcb
-$IBOM_CMD hardware/brain_board_176-pin/176-pin_board.kicad_pcb
-$IBOM_CMD --extra-fields "mfg,mfg#,vend1,vend1#" hardware/CJ125_board/O2_input_CJ125.kicad_pcb --netlist-file hardware/CJ125_board/O2_input_CJ125.net
-$IBOM_CMD --extra-fields "MFG,MFG#,VEND1,VEND1#" hardware/frankenso/frankenso.kicad_pcb --netlist-file hardware/frankenso/frankenso.net
-$IBOM_CMD --extra-fields "mfg,mfg#,vend1,vend1#" hardware/frankenstein/frankenstein.kicad_pcb --netlist-file hardware/frankenstein/frankenstein.net
-$IBOM_CMD hardware/mini48-stm32/mini48-stm32.kicad_pcb
-$IBOM_CMD hardware/HighSideSwitch/VN750PS_E.kicad_pcb
-$IBOM_CMD hardware/can_board/can_brd_1.kicad_pcb
+for f in $(ls hardware/*/*.kicad_pcb); do
+  if ls $(dirname $f)/$(basename $f .kicad_pcb).net; then
+    $IBOM_CMD --netlist-file $(ls $(dirname $f)/$(basename $f .kicad_pcb).net) $f
+  else
+    $IBOM_CMD $f
+  fi
+done


### PR DESCRIPTION
1. Generate iBOMs for all boards with .kicad_pcb files
2. Show netlists for boards with .net files
3. Update InteractiveHtmlBom to get rid of xvfb dependency
4. Switch to official kicad ppa