### PR TITLE
ADC cleanup, enable oversampling on H7

### DIFF
--- a/firmware/hw_layer/adc/adc_inputs.cpp
+++ b/firmware/hw_layer/adc/adc_inputs.cpp
@@ -222,11 +222,6 @@ int getInternalAdcValue(const char *msg, adc_channel_e hwChannel) {
 	}
 #endif // EFI_USE_FAST_ADC
 
-	if (adcHwChannelEnabled[hwChannel] != ADC_SLOW) {
-		// todo: make this not happen during hardware continuous integration
-		warning(CUSTOM_OBD_WRONG_ADC_MODE, "ADC is off [%s] index=%d", msg, hwChannel);
-	}
-
 	return slowAdcSamples[hwChannel - 1];
 }
 

--- a/firmware/hw_layer/adc/adc_inputs.cpp
+++ b/firmware/hw_layer/adc/adc_inputs.cpp
@@ -38,6 +38,9 @@
 #include "perf_trace.h"
 #include "thread_priority.h"
 
+/* Depth of the conversion buffer, channels are sampled X times each.*/
+#define ADC_BUF_DEPTH_FAST      4
+
 static adcsample_t slowAdcSamples[ADC_MAX_CHANNELS_COUNT];
 static NO_CACHE adcsample_t fastAdcSampleBuf[ADC_BUF_DEPTH_FAST * ADC_MAX_CHANNELS_COUNT];
 
