### PR TITLE
avoid various "no connect" scenarios

### DIFF
--- a/firmware/controllers/engine_controller.cpp
+++ b/firmware/controllers/engine_controller.cpp
@@ -554,11 +554,6 @@ void commonInitEngineController(Logging *sharedLogger DECLARE_ENGINE_PARAMETER_S
 	initSensorChart();
 #endif /* EFI_SENSOR_CHART */
 
-
-#if EFI_TUNER_STUDIO
-	startTunerStudioConnectivity();
-#endif /* EFI_TUNER_STUDIO */
-
 #if EFI_PROD_CODE || EFI_SIMULATOR
 	initSettings();
 

--- a/firmware/hw_layer/hardware.cpp
+++ b/firmware/hw_layer/hardware.cpp
@@ -39,7 +39,6 @@
 #include "mcp3208.h"
 #include "hip9011.h"
 #include "histogram.h"
-#include "mmc_card.h"
 #include "neo6m.h"
 #include "lcd_HD44780.h"
 #include "settings.h"
@@ -249,7 +248,7 @@ void adc_callback_fast(ADCDriver *adcp) {
 #endif /* HAL_USE_ADC */
 
 static void calcFastAdcIndexes(void) {
-#if HAL_USE_ADC
+#if HAL_USE_ADC && EFI_USE_FAST_ADC
 	fastMapSampleIndex = fastAdc.internalAdcIndexByHardwareIndex[engineConfiguration->map.sensor.hwChannel];
 	hipSampleIndex =
 			isAdcChannelValid(engineConfiguration->hipOutputChannel) ?
@@ -593,10 +592,6 @@ void initHardware(Logging *l) {
 #if EFI_HIP_9011
 	initHip9011(sharedLogger);
 #endif /* EFI_HIP_9011 */
-
-#if EFI_FILE_LOGGING
-	initMmcCard();
-#endif /* EFI_FILE_LOGGING */
 
 #if EFI_MEMS
 	initAccelerometer(PASS_ENGINE_PARAMETER_SIGNATURE);

--- a/firmware/hw_layer/ports/stm32/serial_over_usb/usbconsole.c
+++ b/firmware/hw_layer/ports/stm32/serial_over_usb/usbconsole.c
@@ -40,7 +40,7 @@ void usb_serial_start(void) {
 // See also https://github.com/rusefi/rusefi/issues/705
 #ifndef EFI_SKIP_USB_DISCONNECT
 	usbDisconnectBus(serusbcfg.usbp);
-	chThdSleepMilliseconds(1500);
+	chThdSleepMilliseconds(250);
 #endif/* EFI_SKIP_USB_DISCONNECT */
 	usbStart(serusbcfg.usbp, &usbcfg);
 	usbConnectBus(serusbcfg.usbp);

--- a/firmware/rusefi.cpp
+++ b/firmware/rusefi.cpp
@@ -124,6 +124,8 @@
 #include "custom_engine.h"
 #include "engine_math.h"
 #include "mpu_util.h"
+#include "tunerstudio.h"
+#include "mmc_card.h"
 
 #if EFI_HD44780_LCD
 #include "lcd_HD44780.h"
@@ -213,10 +215,18 @@ void runRusEfi(void) {
 	 */
 	initializeConsole(&sharedLogger);
 
+#if EFI_TUNER_STUDIO
+	startTunerStudioConnectivity();
+#endif /* EFI_TUNER_STUDIO */
+
 	/**
 	 * Initialize hardware drivers
 	 */
 	initHardware(&sharedLogger);
+
+#if EFI_FILE_LOGGING
+	initMmcCard();
+#endif /* EFI_FILE_LOGGING */
 
 	initStatusLoop();
 	/**


### PR DESCRIPTION
There were cases where we could bail out of initialization before configuring USB or the MMC card (you have to initialize the MSD driver, or Windows will hang during device enumeration), so this change moves init of USB and MMC very early - just after config read