### PR TITLE
remove unused msg parameter

### DIFF
--- a/firmware/controllers/actuators/electronic_throttle.cpp
+++ b/firmware/controllers/actuators/electronic_throttle.cpp
@@ -312,7 +312,7 @@ expected<percent_t> EtbController::getOpenLoop(percent_t target) const {
 	// Don't apply open loop for wastegate/idle valve, only real ETB
 	if (m_function != ETB_Wastegate
 		&& m_function != ETB_IdleValve) {
-		ff = interpolate2d("etbb", target, engineConfiguration->etbBiasBins, engineConfiguration->etbBiasValues);
+		ff = interpolate2d(target, engineConfiguration->etbBiasBins, engineConfiguration->etbBiasValues);
 	}
 
 	engine->engineState.etbFeedForward = ff;

--- a/firmware/controllers/actuators/idle_thread.cpp
+++ b/firmware/controllers/actuators/idle_thread.cpp
@@ -202,7 +202,7 @@ int IdleController::getTargetRpm(float clt) const {
 
 	float fsioBump = engine->fsioState.fsioIdleTargetRPMAdjustment;
 
-	return fsioBump + interpolate2d("cltRpm", clt, CONFIG(cltIdleRpmBins), CONFIG(cltIdleRpm));
+	return fsioBump + interpolate2d(clt, CONFIG(cltIdleRpmBins), CONFIG(cltIdleRpm));
 }
 
 IIdleController::Phase IdleController::determinePhase(int rpm, int targetRpm, SensorResult tps) const {
@@ -233,13 +233,13 @@ IIdleController::Phase IdleController::determinePhase(int rpm, int targetRpm, Se
 float IdleController::getCrankingOpenLoop(float clt) const {
 	return 
 		CONFIG(crankingIACposition)		// Base cranking position (cranking page)
-		 * interpolate2d("cltCrankingT", clt, config->cltCrankingCorrBins, config->cltCrankingCorr);
+		 * interpolate2d(clt, config->cltCrankingCorrBins, config->cltCrankingCorr);
 }
 
 float IdleController::getRunningOpenLoop(float clt, SensorResult tps) const {
 	float running =
 		CONFIG(manIdlePosition)		// Base idle position (slider)
-		* interpolate2d("cltT", clt, config->cltIdleCorrBins, config->cltIdleCorr);
+		* interpolate2d(clt, config->cltIdleCorrBins, config->cltIdleCorr);
 
 	// Now we bump it by the AC/fan amount if necessary
 	running += engine->acSwitchState ? CONFIG(acIdleExtraOffset) : 0;
@@ -429,7 +429,7 @@ static percent_t automaticIdleController(float tpsPos, float rpm, int targetRpm,
 		engine->engineState.idle.idleState = PID_UPPER;
 		const auto [cltValid, clt] = Sensor::get(SensorType::Clt);
 		if (CONFIG(useIacTableForCoasting) && cltValid) {
-			percent_t iacPosForCoasting = interpolate2d("iacCoasting", clt, CONFIG(iacCoastingBins), CONFIG(iacCoasting));
+			percent_t iacPosForCoasting = interpolate2d(clt, CONFIG(iacCoastingBins), CONFIG(iacCoasting));
 			newValue = interpolateClamped(idlePidLowerRpm, newValue, idlePidLowerRpm + CONFIG(idlePidRpmUpperLimit), iacPosForCoasting, rpm);
 		} else {
 			// Well, just leave it as is, without PID regulation...
@@ -490,11 +490,11 @@ static percent_t automaticIdleController(float tpsPos, float rpm, int targetRpm,
 		float cltCorrection;
 		// Use separate CLT correction table for cranking
 		if (engineConfiguration->overrideCrankingIacSetting && phase == IIdleController::Phase::Cranking) {
-			cltCorrection = interpolate2d("cltCrankingT", clt, config->cltCrankingCorrBins, config->cltCrankingCorr);
+			cltCorrection = interpolate2d(clt, config->cltCrankingCorrBins, config->cltCrankingCorr);
 		} else {
 			// this value would be ignored if running in AUTO mode
 			// but we need it while cranking in AUTO mode
-			cltCorrection = interpolate2d("cltT", clt, config->cltIdleCorrBins, config->cltIdleCorr);
+			cltCorrection = interpolate2d(clt, config->cltIdleCorrBins, config->cltIdleCorr);
 		}
 
 		percent_t iacPosition;

--- a/firmware/controllers/algo/accel_enrichment.cpp
+++ b/firmware/controllers/algo/accel_enrichment.cpp
@@ -242,7 +242,7 @@ float LoadAccelEnrichment::getEngineLoadEnrichment(DECLARE_ENGINE_PARAMETER_SIGN
 		if (distance <= 0) // checking if indexes are out of order due to circular buffer nature
 			distance += minI(cb.getCount(), cb.getSize());
 
-		taper = interpolate2d("accel", distance, engineConfiguration->mapAccelTaperBins, engineConfiguration->mapAccelTaperMult);
+		taper = interpolate2d(distance, engineConfiguration->mapAccelTaperBins, engineConfiguration->mapAccelTaperMult);
 
 		result = taper * d * engineConfiguration->engineLoadAccelEnrichmentMultiplier;
 	} else if (d < -engineConfiguration->engineLoadDecelEnleanmentThreshold) {

--- a/firmware/controllers/algo/advance_map.cpp
+++ b/firmware/controllers/algo/advance_map.cpp
@@ -83,7 +83,7 @@ static angle_t getRunningAdvance(int rpm, float engineLoad DECLARE_ENGINE_PARAME
 
 	// get advance from the separate table for Idle
 	if (CONFIG(useSeparateAdvanceForIdle) && isIdling()) {
-		float idleAdvance = interpolate2d("idleAdvance", rpm, config->idleAdvanceBins, config->idleAdvance);
+		float idleAdvance = interpolate2d(rpm, config->idleAdvanceBins, config->idleAdvance);
 
 		auto [valid, tps] = Sensor::get(SensorType::DriverThrottleIntent);
 		if (valid) {
@@ -146,7 +146,7 @@ angle_t getAdvanceCorrections(int rpm DECLARE_ENGINE_PARAMETER_SUFFIX) {
 static angle_t getCrankingAdvance(int rpm, float engineLoad DECLARE_ENGINE_PARAMETER_SUFFIX) {
 	// get advance from the separate table for Cranking
 	if (CONFIG(useSeparateAdvanceForCranking)) {
-		return interpolate2d("crankingAdvance", rpm, CONFIG(crankingAdvanceBins), CONFIG(crankingAdvance));
+		return interpolate2d(rpm, CONFIG(crankingAdvanceBins), CONFIG(crankingAdvance));
 	}
 
 	// Interpolate the cranking timing angle to the earlier running angle for faster engine start

--- a/firmware/controllers/algo/airmass/airmass.cpp
+++ b/firmware/controllers/algo/airmass/airmass.cpp
@@ -26,7 +26,7 @@ float AirmassModelBase::getVe(int rpm, float load) const {
 	auto tps = Sensor::get(SensorType::Tps1);
 	// get VE from the separate table for Idle if idling
 	if (isIdling() && tps && CONFIG(useSeparateVeForIdle)) {
-		float idleVe = interpolate2d("idleVe", rpm, config->idleVeBins, config->idleVe);
+		float idleVe = interpolate2d(rpm, config->idleVeBins, config->idleVe);
 		// interpolate between idle table and normal (running) table using TPS threshold
 		ve = interpolateClamped(0.0f, idleVe, CONFIG(idlePidDeactivationTpsThreshold), ve, tps.Value);
 	}

--- a/firmware/controllers/algo/engine2.cpp
+++ b/firmware/controllers/algo/engine2.cpp
@@ -163,7 +163,7 @@ void EngineState::periodicFastCallback(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 
 	cltTimingCorrection = getCltTimingCorrection(PASS_ENGINE_PARAMETER_SIGNATURE);
 
-	engineNoiseHipLevel = interpolate2d("knock", rpm, engineConfiguration->knockNoiseRpmBins,
+	engineNoiseHipLevel = interpolate2d(rpm, engineConfiguration->knockNoiseRpmBins,
 					engineConfiguration->knockNoise);
 
 	baroCorrection = getBaroCorrection(PASS_ENGINE_PARAMETER_SIGNATURE);

--- a/firmware/controllers/algo/fuel/injector_model.cpp
+++ b/firmware/controllers/algo/fuel/injector_model.cpp
@@ -78,7 +78,6 @@ float InjectorModel::getInjectorMassFlowRate() const {
 
 float InjectorModel::getDeadtime() const {
 	return interpolate2d(
-		"lag",
 		ENGINE(sensors.vBatt),
 		engineConfiguration->injector.battLagCorrBins,
 		engineConfiguration->injector.battLagCorr

--- a/firmware/controllers/algo/fuel_math.cpp
+++ b/firmware/controllers/algo/fuel_math.cpp
@@ -71,7 +71,7 @@ DISPLAY(DISPLAY_IF(isCrankingState)) float getCrankingFuel3(
 	 * Cranking fuel changes over time
 	 */
 	DISPLAY_TEXT(Duration_coef);
-	engine->engineState.DISPLAY_PREFIX(cranking).DISPLAY_FIELD(durationCoefficient) = interpolate2d("crank", revolutionCounterSinceStart, config->crankingCycleBins,
+	engine->engineState.DISPLAY_PREFIX(cranking).DISPLAY_FIELD(durationCoefficient) = interpolate2d(revolutionCounterSinceStart, config->crankingCycleBins,
 			config->crankingCycleCoef);
 	DISPLAY_TEXT(eol);
 
@@ -89,7 +89,7 @@ DISPLAY(DISPLAY_IF(isCrankingState)) float getCrankingFuel3(
 	auto tps = Sensor::get(SensorType::DriverThrottleIntent);
 
 	DISPLAY_TEXT(TPS_coef);
-	engine->engineState.DISPLAY_PREFIX(cranking).DISPLAY_FIELD(tpsCoefficient) = tps.Valid ? 1 : interpolate2d("crankTps", tps.Value, engineConfiguration->crankingTpsBins,
+	engine->engineState.DISPLAY_PREFIX(cranking).DISPLAY_FIELD(tpsCoefficient) = tps.Valid ? 1 : interpolate2d(tps.Value, engineConfiguration->crankingTpsBins,
 			engineConfiguration->crankingTpsCoef);
 
 

--- a/firmware/controllers/algo/fuel_math.cpp
+++ b/firmware/controllers/algo/fuel_math.cpp
@@ -82,7 +82,7 @@ DISPLAY(DISPLAY_IF(isCrankingState)) float getCrankingFuel3(
 	auto clt = Sensor::get(SensorType::Clt);
 	DISPLAY_TEXT(Coolant_coef);
 	engine->engineState.DISPLAY_PREFIX(cranking).DISPLAY_FIELD(coolantTemperatureCoefficient) =
-		interpolate2d("crank", clt.value_or(20), config->crankingFuelBins, config->crankingFuelCoef);
+		interpolate2d(clt.value_or(20), config->crankingFuelBins, config->crankingFuelCoef);
 	DISPLAY_SENSOR(CLT);
 	DISPLAY_TEXT(eol);
 
@@ -96,7 +96,7 @@ DISPLAY(DISPLAY_IF(isCrankingState)) float getCrankingFuel3(
 	/*
 	engine->engineState.DISPLAY_PREFIX(cranking).DISPLAY_FIELD(tpsCoefficient) =
 		tps.Valid 
-		? interpolate2d("crankTps", tps.Value, engineConfiguration->crankingTpsBins, engineConfiguration->crankingTpsCoef)
+		? interpolate2d(tps.Value, engineConfiguration->crankingTpsBins, engineConfiguration->crankingTpsCoef)
 		: 1; // in case of failed TPS, don't correct.*/
 	DISPLAY_SENSOR(TPS);
 	DISPLAY_TEXT(eol);
@@ -367,7 +367,7 @@ float getCltFuelCorrection(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 	if (!valid)
 		return 1; // this error should be already reported somewhere else, let's just handle it
 
-	return interpolate2d("cltf", clt, config->cltFuelCorrBins, config->cltFuelCorr);
+	return interpolate2d(clt, config->cltFuelCorrBins, config->cltFuelCorr);
 }
 
 angle_t getCltTimingCorrection(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
@@ -376,7 +376,7 @@ angle_t getCltTimingCorrection(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 	if (!valid)
 		return 0; // this error should be already reported somewhere else, let's just handle it
 
-	return interpolate2d("timc", clt, engineConfiguration->cltTimingBins, engineConfiguration->cltTimingExtra);
+	return interpolate2d(clt, engineConfiguration->cltTimingBins, engineConfiguration->cltTimingExtra);
 }
 
 float getIatFuelCorrection(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
@@ -385,7 +385,7 @@ float getIatFuelCorrection(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 	if (!valid)
 		return 1; // this error should be already reported somewhere else, let's just handle it
 
-	return interpolate2d("iatc", iat, config->iatFuelCorrBins, config->iatFuelCorr);
+	return interpolate2d(iat, config->iatFuelCorrBins, config->iatFuelCorr);
 }
 
 /**

--- a/firmware/controllers/engine_cycle/aux_valves.cpp
+++ b/firmware/controllers/engine_cycle/aux_valves.cpp
@@ -106,11 +106,11 @@ void recalculateAuxValveTiming(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 		return;
 	}
 
-	engine->engineState.auxValveStart = interpolate2d("aux", tps,
+	engine->engineState.auxValveStart = interpolate2d(tps,
 			engineConfiguration->fsioCurve1Bins,
 			engineConfiguration->fsioCurve1);
 
-	engine->engineState.auxValveEnd = interpolate2d("aux", tps,
+	engine->engineState.auxValveEnd = interpolate2d(tps,
 			engineConfiguration->fsioCurve2Bins,
 			engineConfiguration->fsioCurve2);
 

--- a/firmware/controllers/engine_cycle/map_averaging.cpp
+++ b/firmware/controllers/engine_cycle/map_averaging.cpp
@@ -229,7 +229,7 @@ void refreshMapAveragingPreCalc(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 	int rpm = GET_RPM();
 	if (isValidRpm(rpm)) {
 		MAP_sensor_config_s * c = &engineConfiguration->map;
-		angle_t start = interpolate2d("mapa", rpm, c->samplingAngleBins, c->samplingAngle);
+		angle_t start = interpolate2d(rpm, c->samplingAngleBins, c->samplingAngle);
 		efiAssertVoid(CUSTOM_ERR_MAP_START_ASSERT, !cisnan(start), "start");
 
 		angle_t offsetAngle = ENGINE(triggerCentral.triggerFormDetails).eventAngles[CONFIG(mapAveragingSchedulingAtIndex)];
@@ -245,7 +245,7 @@ void refreshMapAveragingPreCalc(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 			fixAngle(cylinderStart, "cylinderStart", CUSTOM_ERR_6562);
 			engine->engineState.mapAveragingStart[i] = cylinderStart;
 		}
-		engine->engineState.mapAveragingDuration = interpolate2d("samp", rpm, c->samplingWindowBins, c->samplingWindow);
+		engine->engineState.mapAveragingDuration = interpolate2d(rpm, c->samplingWindowBins, c->samplingWindow);
 	} else {
 		for (int i = 0; i < engineConfiguration->specs.cylindersCount; i++) {
 			engine->engineState.mapAveragingStart[i] = NAN;

--- a/firmware/controllers/math/engine_math.cpp
+++ b/firmware/controllers/math/engine_math.cpp
@@ -117,7 +117,7 @@ floatms_t getSparkDwell(int rpm DECLARE_ENGINE_PARAMETER_SUFFIX) {
 	} else {
 		efiAssert(CUSTOM_ERR_ASSERT, !cisnan(rpm), "invalid rpm", NAN);
 
-		dwellMs = interpolate2d("dwell", rpm, engineConfiguration->sparkDwellRpmBins, engineConfiguration->sparkDwellValues);
+		dwellMs = interpolate2d(rpm, engineConfiguration->sparkDwellRpmBins, engineConfiguration->sparkDwellValues);
 	}
 
 	if (cisnan(dwellMs) || dwellMs <= 0) {

--- a/firmware/controllers/sensors/ego.cpp
+++ b/firmware/controllers/sensors/ego.cpp
@@ -130,7 +130,7 @@ float getAfr(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 	float volts = getVoltageDivided("ego", sensor->hwChannel PASS_ENGINE_PARAMETER_SUFFIX);
 
 	if (CONFIG(afr_type) == ES_NarrowBand) {
-		float afr = interpolate2d("narrow", volts, engineConfiguration->narrowToWideOxygenBins, engineConfiguration->narrowToWideOxygen);
+		float afr = interpolate2d(volts, engineConfiguration->narrowToWideOxygenBins, engineConfiguration->narrowToWideOxygen);
 #ifdef EFI_NARROW_EGO_AVERAGING
 		if (useAveraging)
 			afr = updateEgoAverage(afr);

--- a/firmware/controllers/sensors/maf.cpp
+++ b/firmware/controllers/sensors/maf.cpp
@@ -22,7 +22,7 @@ bool hasMafSensor(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 float getRealMaf(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 	float volts = getMafVoltage(PASS_ENGINE_PARAMETER_SIGNATURE);
 
-	return interpolate2d("maf", volts, config->mafDecodingBins, config->mafDecoding);
+	return interpolate2d(volts, config->mafDecodingBins, config->mafDecoding);
 }
 
 static void fillTheRest(persistent_config_s *e, int i) {

--- a/firmware/hw_layer/sensors/cj125.cpp
+++ b/firmware/hw_layer/sensors/cj125.cpp
@@ -578,9 +578,9 @@ float cjGetAfr(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 	float pumpCurrent = (globalInstance.vUa - globalInstance.vUaCal) * globalInstance.amplCoeff * (CJ125_PUMP_CURRENT_FACTOR / CJ125_PUMP_SHUNT_RESISTOR);
 	
 	if (engineConfiguration->cj125isLsu49) {
-		globalInstance.lambda = interpolate2d("cj125Lsu", pumpCurrent, pumpCurrentLsu49, lambdaLsu49);
+		globalInstance.lambda = interpolate2d(pumpCurrent, pumpCurrentLsu49, lambdaLsu49);
 	} else {
-		globalInstance.lambda = interpolate2d("cj125Lsu", pumpCurrent, pumpCurrentLsu42, lambdaLsu42);
+		globalInstance.lambda = interpolate2d(pumpCurrent, pumpCurrentLsu42, lambdaLsu42);
 	}
 
 	// todo: make configurable stoich ratio

--- a/firmware/util/math/interpolation.h
+++ b/firmware/util/math/interpolation.h
@@ -93,7 +93,7 @@ static float linterp(float low, float high, float frac)
 } // namespace priv
 
 template <class TBin, class TValue, int TSize>
-float interpolate2d(const char *msg, const float value, const TBin (&bin)[TSize], const TValue (&values)[TSize]) {
+float interpolate2d(const float value, const TBin (&bin)[TSize], const TValue (&values)[TSize]) {
 	// Enforce numeric only (int, float, uintx_t, etc)
 	static_assert(std::is_arithmetic_v<TBin>, "Table values must be an arithmetic type");
 
@@ -105,11 +105,6 @@ float interpolate2d(const char *msg, const float value, const TBin (&bin)[TSize]
 	float frac = b.Frac;
 
 	return priv::linterp(low, high, frac);
-}
-
-template <class TBin, class TValue, int TSize>
-float interpolate2d(const float value, const TBin (&bin)[TSize], const TValue (&values)[TSize]) {
-	return interpolate2d("", value, bin, values);
 }
 
 int needInterpolationLogging(void);

--- a/unit_tests/test_basic_math/test_find_index.cpp
+++ b/unit_tests/test_basic_math/test_find_index.cpp
@@ -75,19 +75,19 @@ TEST(misc, testInterpolate2d) {
 	int result;
 
 	printf("Left size\r\n");
-	result = interpolate2d("t", 0, bins4, values4);
+	result = interpolate2d(0, bins4, values4);
 	ASSERT_EQ(1, result);
 
 	printf("Right size\r\n");
-	result = interpolate2d("t", 10, bins4, values4);
+	result = interpolate2d(10, bins4, values4);
 	ASSERT_EQ(400, result);
 
 	printf("Middle1\r\n");
-	result = interpolate2d("t", 3, bins4, values4);
+	result = interpolate2d(3, bins4, values4);
 	ASSERT_EQ(30, result);
 
 	printf("Middle1\r\n");
-	result = interpolate2d("t", 3.5, bins4, values4);
+	result = interpolate2d(3.5, bins4, values4);
 	ASSERT_EQ(215, result);
 }
 


### PR DESCRIPTION
`msg` parameter of `interpolate2d` was unused, so now it's gone.