### PR TITLE
Fix doxygen 3

### DIFF
--- a/misc/jenkins/generate_doxygen/gen_upload_docs.sh
+++ b/misc/jenkins/generate_doxygen/gen_upload_docs.sh
@@ -10,6 +10,6 @@ doxygen || { echo "doxygen run FAILED"; exit 1; }
 cd ../doxygen
 if [ -n "$RUSEFI_FTP_SERVER" ]; then
   echo "Uploading Doxygen"
-  ncftpput -R -z -E -u "$RUSEFI_DOXYGEN_FTP_USER" -p "$RUSEFI_DOXYGEN_FTP_PASS" "$RUSEFI_FTP_SERVER" /html html/
+  ncftpput -R -z -m -V -u "$RUSEFI_DOXYGEN_FTP_USER" -p "$RUSEFI_DOXYGEN_FTP_PASS" "$RUSEFI_FTP_SERVER" / html
 fi
 [ $? -eq 0 ] || { echo "upload FAILED"; exit 1; }

--- a/misc/jenkins/generate_doxygen/gen_upload_docs.sh
+++ b/misc/jenkins/generate_doxygen/gen_upload_docs.sh
@@ -10,6 +10,6 @@ doxygen || { echo "doxygen run FAILED"; exit 1; }
 cd ../doxygen
 if [ -n "$RUSEFI_FTP_SERVER" ]; then
   echo "Uploading Doxygen"
-  ncftpput -R -z -u "$RUSEFI_DOXYGEN_FTP_USER" -p "$RUSEFI_DOXYGEN_FTP_PASS" "$RUSEFI_FTP_SERVER" /html html/
+  ncftpput -R -z -E -u "$RUSEFI_DOXYGEN_FTP_USER" -p "$RUSEFI_DOXYGEN_FTP_PASS" "$RUSEFI_FTP_SERVER" /html html/
 fi
 [ $? -eq 0 ] || { echo "upload FAILED"; exit 1; }

--- a/misc/jenkins/generate_ibom/gen_upload_ibom.sh
+++ b/misc/jenkins/generate_ibom/gen_upload_ibom.sh
@@ -7,6 +7,6 @@ bash misc/jenkins/InteractiveHtmlBom/run.sh
 
 if [ -n "$RUSEFI_FTP_SERVER" ]; then
   echo "Uploading IBOMs"
-  ncftpput -R -m -u "$RUSEFI_DOXYGEN_FTP_USER" -p "$RUSEFI_DOXYGEN_FTP_PASS" "$RUSEFI_FTP_SERVER" /ibom hardware/ibom/*
+  ncftpput -R -z -m -V -u "$RUSEFI_DOXYGEN_FTP_USER" -p "$RUSEFI_DOXYGEN_FTP_PASS" "$RUSEFI_FTP_SERVER" / hardware/ibom
 fi
 [ $? -eq 0 ] || { echo "upload FAILED"; exit 1; }

--- a/misc/jenkins/generate_pinouts/gen_upload_pinouts.sh
+++ b/misc/jenkins/generate_pinouts/gen_upload_pinouts.sh
@@ -26,6 +26,6 @@ done
 
 if [ -n "$RUSEFI_FTP_SERVER" ]; then
   echo "Uploading Pinouts"
-  ncftpput -R -m -u "$RUSEFI_DOXYGEN_FTP_USER" -p "$RUSEFI_DOXYGEN_FTP_PASS" "$RUSEFI_FTP_SERVER" /pinouts pinouts/*
+  ncftpput -R -z -m -V -u "$RUSEFI_DOXYGEN_FTP_USER" -p "$RUSEFI_DOXYGEN_FTP_PASS" "$RUSEFI_FTP_SERVER" / pinouts
 fi
 [ $? -eq 0 ] || { echo "upload FAILED"; exit 1; }


### PR DESCRIPTION
It seems my recent pull requests caused the doxygen to be put at html/html. That directory can be deleted after this is merged.
I also took this opportunity to optimize the parameters to the other ncftpput commands, for pinouts and ibom.
The -z flag doesn't seem to be doing anything, but I left it in case it does, but I can't tell.