### PR TITLE
fix usb descriptor mistakes

### DIFF
--- a/firmware/hw_layer/ports/stm32/serial_over_usb/usbcfg.c
+++ b/firmware/hw_layer/ports/stm32/serial_over_usb/usbcfg.c
@@ -161,7 +161,7 @@ static const uint8_t vcom_string0[] = {
  * Vendor string.
  */
 static const uint8_t vcom_string1[] = {
-  USB_DESC_BYTE(24),                    /* bLength.                         */
+  USB_DESC_BYTE(22),                    /* bLength.                         */
   USB_DESC_BYTE(USB_DESCRIPTOR_STRING), /* bDescriptorType.                 */
   'r', 0, 'u', 0, 's', 0, 'E', 0, 'F', 0, 'I', 0, ' ', 0, 'L', 0,
   'L', 0, 'C', 0
@@ -183,7 +183,7 @@ static const uint8_t vcom_string2[] = {
  * Serial Number string.
  */
 static uint8_t vcom_string3[] = {
-  USB_DESC_BYTE(52),                     /* bLength.                         */
+  USB_DESC_BYTE(50),                     /* bLength.                         */
   USB_DESC_BYTE(USB_DESCRIPTOR_STRING), /* bDescriptorType.                 */
   '0', 0, '1', 0, '2', 0, '3', 0, '4', 0, '5', 0, '6', 0, '7', 0,
   '8', 0, '9', 0, 'A', 0, 'B', 0, 'C', 0, 'D', 0, 'E', 0, 'F', 0,


### PR DESCRIPTION
Length was wrong on these descriptors, causing Windows to get a little bit upset.