### PR TITLE
logging cleanup before refactor

### DIFF
--- a/firmware/console/binary/tunerstudio.cpp
+++ b/firmware/console/binary/tunerstudio.cpp
@@ -656,12 +656,12 @@ static void handleGetText(TsChannelBase* tsChannel) {
 	printOverallStatus(getTimeNowSeconds());
 
 	int outputSize;
-	char *output = swapOutputBuffers(&outputSize);
+	const char* output = swapOutputBuffers(&outputSize);
 #if EFI_SIMULATOR
 			logMsg("get test sending [%d]\r\n", outputSize);
 #endif
 
-	tsChannel->writeCrcPacket(TS_RESPONSE_COMMAND_OK, reinterpret_cast<uint8_t*>(output), outputSize);
+	tsChannel->writeCrcPacket(TS_RESPONSE_COMMAND_OK, reinterpret_cast<const uint8_t*>(output), outputSize);
 #if EFI_SIMULATOR
 			logMsg("sent [%d]\r\n", outputSize);
 #endif

--- a/firmware/console/status_loop.cpp
+++ b/firmware/console/status_loop.cpp
@@ -258,7 +258,6 @@ void updateDevConsoleState(void) {
 	if (hasFirmwareError()) {
 		scheduleMsg(&logger, "%s error: %s", CRITICAL_PREFIX, getFirmwareError());
 		warningEnabled = false;
-		scheduleLogging(&logger);
 		return;
 	}
 #endif /* EFI_PROD_CODE */

--- a/firmware/controllers/core/error_handling.cpp
+++ b/firmware/controllers/core/error_handling.cpp
@@ -45,8 +45,6 @@ static LoggingWithStorage logger("error handling");
 
 EXTERN_ENGINE;
 
-#define WARNING_PREFIX "WARNING: "
-
 extern int warningEnabled;
 extern bool main_loop_started;
 
@@ -120,11 +118,6 @@ static void printToStream(MemoryStream *stream, const char *fmt, va_list ap) {
 }
 
 static void printWarning(const char *fmt, va_list ap) {
-	logger.reset(); // todo: is 'reset' really needed here?
-	appendMsgPrefix(&logger);
-
-	logger.append(WARNING_PREFIX);
-
 	printToStream(&errorState.warningStream, fmt, ap);
 
 	if (CONFIG(showHumanReadableWarning)) {
@@ -137,9 +130,7 @@ static void printWarning(const char *fmt, va_list ap) {
 #endif /* EFI_TUNER_STUDIO */
 	}
 
-	logger.append(warningBuffer);
-	logger.append(DELIMETER);
-	scheduleLogging(&logger);
+	scheduleMsg(logging, "WARNING: %s", warningBuffer);
 }
 
 #else

--- a/firmware/controllers/core/error_handling.cpp
+++ b/firmware/controllers/core/error_handling.cpp
@@ -130,7 +130,7 @@ static void printWarning(const char *fmt, va_list ap) {
 #endif /* EFI_TUNER_STUDIO */
 	}
 
-	scheduleMsg(logger, "WARNING: %s", warningBuffer);
+	scheduleMsg(&logger, "WARNING: %s", warningBuffer);
 }
 
 #else

--- a/firmware/controllers/core/error_handling.cpp
+++ b/firmware/controllers/core/error_handling.cpp
@@ -130,7 +130,7 @@ static void printWarning(const char *fmt, va_list ap) {
 #endif /* EFI_TUNER_STUDIO */
 	}
 
-	scheduleMsg(logging, "WARNING: %s", warningBuffer);
+	scheduleMsg(logger, "WARNING: %s", warningBuffer);
 }
 
 #else

--- a/firmware/hw_layer/mmc_card.cpp
+++ b/firmware/hw_layer/mmc_card.cpp
@@ -375,7 +375,6 @@ static BaseBlockDevice* initializeMmcBlockDevice() {
 	sdStatus = SD_STATE_CONNECTING;
 	if (mmcConnect(&MMCD1) != HAL_SUCCESS) {
 		sdStatus = SD_STATE_NOT_CONNECTED;
-		warning(CUSTOM_OBD_MMC_ERROR, "Can't connect or mount MMC/SD");
 		UNLOCK_SD_SPI;
 		return nullptr;
 	}
@@ -399,7 +398,6 @@ static BaseBlockDevice* initializeMmcBlockDevice() {
 	sdStatus = SD_STATE_CONNECTING;
 	if (sdcConnect(&EFI_SDC_DEVICE) != HAL_SUCCESS) {
 		sdStatus = SD_STATE_NOT_CONNECTED;
-		warning(CUSTOM_OBD_MMC_ERROR, "Can't connect or mount MMC/SD");
 		return nullptr;
 	}
 

--- a/firmware/hw_layer/rtc_helper.cpp
+++ b/firmware/hw_layer/rtc_helper.cpp
@@ -144,11 +144,8 @@ void printDateTime(void) {
 		scheduleMsg(&logger, "%D - unix time", unix_time);
 		date_get_tm(&timp);
 
-		appendMsgPrefix(&logger);
-		logger.appendPrintf( "Current RTC localtime is: %04u-%02u-%02u %02u:%02u:%02u w=%d", timp.tm_year + 1900, timp.tm_mon + 1, timp.tm_mday, timp.tm_hour,
+		scheduleMsg(nullptr, "Current RTC localtime is: %04u-%02u-%02u %02u:%02u:%02u w=%d", timp.tm_year + 1900, timp.tm_mon + 1, timp.tm_mday, timp.tm_hour,
 				timp.tm_min, timp.tm_sec, rtcWorks);
-		appendMsgPostfix(&logger);
-		scheduleLogging(&logger);
 	}
 }
 

--- a/firmware/util/loggingcentral.cpp
+++ b/firmware/util/loggingcentral.cpp
@@ -99,7 +99,7 @@ void scheduleLogging(Logging* logging) {
  * this method should always be invoked from the same thread!
  * @return pointer to the buffer which should be print to console
  */
-char * swapOutputBuffers(int *actualOutputBufferSize) {
+const char* swapOutputBuffers(int *actualOutputBufferSize) {
 #if EFI_ENABLE_ASSERTS
 	int expectedOutputSize;
 #endif /* EFI_ENABLE_ASSERTS */

--- a/firmware/util/loggingcentral.h
+++ b/firmware/util/loggingcentral.h
@@ -8,5 +8,5 @@
 
 class Logging;
 
-char * swapOutputBuffers(int *actualOutputBufferSize);
+const char* swapOutputBuffers(int *actualOutputBufferSize);
 void scheduleMsg(Logging *logging, const char *fmt, ...);


### PR DESCRIPTION
handful of spots that we could just call `scheduleMsg` - so do that

change signature of swapOutputBuffers to return `const char*`

remove useless SD card warning, not-plugged-in SD card is a valid case that doesn't deserve a warning