### PR TITLE
implement null block device

### DIFF
--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -273,6 +273,7 @@ INCDIR = $(ALLINC) \
 	$(TESTINC) \
 	$(BOOTLOADERINC) \
 	$(CHIBIOS)/os/various \
+	$(CHIBIOS_CONTRIB)/os/various \
 	$(CHIBIOS)/os/hal/lib/peripherals/sensors \
 	$(CONFDIR) \
 	config/engines \

--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -273,7 +273,6 @@ INCDIR = $(ALLINC) \
 	$(TESTINC) \
 	$(BOOTLOADERINC) \
 	$(CHIBIOS)/os/various \
-	$(CHIBIOS_CONTRIB)/os/various \
 	$(CHIBIOS)/os/hal/lib/peripherals/sensors \
 	$(CONFDIR) \
 	config/engines \
@@ -296,7 +295,9 @@ INCDIR = $(ALLINC) \
 	$(DEVELOPMENT_DIR) \
 	development/hw_layer \
 	development/test \
-	$(CONTROLLERS_INC)
+	$(CONTROLLERS_INC) \
+	$(CHIBIOS_CONTRIB)/os/various
+	# contrib/os/various must go at the end because it also contains pid.h which conflicts with our pid.h
 
 #
 # Project, sources and paths

--- a/firmware/hw_layer/mass_storage/mass_storage.mk
+++ b/firmware/hw_layer/mass_storage/mass_storage.mk
@@ -1,3 +1,4 @@
 
-HW_MASS_STORAGE_SRC_C = $(PROJECT_DIR)/hw_layer/mass_storage/usb_msd_cfg.c \
-  $(PROJECT_DIR)/ChibiOS-Contrib/os/various/lib_scsi.c
+HW_MASS_STORAGE_SRC_C = $(PROJECT_DIR)/ChibiOS-Contrib/os/various/lib_scsi.c
+
+ALLCPPSRC += $(PROJECT_DIR)/hw_layer/mass_storage/null_device.cpp

--- a/firmware/hw_layer/mass_storage/null_device.cpp
+++ b/firmware/hw_layer/mass_storage/null_device.cpp
@@ -1,0 +1,75 @@
+/**
+ * @file	zero_device.cpp
+ *
+ * @date Feb 12, 2021
+ * @author Matthew Kennedy, (c) 2021
+ *
+ * This file implements a special block device that simply reports "no media"
+ * Use it when you need to mount *something* but don't have an SD card available.
+ */
+
+#include "hal.h"
+
+#include <cstring>
+
+struct NullDevice {
+	const struct BaseBlockDeviceVMT *vmt;
+	_base_block_device_data
+};
+
+static bool nd_is_inserted(void*) {
+	// This function is the whole point - we have no media!
+	return false;
+}
+
+static bool nd_is_protected(void*) {
+	return false;
+}
+
+static bool nd_return_success(void*) {
+	return HAL_SUCCESS;
+}
+
+static bool nd_return_success_read(void*, uint32_t, uint8_t* buffer, uint32_t n) {
+	// write zeroes to the buffer to prevent somebody reading random memory
+	memset(buffer, 0, n);
+
+	return HAL_SUCCESS;
+}
+
+static bool nd_return_success_write(void*, uint32_t, const uint8_t*, uint32_t) {
+	return HAL_SUCCESS;
+}
+
+static bool nd_get_info(void*, BlockDeviceInfo* bdip) {
+	// We have to report non-zero size here because Windows
+	// will query the size of the block device even if we indicate
+	// that the device has no media
+	// If we report zeroes, it breaks USB until you unplug this device
+	bdip->blk_num = 1000;
+	bdip->blk_size = 512;
+	return HAL_SUCCESS;
+}
+
+static const struct BaseBlockDeviceVMT ndVmt = {
+	(size_t)0, // instanceOffset
+	nd_is_inserted,
+	nd_is_protected,
+
+	// These functions just claim success to make the host happy
+	nd_return_success,
+	nd_return_success,
+	nd_return_success_read,
+	nd_return_success_write,
+	nd_return_success,
+	nd_get_info
+};
+
+// This device is always ready and has no state
+static NullDevice nd = { &ndVmt, BLK_READY };
+
+#if HAL_USE_USB_MSD
+void msdMountNullDevice(USBMassStorageDriver* msdp, USBDriver *usbp, uint8_t* blkbuf, const scsi_inquiry_response_t* inquiry) {
+	msdStart(msdp, usbp, (BaseBlockDevice*)&nd, blkbuf, inquiry, nullptr);
+}
+#endif

--- a/firmware/hw_layer/mass_storage/null_device.h
+++ b/firmware/hw_layer/mass_storage/null_device.h
@@ -1,0 +1,15 @@
+/**
+ * @file	zero_device.cpp
+ *
+ * @date Feb 12, 2021
+ * @author Matthew Kennedy, (c) 2021
+ *
+ * This file implements a special block device that simply reports "no media"
+ * Use it when you need to mount *something* but don't have an SD card available.
+ */
+
+#include "hal.h"
+
+#if HAL_USE_USB_MSD
+void msdMountNullDevice(USBMassStorageDriver* msdp, USBDriver *usbp, uint8_t* blkbuf, const scsi_inquiry_response_t* inquiry);
+#endif


### PR DESCRIPTION
This is a helper that lets us handle the case when we want to connect USB, but not mount an SD card.