### PR TITLE
hardware CI for clt/iat inputs

### DIFF
--- a/java_console/autotest/src/com/rusefi/proteus/ProteusAnalogTest.java
+++ b/java_console/autotest/src/com/rusefi/proteus/ProteusAnalogTest.java
@@ -61,7 +61,7 @@ public class ProteusAnalogTest extends RusefiTestBase {
 
     void assertSensorValue(Sensor sensor, double expected) {
         double actual = SensorCentral.getInstance().getValue(sensor);
-        assertEquals(expected, actual, 0.25);
+        assertEquals(expected, actual, 0.5);
     }
 
     @Test

--- a/java_console/autotest/src/com/rusefi/proteus/ProteusAnalogTest.java
+++ b/java_console/autotest/src/com/rusefi/proteus/ProteusAnalogTest.java
@@ -58,4 +58,16 @@ public class ProteusAnalogTest extends RusefiTestBase {
         // 100% duty -> failed TPS (voltage too high)
         setIdlePositionAndAssertTps(98, 0);
     }
+
+    void assertSensorValue(Sensor sensor, double expected) {
+        double actual = SensorCentral.getInstance().getValue(sensor);
+        assertEquals(expected, actual, 0.25);
+    }
+
+    @Test
+    public void testUnconnectedInputs() {
+        // CLT/IAT inputs should float at ~5 volts
+        assertSensorValue(Sensor.rawClt, 5.0);
+        assertSensorValue(Sensor.rawIat, 5.0);
+    }
 }

--- a/java_console/models/src/main/java/com/rusefi/core/Sensor.java
+++ b/java_console/models/src/main/java/com/rusefi/core/Sensor.java
@@ -118,6 +118,10 @@ public enum Sensor {
 
     tuneCrc16("tune crc16", SensorCategory.STATUS, FieldType.UINT16, 244, 0, 5),
 
+    // Raw sensors
+    rawClt("raw CLT", SensorCategory.SENSOR_INPUTS, FieldType.INT16, 238, 1 / PACK_MULT_VOLTAGE, 0, 5, "volts"),
+    rawIat("raw IAT", SensorCategory.SENSOR_INPUTS, FieldType.INT16, 240, 1 / PACK_MULT_VOLTAGE, 0, 5, "volts"),
+
     // Synthetic (console only) channels
     ETB_CONTROL_QUALITY("ETB metric", SensorCategory.SNIFFING, "", 100),
     ;

--- a/java_console/models/src/main/java/com/rusefi/core/Sensor.java
+++ b/java_console/models/src/main/java/com/rusefi/core/Sensor.java
@@ -119,8 +119,8 @@ public enum Sensor {
     tuneCrc16("tune crc16", SensorCategory.STATUS, FieldType.UINT16, 244, 0, 5),
 
     // Raw sensors
-    rawClt("raw CLT", SensorCategory.SENSOR_INPUTS, FieldType.INT16, 238, 1 / PACK_MULT_VOLTAGE, 0, 5, "volts"),
-    rawIat("raw IAT", SensorCategory.SENSOR_INPUTS, FieldType.INT16, 240, 1 / PACK_MULT_VOLTAGE, 0, 5, "volts"),
+    rawClt("raw CLT", SensorCategory.SENSOR_INPUTS, FieldType.INT16, 238, 1.0 / PACK_MULT_VOLTAGE, 0, 5, "volts"),
+    rawIat("raw IAT", SensorCategory.SENSOR_INPUTS, FieldType.INT16, 240, 1.0 / PACK_MULT_VOLTAGE, 0, 5, "volts"),
 
     // Synthetic (console only) channels
     ETB_CONTROL_QUALITY("ETB metric", SensorCategory.SNIFFING, "", 100),


### PR DESCRIPTION
Check that the raw values on CLT/IAT are expected.  In the future an external resistor could be added to fake a sensor and check the full system's operation.