### PR TITLE
embiggen mass storage stack

### DIFF
--- a/firmware/hw_layer/ports/rusefi_halconf.h
+++ b/firmware/hw_layer/ports/rusefi_halconf.h
@@ -75,7 +75,7 @@
 // USB Mass Storage
 #ifdef EFI_USE_COMPRESSED_INI_MSD
 // if enabled, we do gzip decompression on the MSD thread - it requires more stack space
-#define USB_MSD_THREAD_WA_SIZE 512
+#define USB_MSD_THREAD_WA_SIZE 2048
 #endif
 
 // SPI


### PR DESCRIPTION
there are some narrow timing conditions that could cause a stack overflow on the mass storage (context switch during decompression, for example), and devices using compressed ini are already guaranteed tons of memory, so just make the stack bigger.