### PR TITLE
Add set wideband index buttons

### DIFF
--- a/firmware/controllers/bench_test.cpp
+++ b/firmware/controllers/bench_test.cpp
@@ -435,6 +435,9 @@ void executeTSCommand(uint16_t subsystem, uint16_t index) {
 	case CMD_TS_X14:
 		handleCommandX14(index);
 		break;
+	case 0x15:
+		setWidebandOffset(logger, index);
+		break;
 	case CMD_TS_BENCH_CATEGORY:
 		handleBenchCategory(index);
 		break;

--- a/firmware/controllers/bench_test.cpp
+++ b/firmware/controllers/bench_test.cpp
@@ -499,6 +499,7 @@ void initBenchTest(Logging *sharedLogger) {
 	addConsoleAction("mainrelaybench", mainRelayBench);
 	addConsoleActionS("fanbench2", fanBenchExt);
 	addConsoleAction("update_wideband", []() { widebandUpdatePending = true; });
+	addConsoleActionI("set_wideband_index", [](int index) { setWidebandOffset(logger, index); });
 
 	addConsoleAction(CMD_STARTER_BENCH, starterRelayBench);
 	addConsoleAction(CMD_MIL_BENCH, milBench);

--- a/firmware/controllers/bench_test.cpp
+++ b/firmware/controllers/bench_test.cpp
@@ -435,9 +435,11 @@ void executeTSCommand(uint16_t subsystem, uint16_t index) {
 	case CMD_TS_X14:
 		handleCommandX14(index);
 		break;
+#ifdef EFI_WIDEBAND_FIRMWARE_UPDATE
 	case 0x15:
 		setWidebandOffset(logger, index);
 		break;
+#endif // EFI_WIDEBAND_FIRMWARE_UPDATE
 	case CMD_TS_BENCH_CATEGORY:
 		handleBenchCategory(index);
 		break;
@@ -501,8 +503,11 @@ void initBenchTest(Logging *sharedLogger) {
 	addConsoleAction("fanbench", fanBench);
 	addConsoleAction("mainrelaybench", mainRelayBench);
 	addConsoleActionS("fanbench2", fanBenchExt);
+
+#if EFI_WIDEBAND_FIRMWARE_UPDATE
 	addConsoleAction("update_wideband", []() { widebandUpdatePending = true; });
 	addConsoleActionI("set_wideband_index", [](int index) { setWidebandOffset(logger, index); });
+#endif // EFI_WIDEBAND_FIRMWARE_UPDATE
 
 	addConsoleAction(CMD_STARTER_BENCH, starterRelayBench);
 	addConsoleAction(CMD_MIL_BENCH, milBench);

--- a/firmware/controllers/can/can.h
+++ b/firmware/controllers/can/can.h
@@ -29,6 +29,8 @@ void registerCanSensor(CanSensorBase& sensor);
 void handleWidebandBootloaderAck();
 // Update the firmware on any connected wideband controller
 void updateWidebandFirmware(Logging*);
+// Set the CAN index offset of any attached wideband controller
+void setWidebandOffset(Logging* logging, uint8_t index);
 
 class CanWrite final : public PeriodicController<512> {
 public:

--- a/firmware/controllers/can/wideband_bootloader.cpp
+++ b/firmware/controllers/can/wideband_bootloader.cpp
@@ -112,7 +112,9 @@ void setWidebandOffset(Logging* logging, uint8_t index) {
 		m[0] = index;
 	}
 
-	waitAck();
+	if (!waitAck()) {
+		firmwareError(OBD_PCM_Processor_Fault, "Wideband index set failed: no controller detected!");
+	}
 
 	waitingBootloaderThread = nullptr;
 }

--- a/firmware/controllers/can/wideband_bootloader.cpp
+++ b/firmware/controllers/can/wideband_bootloader.cpp
@@ -95,4 +95,26 @@ void updateWidebandFirmware(Logging* logging) {
 	waitingBootloaderThread = nullptr;
 }
 
+void setWidebandOffset(Logging* logging, uint8_t index) {
+	// Clear any pending acks for this thread
+	chEvtGetAndClearEvents(EVT_BOOTLOADER_ACK);
+
+	// Send messages to the current thread when acks come in
+	waitingBootloaderThread = chThdGetSelfX();
+
+	scheduleMsg(logging, "***************************************");
+	scheduleMsg(logging, "          WIDEBAND INDEX SET");
+	scheduleMsg(logging, "***************************************");
+	scheduleMsg(logging, "Setting all connected widebands to index %d...", index);
+
+	{
+		CanTxMessage m(0xEF4'0000, 1, true);
+		m[0] = index;
+	}
+
+	waitAck();
+
+	waitingBootloaderThread = nullptr;
+}
+
 #endif // EFI_WIDEBAND_FIRMWARE_UPDATE && HAL_USE_CAN

--- a/firmware/tunerstudio/rusefi.input
+++ b/firmware/tunerstudio/rusefi.input
@@ -1663,6 +1663,9 @@ cmb_etb_auto_calibrate_2     = "@@TS_IO_TEST_COMMAND_char@@\x00\x14\x00\x11"
 cmd_wideband_firmare_update  = "@@TS_IO_TEST_COMMAND_char@@\x00\x14\x00\x12"
 cmd_enable_ext_stim          = "@@TS_IO_TEST_COMMAND_char@@\x00\x14\x00\x13"
 
+cmd_set_wideband_idx_0       = "@@TS_IO_TEST_COMMAND_char@@\x00\x15\x00\x00"
+cmd_set_wideband_idx_1       = "@@TS_IO_TEST_COMMAND_char@@\x00\x15\x00\x01"
+
 cmd_cj125_calibrate          = "@@TS_IO_TEST_COMMAND_char@@\x00\x18\x00\x00"
 cmd_call_from_pit            = "@@TS_IO_TEST_COMMAND_char@@\x00\x20\x34\x56"
 cmd_stop_engine              = "@@TS_IO_TEST_COMMAND_char@@\x00\x79\x00\x00"
@@ -3357,9 +3360,13 @@ cmd_set_engine_type_default					= "@@TS_IO_TEST_COMMAND_char@@\x00\x31\x00\x00"
 		panel = testMisc
 
 	dialog = widebandConfig, "rusEFI Wideband Config"
-		field = "!Please connect exactly one wideband controller before pressing this button!"
+		field = "!Please connect exactly one wideband controller before pressing these buttons!"
 		commandButton = "Update Firmware", cmd_wideband_firmare_update
-	
+		field = "!These buttons will set ALL connected controllers to the specified index."
+		field = "!Disconnect all controllers you don't want to set!"
+		commandButton = "Set Index 0",     cmd_set_wideband_idx_0
+		commandButton = "Set Index 1",     cmd_set_wideband_idx_1
+
 	dialog = engineTypeDialog, "Popular vehicles"
 		field = "!These buttons send a command to rusEFI controller to apply preset values"
 		field = "!Once you send the command, please reconnect to rusEFI controller in order to read fresh values"


### PR DESCRIPTION
Problem: you have multiple wideband contollers
Solution: you can now set which physical device gets which logical index!

also updates the controller image to support the new command/message.