### PR TITLE
Hellen72: Set the default pin states to input-pulldown instead of input-pullup

### DIFF
--- a/firmware/config/boards/hellen/hellen72/board.h
+++ b/firmware/config/boards/hellen/hellen72/board.h
@@ -40,10 +40,11 @@
 #define BOARD_OTG_NOVBUSSENS TRUE
 
 /*
- * Default to input mode, with internal pulldown resistor enabled.
+ * Default to input mode, with internal PULLDOWN resistor enabled.
+ * Pulldowns are more safe because most of MCU outputs on Hellen are high-active.
  */
 #define EFI_PIN_MODE_DEFAULT PIN_MODE_INPUT
-#define EFI_DR_DEFAULT PIN_PUPDR_PULLUP
+#define EFI_DR_DEFAULT PIN_PUPDR_PULLDOWN
 
 // See https://github.com/rusefi/rusefi/issues/397
 #define DEFAULT_GPIO_SPEED PIN_OSPEED_HIGH


### PR DESCRIPTION
This may solve some transient startup issues with Idle and VVT