### PR TITLE
various TS project improvements, dead config fields

### DIFF
--- a/firmware/config/engines/mazda_miata_vvt.cpp
+++ b/firmware/config/engines/mazda_miata_vvt.cpp
@@ -317,8 +317,8 @@ static void setMazdaMiataEngineNB2Defaults(DECLARE_CONFIG_PARAMETER_SIGNATURE) {
 	 * Wall wetting AE could be an argument for honest injectorFlow(MAP)
 	 */
 	engineConfiguration->injector.flow = 265;
-	engineConfiguration->fuelRailPressure = 400; // 400 kPa, 58 psi
-	engineConfiguration->absoluteFuelPressure = true;
+	engineConfiguration->fuelReferencePressure = 400; // 400 kPa, 58 psi
+	engineConfiguration->injectorCompensationMode = ICM_FixedRailPressure;
 
 	engineConfiguration->crankingIACposition = 90;
 

--- a/firmware/config/engines/vw_b6.cpp
+++ b/firmware/config/engines/vw_b6.cpp
@@ -32,7 +32,7 @@ void setVwPassatB6(DECLARE_CONFIG_PARAMETER_SIGNATURE) {
 	// setting to Sensed Rail Pressure mode
 	engineConfiguration->injectorCompensationMode = ICM_SensedRailPressure;
 	// setting Fuel rail pressure to 10 000 kPa
-	engineConfiguration->fuelRailPressure = 10000;
+	engineConfiguration->fuelReferencePressure = 10000;
 	//setting "flat" 0.2 ms injector's lag time
 	setArrayValues(engineConfiguration->injector.battLagCorr, 0.2);
 	

--- a/firmware/config/engines/vw_b6.cpp
+++ b/firmware/config/engines/vw_b6.cpp
@@ -25,13 +25,13 @@ void setVwPassatB6(DECLARE_CONFIG_PARAMETER_SIGNATURE) {
 	engineConfiguration->vvtMode[0] = VVT_BOSCH_QUICK_START;
 	engineConfiguration->map.sensor.type = MT_BOSCH_2_5;
 
-	// seting Injectors flow rate equal 1214 cc/min
+	// Injectors flow 1214 cc/min at 100 bar pressure
 	engineConfiguration->injector.flow = 1214;
-	// seting pressure to high
+	// Use high pressure sensor
 	engineConfiguration->injectorPressureType = IPT_High;
-	// setting to Sensed Rail Pressure mode
+	// Automatic compensation of injector flow based on rail pressure
 	engineConfiguration->injectorCompensationMode = ICM_SensedRailPressure;
-	// setting Fuel rail pressure to 10 000 kPa
+	// Reference rail pressure is 10 000 kPa = 100 bar
 	engineConfiguration->fuelReferencePressure = 10000;
 	//setting "flat" 0.2 ms injector's lag time
 	setArrayValues(engineConfiguration->injector.battLagCorr, 0.2);

--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -949,9 +949,9 @@ custom maf_sensor_type_e 4 bits, S32, @OFFSET@, [0:1], @@maf_sensor_type_e_enum@
 	switch_input_pin_e clutchUpPin;Some vehicles have a switch to indicate that clutch pedal is all the way up
 	brain_input_pin_e frequencyReportingMapInputPin;
 	pin_input_mode_e clutchUpPinMode;
-	uint16_t multisparkMaxRpm;;"rpm", 1, 0, 0, 3000, 0
-	uint8_t multisparkMaxSparkingAngle;;"deg", 1, 0, 0, 60, 0
-	uint8_t multisparkMaxExtraSparkCount;;"count", 1, 0, 0, 5, 0
+	uint16_t multisparkMaxRpm;+Disable multispark above this engine speed.;"rpm", 1, 0, 0, 3000, 0
+	uint8_t multisparkMaxSparkingAngle;+This parameter sets the latest that the last multispark can occur after the main ignition event.  For example, if the ignition timing is 30 degrees BTDC, and this parameter is set to 45, no multispark will ever be fired after 15 degrees ATDC.;"deg", 1, 0, 0, 60, 0
+	uint8_t multisparkMaxExtraSparkCount;+Configures the maximum number of extra sparks to fire (does not include main spark);"count", 1, 0, 1, 5, 0
 	bit todoClutchUpPinInverted
 	bit todoClutchDownPinInverted
 	bit useHbridges;+If enabled we use two H-bridges to drive stepper idle air valve
@@ -1180,8 +1180,8 @@ int16_t tps2Max;Full throttle#2. tpsMax value as 10 bit ADC value. Not Voltage!\
 ! todo: mapErrorDetectionIdleTooLow? 30kPa is usually lowest on idle	
 	float mapErrorDetectionTooLow;kPa value which is too low to be true;"kPa",        1,     0,    -100.0,    100.0,  2
 	float mapErrorDetectionTooHigh;kPa value which is too high to be true;"kPa",        1,     0,    -100.0,    800.0,  2
-	uint16_t multisparkSparkDuration;; "ms", 0.001, 0, 0, 3, 2
-	uint16_t multisparkDwell;; "ms", 0.001, 0, 0, 3, 2
+	uint16_t multisparkSparkDuration;+How long to wait for the spark to fire before recharging the coil for another spark.; "ms", 0.001, 0, 0, 3, 2
+	uint16_t multisparkDwell;+This sets the dwell time for subsequent sparks. The main spark's dwell is set by the dwell table.; "ms", 0.001, 0, 0, 3, 2
 	pid_s idleRpmPid;See cltIdleRpmBins
 	float wwaeBeta;+0 = No fuel settling on port walls 1 = All the fuel settling on port walls setting this to 0 disables the wall wetting enrichment. ;"Fraction",        1,     0,    0.0,    1.0,  2
 	

--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -524,7 +524,7 @@ bit cj125isUrDivided;+Is your UR CJ125 output wired to MCU via resistor divider?
 bit useCicPidForIdle;+Switch between Industrial and Cic PID implementation
 bit useTLE8888_cranking_hack;
 bit useInstantRpmForIdle;
-bit absoluteFuelPressure;+If your fuel regulator does not have vacuum line
+bit unused76b19;
 bit launchControlEnabled;
 bit rollingLaunchEnabled;
 bit antiLagEnabled;
@@ -1167,7 +1167,7 @@ custom pin_mode_e 1 bits,    U08,   @OFFSET@, [0:6], @@pin_mode_e_enum@@
 	float wwaeTau;+Length of time the deposited wall fuel takes to dissipate after the start of acceleration. ;"Seconds",        1,     0,    0.0,    3.0,  2
 	pid_s alternatorControl;
 	pid_s etb;
-	float fuelRailPressure;;     "kPa",    1,      0.0,       0,  1000.0,        2
+	float unused1756;;"",1,0,0,1,0
 	float alternator_derivativeFilterLoss;;    "x",    1,      0.0,       -1000000,  1000000,        4
 	float alternator_antiwindupFreq;;    "x",    1,      0.0,       -1000000,  1000000,        4
 int16_t tps2Min;Closed throttle#2. todo: extract these two fields into a structure\nSee also tps2_1AdcChannel\nset tps2_min X;"ADC",      1,     0,    0, 1023,      0

--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -1328,8 +1328,8 @@ tle8888_mode_e tle8888mode;
 	float unused244_2;;"units", 1, 0, -20, 100, 0
 	float unused244_3;;"units", 1, 0, -20, 100, 0
 	float unused2432;;"units", 1, 0, -20, 100, 0
-	float postCrankingFactor;+Fuel multiplier (enrichment) immediately after engine start;"mult",        1,     0,  0,    100,  4
-	float postCrankingDurationSec;+Time over which to taper out after start enrichment;"seconds",        1,     0,  0,    100,  2
+	float postCrankingFactor;+Fuel multiplier (enrichment) immediately after engine start;"mult",        1,     0,  1,    3,  2
+	float postCrankingDurationSec;+Time over which to taper out after start enrichment;"seconds",        1,     0,  0,    30,  2
 	ThermistorConf auxTempSensor1;todo: finish implementation #332
 	ThermistorConf auxTempSensor2;todo: finish implementation #332
 	uint8_t[6] unused2508;;"units", 1, 0, -20, 100, 0

--- a/firmware/tunerstudio/rusefi.input
+++ b/firmware/tunerstudio/rusefi.input
@@ -1372,7 +1372,7 @@ menuDialog = main
 		# Digital outputs
 		subMenu = mainRelayDialog,			"Main relay"
 		subMenu = starterRelay,				"Starter Disable relay"
-		subMenu = fuelPump,					"Fuel pump & rail"
+		subMenu = fuelPump,					"Fuel pump"
 		subMenu = fanSetting,				"Fan"
 		subMenu = tachSettings,				"Tachometer"
 		subMenu = malfunction,				"Check engine light"
@@ -1475,7 +1475,7 @@ menuDialog = main
 		subMenu = pedalToTpsTbl,			"ETB pedal target" @@if_ts_show_etb
 
 		subMenu = std_separator
-		subMenu = vvtPidDialog,				"VVT outputs & PID"
+		subMenu = vvtPidDialog,				"VVT outputs and PID"
         subMenu = vvtTable1Tbl,             "VVT intake target"
         subMenu = vvtTable2Tbl,             "VVT exhaust target"
 
@@ -2645,19 +2645,10 @@ cmd_set_engine_type_default					= "@@TS_IO_TEST_COMMAND_char@@\x00\x31\x00\x00"
 		field = "A/C Relay",						acRelayPin
 		field = "A/C Relay Mode",					acRelayPinMode
 
-	dialog = fuelPumpConfig, "Fuel Pump"
+	dialog = fuelPump, "Fuel Pump"
 		field = "Pin",						fuelPumpPin
 		field = "Pin mode",         	        fuelPumpPinMode
 		field = "Prime duration",				startUpFuelPumpDuration
-
-	dialog = fuelRailConfig, "Fuel Rail"
-		field = "Absolute Fuel Pressure",			absoluteFuelPressure
-		field = "Fuel Rail pressure",			fuelRailPressure, {absoluteFuelPressure == 1}
-
-	dialog = fuelPump, ""
-		panel = fuelPumpConfig
-		panel = fuelRailConfig
-
 
 ;			Controller->Actuator Outputs
 	dialog = mainRelayDialog, "Main relay output"

--- a/firmware/tunerstudio/rusefi.input
+++ b/firmware/tunerstudio/rusefi.input
@@ -1382,7 +1382,7 @@ menuDialog = main
 		# basic
 		subMenu = injectorConfig,			"Injection configuration"
 		subMenu = injectionSettings,		"Injection hardware", 0, {isInjectionEnabled == 1}
-		subMenu = cylinderBankSelect,		"Cylinder Bank Selection"
+		subMenu = cylinderBankSelect,		"Cylinder bank selection"
 		subMenu = std_separator
 
 		# Air mass model
@@ -1973,8 +1973,8 @@ cmd_set_engine_type_default					= "@@TS_IO_TEST_COMMAND_char@@\x00\x31\x00\x00"
 		field = "Extra cyl #12",                       timing_offset_cylinder12, {cylindersCount > 11}
 
 	dialog = multisparkDwellParams, "Delay & Dwell"
-		field = "Spark Duration",						multisparkSparkDuration, {multisparkEnable}
-		field = "Dwell",								multisparkDwell, {multisparkEnable}
+		field = "Spark duration",						multisparkSparkDuration, {multisparkEnable}
+		field = "Subsequent spark dwell",				multisparkDwell, {multisparkEnable}
 
 	dialog = multisparkMain, "Configuration"
 		field = "Maximum engine speed",					multisparkMaxRpm, {multisparkEnable}

--- a/firmware/tunerstudio/rusefi.input
+++ b/firmware/tunerstudio/rusefi.input
@@ -1382,6 +1382,7 @@ menuDialog = main
 		# basic
 		subMenu = injectorConfig,			"Injection configuration"
 		subMenu = injectionSettings,		"Injection hardware", 0, {isInjectionEnabled == 1}
+		subMenu = cylinderBankSelect,		"Cylinder Bank Selection"
 		subMenu = std_separator
 
 		# Air mass model
@@ -1419,8 +1420,7 @@ menuDialog = main
 
 		subMenu = dwellSettings,			"Dwell", 0, {isIgnitionEnabled == 1}
 		subMenu = ignitionCylExtra,			"Ignition cylinder trim", 0, {isIgnitionEnabled == 1}
-		; todo: once proven, uncomment and remove from the "broken" menu
-		; subMenu = multisparkSettings,		"Multispark", 0, {isIgnitionEnabled == 1}
+		subMenu = multisparkSettings,		"Multispark", 0, {isIgnitionEnabled == 1}
 		subMenu = std_separator
 
 		subMenu = ignitionTableTbl,			"Ignition advance", 0, {isIgnitionEnabled}
@@ -1469,18 +1469,26 @@ menuDialog = main
 		subMenu = gppwm3, "General Purpose PWM 3"
 		subMenu = gppwm4, "General Purpose PWM 4"
 
+		subMenu = std_separator				@@if_ts_show_etb
+		subMenu = etbDialog,				"Electronic throttle body" @@if_ts_show_etb
+		subMenu = etbTpsBiasCurve,			"ETB bias curve (feed forward)" @@if_ts_show_etb
+		subMenu = pedalToTpsTbl,			"ETB pedal target" @@if_ts_show_etb
+
+		subMenu = std_separator
+		subMenu = vvtPidDialog,				"VVT outputs & PID"
+        subMenu = vvtTable1Tbl,             "VVT intake target"
+        subMenu = vvtTable2Tbl,             "VVT exhaust target"
+
 		subMenu = std_separator
 		subMenu = fsioInputsDialog,        	"FSIO inputs"
-		subMenu = vvtPidDialog,				"VVT PID"
-        subMenu = vvtTable1Tbl,             "VVT Table #1"
-        subMenu = vvtTable2Tbl,             "VVT Table #2"
-        subMenu = std_separator
 		subMenu = fsioOutputsDialog,        "FSIO outputs"
+		subMenu = fsioFormulas,				"FSIO Formulas"
+
+		subMenu = std_separator
 		subMenu = fsioTable1Tbl,			"FSIO Table #1"
 		subMenu = fsioTable2Tbl,			"FSIO Table #2"
 		subMenu = fsioTable3Tbl,			"FSIO Table #3"
 		subMenu = fsioTable4Tbl,			"FSIO Table #4"
-		subMenu = fsioFormulas,				"FSIO Formulas"
 		subMenu = fsioCurve1,			    "FSIO Curve #1"
 		subMenu = fsioCurve2,			    "FSIO Curve #2"
 		subMenu = fsioCurve3,			    "FSIO Curve #3"
@@ -1521,6 +1529,7 @@ menuDialog = main
 
 		# O2 sensor(s)
 		subMenu = egoSettings,				"EGO sensor"
+		subMenu = widebandConfig,			"rusEFI Wideband Controller", 0, { canReadEnabled && canWriteEnabled }
 		subMenu = narrowToWideOxygenCurve,	"Narrow to Wideband approximation"
 		subMenu = cj125Function,			"CJ125 settings (wbo decoder)" @@if_ts_show_cj125
 		subMenu = std_separator
@@ -1559,21 +1568,14 @@ menuDialog = main
 
 		# EXPERIMENTAL FEATURES
 		subMenu = parkingLot,				"Experimental/Broken"
-		subMenu = multisparkSettings,		"Multispark", 0, {isIgnitionEnabled == 1}
 		subMenu = mc33Dialog,			"GDI Dreams"
-		subMenu = widebandConfig,			"rusEFI Wideband Controller", 0, { canReadEnabled && canWriteEnabled }
-		subMenu = cylinderBankSelect,		"Cylinder Bank Selection"
 		subMenu = std_separator
 		
 		subMenu = hipFunction,				"HIP9011 settings (knock sensor) (alpha version)" @@if_ts_show_hip9011
 		subMenu = softwareKnock,			"Software Knock" @@if_ts_show_software_knock
 		subMenu = std_separator
 
-		subMenu = etbDialog,				"Electronic throttle body (beta version)" @@if_ts_show_etb
-		subMenu = etbTpsBiasCurve,			"Electronic throttle body bias curve" @@if_ts_show_etb
-		subMenu = pedalToTpsTbl,			"Electronic Pedal Map" @@if_ts_show_etb
-		subMenu = std_separator
-        subMenu = smLaunchControl,			"Launch Control"
+		subMenu = smLaunchControl,			"Launch Control"
 		subMenu = std_separator
 #		subMenu = smRollingLaunch,			"Rolling Launch"
 #		subMenu = std_separator
@@ -2805,16 +2807,15 @@ cmd_set_engine_type_default					= "@@TS_IO_TEST_COMMAND_char@@\x00\x31\x00\x00"
 		panel = stftPartitionSettingsPower, {fuelClosedLoopCorrectionEnabled == 1}
 		panel = stftPartitionSettingsOverrun, {fuelClosedLoopCorrectionEnabled == 1}
 
-	dialog = vvtPidDialog0, "VVT PID0"
-		field = "First Shaft Bank#1",					auxPidPins1
-        field = "Second Shaft Bank#1",                  auxPidPins2
-        field = "First Shaft Bank#2",                   auxPidPins3
-        field = "Second Shaft Bank#2",                  auxPidPins4
-		field = "PWM Frequency",						auxPidFrequency1, {auxPidPins1 != 0 || auxPidPins2 != 0}
+	dialog = vvtPidDialog0, "Configuration"
+		field = "VVT solenoid bank 1 intake",					auxPidPins1
+        field = "VVT solenoid bank 1 exhaust",                  auxPidPins2
+        field = "VVT solenoid bank 2 intake",                   auxPidPins3
+        field = "VVT solenoid bank 2 exhaust",                  auxPidPins4
+		field = "PWM frequency",						auxPidFrequency1, {auxPidPins1 != 0 || auxPidPins2 != 0}
 		field = "Detailed status in console",			isVerboseAuxPid1, {auxPidPins1 != 0 || auxPidPins2 != 0}
-		field = "control period",						auxPid1_periodMs, {auxPidPins1 != 0 || auxPidPins2 != 0}
 
-    dialog = vvtPidDialog1, "First Shaft PID"
+    dialog = vvtPidDialog1, "Intake PID"
         field = "offset",                               auxPid1_offset, {auxPidPins1 != 0}
         field = "P factor",                             auxPid1_pFactor, {auxPidPins1 != 0}
         field = "I factor",                             auxPid1_iFactor, {auxPidPins1 != 0}
@@ -2822,7 +2823,7 @@ cmd_set_engine_type_default					= "@@TS_IO_TEST_COMMAND_char@@\x00\x31\x00\x00"
         field = "Min",                                  auxPid1_minValue, {auxPidPins1 != 0}
         field = "Max",                                  auxPid1_maxValue, {auxPidPins1 != 0}
 
-    dialog = vvtPidDialog2, "Second Shaft PID"
+    dialog = vvtPidDialog2, "Exhaust PID"
         field = "offset",                               auxPid2_offset, {auxPidPins2 != 0}
         field = "P factor",                             auxPid2_pFactor, {auxPidPins2 != 0}
         field = "I factor",                             auxPid2_iFactor, {auxPidPins2 != 0}
@@ -2830,7 +2831,7 @@ cmd_set_engine_type_default					= "@@TS_IO_TEST_COMMAND_char@@\x00\x31\x00\x00"
         field = "Min",                                  auxPid2_minValue, {auxPidPins2 != 0}
         field = "Max",                                  auxPid2_maxValue, {auxPidPins2 != 0}
 
-    dialog = vvtPidDialog, "VVT PID", border
+    dialog = vvtPidDialog, "VVT Configuration & PID", border
         panel = vvtPidDialog0,         West
         panel = vvtPidDialog1,  Center
         panel = vvtPidDialog2,    East


### PR DESCRIPTION
- remove dead `fuelRailPressure` field, fix corresponding NB miata and VW defaults to use correct config for fixed rail pressure
- Shuffle around some menu options, mostly moving things out of the giant controller menu in to places where they belong
- Write tooltips for multispark
- update language on VVT PID page to match trigger input page
- a little bit of "human proofing" for after start enrichment options so you can't set it to options that makes your engine hard to start