### PR TITLE
gppwm zero option

### DIFF
--- a/firmware/controllers/actuators/gppwm/gppwm_channel.cpp
+++ b/firmware/controllers/actuators/gppwm/gppwm_channel.cpp
@@ -28,6 +28,8 @@ expected<float> readGppwmChannel(gppwm_channel_e channel DECLARE_ENGINE_PARAMETE
 		return Sensor::get(SensorType::AuxTemp1);
 	case GPPWM_AuxTemp2:
 		return Sensor::get(SensorType::AuxTemp2);
+	case GPPWM_Zero:
+		return 0;
 	}
 
 	return unexpected;

--- a/firmware/controllers/algo/rusefi_enums.h
+++ b/firmware/controllers/algo/rusefi_enums.h
@@ -1013,6 +1013,7 @@ typedef enum __attribute__ ((__packed__)) {
 	GPPWM_IgnLoad = 5,
 	GPPWM_AuxTemp1 = 6,
 	GPPWM_AuxTemp2 = 7,
+	GPPWM_Zero = 8,
 } gppwm_channel_e;
 
 typedef enum __attribute__ ((__packed__)) {

--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -331,8 +331,8 @@ struct spi_pins
 end_struct
 
 
-#define gppwm_channel_e_enum "TPS", "MAP", "CLT", "IAT", "Fuel Load", "Ignition Load", "Aux Temp 1", "Aux Temp 2"
-custom gppwm_channel_e 1 bits, U08, @OFFSET@, [0:2], @@gppwm_channel_e_enum@@
+#define gppwm_channel_e_enum "TPS", "MAP", "CLT", "IAT", "Fuel Load", "Ignition Load", "Aux Temp 1", "Aux Temp 2", "Zero"
+custom gppwm_channel_e 1 bits, U08, @OFFSET@, [0:3], @@gppwm_channel_e_enum@@
 
 struct gppwm_channel
 	output_pin_e pin;+Select a pin to use for PWM or on-off output.;


### PR DESCRIPTION
add a Y axis option that's forced to zero, in case you want to emulate a 1d table instead of a 2d table