### PR TITLE
Map fallback logic, TS cleanup

### DIFF
--- a/firmware/controllers/algo/airmass/speed_density_airmass.cpp
+++ b/firmware/controllers/algo/airmass/speed_density_airmass.cpp
@@ -17,15 +17,11 @@ AirmassResult SpeedDensityAirmass::getAirmass(int rpm) {
 		return {};
 	}
 
-	auto map = Sensor::get(SensorType::Map);
-	if (!map) {
-		warning(CUSTOM_ERR_TCHARGE_NOT_READY2, "map not ready"); // this could happen during HW CI during configuration reset
-		return {};
-	}
+	auto map = Sensor::get(SensorType::Map).value_or(CONFIG(failedMapFallback));
 
 	engine->engineState.sd.manifoldAirPressureAccelerationAdjustment = engine->engineLoadAccelEnrichment.getEngineLoadEnrichment(PASS_ENGINE_PARAMETER_SIGNATURE);
 
-	float adjustedMap = engine->engineState.sd.adjustedManifoldAirPressure = map.Value + engine->engineState.sd.manifoldAirPressureAccelerationAdjustment;
+	float adjustedMap = engine->engineState.sd.adjustedManifoldAirPressure = map + engine->engineState.sd.manifoldAirPressureAccelerationAdjustment;
 	efiAssert(CUSTOM_ERR_ASSERT, !cisnan(adjustedMap), "NaN adjustedMap", {});
 
 	float ve = getVe(rpm, adjustedMap);
@@ -42,6 +38,6 @@ AirmassResult SpeedDensityAirmass::getAirmass(int rpm) {
 
 	return {
 		airMass,
-		map.Value,	// AFR/VE table Y axis
+		map,	// AFR/VE table Y axis
 	};
 }