@@ -517,10 +520,6 @@ static SlowAdcController slowAdcController;
 
 void initAdcInputs() {
 	scheduleMsg(&logger, "initAdcInputs()");
-	if (ADC_BUF_DEPTH_FAST > MAX_ADC_GRP_BUF_DEPTH)
-		firmwareError(CUSTOM_ERR_ADC_DEPTH_FAST, "ADC_BUF_DEPTH_FAST too high");
-	if (ADC_BUF_DEPTH_SLOW > MAX_ADC_GRP_BUF_DEPTH)
-		firmwareError(CUSTOM_ERR_ADC_DEPTH_SLOW, "ADC_BUF_DEPTH_SLOW too high");
 
 	configureInputs();
 

--- a/firmware/hw_layer/adc/adc_inputs.cpp
+++ b/firmware/hw_layer/adc/adc_inputs.cpp
@@ -39,7 +39,9 @@
 #include "thread_priority.h"
 
 /* Depth of the conversion buffer, channels are sampled X times each.*/
+#ifndef ADC_BUF_DEPTH_FAST
 #define ADC_BUF_DEPTH_FAST      4
+#endif
 
 static NO_CACHE adcsample_t slowAdcSamples[ADC_MAX_CHANNELS_COUNT];
 static NO_CACHE adcsample_t fastAdcSampleBuf[ADC_BUF_DEPTH_FAST * ADC_MAX_CHANNELS_COUNT];

--- a/firmware/hw_layer/adc/adc_inputs.cpp
+++ b/firmware/hw_layer/adc/adc_inputs.cpp
@@ -41,7 +41,7 @@
 /* Depth of the conversion buffer, channels are sampled X times each.*/
 #define ADC_BUF_DEPTH_FAST      4
 
-static adcsample_t slowAdcSamples[ADC_MAX_CHANNELS_COUNT];
+static NO_CACHE adcsample_t slowAdcSamples[ADC_MAX_CHANNELS_COUNT];
 static NO_CACHE adcsample_t fastAdcSampleBuf[ADC_BUF_DEPTH_FAST * ADC_MAX_CHANNELS_COUNT];
 
 static adc_channel_mode_e adcHwChannelEnabled[HW_MAX_ADC_INDEX];

--- a/firmware/hw_layer/adc/adc_inputs.h
+++ b/firmware/hw_layer/adc/adc_inputs.h
@@ -56,19 +56,6 @@ float getMCUInternalTemperature(void);
 void addChannel(const char *name, adc_channel_e setting, adc_channel_mode_e mode);
 void removeChannel(const char *name, adc_channel_e setting);
 
-/* Depth of the conversion buffer, channels are sampled X times each.*/
-#ifndef ADC_BUF_DEPTH_SLOW
-#define ADC_BUF_DEPTH_SLOW      8
-#endif /* ADC_BUF_DEPTH_SLOW */
-
-#ifndef ADC_BUF_DEPTH_FAST
-#define ADC_BUF_DEPTH_FAST      4
-#endif /* ADC_BUF_DEPTH_FAST */
-
-// todo: preprocessor way of doing 'max'?
-// max(ADC_BUF_DEPTH_SLOW, ADC_BUF_DEPTH_FAST)
-#define MAX_ADC_GRP_BUF_DEPTH 8
-
 #define getAdcValue(msg, hwChannel) getInternalAdcValue(msg, hwChannel)
 
 #define adcToVoltsDivided(adc) (adcToVolts(adc) * engineConfiguration->analogInputDividerCoefficient)

--- a/firmware/hw_layer/algo/adc_math.h
+++ b/firmware/hw_layer/algo/adc_math.h
@@ -10,8 +10,12 @@
 
 #pragma once
 
+#if EFI_PROD_CODE
 #include "port_mpu_util.h"
 #include "rusefi_hw_enums.h"
+#else // not EFI_PROD_CODE
+#define ADC_MAX_VALUE 4095
+#endif
 
 #define adcToVolts(adc) ((engineConfiguration->adcVcc) / ADC_MAX_VALUE * (adc))
 

--- a/firmware/hw_layer/algo/adc_math.h
+++ b/firmware/hw_layer/algo/adc_math.h
@@ -10,7 +10,8 @@
 
 #pragma once
 
-#include "engine_configuration.h"
+#include "port_mpu_util.h"
+#include "rusefi_hw_enums.h"
 
 #define adcToVolts(adc) ((engineConfiguration->adcVcc) / ADC_MAX_VALUE * (adc))
 

--- a/firmware/hw_layer/algo/adc_math.h
+++ b/firmware/hw_layer/algo/adc_math.h
@@ -11,7 +11,6 @@
 #pragma once
 
 #include "engine_configuration.h"
-#define ADC_MAX_VALUE 4095
 
 #define adcToVolts(adc) ((engineConfiguration->adcVcc) / ADC_MAX_VALUE * (adc))
 

--- a/firmware/hw_layer/ports/cypress/port_mpu_util.h
+++ b/firmware/hw_layer/ports/cypress/port_mpu_util.h
@@ -46,3 +46,5 @@ typedef enum {
 // TODO
 #define SPI_CR1_24BIT_MODE 0
 #define SPI_CR2_24BIT_MODE 0
+
+#define ADC_MAX_VALUE 4095

--- a/firmware/hw_layer/ports/kinetis/port_mpu_util.h
+++ b/firmware/hw_layer/ports/kinetis/port_mpu_util.h
@@ -34,3 +34,5 @@ typedef enum {
 // TODO
 #define SPI_CR1_24BIT_MODE 0
 #define SPI_CR2_24BIT_MODE 0
+
+#define ADC_MAX_VALUE 4095

--- a/firmware/hw_layer/ports/stm32/stm32_adc_v2.cpp
+++ b/firmware/hw_layer/ports/stm32/stm32_adc_v2.cpp
@@ -154,7 +154,7 @@ bool readSlowAnalogInputs(adcsample_t* convertedSamples) {
 	msg_t result = adcConvert(&ADCD1, &convGroupSlow, slowSampleBuffer, SLOW_ADC_OVERSAMPLE);
 
 	// If something went wrong - try again later
-	if (result == MSG_RESET || result == MSG_TIMEOUT) {
+	if (result != MSG_OK) {
 		return false;
 	}
 

--- a/firmware/hw_layer/ports/stm32/stm32_adc_v2.cpp
+++ b/firmware/hw_layer/ports/stm32/stm32_adc_v2.cpp
@@ -14,9 +14,7 @@
 EXTERN_CONFIG;
 
 /* Depth of the conversion buffer, channels are sampled X times each.*/
-#ifndef ADC_BUF_DEPTH_SLOW
-#define ADC_BUF_DEPTH_SLOW      8
-#endif /* ADC_BUF_DEPTH_SLOW */
+#define SLOW_ADC_OVERSAMPLE      8
 
 void portInitAdc() {
 	// Init slow ADC
@@ -150,10 +148,10 @@ static constexpr ADCConversionGroup convGroupSlow = {
 	.sqr3	= ADC_SQR3_SQ1_N(0)   | ADC_SQR3_SQ2_N(1)   | ADC_SQR3_SQ3_N(2)   |  ADC_SQR3_SQ4_N(3)  |   ADC_SQR3_SQ5_N(4) |   ADC_SQR3_SQ6_N(5), // Conversion group sequence 1...6
 };
 
-static NO_CACHE adcsample_t slowSampleBuffer[ADC_BUF_DEPTH_SLOW * slowChannelCount];
+static NO_CACHE adcsample_t slowSampleBuffer[SLOW_ADC_OVERSAMPLE * slowChannelCount];
 
 bool readSlowAnalogInputs(adcsample_t* convertedSamples) {
-	msg_t result = adcConvert(&ADCD1, &convGroupSlow, slowSampleBuffer, ADC_BUF_DEPTH_SLOW);
+	msg_t result = adcConvert(&ADCD1, &convGroupSlow, slowSampleBuffer, SLOW_ADC_OVERSAMPLE);
 
 	// If something went wrong - try again later
 	if (result == MSG_RESET || result == MSG_TIMEOUT) {
@@ -164,12 +162,12 @@ bool readSlowAnalogInputs(adcsample_t* convertedSamples) {
 	for (int i = 0; i < slowChannelCount; i++) {
 		uint32_t sum = 0;
 		size_t index = i;
-		for (size_t j = 0; j < ADC_BUF_DEPTH_SLOW; j++) {
+		for (size_t j = 0; j < SLOW_ADC_OVERSAMPLE; j++) {
 			sum += slowSampleBuffer[index];
 			index += slowChannelCount;
 		}
 
-		adcsample_t value = static_cast<adcsample_t>(sum / ADC_BUF_DEPTH_SLOW);
+		adcsample_t value = static_cast<adcsample_t>(sum / SLOW_ADC_OVERSAMPLE);
 		convertedSamples[i] = value;
 	}
 

--- a/firmware/hw_layer/ports/stm32/stm32_adc_v4.cpp
+++ b/firmware/hw_layer/ports/stm32/stm32_adc_v4.cpp
@@ -24,6 +24,10 @@ float getMcuTemperature() {
 	return 0;
 }
 
+// ADC Clock is 25MHz
+// 32.5 sampling + 8.5 conversion = 41 cycles per sample total
+// 16 channels * 16x oversample = 256 samples per batch
+// (41 * 256) / 25MHz -> 419 microseconds to sample all channels
 #define ADC_SAMPLING_SLOW ADC_SMPR_SMP_32P5
 
 // Sample the 16 channels that line up with the STM32F4/F7
@@ -37,8 +41,8 @@ static constexpr ADCConversionGroup convGroupSlow = {
 	.end_cb				= nullptr,
 	.error_cb			= nullptr,
 	.cfgr				= 0,
-	.cfgr2				= 	8 << ADC_CFGR2_OVSR_Pos |	// Oversample by 8x
-							3 << ADC_CFGR2_OVSS_Pos |	// shift the result right 3 bits to make a 16 bit result
+	.cfgr2				= 	16 << ADC_CFGR2_OVSR_Pos |	// Oversample by 16x
+							4 << ADC_CFGR2_OVSS_Pos |	// shift the result right 4 bits to make a 16 bit result
 							ADC_CFGR2_ROVSE,			// Enable oversampling
 	.ccr				= 0,
 	.pcsel				= 0xFFFFFFFF, // enable analog switches on all channels

--- a/firmware/hw_layer/ports/stm32/stm32_adc_v4.cpp
+++ b/firmware/hw_layer/ports/stm32/stm32_adc_v4.cpp
@@ -38,7 +38,7 @@ static constexpr ADCConversionGroup convGroupSlow = {
 	.error_cb			= nullptr,
 	.cfgr				= 0,
 	.cfgr2				= 	8 << ADC_CFGR2_OVSR_Pos |	// Oversample by 8x
-							7 << ADC_CFGR2_OVSS_Pos |	// shift the result right 7 bits to make a 12 bit result compatible with v2 ADC
+							3 << ADC_CFGR2_OVSS_Pos |	// shift the result right 3 bits to make a 16 bit result
 							ADC_CFGR2_ROVSE,			// Enable oversampling
 	.ccr				= 0,
 	.pcsel				= 0xFFFFFFFF, // enable analog switches on all channels
@@ -90,6 +90,7 @@ static constexpr ADCConversionGroup convGroupSlow = {
 };
 
 bool readSlowAnalogInputs(adcsample_t* convertedSamples) {
+	// Oversampling and right-shift happen in hardware, so we can sample directly to the output buffer
 	msg_t result = adcConvert(&ADCD1, &convGroupSlow, convertedSamples, 1);
 
 	// Return true if OK

--- a/firmware/hw_layer/ports/stm32/stm32f4/device_mpu_util.h
+++ b/firmware/hw_layer/ports/stm32/stm32f4/device_mpu_util.h
@@ -21,3 +21,4 @@
 #define SPI_CR1_24BIT_MODE 0
 #define SPI_CR2_24BIT_MODE 0
 
+#define ADC_MAX_VALUE 4095

--- a/firmware/hw_layer/ports/stm32/stm32f7/device_mpu_util.h
+++ b/firmware/hw_layer/ports/stm32/stm32f7/device_mpu_util.h
@@ -20,3 +20,5 @@
 /* 3 x 8-bit transfer */
 #define SPI_CR1_24BIT_MODE 0
 #define SPI_CR2_24BIT_MODE SPI_CR2_DS_2 | SPI_CR2_DS_1 | SPI_CR2_DS_0
+
+#define ADC_MAX_VALUE 4095

--- a/firmware/hw_layer/ports/stm32/stm32h7/device_mpu_util.h
+++ b/firmware/hw_layer/ports/stm32/stm32h7/device_mpu_util.h
@@ -12,3 +12,5 @@
 #define MCU_SERIAL_NUMBER_LOCATION (uint8_t*)(0x1FF1E800)
 
 // todo SPI! #2284
+
+#define ADC_MAX_VALUE 65535


### PR DESCRIPTION
Clean up ADC defines, oversampling.

Move ADC_MAX_VALUE in to port_mpu_util.h since H7 has a 16 bit ADC.

Enable hardware oversampling on H7, and actually use all 16 bits instead of discarding 4.