### PR TITLE
harden against various no-boot scenarios

### DIFF
--- a/firmware/console/status_loop.cpp
+++ b/firmware/console/status_loop.cpp
@@ -219,7 +219,8 @@ void printOverallStatus(efitimesec_t nowSeconds) {
 	printOutPin(PROTOCOL_WA_CHANNEL_2, CONFIG(logicAnalyzerPins)[1]);
 #endif /* EFI_LOGIC_ANALYZER */
 
-	for (int i = 0; i < engineConfiguration->specs.cylindersCount; i++) {
+	int cylCount = minI(minI(CONFIG(specs.cylindersCount), INJECTION_PIN_COUNT), IGNITION_PIN_COUNT);
+	for (int i = 0; i < cylCount; i++) {
 		printOutPin(enginePins.coils[i].getShortName(), CONFIG(ignitionPins)[i]);
 
 		printOutPin(enginePins.injectors[i].getShortName(), CONFIG(injectionPins)[i]);

--- a/firmware/controllers/algo/rusefi_types.h
+++ b/firmware/controllers/algo/rusefi_types.h
@@ -113,7 +113,7 @@ typedef uint8_t gppwm_table_t[GPPWM_LOAD_COUNT][GPPWM_RPM_COUNT];
 // this is different type simply to have different hi/low range in rusefi.ini
 typedef ignition_table_t angle_table_t;
 
-typedef int cylinders_count_t;
+typedef uint32_t cylinders_count_t;
 
 typedef int32_t bool32_t;
 

--- a/firmware/controllers/trigger/decoders/trigger_structure.cpp
+++ b/firmware/controllers/trigger/decoders/trigger_structure.cpp
@@ -367,7 +367,7 @@ void TriggerWaveform::setTriggerSynchronizationGap3(int gapIndex, float syncRati
 uint16_t TriggerWaveform::findAngleIndex(TriggerFormDetails *details, float target) const {
 	size_t engineCycleEventCount = getLength();
 
-	efiAssert(CUSTOM_ERR_ASSERT, engineCycleEventCount <= 0xFFFF, "engineCycleEventCount", 0);
+	efiAssert(CUSTOM_ERR_ASSERT, engineCycleEventCount != 0 && engineCycleEventCount <= 0xFFFF, "engineCycleEventCount", 0);
 
 	uint32_t left = 0;
 	uint32_t right = engineCycleEventCount - 1;

--- a/firmware/hw_layer/mmc_card.cpp
+++ b/firmware/hw_layer/mmc_card.cpp
@@ -366,6 +366,11 @@ static BaseBlockDevice* initializeMmcBlockDevice() {
 	mmc_hs_spicfg.sspad = mmc_ls_spicfg.sspad = getHwPin("mmc", CONFIG(sdCardCsPin));
 	mmccfg.spip = getSpiDevice(mmcSpiDevice);
 
+	// Invalid SPI device, abort.
+	if (!mmccfg.spip) {
+		return nullptr;
+	}
+
 	// We think we have everything for the card, let's try to mount it!
 	mmcObjectInit(&MMCD1);
 	mmcStart(&MMCD1, &mmccfg);

--- a/firmware/hw_layer/pin_repository.cpp
+++ b/firmware/hw_layer/pin_repository.cpp
@@ -237,11 +237,6 @@ bool brain_pin_markUsed(brain_pin_e brainPin, const char *msg) {
 
 	if (getBrainUsedPin(index) != NULL) {
 		/* TODO: get readable name of brainPin... */
-		/**
-		 * todo: the problem is that this warning happens before the console is even
-		 * connected, so the warning is never displayed on the console and that's quite a problem!
-		 */
-//		warning(OBD_PCM_Processor_Fault, "brain pin %d req by %s used by %s", brainPin, msg, getBrainUsedPin(index));
 		firmwareError(CUSTOM_ERR_PIN_ALREADY_USED_1, "Pin \"%s\" required by \"%s\" but is used by \"%s\" %s",
 				hwPortname(brainPin),
 				msg,

--- a/firmware/rusefi.cpp
+++ b/firmware/rusefi.cpp
@@ -161,6 +161,16 @@ static void scheduleReboot(void) {
 	chVTSetI(&resetTimer, TIME_MS2I(3000), (vtfunc_t) rebootNow, NULL);
 }
 
+// Returns false if there's an obvious problem with the loaded configuration
+static bool validateConfig() {
+	if (CONFIG(specs.cylindersCount) > minI(INJECTION_PIN_COUNT, IGNITION_PIN_COUNT)) {
+		firmwareError(OBD_PCM_Processor_Fault, "Invalid cylinder count: %d", CONFIG(specs.cylindersCount));
+		return false;
+	}
+
+	return true;
+}
+
 void runRusEfi(void) {
 	efiAssertVoid(CUSTOM_RM_STACK_1, getCurrentRemainingStack() > 512, "init s");
 	assertEngineReference();
@@ -229,24 +239,27 @@ void runRusEfi(void) {
 	initMmcCard();
 #endif /* EFI_FILE_LOGGING */
 
-	initStatusLoop();
-	/**
-	 * Now let's initialize actual engine control logic
-	 * todo: should we initialize some? most? controllers before hardware?
-	 */
-	initEngineContoller(&sharedLogger PASS_ENGINE_PARAMETER_SIGNATURE);
-	rememberCurrentConfiguration();
+	// Config could be completely bogus - don't start anything else!
+	if (validateConfig()) {
+		initStatusLoop();
+		/**
+		 * Now let's initialize actual engine control logic
+		 * todo: should we initialize some? most? controllers before hardware?
+		 */
+		initEngineContoller(&sharedLogger PASS_ENGINE_PARAMETER_SIGNATURE);
+		rememberCurrentConfiguration();
 
-#if EFI_PERF_METRICS
-	initTimePerfActions(&sharedLogger);
-#endif
-        
-#if EFI_ENGINE_EMULATOR
-	initEngineEmulator(&sharedLogger PASS_ENGINE_PARAMETER_SIGNATURE);
-#endif
-	startStatusThreads();
+	#if EFI_PERF_METRICS
+		initTimePerfActions(&sharedLogger);
+	#endif
+			
+	#if EFI_ENGINE_EMULATOR
+		initEngineEmulator(&sharedLogger PASS_ENGINE_PARAMETER_SIGNATURE);
+	#endif
+		startStatusThreads();
 
-	runSchedulingPrecisionTestIfNeeded();
+		runSchedulingPrecisionTestIfNeeded();
+	}
 
 	print("Running main loop\r\n");
 	main_loop_started = true;


### PR DESCRIPTION
Some configurations can cause a no-boot.  This avoids some of them: particularly invalid cylinder counts and invalid trigger shapes.