### PR TITLE
try removing -m and glob

### DIFF
--- a/misc/jenkins/generate_doxygen/gen_upload_docs.sh
+++ b/misc/jenkins/generate_doxygen/gen_upload_docs.sh
@@ -10,6 +10,6 @@ doxygen || { echo "doxygen run FAILED"; exit 1; }
 cd ../doxygen
 if [ -n "$RUSEFI_FTP_SERVER" ]; then
   echo "Uploading Doxygen"
-  ncftpput -R -m -u "$RUSEFI_DOXYGEN_FTP_USER" -p "$RUSEFI_DOXYGEN_FTP_PASS" "$RUSEFI_FTP_SERVER" /html html/*
+  ncftpput -R -u "$RUSEFI_DOXYGEN_FTP_USER" -p "$RUSEFI_DOXYGEN_FTP_PASS" "$RUSEFI_FTP_SERVER" /html html/
 fi
 [ $? -eq 0 ] || { echo "upload FAILED"; exit 1; }


### PR DESCRIPTION
-m was added to create the directory if it doesn't exist. For some reason this had the side effect of putting the source directory inside of the target directory, instead of putting the /contents/ of the source directory inside the target directory. To solve this I added a asterisk to get the contents of the source dir rather than the dir itself. However, Windows has a limit on the number of arguments that can be passed to a command that is way too low to handle the number of files that doxygen generates.