--- a/firmware/controllers/algo/engine_configuration.cpp
+++ b/firmware/controllers/algo/engine_configuration.cpp
@@ -848,7 +848,7 @@ static void setDefaultEngineConfiguration(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 	engineConfiguration->cranking.rpm = 550;
 	engineConfiguration->cutFuelOnHardLimit = true;
 	engineConfiguration->cutSparkOnHardLimit = true;
-
+	engineConfiguration->failedMapFallback = 60;
 
 	engineConfiguration->tChargeMinRpmMinTps = 0.25;
 	engineConfiguration->tChargeMinRpmMaxTps = 0.25;

--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -658,7 +658,7 @@ trigger_config_s trigger;
 
 custom spi_device_e 1 bits, U08,   @OFFSET@, [0:2], "Off", "SPI1", "SPI2", "SPI3", "SPI4", "INVALID", "INVALID", "INVALID" 
 	spi_device_e hip9011SpiDevice;
-	uint8_t unused541;;"unit",      1,     0,    0, 100,     0
+	uint8_t failedMapFallback;+This value is only used for speed density fueling calculations.;"kPa",      1,     0,    0, 100,     0
 	uint8_t unused542;;"unit",      1,     0,    0, 100,     0
 	adc_channel_e mafAdcChannel;See hasMafSensor
 
@@ -1261,7 +1261,7 @@ int16_t tps2Max;Full throttle#2. tpsMax value as 10 bit ADC value. Not Voltage!\
 	output_pin_e hpfpValvePin;
 	pin_output_mode_e hpfpValvePinMode;
 
-	float boostCutPressure;+MAP value above which fuel is cut in case of overboost.\n0 to disable overboost cut.;"kPa (absolute)",        1,     0,    0, 500,     0
+	float boostCutPressure;+MAP value above which fuel is cut in case of overboost.\nSet to 0 to disable overboost cut.;"kPa (absolute)",        1,     0,    0, 500,     0
 
 float[MAP_ACCEL_TAPER] mapAccelTaperBins;;"counter",      1,     0,   0.0,    300,   0
 float[MAP_ACCEL_TAPER] mapAccelTaperMult;;"mult",      1,     0,   0.0,    300,   2

--- a/firmware/tunerstudio/rusefi.input
+++ b/firmware/tunerstudio/rusefi.input
@@ -1334,6 +1334,7 @@ menuDialog = main
 
 	menu = "&Base &Engine"
 		subMenu = engineChars,				"Base engine"
+		subMenu = limitsAndFallback,		"Limits and fallbacks"
 		subMenu = triggerConfiguration,		"Trigger"
 		subMenu = triggerConfiguration_IO, "Advanced Trigger"
 		subMenu = std_separator
@@ -2940,17 +2941,24 @@ cmd_set_engine_type_default					= "@@TS_IO_TEST_COMMAND_char@@\x00\x31\x00\x00"
 		field = "Warning Text",						warning_message
 		field = "showHumanReadableWarning (affects Burn)",	showHumanReadableWarning
 
-	
 	dialog = limits, "Limits"
 		field = "RPM hard limit",         	    		rpmHardLimit
+		field = "Cut fuel on RPM limit",				cutFuelOnHardLimit
+		field = "Cut spark on RPM limit",				cutSparkOnHardLimit
 		field = "Boost cut pressure",					boostCutPressure
+	
+	dialog = fallbacks, "Fallbacks"
+		field = "Failed MAP sensor fallback",			failedMapFallback
+
+	dialog = limitsAndFallback, "Limits and fallbacks"
+		panel = limits
+		panel = fallbacks
 	
 ;			Engine->Base Engine Settings
 	dialog = engineChars, "Base Engine Settings"
 		topicHelp = "baseHelp"
 		panel = baseEngineConfig
 		panel = generalSettings
-		panel = limits
 		panel = debugging
 
 	dialog = crankingFuel, "Fuel"

--- a/firmware/tunerstudio/rusefi.input
+++ b/firmware/tunerstudio/rusefi.input
@@ -1751,20 +1751,18 @@ cmd_set_engine_type_default					= "@@TS_IO_TEST_COMMAND_char@@\x00\x31\x00\x00"
 		panel = ignitionOutputs
 
 	dialog = baseEngineConfig, "Engine Configuration"
-;		field = "Engine Preset",						engineType
-; this field is useful for rusEFI online catalog
+;		field = "Engine preset",						engineType
+		field = "Number of cylinders",					cylindersCount
+		field = "Displacement",         			displacement
+		field = "Firing order",							firingOrder
+		field = "Vehicle weight",						vehicleWeight
+
+	dialog = engineMetadata, "Engine Metadata"
+		field = "#These metadata are used by rusEFI Online"
 		field = "Engine Make",							engineMake
-; this field is useful for rusEFI online catalog
 		field = "Manufacturer Engine Code",				engineCode
-; this field is useful for rusEFI online catalog
 		field = "Vehicle Name",							vehicleName
-		field = "Number of Cylinders",					cylindersCount
-		field = "Engine Displacement",         			displacement
-		field = "Firing Order",							firingOrder
-		field = "Vehicle Weight",						vehicleWeight
-; this field is useful for rusEFI online catalog
 		field = "Compression Ratio",					compressionRatio
-; this field is useful for rusEFI online catalog
 		field = "Forced Induction?",					isForcedInduction
 
 ;			Engine->Trigger configuration
@@ -2938,8 +2936,6 @@ cmd_set_engine_type_default					= "@@TS_IO_TEST_COMMAND_char@@\x00\x31\x00\x00"
 	dialog = debugging, "Debug"
 		field = "!https://rusefi.com/s/debugmode"
 		field = "Debug mode",							debugMode
-		field = "Warning Text",						warning_message
-		field = "showHumanReadableWarning (affects Burn)",	showHumanReadableWarning
 
 	dialog = limits, "Limits"
 		field = "RPM hard limit",         	    		rpmHardLimit
@@ -2958,6 +2954,7 @@ cmd_set_engine_type_default					= "@@TS_IO_TEST_COMMAND_char@@\x00\x31\x00\x00"
 	dialog = engineChars, "Base Engine Settings"
 		topicHelp = "baseHelp"
 		panel = baseEngineConfig
+		panel = engineMetadata
 		panel = generalSettings
 		panel = debugging
 
@@ -3433,6 +3430,7 @@ cmd_set_engine_type_default					= "@@TS_IO_TEST_COMMAND_char@@\x00\x31\x00\x00"
 		field = "Global fuel correction", 				globalFuelCorrection
 		field = "Ignition Math Logic @",				ignMathCalculateAtIndex
 		field = "MAP Averaging Logic @",				mapAveragingSchedulingAtIndex
+		field = "showHumanReadableWarning (affects Burn)",	showHumanReadableWarning
 
 
        help = helpGeneral, "rusEFI General Help"


### PR DESCRIPTION
progress on #2244 

- in case of MAP failure, use configured value instead for SD fueling
- TS cleanup so now it looks like this:
![image](https://user-images.githubusercontent.com/568254/106076262-19583600-60c4-11eb-832d-4723bf457bec.png)
