### PR TITLE
increase SD card speed

### DIFF
--- a/firmware/hw_layer/mmc_card.cpp
+++ b/firmware/hw_layer/mmc_card.cpp
@@ -84,6 +84,13 @@ static THD_WORKING_AREA(mmcThreadStack,3 * UTILITY_THREAD_STACK_SIZE);		// MMC m
  */
 MMCDriver MMCD1;
 
+// SD cards are good up to 25MHz in "slow" mode, and 50MHz in "fast" mode
+// 168mhz F4:
+// Slow mode is 10.5 or 5.25 MHz, depending on which SPI device
+// Fast mode is 42 or 21 MHz
+// 216mhz F7:
+// Slow mode is 13.5 or 6.75 MHz
+// Fast mode is 54 or 27 MHz (technically out of spec, needs testing!)
 static SPIConfig hs_spicfg = {
 		.circular = false,
 		.end_cb = NULL,

--- a/firmware/hw_layer/mmc_card.cpp
+++ b/firmware/hw_layer/mmc_card.cpp
@@ -89,14 +89,14 @@ static SPIConfig hs_spicfg = {
 		.end_cb = NULL,
 		.ssport = NULL,
 		.sspad = 0,
-		.cr1 = SPI_BaudRatePrescaler_8,
+		.cr1 = SPI_BaudRatePrescaler_2,
 		.cr2 = 0};
 static SPIConfig ls_spicfg = {
 		.circular = false,
 		.end_cb = NULL,
 		.ssport = NULL,
 		.sspad = 0,
-		.cr1 = SPI_BaudRatePrescaler_256,
+		.cr1 = SPI_BaudRatePrescaler_8,
 		.cr2 = 0};
 
 /* MMC/SD over SPI driver configuration.*/


### PR DESCRIPTION
SD spec says 0-25MHz for slow mode, and 0-50MHz for fast mode.

Increases slow mode to either 10.5MHz or 5.25MHz (depending on which SPI device it is), and fast mode to 42MHz or 21MHz (depending on which SPI device it is).  On an F7 that means 13.5mhz/6.75mhz slow mode and 54MHz/27MHz fast mode, which is pushing it a little bit on SPI1, but will probably be just fine.