### PR TITLE
write flash on separate thread for H7

### DIFF
--- a/firmware/config/stm32h7ems/efifeatures.h
+++ b/firmware/config/stm32h7ems/efifeatures.h
@@ -40,3 +40,6 @@
 #define BOARD_EXT_GPIOCHIPS			(BOARD_TLE6240_COUNT + BOARD_MC33972_COUNT + BOARD_TLE8888_COUNT + BOARD_DRV8860_COUNT + BOARD_MC33810_COUNT)
 
 #define EFI_USE_COMPRESSED_INI_MSD
+
+// H7 has dual bank, so flash on its own (low priority) thread so as to not block any other operations
+#define EFI_FLASH_WRITE_THREAD TRUE

--- a/firmware/controllers/flash_main.cpp
+++ b/firmware/controllers/flash_main.cpp
@@ -222,7 +222,7 @@ void initFlash(Logging *sharedLogger) {
 	addConsoleAction("rewriteconfig", rewriteConfig);
 
 #if EFI_FLASH_WRITE_THREAD
-	chThdCreateStatic(flashWriteStack, sizeof(flashWriteStack), flashWriteThread, PRIO_FLASH_WRITE, nullptr);
+	chThdCreateStatic(flashWriteStack, sizeof(flashWriteStack), PRIO_FLASH_WRITE, flashWriteThread, nullptr);
 #endif
 }
 

--- a/firmware/controllers/flash_main.cpp
+++ b/firmware/controllers/flash_main.cpp
@@ -61,12 +61,11 @@ static void flashWriteThread(void*) {
 
 void setNeedToWriteConfiguration(void) {
 	scheduleMsg(logger, "Scheduling configuration write");
+	needToWriteConfiguration = true;
 
 #if EFI_FLASH_WRITE_THREAD
 	// Signal the flash writer thread to wake up and write at its leisure
 	flashWriteSemaphore.signal();
-#else // not EFI_FLASH_WRITE_THREAD
-	needToWriteConfiguration = true;
 #endif // EFI_FLASH_WRITE_THREAD
 }
 
@@ -75,13 +74,13 @@ bool getNeedToWriteConfiguration(void) {
 }
 
 void writeToFlashIfPending() {
-// with a flash write thread, the schedule happens directly from setNeedToWriteConfiguration
-#if ! EFI_FLASH_WRITE_THREAD
+// with a flash write thread, the schedule happens directly from
+// setNeedToWriteConfiguration, so there's nothing to do here
+#if !EFI_FLASH_WRITE_THREAD
 	if (!getNeedToWriteConfiguration()) {
 		return;
 	}
 
-	scheduleMsg(logger, "Writing pending configuration");
 	writeToFlashNow();
 #endif
 }
@@ -95,7 +94,7 @@ int eraseAndFlashCopy(flashaddr_t storageAddress, const TStorage& data)
 }
 
 void writeToFlashNow(void) {
-	scheduleMsg(logger, " !!!!!!!!!!!!!!!!!!!! BE SURE NOT WRITE WITH IGNITION ON !!!!!!!!!!!!!!!!!!!!");
+	scheduleMsg(logger, "Writing pending configuration...");
 
 	// Set up the container
 	persistentState.size = sizeof(persistentState);

--- a/firmware/controllers/thread_priority.h
+++ b/firmware/controllers/thread_priority.h
@@ -29,10 +29,14 @@
 
 // Less important things
 #define PRIO_MMC (NORMALPRIO - 1)
-// USB mass storage
-#define MSD_THD_PRIO LOWPRIO
 
 // These can get starved without too much adverse effect
 #define PRIO_AUX_SERIAL NORMALPRIO
 #define PRIO_KNOCK_PROCESS (NORMALPRIO - 10)
 #define PRIO_HIP9011 (NORMALPRIO - 10)
+
+// These are intentionally low priority so they can't get in the way of anything else
+#define PRIO_FLASH_WRITE LOWPRIO
+
+// USB mass storage
+#define MSD_THD_PRIO LOWPRIO


### PR DESCRIPTION
Enable writing H7 flash while the engine is running.  H7 uses dual bank flash, and this change moves the flash write to a low-priority thread (only when enabled) so as to not block any other operations on the ECU.  Behavior for F4/F7 is currently unchanged.

It also moves clearing the `needToWriteConfiguration` flag to *after* the flash write, so the indicator is extinguished in TS once the operation is actually done.