### PR TITLE
put CAN debug mode check back

### DIFF
--- a/firmware/controllers/can/can_rx.cpp
+++ b/firmware/controllers/can/can_rx.cpp
@@ -24,10 +24,10 @@ EXTERN_ENGINE;
  */
 static void printPacket(const CANRxFrame& rx, Logging* logger) {
 	// only print info if we're in can debug mode
-
+	if (CONFIG(debugMode) == DBG_CAN) {
 		scheduleMsg(logger, "Got CAN message: SID %x/%x %x %x %x %x %x %x %x %x", rx.SID, rx.DLC, rx.data8[0], rx.data8[1],
 				rx.data8[2], rx.data8[3], rx.data8[4], rx.data8[5], rx.data8[6], rx.data8[7]);
-
+	}
 }
 
 volatile float canMap = 0;


### PR DESCRIPTION
put the debug check back - this causes serious performance problems on a busy CAN bus