### PR TITLE
move some initialization steps earlier

### DIFF
--- a/firmware/controllers/settings.cpp
+++ b/firmware/controllers/settings.cpp
@@ -1001,6 +1001,7 @@ const plain_get_integer_s getI_plain[] = {
 //		{"idle_solenoid_freq", setIdleSolenoidFrequency},
 //		{"tps_accel_len", setTpsAccelLen},
 //		{"engine_load_accel_len", setEngineLoadAccelLen},
+//		{"bor", setBor},
 //		{"can_mode", setCanType},
 //		{"idle_rpm", setTargetIdleRpm},
 };
@@ -1052,6 +1053,10 @@ static void getValue(const char *paramStr) {
 
 	if (strEqualCaseInsensitive(paramStr, "isCJ125Enabled")) {
 		scheduleMsg(&logger, "isCJ125Enabled=%d", engineConfiguration->isCJ125Enabled);
+#if EFI_PROD_CODE
+	} else if (strEqualCaseInsensitive(paramStr, "bor")) {
+		showBor();
+#endif /* EFI_PROD_CODE */
 	} else if (strEqualCaseInsensitive(paramStr, "tps_min")) {
 		scheduleMsg(&logger, "tps_min=%d", engineConfiguration->tpsMin);
 	} else if (strEqualCaseInsensitive(paramStr, "trigger_only_front")) {
@@ -1196,6 +1201,7 @@ const command_i_s commandsI[] = {{"ignition_mode", setIgnitionMode},
 		{"engine_load_accel_len", setEngineLoadAccelLen},
 #endif // EFI_ENGINE_CONTROL
 #if EFI_PROD_CODE
+		{"bor", setBor},
 #if EFI_CAN_SUPPORT
 		{"can_mode", setCanType},
 		{"can_vss", setCanVss},

--- a/firmware/controllers/settings.cpp
+++ b/firmware/controllers/settings.cpp
@@ -1001,7 +1001,6 @@ const plain_get_integer_s getI_plain[] = {
 //		{"idle_solenoid_freq", setIdleSolenoidFrequency},
 //		{"tps_accel_len", setTpsAccelLen},
 //		{"engine_load_accel_len", setEngineLoadAccelLen},
-//		{"bor", setBor},
 //		{"can_mode", setCanType},
 //		{"idle_rpm", setTargetIdleRpm},
 };
@@ -1053,10 +1052,6 @@ static void getValue(const char *paramStr) {
 
 	if (strEqualCaseInsensitive(paramStr, "isCJ125Enabled")) {
 		scheduleMsg(&logger, "isCJ125Enabled=%d", engineConfiguration->isCJ125Enabled);
-#if EFI_PROD_CODE
-	} else if (strEqualCaseInsensitive(paramStr, "bor")) {
-		showBor();
-#endif /* EFI_PROD_CODE */
 	} else if (strEqualCaseInsensitive(paramStr, "tps_min")) {
 		scheduleMsg(&logger, "tps_min=%d", engineConfiguration->tpsMin);
 	} else if (strEqualCaseInsensitive(paramStr, "trigger_only_front")) {
@@ -1201,7 +1196,6 @@ const command_i_s commandsI[] = {{"ignition_mode", setIgnitionMode},
 		{"engine_load_accel_len", setEngineLoadAccelLen},
 #endif // EFI_ENGINE_CONTROL
 #if EFI_PROD_CODE
-		{"bor", setBor},
 #if EFI_CAN_SUPPORT
 		{"can_mode", setCanType},
 		{"can_vss", setCanVss},

--- a/firmware/hw_layer/hardware.cpp
+++ b/firmware/hw_layer/hardware.cpp
@@ -453,6 +453,16 @@ void applyNewHardwareSettings(void) {
 	adcConfigListener(engine);
 }
 
+void setBor(int borValue) {
+	scheduleMsg(sharedLogger, "setting BOR to %d", borValue);
+	BOR_Set((BOR_Level_t)borValue);
+	showBor();
+}
+
+void showBor(void) {
+	scheduleMsg(sharedLogger, "BOR=%d", (int)BOR_Get());
+}
+
 // This function initializes hardware that can do so before configuration is loaded
 void initHardwareNoConfig(Logging *l) {
 	efiAssertVoid(CUSTOM_IH_STACK, getCurrentRemainingStack() > EXPECTED_REMAINING_STACK, "init h");

--- a/firmware/hw_layer/hardware.cpp
+++ b/firmware/hw_layer/hardware.cpp
@@ -32,7 +32,7 @@
 #include "serial_hw.h"
 
 #include "mpu_util.h"
-//#include "usb_msd.h"
+#include "mmc_card.h"
 
 #include "AdcConfiguration.h"
 #include "idle_hardware.h"
@@ -453,26 +453,16 @@ void applyNewHardwareSettings(void) {
 	adcConfigListener(engine);
 }
 
-void setBor(int borValue) {
-	scheduleMsg(sharedLogger, "setting BOR to %d", borValue);
-	BOR_Set((BOR_Level_t)borValue);
-	showBor();
-}
-
-void showBor(void) {
-	scheduleMsg(sharedLogger, "BOR=%d", (int)BOR_Get());
-}
-
-void initHardware(Logging *l) {
+// This function initializes hardware that can do so before configuration is loaded
+void initHardwareNoConfig(Logging *l) {
 	efiAssertVoid(CUSTOM_IH_STACK, getCurrentRemainingStack() > EXPECTED_REMAINING_STACK, "init h");
 	sharedLogger = l;
 	efiAssertVoid(CUSTOM_EC_NULL, engineConfiguration!=NULL, "engineConfiguration");
 	
 
 	printMsg(sharedLogger, "initHardware()");
-	// todo: enable protection. it's disabled because it takes
-	// 10 extra seconds to re-flash the chip
-	//flashProtect();
+
+	initPinRepository();
 
 #if EFI_HISTOGRAMS
 	/**
@@ -486,12 +476,27 @@ void initHardware(Logging *l) {
 	 */
 	initPrimaryPins(sharedLogger);
 
-	if (hasFirmwareError()) {
-		return;
-	}
+	// it's important to initialize this pretty early in the game before any scheduling usages
+	initSingleTimerExecutorHardware();
+
+	initRtc();
 
 #if EFI_INTERNAL_FLASH
+	initFlash(sharedLogger);
+#endif
 
+#if EFI_SHAFT_POSITION_INPUT
+	// todo: figure out better startup logic
+	initTriggerCentral(sharedLogger);
+#endif /* EFI_SHAFT_POSITION_INPUT */
+
+#if EFI_FILE_LOGGING
+	initEarlyMmcCard();
+#endif // EFI_FILE_LOGGING
+}
+
+void initHardware() {
+#if EFI_INTERNAL_FLASH
 #ifdef CONFIG_RESET_SWITCH_PORT
 // this pin is not configurable at runtime so that we have a reliable way to reset configuration
 #define SHOULD_IGNORE_FLASH() (palReadPad(CONFIG_RESET_SWITCH_PORT, CONFIG_RESET_SWITCH_PIN) == 0)
@@ -503,7 +508,6 @@ void initHardware(Logging *l) {
 	palSetPadMode(CONFIG_RESET_SWITCH_PORT, CONFIG_RESET_SWITCH_PIN, PAL_MODE_INPUT_PULLUP);
 #endif /* CONFIG_RESET_SWITCH_PORT */
 
-	initFlash(sharedLogger);
 	/**
 	 * this call reads configuration from flash memory or sets default configuration
 	 * if flash state does not look right.
@@ -521,9 +525,6 @@ void initHardware(Logging *l) {
 	engineConfiguration->engineType = DEFAULT_ENGINE_TYPE;
 	resetConfigurationExt(sharedLogger, engineConfiguration->engineType PASS_ENGINE_PARAMETER_SUFFIX);
 #endif /* EFI_INTERNAL_FLASH */
-
-	// it's important to initialize this pretty early in the game before any scheduling usages
-	initSingleTimerExecutorHardware();
 
 #if EFI_HD44780_LCD
 	lcd_HD44780_init(sharedLogger);
@@ -548,8 +549,6 @@ void initHardware(Logging *l) {
 #if EFI_SOFTWARE_KNOCK
 	initSoftwareKnock();
 #endif /* EFI_SOFTWARE_KNOCK */
-
-	initRtc();
 
 #if HAL_USE_SPI
 	initSpiModules(engineConfiguration);
@@ -582,11 +581,6 @@ void initHardware(Logging *l) {
 //	init_adc_mcp3208(&adcState, &SPID2);
 //	requestAdcValue(&adcState, 0);
 
-#if EFI_SHAFT_POSITION_INPUT
-	// todo: figure out better startup logic
-	initTriggerCentral(sharedLogger);
-#endif /* EFI_SHAFT_POSITION_INPUT */
-
 	turnOnHardware(sharedLogger);
 
 #if EFI_HIP_9011
@@ -596,14 +590,10 @@ void initHardware(Logging *l) {
 #if EFI_MEMS
 	initAccelerometer(PASS_ENGINE_PARAMETER_SIGNATURE);
 #endif
-//	initFixedLeds();
-
 
 #if EFI_BOSCH_YAW
 	initBoschYawRateSensor();
 #endif /* EFI_BOSCH_YAW */
-
-	//	initBooleanInputs();
 
 #if EFI_UART_GPS
 	initGps();

--- a/firmware/hw_layer/hardware.h
+++ b/firmware/hw_layer/hardware.h
@@ -49,11 +49,14 @@ brain_pin_e getSckPin(spi_device_e device);
 #include "debounce.h"
 
 void applyNewHardwareSettings(void);
-void initHardware(Logging *logging);
-#endif /* EFI_PROD_CODE */
 
-void showBor(void);
-void setBor(int borValue);
+// Initialize hardware that doesn't require configuration to be loaded
+void initHardwareNoConfig(Logging *l);
+
+// Initialize hardware with configuration loaded
+void initHardware();
+
+#endif /* EFI_PROD_CODE */
 
 class ButtonDebounce;
 

--- a/firmware/hw_layer/hardware.h
+++ b/firmware/hw_layer/hardware.h
@@ -58,7 +58,7 @@ void initHardware();
 
 #endif /* EFI_PROD_CODE */
 
-void setBor(void);
+void showBor(void);
 void setBor(int borValue);
 
 class ButtonDebounce;

--- a/firmware/hw_layer/hardware.h
+++ b/firmware/hw_layer/hardware.h
@@ -58,6 +58,9 @@ void initHardware();
 
 #endif /* EFI_PROD_CODE */
 
+void setBor(void);
+void setBor(int borValue);
+
 class ButtonDebounce;
 
 #endif /* __cplusplus */

--- a/firmware/hw_layer/mmc_card.cpp
+++ b/firmware/hw_layer/mmc_card.cpp
@@ -534,19 +534,22 @@ bool isSdCardAlive(void) {
 	return fs_ready;
 }
 
-void initMmcCard(void) {
+// Pre-config load init
+void initEarlyMmcCard() {
 	logName[0] = 0;
 
 #if HAL_USE_USB_MSD
 	chBSemObjectInit(&usbConnectedSemaphore, true);
 #endif
 
-	chThdCreateStatic(mmcThreadStack, sizeof(mmcThreadStack), PRIO_MMC, (tfunc_t)(void*) MMCmonThread, NULL);
-
 	addConsoleAction("sdinfo", sdStatistics);
 	addConsoleActionS("ls", listDirectory);
 	addConsoleActionS("del", removeFile);
 	addConsoleAction("incfilename", incLogFileName);
+}
+
+void initMmcCard() {
+	chThdCreateStatic(mmcThreadStack, sizeof(mmcThreadStack), PRIO_MMC, (tfunc_t)(void*) MMCmonThread, NULL);
 }
 
 #endif /* EFI_FILE_LOGGING */

--- a/firmware/hw_layer/mmc_card.h
+++ b/firmware/hw_layer/mmc_card.h
@@ -15,7 +15,8 @@
 #define DOT_MLG ".mlg"
 
 bool isLogFile(const char *fileName);
-void initMmcCard(void);
+void initEarlyMmcCard();
+void initMmcCard();
 bool isSdCardAlive(void);
 
 void readLogFileContent(char *buffer, short fileId, short offset, short length);

--- a/firmware/rusefi.cpp
+++ b/firmware/rusefi.cpp
@@ -192,10 +192,7 @@ void runRusEfi(void) {
 	 */
 	initDataStructures(PASS_ENGINE_PARAMETER_SIGNATURE);
 
-	/**
-	 * First data structure keeps track of which hardware I/O pins are used by whom
-	 */
-	initPinRepository();
+	initHardwareNoConfig(&sharedLogger);
 
 #if EFI_INTERNAL_FLASH
  #if IGNORE_FLASH_CONFIGURATION
@@ -234,7 +231,7 @@ void runRusEfi(void) {
 	/**
 	 * Initialize hardware drivers
 	 */
-	initHardware(&sharedLogger);
+	initHardware();
 
 #if HW_CHECK_ALWAYS_STIMULATE
 	// we need a special binary for final assembly check. We cannot afford to require too much software or too many steps


### PR DESCRIPTION
prep related to #2464, also just general refactoring to make initialization a little less spaghetti

also removes the nearby `getBor` and `setBor` console commands for setting/setting the brownout threshold, which has been set reasonably by `mpu_util` for a long time now, and has no reason to be settable via console.