### PR TITLE
implement bit-banged I2C driver

### DIFF
--- a/firmware/hw_layer/hw_layer.mk
+++ b/firmware/hw_layer/hw_layer.mk
@@ -41,7 +41,9 @@ HW_LAYER_EMS_CPP = $(HW_LAYER_EGT_CPP) \
 	$(PROJECT_DIR)/hw_layer/io_pins.cpp \
 	$(PROJECT_DIR)/hw_layer/rtc_helper.cpp \
 	$(PROJECT_DIR)/hw_layer/cdm_ion_sense.cpp \
-	$(PROJECT_DIR)/hw_layer/debounce.cpp
+	$(PROJECT_DIR)/hw_layer/debounce.cpp \
+	$(PROJECT_DIR)/hw_layer/i2c_bb.cpp \
+
 
 #
 # '-include' is a magic kind of 'include' which would survive if file to be included is not found

--- a/firmware/hw_layer/i2c_bb.cpp
+++ b/firmware/hw_layer/i2c_bb.cpp
@@ -100,8 +100,7 @@ bool BitbangI2c::readBit() {
 
 bool BitbangI2c::writeByte(uint8_t data) {
 	// write out 8 data bits
-	for (size_t i = 0; i < 8; i++)
-	{
+	for (size_t i = 0; i < 8; i++) {
 		// Send the MSB
 		sendBit((data & 0x80) != 0);
 
@@ -114,15 +113,16 @@ bool BitbangI2c::writeByte(uint8_t data) {
 	// Read the ack bit
 	bool ackBit = readBit();
 
-	// ACK = 0 -> acknowledged, so return true
+	// 0 -> ack
+	// 1 -> nack
 	return !ackBit;
 }
 
 uint8_t BitbangI2c::readByte(bool ack) {
 	uint8_t result = 0;
 
-	for (size_t i = 0; i < 8; i++)
-	{
+	// Read in 8 data bits
+	for (size_t i = 0; i < 8; i++) {
 		result = result << 1;
 
 		result |= readBit() ? 1 : 0;
@@ -149,8 +149,7 @@ void BitbangI2c::write(uint8_t addr, const uint8_t* writeData, size_t writeSize)
 	writeByte(addr << 1 | 0);
 
 	// Write outbound bytes
-	for (size_t i = 0; i < writeSize; i++)
-	{
+	for (size_t i = 0; i < writeSize; i++) {
 		writeByte(writeData[i]);
 	}
 
@@ -164,8 +163,7 @@ void BitbangI2c::writeRead(uint8_t addr, const uint8_t* writeData, size_t writeS
 	writeByte(addr << 1 | 0);
 
 	// Write outbound bytes
-	for (size_t i = 0; i < writeSize; i++)
-	{
+	for (size_t i = 0; i < writeSize; i++) {
 		writeByte(writeData[i]);
 	}
 	

--- a/firmware/hw_layer/i2c_bb.cpp
+++ b/firmware/hw_layer/i2c_bb.cpp
@@ -1,3 +1,11 @@
+/**
+ * @file        i2c_bb.cpp
+ * @brief       Bit-banged I2C driver
+ *
+ * @date February 6, 2020
+ * @author Matthew Kennedy, (c) 2020
+ */
+
 #include "i2c_bb.h"
 
 #if EFI_PROD_CODE

--- a/firmware/hw_layer/i2c_bb.cpp
+++ b/firmware/hw_layer/i2c_bb.cpp
@@ -1,5 +1,7 @@
 #include "i2c_bb.h"
 
+#if EFI_PROD_CODE
+
 #include "io_pins.h"
 #include "efi_gpio.h"
 
@@ -199,3 +201,5 @@ void BitbangI2c::writeRegister(uint8_t addr, uint8_t reg, uint8_t val) {
 
 	write(addr, buf, 2);
 }
+
+#endif // EFI_PROD_CODE

--- a/firmware/hw_layer/i2c_bb.cpp
+++ b/firmware/hw_layer/i2c_bb.cpp
@@ -37,6 +37,7 @@ void BitbangI2c::init(brain_pin_e scl, brain_pin_e sda) {
 }
 
 void BitbangI2c::start() {
+	// Start with both lines high (bus idle)
 	sda_high();
 	waitQuarterBit();
 	scl_high();
@@ -124,9 +125,7 @@ uint8_t BitbangI2c::readByte(bool ack) {
 	{
 		result = result << 1;
 
-		bool bit = readBit();
-
-		result |= bit ? 1 : 0;
+		result |= readBit() ? 1 : 0;
 	}
 
 	// 0 -> ack

--- a/firmware/hw_layer/i2c_bb.cpp
+++ b/firmware/hw_layer/i2c_bb.cpp
@@ -37,11 +37,12 @@ void BitbangI2c::init(brain_pin_e scl, brain_pin_e sda) {
 }
 
 void BitbangI2c::start() {
-	// SDA goes low while SCL is high
 	sda_high();
 	waitQuarterBit();
 	scl_high();
 	waitQuarterBit();
+
+	// SDA goes low while SCL is high
 	sda_low();
 	waitQuarterBit();
 	scl_low();
@@ -49,23 +50,19 @@ void BitbangI2c::start() {
 }
 
 void BitbangI2c::stop() {
-	// Clock goes high while data is low
 	scl_low();
 	waitQuarterBit();
 	sda_low();
 	waitQuarterBit();
 	scl_high();
 	waitQuarterBit();
+	// SDA goes high while SCL is high
 	sda_high();
-
-	for (size_t i = 0; i < count; i++) {
-		waitQuarterBit();
-	}
 }
 
 void BitbangI2c::sendBit(bool val) {
 	waitQuarterBit();
-	
+
 	// Write the bit (write while SCL is low)
 	if (val) {
 		sda_high();
@@ -73,6 +70,7 @@ void BitbangI2c::sendBit(bool val) {
 		sda_low();
 	}
 
+	// Data setup time (~100ns min)
 	waitQuarterBit();
 
 	// Strobe the clock

--- a/firmware/hw_layer/i2c_bb.cpp
+++ b/firmware/hw_layer/i2c_bb.cpp
@@ -1,0 +1,85 @@
+#include "i2c_bb.h"
+
+#include "io_pins.h"
+#include "efi_gpio.h"
+
+void BitbangI2c::init(brain_pin_e scl, brain_pin_e sda) {
+	efiSetPadMode("i2c", scl, PAL_STM32_OTYPE_OPENDRAIN);
+	efiSetPadMode("i2c", sda, PAL_STM32_OTYPE_OPENDRAIN);
+
+	m_sclPort = getHwPort("i2c", scl);
+	m_sclPin = getHwPin("i2c", scl);
+
+	m_sdaPort = getHwPort("i2c", sda);
+	m_sdaPin = getHwPin("i2c", sda);
+
+	// Both lines idle high
+	scl_high();
+	sda_high();
+}
+
+void BitbangI2c::start() {
+	// SDA goes low while SCL is high
+	sda_high();
+	scl_high();
+	sda_low();
+	scl_low();
+}
+
+void BitbangI2c::stop() {
+	// Clock goes high while data is low
+	scl_low();
+	sda_low();
+	scl_high();
+	sda_high();
+}
+
+void BitbangI2c::sendBit(bool val) {
+	// Write the bit (write while SCL is low)
+	if (val) {
+		sda_high();
+	} else {
+		sda_low();
+	}
+
+	// Strobe the clock
+	scl_high();
+	scl_low();
+}
+
+bool BitbangI2c::readBit() {
+	scl_high();
+
+	// Read while the clock is high
+	bool val = palReadPad(m_sdaPort, m_sdaPin);
+
+	scl_low();
+
+	return val;
+}
+
+bool BitbangI2c::writeByte(uint8_t data) {
+	// write out 8 data bits
+	for (size_t i = 0; i < 8; i++)
+	{
+		// Send the MSB
+		sendBit((data & 0x80) != 0);
+
+		data = data << 1;
+	}
+	
+	// Force a release of the data line so the slave can ACK
+	sda_high();
+
+	// Read the ack bit
+	bool ackBit = readBit();
+
+	// ACK = 0 -> acknowledged, so return true
+	return !ackBit;
+}
+
+uint8_t BitbangI2c::readByte() {
+	uint8_t result;
+
+
+}

--- a/firmware/hw_layer/i2c_bb.h
+++ b/firmware/hw_layer/i2c_bb.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "hal.h"
+#include "rusefi_hw_enums.h"
+#include <cstdint>
+#include <cstddef>
+
+class BitbangI2c {
+public:
+	void init(brain_pin_e scl, brain_pin_e sda);
+
+	void write(uint8_t addr, uint8_t* data, size_t size);
+
+	// Returns true if the remote device acknowledged the transmission
+	bool writeByte(uint8_t data);
+
+
+private:
+	void sda_low();
+	void sda_high();
+	void scl_low();
+	void scl_high();
+
+	void start();
+	void stop();
+
+	void sendBit(bool val);
+	bool readBit();
+
+	ioportid_t m_sclPort = 0;
+	ioportmask_t m_sclPin = 0;
+	ioportid_t m_sdaPort = 0;
+	ioportmask_t m_sdaPin = 0;
+};

--- a/firmware/hw_layer/i2c_bb.h
+++ b/firmware/hw_layer/i2c_bb.h
@@ -9,13 +9,21 @@ class BitbangI2c {
 public:
 	void init(brain_pin_e scl, brain_pin_e sda);
 
-	void write(uint8_t addr, uint8_t* data, size_t size);
+	// Write a sequence of bytes to the specified device
+	void write(uint8_t addr, const uint8_t* data, size_t size);
+	// Write some bytes then read some bytes back after a repeated start bit
+	void writeRead(uint8_t addr, const uint8_t* writeData, size_t writeSize, uint8_t* readData, size_t readSize);
 
-	// Returns true if the remote device acknowledged the transmission
-	bool writeByte(uint8_t data);
-
+	// Read a register at the specified address and register index
+	uint8_t readRegister(uint8_t addr, uint8_t reg);
+	// Write a register at the specified address and register index
+	void writeRegister(uint8_t addr, uint8_t reg, uint8_t val);
 
 private:
+	// Returns true if the remote device acknowledged the transmission
+	bool writeByte(uint8_t data);
+	uint8_t readByte(bool ack);
+
 	void sda_low();
 	void sda_high();
 	void scl_low();
@@ -26,6 +34,8 @@ private:
 
 	void sendBit(bool val);
 	bool readBit();
+
+	void waitQuarterBit();
 
 	ioportid_t m_sclPort = 0;
 	ioportmask_t m_sclPin = 0;

--- a/firmware/hw_layer/i2c_bb.h
+++ b/firmware/hw_layer/i2c_bb.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#if EFI_PROD_CODE
+
 #include "hal.h"
 #include "rusefi_hw_enums.h"
 #include <cstdint>
@@ -42,3 +44,5 @@ private:
 	ioportid_t m_sdaPort = 0;
 	ioportmask_t m_sdaPin = 0;
 };
+
+#endif // EFI_PROD_CODE

--- a/firmware/hw_layer/i2c_bb.h
+++ b/firmware/hw_layer/i2c_bb.h
@@ -1,3 +1,11 @@
+/**
+ * @file        i2c_bb.h
+ * @brief       Bit-banged I2C driver
+ *
+ * @date February 6, 2020
+ * @author Matthew Kennedy, (c) 2020
+ */
+
 #pragma once
 
 #if EFI_PROD_CODE
@@ -9,6 +17,7 @@
 
 class BitbangI2c {
 public:
+	// Initialize the I2C driver
 	void init(brain_pin_e scl, brain_pin_e sda);
 
 	// Write a sequence of bytes to the specified device
@@ -31,12 +40,17 @@ private:
 	void scl_low();
 	void scl_high();
 
+	// Send an I2C start condition
 	void start();
+	// Send an I2C stop condition
 	void stop();
 
+	// Send a single bit
 	void sendBit(bool val);
+	// Read a single bit
 	bool readBit();
 
+	// Wait for 1/4 of a bit time
 	void waitQuarterBit();
 
 	ioportid_t m_sclPort = 0;


### PR DESCRIPTION
Implement a bit-banged I2C controller for low priority I2C operations.

Bit-banged (as opposed to hardware accelerated) provides several benefits:
- No interrupts required
- No usage of microcontroller resources (particularly DMA channels)
- No operating system locks (any other thread can preempt an operation)
- Smaller code size
- No restriction on pins: can use any two GPIO pins

progress on #2288 and #2281 