### PR TITLE
USB reports real STM32 Serial Number

### DIFF
--- a/firmware/hw_layer/ports/stm32/port_mpu_util.h
+++ b/firmware/hw_layer/ports/stm32/port_mpu_util.h
@@ -10,6 +10,8 @@
 
 #include "device_mpu_util.h"
 
+#define MCU_SERIAL_NUMBER_BYTES 12
+
 // 12mhz was chosen because it's the GCD of (168, 180, 216), the three speeds of STM32 currently supported
 // https://www.wolframalpha.com/input/?i=common+factors+of+168+180+216
 #define US_TO_NT_MULTIPLIER (12)

--- a/firmware/hw_layer/ports/stm32/serial_over_usb/usbcfg.h
+++ b/firmware/hw_layer/ports/stm32/serial_over_usb/usbcfg.h
@@ -21,6 +21,8 @@ extern const USBConfig usbcfg;
 extern SerialUSBConfig serusbcfg;
 extern SerialUSBDriver SDU1;
 
+void usbPopulateSerialNumber(const uint8_t* serialNumber, size_t bytes);
+
 #endif  /* USBCFG_H */
 
 /** @} */

--- a/firmware/hw_layer/ports/stm32/serial_over_usb/usbconsole.c
+++ b/firmware/hw_layer/ports/stm32/serial_over_usb/usbconsole.c
@@ -13,6 +13,7 @@
 
 #include "usbconsole.h"
 #include "usbcfg.h"
+#include "mpu_util.h"
 
 static bool isUsbSerialInitialized = false;
 
@@ -20,6 +21,8 @@ static bool isUsbSerialInitialized = false;
  * start USB serial using hard-coded communications pins (see comments inside the code)
  */
 void usb_serial_start(void) {
+	usbPopulateSerialNumber(MCU_SERIAL_NUMBER_LOCATION, MCU_SERIAL_NUMBER_BYTES);
+
 	/*
 	 * Initializes a serial-over-USB CDC driver.
 	 */

--- a/firmware/hw_layer/ports/stm32/stm32f4/device_mpu_util.h
+++ b/firmware/hw_layer/ports/stm32/stm32f4/device_mpu_util.h
@@ -9,6 +9,8 @@
 
 #include "stm32f4xx_hal_flash_ex.h"
 
+#define MCU_SERIAL_NUMBER_LOCATION (uint8_t*)(0x1FFF7A10)
+
 #define SPI_CR1_8BIT_MODE 0
 #define SPI_CR2_8BIT_MODE 0
 

--- a/firmware/hw_layer/ports/stm32/stm32f7/device_mpu_util.h
+++ b/firmware/hw_layer/ports/stm32/stm32f7/device_mpu_util.h
@@ -9,6 +9,8 @@
 
 #include "stm32f7xx_hal_flash_ex.h"
 
+#define MCU_SERIAL_NUMBER_LOCATION (uint8_t*)(0x1FF0F420)
+
 #define SPI_CR1_8BIT_MODE 0
 #define SPI_CR2_8BIT_MODE (SPI_CR2_DS_2 | SPI_CR2_DS_1 | SPI_CR2_DS_0)
 


### PR DESCRIPTION
- Report the real serial number over USB, so that you can tell multiple ECUs apart when they're connected at the same time.
- Set the USB manufacturer string to "rusEFI LLC"
- Fix the casing on the device name string so the R is lower case in rusEFI
- Set our max power to 200mA which is a little closer to reality than 100mA (there is a very narrow possibility that this well help with the USB stability problems some people see)