### PR TITLE
Enable trigger stimulation after HW timer initialized

### DIFF
--- a/firmware/rusefi.cpp
+++ b/firmware/rusefi.cpp
@@ -199,13 +199,6 @@ void runRusEfi(void) {
  #endif // IGNORE_FLASH_CONFIGURATION
 #endif /* EFI_INTERNAL_FLASH */
 
-#if HW_CHECK_ALWAYS_STIMULATE
-	// we need a special binary for final assembly check. We cannot afford to require too much software or too many steps
-	// to be executed at the place of assembly
-	enableTriggerStimulator();
-#endif // HW_CHECK_ALWAYS_STIMULATE
-
-
 #if ! EFI_ACTIVE_CONFIGURATION_IN_FLASH
 	// TODO: need to fix this place!!! should be a version of PASS_ENGINE_PARAMETER_SIGNATURE somehow
 	prepareVoidConfiguration(&activeConfiguration);
@@ -224,6 +217,12 @@ void runRusEfi(void) {
 	 * Initialize hardware drivers
 	 */
 	initHardware(&sharedLogger);
+
+#if HW_CHECK_ALWAYS_STIMULATE
+	// we need a special binary for final assembly check. We cannot afford to require too much software or too many steps
+	// to be executed at the place of assembly
+	enableTriggerStimulator();
+#endif // HW_CHECK_ALWAYS_STIMULATE
 
 #if EFI_FILE_LOGGING
 	initMmcCard();


### PR DESCRIPTION
To avoid 'CRITICAL error: hwTimer not alive' error