### PR TITLE
remove disused BOR (brown-out reset) console command

### DIFF
--- a/firmware/controllers/settings.cpp
+++ b/firmware/controllers/settings.cpp
@@ -1001,7 +1001,6 @@ const plain_get_integer_s getI_plain[] = {
 //		{"idle_solenoid_freq", setIdleSolenoidFrequency},
 //		{"tps_accel_len", setTpsAccelLen},
 //		{"engine_load_accel_len", setEngineLoadAccelLen},
-//		{"bor", setBor},
 //		{"can_mode", setCanType},
 //		{"idle_rpm", setTargetIdleRpm},
 };
@@ -1053,10 +1052,6 @@ static void getValue(const char *paramStr) {
 
 	if (strEqualCaseInsensitive(paramStr, "isCJ125Enabled")) {
 		scheduleMsg(&logger, "isCJ125Enabled=%d", engineConfiguration->isCJ125Enabled);
-#if EFI_PROD_CODE
-	} else if (strEqualCaseInsensitive(paramStr, "bor")) {
-		showBor();
-#endif /* EFI_PROD_CODE */
 	} else if (strEqualCaseInsensitive(paramStr, "tps_min")) {
 		scheduleMsg(&logger, "tps_min=%d", engineConfiguration->tpsMin);
 	} else if (strEqualCaseInsensitive(paramStr, "trigger_only_front")) {
@@ -1201,7 +1196,6 @@ const command_i_s commandsI[] = {{"ignition_mode", setIgnitionMode},
 		{"engine_load_accel_len", setEngineLoadAccelLen},
 #endif // EFI_ENGINE_CONTROL
 #if EFI_PROD_CODE
-		{"bor", setBor},
 #if EFI_CAN_SUPPORT
 		{"can_mode", setCanType},
 		{"can_vss", setCanVss},

--- a/firmware/hw_layer/hardware.cpp
+++ b/firmware/hw_layer/hardware.cpp
@@ -453,16 +453,6 @@ void applyNewHardwareSettings(void) {
 	adcConfigListener(engine);
 }
 
-void setBor(int borValue) {
-	scheduleMsg(sharedLogger, "setting BOR to %d", borValue);
-	BOR_Set((BOR_Level_t)borValue);
-	showBor();
-}
-
-void showBor(void) {
-	scheduleMsg(sharedLogger, "BOR=%d", (int)BOR_Get());
-}
-
 void initHardware(Logging *l) {
 	efiAssertVoid(CUSTOM_IH_STACK, getCurrentRemainingStack() > EXPECTED_REMAINING_STACK, "init h");
 	sharedLogger = l;

--- a/firmware/hw_layer/hardware.h
+++ b/firmware/hw_layer/hardware.h
@@ -52,9 +52,6 @@ void applyNewHardwareSettings(void);
 void initHardware(Logging *logging);
 #endif /* EFI_PROD_CODE */
 
-void showBor(void);
-void setBor(int borValue);
-
 class ButtonDebounce;
 
 #endif /* __cplusplus */


### PR DESCRIPTION
also removes the nearby getBor and setBor console commands for setting/setting the brownout threshold, which has been set reasonably by mpu_util for a long time now, and has no reason to be settable via console.

:slightly_smiling_face: 