### PR TITLE
set MCU type properly

### DIFF
--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -307,7 +307,9 @@ INCDIR = $(ALLINC) \
 # Compiler settings
 #
 
-MCU  = cortex-m4
+ifeq ($(MCU),)
+	MCU = cortex-m4
+endif
 
 ifeq ($(CROSS_COMPILE),)
   TRGT = arm-none-eabi-

--- a/firmware/hw_layer/ports/stm32/stm32f4/hw_ports.mk
+++ b/firmware/hw_layer/ports/stm32/stm32f4/hw_ports.mk
@@ -7,6 +7,7 @@ HW_LAYER_EMS_CPP += $(PROJECT_DIR)/hw_layer/ports/stm32/stm32f4/mpu_util.cpp \
 					$(PROJECT_DIR)/hw_layer/ports/stm32/stm32_adc_v2.cpp \
 
 DDEFS += -DSTM32F407xx
+MCU = cortex-m4
 LDSCRIPT = $(PROJECT_DIR)/hw_layer/ports/stm32/stm32f4/STM32F405xG.ld
 ALLCSRC += $(CHIBIOS)/os/hal/boards/ST_STM32F4_DISCOVERY/board.c
 CONFDIR = $(PROJECT_DIR)/hw_layer/ports/stm32/stm32f4/cfg

--- a/firmware/hw_layer/ports/stm32/stm32f7/hw_ports.mk
+++ b/firmware/hw_layer/ports/stm32/stm32f7/hw_ports.mk
@@ -7,6 +7,7 @@ HW_LAYER_EMS_CPP += $(PROJECT_DIR)/hw_layer/ports/stm32/stm32f7/mpu_util.cpp \
 					$(PROJECT_DIR)/hw_layer/ports/stm32/stm32_adc_v2.cpp \
 
 DDEFS += -DSTM32F767xx
+MCU = cortex-m7
 LDSCRIPT = $(PROJECT_DIR)/hw_layer/ports/stm32/stm32f7/STM32F76xxI.ld
 ALLCSRC += $(CHIBIOS)/os/hal/boards/ST_NUCLEO144_F767ZI/board.c
 CONFDIR = $(PROJECT_DIR)/hw_layer/ports/stm32/stm32f7/cfg

--- a/firmware/hw_layer/ports/stm32/stm32h7/hw_ports.mk
+++ b/firmware/hw_layer/ports/stm32/stm32h7/hw_ports.mk
@@ -6,6 +6,7 @@ HW_LAYER_EMS += $(PROJECT_DIR)/hw_layer/ports/stm32/stm32h7/stm32h7xx_hal_flash.
 HW_LAYER_EMS_CPP += $(PROJECT_DIR)/hw_layer/ports/stm32/stm32h7/mpu_util.cpp
 
 DDEFS += -DSTM32H743xx
+MCU = cortex-m7
 LDSCRIPT = $(PROJECT_DIR)/hw_layer/ports/stm32/stm32h7/STM32H743xI.ld
 ALLCSRC += $(CHIBIOS)/os/hal/boards/ST_NUCLEO144_H743ZI/board.c
 CONFDIR = $(PROJECT_DIR)/hw_layer/ports/stm32/stm32h7/cfg


### PR DESCRIPTION
the compiler knows some tricks to get better perf on cm4 vs cm7 because of the different pipeline and architecture, so use it!