### PR TITLE
small fsio cleanup

### DIFF
--- a/firmware/controllers/core/fsio_core.cpp
+++ b/firmware/controllers/core/fsio_core.cpp
@@ -95,19 +95,9 @@ LECalculator::LECalculator() {
 }
 
 void LECalculator::reset() {
-	m_program = nullptr;
 	stack.reset();
 	currentCalculationLogPosition = 0;
 	memset(calcLogAction, 0, sizeof(calcLogAction));
-}
-
-void LECalculator::reset(LEElement *element) {
-	reset();
-	setProgram(element);
-}
-
-void LECalculator::setProgram(LEElement* program) {
-	m_program = program;
 }
 
 bool float2bool(float v) {
@@ -269,24 +259,13 @@ FsioResult LECalculator::processElement(const LEElement *element DECLARE_ENGINE_
 	}
 }
 
-float LECalculator::getValue2(float selfValue, LEElement *fistElementInList DECLARE_ENGINE_PARAMETER_SUFFIX) {
-	reset(fistElementInList);
-	return getValue(selfValue PASS_ENGINE_PARAMETER_SUFFIX);
-}
-
-bool LECalculator::isEmpty() const {
-	return !m_program;
-}
-
-float LECalculator::getValue(float selfValue DECLARE_ENGINE_PARAMETER_SUFFIX) {
-	if (isEmpty()) {
+float LECalculator::evaluate(float selfValue, const LEElement* element DECLARE_ENGINE_PARAMETER_SUFFIX) {
+	if (!element) {
 		warning(CUSTOM_NO_FSIO, "no FSIO code");
 		return NAN;
 	}
 
-	const LEElement* element = m_program;
-
-	stack.reset();
+	reset();
 
 	int counter = 0;
 

--- a/firmware/controllers/core/fsio_core.h
+++ b/firmware/controllers/core/fsio_core.h
@@ -130,12 +130,8 @@ typedef FLStack<float, MAX_STACK_DEPTH> calc_stack_t;
 class LECalculator {
 public:
 	LECalculator();
-	float getValue(float selfValue DECLARE_ENGINE_PARAMETER_SUFFIX);
-	float getValue2(float selfValue, LEElement *fistElementInList DECLARE_ENGINE_PARAMETER_SUFFIX);
-
-	bool isEmpty() const;
+	float evaluate(float selfValue, const LEElement* element DECLARE_ENGINE_PARAMETER_SUFFIX);
 	void reset();
-	void reset(LEElement *element);
 
 	// Log history of calculation actions for debugging
 	le_action_e calcLogAction[MAX_CALC_LOG];
@@ -143,13 +139,9 @@ public:
 	int currentCalculationLogPosition;
 
 private:
-	void setProgram(LEElement* program);
-
 	void push(le_action_e action, float value);
 	FsioResult processElement(const LEElement* element DECLARE_ENGINE_PARAMETER_SUFFIX);
 	float pop(le_action_e action);
-
-	LEElement* m_program = nullptr;
 
 	calc_stack_t stack;
 };

--- a/firmware/controllers/core/fsio_impl.cpp
+++ b/firmware/controllers/core/fsio_impl.cpp
@@ -337,7 +337,7 @@ float getFsioOutputValue(int index DECLARE_ENGINE_PARAMETER_SUFFIX) {
 		warning(CUSTOM_NO_FSIO, "no FSIO for #%d %s", index + 1, hwPortname(CONFIG(fsioOutputPins)[index]));
 		return NAN;
 	} else {
-		return calc.getValue2(engine->fsioState.fsioLastValue[index], state.fsioLogics[index] PASS_ENGINE_PARAMETER_SUFFIX);
+		return calc.evaluate(engine->fsioState.fsioLastValue[index], state.fsioLogics[index] PASS_ENGINE_PARAMETER_SUFFIX);
 	}
 }
 
@@ -404,7 +404,7 @@ static void setPinState(const char * msg, OutputPin *pin, LEElement *element DEC
 	if (!element) {
 		warning(CUSTOM_FSIO_INVALID_EXPRESSION, "invalid expression for %s", msg);
 	} else {
-		int value = (int)calc.getValue2(pin->getLogicValue(), element PASS_ENGINE_PARAMETER_SUFFIX);
+		int value = (int)calc.evaluate(pin->getLogicValue(), element PASS_ENGINE_PARAMETER_SUFFIX);
 		if (pin->isInitialized() && value != pin->getLogicValue()) {
 
 			for (int i = 0;i < calc.currentCalculationLogPosition;i++) {
@@ -446,7 +446,7 @@ static bool updateValueOrWarning(int humanIndex, const char *msg, float *value D
 		return false;
 	} else {
 		float beforeValue = *value;
-		*value = calc.getValue2(beforeValue, element PASS_ENGINE_PARAMETER_SUFFIX);
+		*value = calc.evaluate(beforeValue, element PASS_ENGINE_PARAMETER_SUFFIX);
 		// floating '==' comparison without EPS seems fine here
 		return (beforeValue != *value);
 	}
@@ -666,7 +666,7 @@ static void rpnEval(char *line) {
 	if (e == NULL) {
 		scheduleMsg(logger, "parsing failed");
 	} else {
-		float result = evalCalc.getValue2(0, e PASS_ENGINE_PARAMETER_SUFFIX);
+		float result = evalCalc.evaluate(0, e PASS_ENGINE_PARAMETER_SUFFIX);
 		scheduleMsg(logger, "Evaluate result: %.2f", result);
 	}
 #endif

--- a/unit_tests/tests/test_logic_expression.cpp
+++ b/unit_tests/tests/test_logic_expression.cpp
@@ -117,7 +117,7 @@ static void testExpression2(float selfValue, const char *line, float expected, E
 
 	EXPAND_Engine;
 
-	ASSERT_NEAR(expected, c.getValue2(selfValue, element PASS_ENGINE_PARAMETER_SUFFIX), EPS4D) << line;
+	ASSERT_NEAR(expected, c.evaluate(selfValue, element PASS_ENGINE_PARAMETER_SUFFIX), EPS4D) << line;
 }
 
 static void testExpression2(float selfValue, const char *line, float expected, const std::unordered_map<SensorType, float>& sensorVals = {}) {
@@ -144,20 +144,20 @@ TEST(fsio, testHysteresisSelf) {
 	double selfValue = 0;
 
 	engine->fsioState.mockRpm = 0;
-	selfValue = c.getValue2(selfValue, element PASS_ENGINE_PARAMETER_SUFFIX);
+	selfValue = c.evaluate(selfValue, element PASS_ENGINE_PARAMETER_SUFFIX);
 	ASSERT_EQ(0, selfValue);
 
 	engine->fsioState.mockRpm = 430;
-	selfValue = c.getValue2(selfValue, element PASS_ENGINE_PARAMETER_SUFFIX);
+	selfValue = c.evaluate(selfValue, element PASS_ENGINE_PARAMETER_SUFFIX);
 	// OFF since not ON yet
 	ASSERT_EQ(0, selfValue);
 
 	engine->fsioState.mockRpm = 460;
-	selfValue = c.getValue2(selfValue, element PASS_ENGINE_PARAMETER_SUFFIX);
+	selfValue = c.evaluate(selfValue, element PASS_ENGINE_PARAMETER_SUFFIX);
 	ASSERT_EQ(1, selfValue);
 
 	engine->fsioState.mockRpm = 430;
-	selfValue = c.getValue2(selfValue, element PASS_ENGINE_PARAMETER_SUFFIX);
+	selfValue = c.evaluate(selfValue, element PASS_ENGINE_PARAMETER_SUFFIX);
 	// OFF since was ON yet
 	ASSERT_EQ(1, selfValue);
 }
@@ -241,7 +241,7 @@ TEST(fsio, testLogicExpressions) {
 		LEElement * element = pool.parseExpression("fan NOT coolant 90 > AND fan coolant 85 > AND OR");
 		ASSERT_TRUE(element != NULL) << "Not NULL expected";
 		LECalculator c;
-		ASSERT_EQ( 1,  c.getValue2(0, element PASS_ENGINE_PARAMETER_SUFFIX)) << "that expression";
+		ASSERT_EQ( 1,  c.evaluate(0, element PASS_ENGINE_PARAMETER_SUFFIX)) << "that expression";
 
 		ASSERT_EQ(12, c.currentCalculationLogPosition);
 		ASSERT_EQ(102, c.calcLogAction[0]);


### PR DESCRIPTION
no need to store a pointer to the program in `LECalculator` when we always pass it in when evaluating.

cleanup from #2374