### PR TITLE
Limp handles inj/ign disable

### DIFF
--- a/firmware/console/status_loop.cpp
+++ b/firmware/console/status_loop.cpp
@@ -681,8 +681,8 @@ void updateTunerStudioState(TunerStudioOutputChannels *tsOutputChannels DECLARE_
 	tsOutputChannels->isFuelPumpOn = enginePins.fuelPumpRelay.getLogicValue();
 	tsOutputChannels->isFanOn = enginePins.fanRelay.getLogicValue();
 	tsOutputChannels->isO2HeaterOn = enginePins.o2heater.getLogicValue();
-	tsOutputChannels->isIgnitionEnabledIndicator = engineConfiguration->isIgnitionEnabled && ENGINE(limpManager).allowIgnition();
-	tsOutputChannels->isInjectionEnabledIndicator = engineConfiguration->isInjectionEnabled && ENGINE(limpManager).allowInjection();
+	tsOutputChannels->isIgnitionEnabledIndicator = ENGINE(limpManager).allowIgnition();
+	tsOutputChannels->isInjectionEnabledIndicator = ENGINE(limpManager).allowInjection();
 	tsOutputChannels->isCylinderCleanupEnabled = engineConfiguration->isCylinderCleanupEnabled;
 	tsOutputChannels->isCylinderCleanupActivated = engine->isCylinderCleanupMode;
 

--- a/firmware/controllers/engine_cycle/main_trigger_callback.cpp
+++ b/firmware/controllers/engine_cycle/main_trigger_callback.cpp
@@ -320,7 +320,7 @@ static void handleFuel(const bool limitedFuel, uint32_t trgEventIndex, int rpm, 
 	efiAssertVoid(CUSTOM_STACK_6627, getCurrentRemainingStack() > 128, "lowstck#3");
 	efiAssertVoid(CUSTOM_ERR_6628, trgEventIndex < engine->engineCycleEventCount, "handleFuel/event index");
 
-	if (!isInjectionEnabled(PASS_ENGINE_PARAMETER_SIGNATURE) || limitedFuel) {
+	if (limitedFuel) {
 		return;
 	}
 	if (ENGINE(isCylinderCleanupMode)) {
@@ -554,8 +554,6 @@ void initMainEventListener(Logging *sharedLogger DECLARE_ENGINE_PARAMETER_SUFFIX
 	addConsoleActionP("maininfo", (VoidPtr) showMainInfo, engine);
 
 	printMsg(logger, "initMainLoop: %d", currentTimeMillis());
-	if (!isInjectionEnabled(PASS_ENGINE_PARAMETER_SIGNATURE))
-		printMsg(logger, "!!!!!!!!!!!!!!!!!!! injection disabled");
 #endif
 
 

--- a/firmware/controllers/engine_cycle/spark_logic.cpp
+++ b/firmware/controllers/engine_cycle/spark_logic.cpp
@@ -35,11 +35,6 @@ static Logging *logger;
 
 static const char *prevSparkName = nullptr;
 
-int isInjectionEnabled(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
-	// todo: is this worth a method? should this be inlined?
-	return CONFIG(isInjectionEnabled);
-}
-
 int isIgnitionTimingError(void) {
 	return ignitionErrorDetection.sum(6) > 4;
 }

--- a/firmware/controllers/engine_cycle/spark_logic.h
+++ b/firmware/controllers/engine_cycle/spark_logic.h
@@ -9,7 +9,6 @@
 
 #include "engine.h"
 
-int isInjectionEnabled(DECLARE_ENGINE_PARAMETER_SIGNATURE);
 void onTriggerEventSparkLogic(bool limitedSpark, uint32_t trgEventIndex, int rpm, efitick_t edgeTimestamp DECLARE_ENGINE_PARAMETER_SUFFIX);
 void initSparkLogic(Logging *sharedLogger);
 void turnSparkPinHigh(IgnitionEvent *event);

--- a/firmware/controllers/limp_manager.cpp
+++ b/firmware/controllers/limp_manager.cpp
@@ -10,9 +10,13 @@ void LimpManager::updateState(int rpm) {
 
 	// User-configured hard RPM limit
 	if (rpm > engine->getRpmHardLimit(PASS_ENGINE_PARAMETER_SIGNATURE)) {
-		// TODO: user configurable what gets limited
-		allowFuel.clear();
-		allowSpark.clear();
+		if (CONFIG(cutFuelOnHardLimit)) {
+			allowFuel.clear();
+		}
+
+		if (CONFIG(cutSparkOnHardLimit)) {
+			allowSpark.clear();
+		}
 	}
 
 	// Force fuel limiting on the fault rev limit

--- a/firmware/controllers/limp_manager.cpp
+++ b/firmware/controllers/limp_manager.cpp
@@ -5,27 +5,30 @@
 EXTERN_ENGINE;
 
 void LimpManager::updateState(int rpm) {
-	// User-configured hard RPM limit
-	bool isRevLimited = rpm > engine->getRpmHardLimit(PASS_ENGINE_PARAMETER_SIGNATURE);
+	Clearable allowFuel = CONFIG(isInjectionEnabled);
+	Clearable allowSpark = CONFIG(isIgnitionEnabled);
 
-	// TODO: user configurable what gets limited
-	bool limitFuel = isRevLimited;
-	bool limitSpark = isRevLimited;
+	// User-configured hard RPM limit
+	if (rpm > engine->getRpmHardLimit(PASS_ENGINE_PARAMETER_SIGNATURE)) {
+		// TODO: user configurable what gets limited
+		allowFuel.clear();
+		allowSpark.clear();
+	}
 
 	// Force fuel limiting on the fault rev limit
 	if (rpm > m_faultRevLimit) {
-		limitFuel = true;
+		allowFuel.clear();
 	}
 
 	// Limit fuel only on boost pressure (limiting spark bends valves)
 	if (CONFIG(boostCutPressure) != 0) {
 		if (Sensor::get(SensorType::Map).value_or(0) > CONFIG(boostCutPressure)) {
-			limitFuel = true;
+			allowFuel.clear();
 		}
 	}
 
-	m_transientLimitInjection = limitFuel;
-	m_transientLimitIgnition = limitSpark;
+	m_transientAllowInjection = allowFuel;
+	m_transientAllowIgnition = allowSpark;
 }
 
 void LimpManager::etbProblem() {
@@ -57,9 +60,9 @@ bool LimpManager::allowTriggerInput() const {
 }
 
 bool LimpManager::allowInjection() const {
-	return !m_transientLimitInjection && m_allowInjection;
+	return m_transientAllowInjection && m_allowInjection;
 }
 
 bool LimpManager::allowIgnition() const {
-	return !m_transientLimitIgnition && m_allowIgnition;
+	return m_transientAllowIgnition && m_allowIgnition;
 }

--- a/firmware/controllers/limp_manager.h
+++ b/firmware/controllers/limp_manager.h
@@ -7,6 +7,9 @@
 // Only allows clearing the value, but never resetting it.
 class Clearable {
 public:
+	Clearable() : m_value(true) {}
+	Clearable(bool value) : m_value(value) {}
+
 	void clear() {
 		m_value = false;
 	}
@@ -49,6 +52,6 @@ private:
 	Clearable m_allowIgnition;
 	Clearable m_allowTriggerInput;
 
-	bool m_transientLimitInjection = false;
-	bool m_transientLimitIgnition = false;
+	bool m_transientAllowInjection = true;
+	bool m_transientAllowIgnition = true;
 };


### PR DESCRIPTION
let the limp manager completely handle disabling injection/ignition, either by user selection or by rev limit/boost cut/whatever

also, since apparently the bits for it already exist, allows user selection of whether to limit fuel/spark for rev limit

progress #2244 