### PR TITLE
rip the bandaid: find-replace most of scheduleMsg

### DIFF
--- a/firmware/console/eficonsole.cpp
+++ b/firmware/console/eficonsole.cpp
@@ -27,8 +27,6 @@
 #include "console_io.h"
 #include "svnversion.h"
 
-static LoggingWithStorage logger("console");
-
 static void testCritical(void) {
 	chDbgCheck(0);
 }
@@ -38,78 +36,75 @@ static void myerror(void) {
 }
 
 static void sayHello(void) {
-	scheduleMsg(&logger, PROTOCOL_HELLO_PREFIX " rusEFI LLC (c) 2012-2021. All rights reserved.");
-	scheduleMsg(&logger, PROTOCOL_HELLO_PREFIX " rusEFI v%d@%s", getRusEfiVersion(), VCS_VERSION);
-	scheduleMsg(&logger, PROTOCOL_HELLO_PREFIX " Chibios Kernel:       %s", CH_KERNEL_VERSION);
-	scheduleMsg(&logger, PROTOCOL_HELLO_PREFIX " Compiled:     " __DATE__ " - " __TIME__ "");
-	scheduleMsg(&logger, PROTOCOL_HELLO_PREFIX " COMPILER=%s", __VERSION__);
+	efiPrintf(PROTOCOL_HELLO_PREFIX " rusEFI LLC (c) 2012-2021. All rights reserved.");
+	efiPrintf(PROTOCOL_HELLO_PREFIX " rusEFI v%d@%s", getRusEfiVersion(), VCS_VERSION);
+	efiPrintf(PROTOCOL_HELLO_PREFIX " Chibios Kernel:       %s", CH_KERNEL_VERSION);
+	efiPrintf(PROTOCOL_HELLO_PREFIX " Compiled:     " __DATE__ " - " __TIME__ "");
+	efiPrintf(PROTOCOL_HELLO_PREFIX " COMPILER=%s", __VERSION__);
 
 #if defined(STM32F4) || defined(STM32F7)
 	uint32_t *uid = ((uint32_t *)UID_BASE);
-	scheduleMsg(&logger, "UID=%x %x %x", uid[0], uid[1], uid[2]);
+	efiPrintf("UID=%x %x %x", uid[0], uid[1], uid[2]);
 
 #define 	TM_ID_GetFlashSize()    (*(__IO uint16_t *) (FLASHSIZE_BASE))
 #define MCU_REVISION_MASK  0xfff
 
 	int mcuRevision = DBGMCU->IDCODE & MCU_REVISION_MASK;
 
-	scheduleMsg(&logger, "rev=%x size=%d", mcuRevision, TM_ID_GetFlashSize());
+	efiPrintf("rev=%x size=%d", mcuRevision, TM_ID_GetFlashSize());
 #endif
 
 
 #ifdef CH_FREQUENCY
-	scheduleMsg(&logger, "CH_FREQUENCY=%d", CH_FREQUENCY);
+	efiPrintf("CH_FREQUENCY=%d", CH_FREQUENCY);
 #endif
 
 #ifdef CORTEX_MAX_KERNEL_PRIORITY
-	scheduleMsg(&logger, "CORTEX_MAX_KERNEL_PRIORITY=%d", CORTEX_MAX_KERNEL_PRIORITY);
+	efiPrintf("CORTEX_MAX_KERNEL_PRIORITY=%d", CORTEX_MAX_KERNEL_PRIORITY);
 #endif
 
 #ifdef STM32_ADCCLK
-	scheduleMsg(&logger, "STM32_ADCCLK=%d", STM32_ADCCLK);
-	scheduleMsg(&logger, "STM32_TIMCLK1=%d", STM32_TIMCLK1);
-	scheduleMsg(&logger, "STM32_TIMCLK2=%d", STM32_TIMCLK2);
+	efiPrintf("STM32_ADCCLK=%d", STM32_ADCCLK);
+	efiPrintf("STM32_TIMCLK1=%d", STM32_TIMCLK1);
+	efiPrintf("STM32_TIMCLK2=%d", STM32_TIMCLK2);
 #endif
 #ifdef STM32_PCLK1
-	scheduleMsg(&logger, "STM32_PCLK1=%d", STM32_PCLK1);
-	scheduleMsg(&logger, "STM32_PCLK2=%d", STM32_PCLK2);
+	efiPrintf("STM32_PCLK1=%d", STM32_PCLK1);
+	efiPrintf("STM32_PCLK2=%d", STM32_PCLK2);
 #endif
 
-	scheduleMsg(&logger, "PORT_IDLE_THREAD_STACK_SIZE=%d", PORT_IDLE_THREAD_STACK_SIZE);
+	efiPrintf("PORT_IDLE_THREAD_STACK_SIZE=%d", PORT_IDLE_THREAD_STACK_SIZE);
 
-	scheduleMsg(&logger, "CH_DBG_ENABLE_ASSERTS=%d", CH_DBG_ENABLE_ASSERTS);
+	efiPrintf("CH_DBG_ENABLE_ASSERTS=%d", CH_DBG_ENABLE_ASSERTS);
 #ifdef CH_DBG_ENABLED
-	scheduleMsg(&logger, "CH_DBG_ENABLED=%d", CH_DBG_ENABLED);
+	efiPrintf("CH_DBG_ENABLED=%d", CH_DBG_ENABLED);
 #endif
-	scheduleMsg(&logger, "CH_DBG_SYSTEM_STATE_CHECK=%d", CH_DBG_SYSTEM_STATE_CHECK);
-	scheduleMsg(&logger, "CH_DBG_ENABLE_STACK_CHECK=%d", CH_DBG_ENABLE_STACK_CHECK);
+	efiPrintf("CH_DBG_SYSTEM_STATE_CHECK=%d", CH_DBG_SYSTEM_STATE_CHECK);
+	efiPrintf("CH_DBG_ENABLE_STACK_CHECK=%d", CH_DBG_ENABLE_STACK_CHECK);
 
 #ifdef EFI_LOGIC_ANALYZER
-	scheduleMsg(&logger, "EFI_LOGIC_ANALYZER=%d", EFI_LOGIC_ANALYZER);
+	efiPrintf("EFI_LOGIC_ANALYZER=%d", EFI_LOGIC_ANALYZER);
 #endif
 #ifdef EFI_TUNER_STUDIO
-	scheduleMsg(&logger, "EFI_TUNER_STUDIO=%d", EFI_TUNER_STUDIO);
+	efiPrintf("EFI_TUNER_STUDIO=%d", EFI_TUNER_STUDIO);
 #else
-	scheduleMsg(&logger, "EFI_TUNER_STUDIO=%d", 0);
+	efiPrintf("EFI_TUNER_STUDIO=%d", 0);
 #endif
 
 #ifdef EFI_SIGNAL_EXECUTOR_SLEEP
-	scheduleMsg(&logger, "EFI_SIGNAL_EXECUTOR_SLEEP=%d", EFI_SIGNAL_EXECUTOR_SLEEP);
+	efiPrintf("EFI_SIGNAL_EXECUTOR_SLEEP=%d", EFI_SIGNAL_EXECUTOR_SLEEP);
 #endif
 
 #ifdef EFI_SIGNAL_EXECUTOR_HW_TIMER
-	scheduleMsg(&logger, "EFI_SIGNAL_EXECUTOR_HW_TIMER=%d", EFI_SIGNAL_EXECUTOR_HW_TIMER);
+	efiPrintf("EFI_SIGNAL_EXECUTOR_HW_TIMER=%d", EFI_SIGNAL_EXECUTOR_HW_TIMER);
 #endif
 
 #if defined(EFI_SHAFT_POSITION_INPUT)
-	scheduleMsg(&logger, "EFI_SHAFT_POSITION_INPUT=%d", EFI_SHAFT_POSITION_INPUT);
+	efiPrintf("EFI_SHAFT_POSITION_INPUT=%d", EFI_SHAFT_POSITION_INPUT);
 #endif
 #ifdef EFI_INTERNAL_ADC
-	scheduleMsg(&logger, "EFI_INTERNAL_ADC=%d", EFI_INTERNAL_ADC);
+	efiPrintf("EFI_INTERNAL_ADC=%d", EFI_INTERNAL_ADC);
 #endif
-
-//	printSimpleMsg(&logger, "", );
-//	printSimpleMsg(&logger, "", );
 
 	/**
 	 * Time to finish output. This is needed to avoid mix-up of this methods output and console command confirmation
@@ -151,21 +146,21 @@ static void cmd_threads(void) {
 
 	thread_t* tp = chRegFirstThread();
 
-	scheduleMsg(&logger, "name\twabase\ttime\tfree stack");
+	efiPrintf("name\twabase\ttime\tfree stack");
 
 	while (tp) {
 		int freeBytes = CountFreeStackSpace(tp->wabase);
-		scheduleMsg(&logger, "%s\t%08x\t%lu\t%d", tp->name, tp->wabase, tp->time, freeBytes);
+		efiPrintf("%s\t%08x\t%lu\t%d", tp->name, tp->wabase, tp->time, freeBytes);
 
 		tp = chRegNextThread(tp);
 	}
 
 	int isrSpace = CountFreeStackSpace(reinterpret_cast<void*>(0x20000000));
-	scheduleMsg(&logger, "isr\t0\t0\t%d", isrSpace);
+	efiPrintf("isr\t0\t0\t%d", isrSpace);
 
 #else // CH_DBG_THREADS_PROFILING && CH_DBG_FILL_THREADS
 
-  scheduleMsg(&logger, "CH_DBG_THREADS_PROFILING && CH_DBG_FILL_THREADS is not enabled");
+  efiPrintf("CH_DBG_THREADS_PROFILING && CH_DBG_FILL_THREADS is not enabled");
 
 #endif
 }

--- a/firmware/console/status_loop.cpp
+++ b/firmware/console/status_loop.cpp
@@ -179,8 +179,6 @@ void writeLogLine(Writer& buffer) {
 
 static int prevCkpEventCounter = -1;
 
-static LoggingWithStorage logger2("main event handler");
-
 /**
  * Time when the firmware version was reported last time, in seconds
  * TODO: implement a request/response instead of just constantly sending this out
@@ -257,7 +255,7 @@ void updateDevConsoleState(void) {
 #if EFI_PROD_CODE
 	// todo: unify with simulator!
 	if (hasFirmwareError()) {
-		scheduleMsg(&logger, "%s error: %s", CRITICAL_PREFIX, getFirmwareError());
+		efiPrintf("%s error: %s", CRITICAL_PREFIX, getFirmwareError());
 		warningEnabled = false;
 		return;
 	}
@@ -295,27 +293,27 @@ void updateDevConsoleState(void) {
  */
 
 static void showFuelInfo2(float rpm, float engineLoad) {
-	scheduleMsg(&logger, "inj flow %.2fcc/min displacement %.2fL", engineConfiguration->injector.flow,
+	efiPrintf("inj flow %.2fcc/min displacement %.2fL", engineConfiguration->injector.flow,
 			engineConfiguration->specs.displacement);
 
-	scheduleMsg(&logger2, "algo=%s/pump=%s", getEngine_load_mode_e(engineConfiguration->fuelAlgorithm),
+	efiPrintf("algo=%s/pump=%s", getEngine_load_mode_e(engineConfiguration->fuelAlgorithm),
 			boolToString(enginePins.fuelPumpRelay.getLogicValue()));
 
-	scheduleMsg(&logger2, "injection phase=%.2f/global fuel correction=%.2f", getInjectionOffset(rpm, getFuelingLoad()), engineConfiguration->globalFuelCorrection);
+	efiPrintf("injection phase=%.2f/global fuel correction=%.2f", getInjectionOffset(rpm, getFuelingLoad()), engineConfiguration->globalFuelCorrection);
 
-	scheduleMsg(&logger2, "baro correction=%.2f", engine->engineState.baroCorrection);
+	efiPrintf("baro correction=%.2f", engine->engineState.baroCorrection);
 
 #if EFI_ENGINE_CONTROL
-	scheduleMsg(&logger, "base cranking fuel %.2f", engineConfiguration->cranking.baseFuel);
-	scheduleMsg(&logger2, "cranking fuel: %.2f", ENGINE(engineState.cranking.fuel));
+	efiPrintf("base cranking fuel %.2f", engineConfiguration->cranking.baseFuel);
+	efiPrintf("cranking fuel: %.2f", ENGINE(engineState.cranking.fuel));
 
 	if (!engine->rpmCalculator.isStopped()) {
 		float iatCorrection = engine->engineState.running.intakeTemperatureCoefficient;
 		float cltCorrection = engine->engineState.running.coolantTemperatureCoefficient;
 		floatms_t injectorLag = engine->engineState.running.injectorLag;
-		scheduleMsg(&logger2, "rpm=%.2f engineLoad=%.2f", rpm, engineLoad);
+		efiPrintf("rpm=%.2f engineLoad=%.2f", rpm, engineLoad);
 
-		scheduleMsg(&logger2, "iatCorrection=%.2f cltCorrection=%.2f injectorLag=%.2f", iatCorrection, cltCorrection,
+		efiPrintf("iatCorrection=%.2f cltCorrection=%.2f injectorLag=%.2f", iatCorrection, cltCorrection,
 				injectorLag);
 	}
 #endif

--- a/firmware/controllers/actuators/alternator_controller.cpp
+++ b/firmware/controllers/actuators/alternator_controller.cpp
@@ -109,7 +109,7 @@ class AlternatorController : public PeriodicTimerController {
 		} else {
 			currentAltDuty = alternatorPid.getOutput(targetVoltage, vBatt.Value);
 			if (CONFIG(isVerboseAlternator)) {
-				scheduleMsg(logger, "alt duty: %.2f/vbatt=%.2f/p=%.2f/i=%.2f/d=%.2f int=%.2f", currentAltDuty, vBatt.Value,
+				efiPrintf("alt duty: %.2f/vbatt=%.2f/p=%.2f/i=%.2f/d=%.2f int=%.2f", currentAltDuty, vBatt.Value,
 						alternatorPid.getP(), alternatorPid.getI(), alternatorPid.getD(), alternatorPid.getIntegration());
 			}
 
@@ -121,18 +121,18 @@ class AlternatorController : public PeriodicTimerController {
 static AlternatorController instance;
 
 void showAltInfo(void) {
-	scheduleMsg(logger, "alt=%s @%s t=%dms", boolToString(engineConfiguration->isAlternatorControlEnabled),
+	efiPrintf("alt=%s @%s t=%dms", boolToString(engineConfiguration->isAlternatorControlEnabled),
 			hwPortname(CONFIG(alternatorControlPin)),
 			engineConfiguration->alternatorControl.periodMs);
-	scheduleMsg(logger, "p=%.2f/i=%.2f/d=%.2f offset=%.2f", engineConfiguration->alternatorControl.pFactor,
+	efiPrintf("p=%.2f/i=%.2f/d=%.2f offset=%.2f", engineConfiguration->alternatorControl.pFactor,
 			0, 0, engineConfiguration->alternatorControl.offset); // todo: i & d
-	scheduleMsg(logger, "vbatt=%.2f/duty=%.2f/target=%.2f", Sensor::get(SensorType::BatteryVoltage).value_or(0), currentAltDuty,
+	efiPrintf("vbatt=%.2f/duty=%.2f/target=%.2f", Sensor::get(SensorType::BatteryVoltage).value_or(0), currentAltDuty,
 			engineConfiguration->targetVBatt);
 }
 
 void setAltPFactor(float p) {
 	engineConfiguration->alternatorControl.pFactor = p;
-	scheduleMsg(logger, "setAltPid: %.2f", p);
+	efiPrintf("setAltPid: %.2f", p);
 	pidReset();
 	showAltInfo();
 }

--- a/firmware/controllers/actuators/electronic_throttle.cpp
+++ b/firmware/controllers/actuators/electronic_throttle.cpp
@@ -93,7 +93,6 @@
 #define ETB_MAX_COUNT 2
 #endif /* ETB_MAX_COUNT */
 
-static LoggingWithStorage logger("ETB");
 static pedal2tps_t pedal2tpsMap("Pedal2Tps");
 
 EXTERN_ENGINE;
@@ -697,23 +696,23 @@ static EtbThread etbThread;
 
 static void showEthInfo(void) {
 #if EFI_PROD_CODE
-	scheduleMsg(&logger, "etbAutoTune=%d",
+	efiPrintf("etbAutoTune=%d",
 			engine->etbAutoTune);
 
-	scheduleMsg(&logger, "TPS=%.2f", Sensor::get(SensorType::Tps1).value_or(0));
+	efiPrintf("TPS=%.2f", Sensor::get(SensorType::Tps1).value_or(0));
 
 
-	scheduleMsg(&logger, "etbControlPin1=%s duty=%.2f freq=%d",
+	efiPrintf("etbControlPin1=%s duty=%.2f freq=%d",
 			hwPortname(CONFIG(etbIo[0].controlPin1)),
 			currentEtbDuty,
 			engineConfiguration->etbFreq);
 
 	for (int i = 0; i < ETB_COUNT; i++) {
-		scheduleMsg(&logger, "ETB%d", i);
-		scheduleMsg(&logger, " dir1=%s", hwPortname(CONFIG(etbIo[i].directionPin1)));
-		scheduleMsg(&logger, " dir2=%s", hwPortname(CONFIG(etbIo[i].directionPin2)));
-		scheduleMsg(&logger, " control=%s", hwPortname(CONFIG(etbIo[i].controlPin1)));
-		scheduleMsg(&logger, " disable=%s", hwPortname(CONFIG(etbIo[i].disablePin)));
+		efiPrintf("ETB%d", i);
+		efiPrintf(" dir1=%s", hwPortname(CONFIG(etbIo[i].directionPin1)));
+		efiPrintf(" dir2=%s", hwPortname(CONFIG(etbIo[i].directionPin2)));
+		efiPrintf(" control=%s", hwPortname(CONFIG(etbIo[i].controlPin1)));
+		efiPrintf(" disable=%s", hwPortname(CONFIG(etbIo[i].disablePin)));
 		showDcMotorInfo(i);
 	}
 
@@ -738,7 +737,7 @@ static void etbPidReset(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
  * manual duty cycle control without PID. Percent value from 0 to 100
  */
 void setThrottleDutyCycle(percent_t level) {
-	scheduleMsg(&logger, "setting ETB duty=%f%%", level);
+	efiPrintf("setting ETB duty=%f%%", level);
 	if (cisnan(level)) {
 		directPwmValue = NAN;
 		return;
@@ -749,7 +748,7 @@ void setThrottleDutyCycle(percent_t level) {
 	for (int i = 0 ; i < ETB_COUNT; i++) {
 		setDcMotorDuty(i, dc);
 	}
-	scheduleMsg(&logger, "duty ETB duty=%f", dc);
+	efiPrintf("duty ETB duty=%f", dc);
 }
 
 static void setEtbFrequency(int frequency) {
@@ -761,7 +760,7 @@ static void setEtbFrequency(int frequency) {
 }
 
 static void etbReset() {
-	scheduleMsg(&logger, "etbReset");
+	efiPrintf("etbReset");
 	
 	for (int i = 0 ; i < ETB_COUNT; i++) {
 		setDcMotorDuty(i, 0);

--- a/firmware/controllers/actuators/pwm_tester.cpp
+++ b/firmware/controllers/actuators/pwm_tester.cpp
@@ -15,8 +15,6 @@
 #include "pwm_generator_logic.h"
 #include "engine.h"
 
-static LoggingWithStorage logger;
-
 static SimplePwm pwmTest[5];
 
 extern OutputPin warningLedPin;
@@ -24,7 +22,7 @@ extern OutputPin warningLedPin;
 EXTERN_ENGINE;
 
 static void startPwmTest(int freq) {
-	scheduleMsg(&logger, "running pwm test @%d", freq);
+	efiPrintf("running pwm test @%d", freq);
 
 	engine->isRunningPwmTest = true;
 

--- a/firmware/controllers/algo/accel_enrichment.cpp
+++ b/firmware/controllers/algo/accel_enrichment.cpp
@@ -329,14 +329,14 @@ static void accelInfo() {
 	if (!logger) {
 		return;
 	}
-//	scheduleMsg(logger, "EL accel length=%d", mapInstance.cb.getSize());
-	scheduleMsg(logger, "EL accel th=%.2f/mult=%.2f", engineConfiguration->engineLoadAccelEnrichmentThreshold, engineConfiguration->engineLoadAccelEnrichmentMultiplier);
-	scheduleMsg(logger, "EL decel th=%.2f/mult=%.2f", engineConfiguration->engineLoadDecelEnleanmentThreshold, engineConfiguration->engineLoadDecelEnleanmentMultiplier);
+//	efiPrintf("EL accel length=%d", mapInstance.cb.getSize());
+	efiPrintf("EL accel th=%.2f/mult=%.2f", engineConfiguration->engineLoadAccelEnrichmentThreshold, engineConfiguration->engineLoadAccelEnrichmentMultiplier);
+	efiPrintf("EL decel th=%.2f/mult=%.2f", engineConfiguration->engineLoadDecelEnleanmentThreshold, engineConfiguration->engineLoadDecelEnleanmentMultiplier);
 
-//	scheduleMsg(logger, "TPS accel length=%d", tpsInstance.cb.getSize());
-	scheduleMsg(logger, "TPS accel th=%.2f/mult=%.2f", engineConfiguration->tpsAccelEnrichmentThreshold, -1);
+//	efiPrintf("TPS accel length=%d", tpsInstance.cb.getSize());
+	efiPrintf("TPS accel th=%.2f/mult=%.2f", engineConfiguration->tpsAccelEnrichmentThreshold, -1);
 
-	scheduleMsg(logger, "beta=%.2f/tau=%.2f", engineConfiguration->wwaeBeta, engineConfiguration->wwaeTau);
+	efiPrintf("beta=%.2f/tau=%.2f", engineConfiguration->wwaeBeta, engineConfiguration->wwaeTau);
 }
 
 void setEngineLoadAccelThr(float value) {
@@ -376,7 +376,7 @@ void setDecelMult(float value) {
 
 void setTpsAccelLen(int length) {
 	if (length < 1) {
-		scheduleMsg(logger, "Length should be positive");
+		efiPrintf("Length should be positive");
 		return;
 	}
 	engine->tpsAccelEnrichment.setLength(length);
@@ -385,7 +385,7 @@ void setTpsAccelLen(int length) {
 
 void setEngineLoadAccelLen(int length) {
 	if (length < 1) {
-		scheduleMsg(logger, "Length should be positive");
+		efiPrintf("Length should be positive");
 		return;
 	}
 	engine->engineLoadAccelEnrichment.setLength(length);

--- a/firmware/controllers/algo/engine_configuration.cpp
+++ b/firmware/controllers/algo/engine_configuration.cpp
@@ -1507,7 +1507,7 @@ void validateConfiguration(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 void applyNonPersistentConfiguration(Logging * logger DECLARE_ENGINE_PARAMETER_SUFFIX) {
 #if EFI_PROD_CODE
 	efiAssertVoid(CUSTOM_APPLY_STACK, getCurrentRemainingStack() > EXPECTED_REMAINING_STACK, "apply c");
-	scheduleMsg(logger, "applyNonPersistentConfiguration()");
+	efiPrintf("applyNonPersistentConfiguration()");
 #endif
 
 	assertEngineReference();

--- a/firmware/controllers/bench_test.cpp
+++ b/firmware/controllers/bench_test.cpp
@@ -89,8 +89,8 @@ static void runBench(brain_pin_e brainPin, OutputPin *output, float delayMs, flo
 		return;
 	}
 
-	scheduleMsg(logger, "Running bench: ON_TIME=%d us OFF_TIME=%d us Counter=%d", onTimeUs, offTimeUs, count);
-	scheduleMsg(logger, "output on %s", hwPortname(brainPin));
+	efiPrintf("Running bench: ON_TIME=%d us OFF_TIME=%d us Counter=%d", onTimeUs, offTimeUs, count);
+	efiPrintf("output on %s", hwPortname(brainPin));
 
 	chThdSleepMicroseconds(delayUs);
 
@@ -110,7 +110,7 @@ static void runBench(brain_pin_e brainPin, OutputPin *output, float delayMs, flo
 		chThdSleepMicroseconds(onTimeUs + offTimeUs);
 	}
 
-	scheduleMsg(logger, "Done!");
+	efiPrintf("Done!");
 	isRunningBench = false;
 }
 
@@ -138,7 +138,7 @@ static void pinbench(const char *delayStr, const char *onTimeStr, const char *of
 static void doRunFuel(cylinders_count_t humanIndex, const char *delayStr, const char * onTimeStr, const char *offTimeStr,
 		const char *countStr) {
 	if (humanIndex < 1 || humanIndex > engineConfiguration->specs.cylindersCount) {
-		scheduleMsg(logger, "Invalid index: %d", humanIndex);
+		efiPrintf("Invalid index: %d", humanIndex);
 		return;
 	}
 	brain_pin_e b = CONFIG(injectionPins)[humanIndex - 1];
@@ -148,7 +148,7 @@ static void doRunFuel(cylinders_count_t humanIndex, const char *delayStr, const 
 static void doTestSolenoid(int humanIndex, const char *delayStr, const char * onTimeStr, const char *offTimeStr,
 		const char *countStr) {
 	if (humanIndex < 1 || humanIndex > TCU_SOLENOID_COUNT) {
-		scheduleMsg(logger, "Invalid index: %d", humanIndex);
+		efiPrintf("Invalid index: %d", humanIndex);
 		return;
 	}
 	brain_pin_e b = CONFIG(tcu_solenoid)[humanIndex - 1];
@@ -158,7 +158,7 @@ static void doTestSolenoid(int humanIndex, const char *delayStr, const char * on
 static void doBenchTestFsio(int humanIndex, const char *delayStr, const char * onTimeStr, const char *offTimeStr,
 		const char *countStr) {
 	if (humanIndex < 1 || humanIndex > FSIO_COMMAND_COUNT) {
-		scheduleMsg(logger, "Invalid index: %d", humanIndex);
+		efiPrintf("Invalid index: %d", humanIndex);
 		return;
 	}
 	brain_pin_e b = CONFIG(fsioOutputPins)[humanIndex - 1];
@@ -243,7 +243,7 @@ static void fuelbench(const char * onTimeStr, const char *offTimeStr, const char
 static void doRunSpark(cylinders_count_t humanIndex, const char *delayStr, const char * onTimeStr, const char *offTimeStr,
 		const char *countStr) {
 	if (humanIndex < 1 || humanIndex > engineConfiguration->specs.cylindersCount) {
-		scheduleMsg(logger, "Invalid index: %d", humanIndex);
+		efiPrintf("Invalid index: %d", humanIndex);
 		return;
 	}
 	brain_pin_e b = CONFIG(ignitionPins)[humanIndex - 1];
@@ -399,7 +399,7 @@ static void fatalErrorForPresetApply() {
 }
 
 void executeTSCommand(uint16_t subsystem, uint16_t index) {
-	scheduleMsg(logger, "IO test subsystem=%d index=%d", subsystem, index);
+	efiPrintf("IO test subsystem=%d index=%d", subsystem, index);
 
 	bool running = !ENGINE(rpmCalculator).isStopped();
 

--- a/firmware/controllers/can/can_vss.cpp
+++ b/firmware/controllers/can/can_vss.cpp
@@ -70,10 +70,10 @@ void processW202(const CANRxFrame& frame) {
 /* End of specific processing functions */
 
 void canVssInfo(void) {
-    scheduleMsg(logger, "vss using can option selected %x", CONFIG(canVssNbcType));
-    scheduleMsg(logger, "vss filter for %x canID", filterCanID);
-    scheduleMsg(logger, "Vss module is %d", isInit);
-    scheduleMsg(logger, "CONFIG_enableCanVss is %d", CONFIG(enableCanVss));
+    efiPrintf("vss using can option selected %x", CONFIG(canVssNbcType));
+    efiPrintf("vss filter for %x canID", filterCanID);
+    efiPrintf("Vss module is %d", isInit);
+    efiPrintf("CONFIG_enableCanVss is %d", CONFIG(enableCanVss));
 }
 
 void processCanRxVss(const CANRxFrame& frame, efitick_t nowNt) {
@@ -95,7 +95,7 @@ void processCanRxVss(const CANRxFrame& frame, efitick_t nowNt) {
             processW202(frame);
             break;
         default:
-            scheduleMsg(logger, "vss unsupported can option selected %x", CONFIG(canVssNbcType) );
+            efiPrintf("vss unsupported can option selected %x", CONFIG(canVssNbcType) );
             break;
     }
 

--- a/firmware/controllers/core/fsio_impl.cpp
+++ b/firmware/controllers/core/fsio_impl.cpp
@@ -190,50 +190,50 @@ static void setFsioAnalogInputPin(const char *indexStr, const char *pinName) {
 // todo: reduce code duplication between all "set pin methods"
 	int index = atoi(indexStr) - 1;
 	if (index < 0 || index >= FSIO_ANALOG_INPUT_COUNT) {
-		scheduleMsg(logger, "invalid FSIO index: %d", index);
+		efiPrintf("invalid FSIO index: %d", index);
 		return;
 	}
 	brain_pin_e pin = parseBrainPin(pinName);
 	// todo: extract method - code duplication with other 'set_xxx_pin' methods?
 	if (pin == GPIO_INVALID) {
-		scheduleMsg(logger, "invalid pin name [%s]", pinName);
+		efiPrintf("invalid pin name [%s]", pinName);
 		return;
 	}
 	engineConfiguration->fsioAdc[index] = (adc_channel_e) pin;
-	scheduleMsg(logger, "FSIO analog input pin #%d [%s]", (index + 1), hwPortname(pin));
+	efiPrintf("FSIO analog input pin #%d [%s]", (index + 1), hwPortname(pin));
 }
 
 static void setFsioDigitalInputPin(const char *indexStr, const char *pinName) {
 	// todo: reduce code duplication between all "set pin methods"
 	int index = atoi(indexStr) - 1;
 	if (index < 0 || index >= FSIO_COMMAND_COUNT) {
-		scheduleMsg(logger, "invalid FSIO index: %d", index);
+		efiPrintf("invalid FSIO index: %d", index);
 		return;
 	}
 	brain_pin_e pin = parseBrainPin(pinName);
 	// todo: extract method - code duplication with other 'set_xxx_pin' methods?
 	if (pin == GPIO_INVALID) {
-		scheduleMsg(logger, "invalid pin name [%s]", pinName);
+		efiPrintf("invalid pin name [%s]", pinName);
 		return;
 	}
 	CONFIG(fsioDigitalInputs)[index] = pin;
-	scheduleMsg(logger, "FSIO digital input pin #%d [%s]", (index + 1), hwPortname(pin));
+	efiPrintf("FSIO digital input pin #%d [%s]", (index + 1), hwPortname(pin));
 }
 
 static void setFsioPidOutputPin(const char *indexStr, const char *pinName) {
 	int index = atoi(indexStr) - 1;
 	if (index < 0 || index >= CAM_INPUTS_COUNT) {
-		scheduleMsg(logger, "invalid VVT index: %d", index);
+		efiPrintf("invalid VVT index: %d", index);
 		return;
 	}
 	brain_pin_e pin = parseBrainPin(pinName);
 	// todo: extract method - code duplication with other 'set_xxx_pin' methods?
 	if (pin == GPIO_INVALID) {
-		scheduleMsg(logger, "invalid pin name [%s]", pinName);
+		efiPrintf("invalid pin name [%s]", pinName);
 		return;
 	}
 	engineConfiguration->auxPidPins[index] = pin;
-	scheduleMsg(logger, "VVT pid pin #%d [%s]", (index + 1), hwPortname(pin));
+	efiPrintf("VVT pid pin #%d [%s]", (index + 1), hwPortname(pin));
 }
 
 static void showFsioInfo(void);
@@ -241,18 +241,18 @@ static void showFsioInfo(void);
 static void setFsioOutputPin(const char *indexStr, const char *pinName) {
 	int index = atoi(indexStr) - 1;
 	if (index < 0 || index >= FSIO_COMMAND_COUNT) {
-		scheduleMsg(logger, "invalid FSIO index: %d", index);
+		efiPrintf("invalid FSIO index: %d", index);
 		return;
 	}
 	brain_pin_e pin = parseBrainPin(pinName);
 	// todo: extract method - code duplication with other 'set_xxx_pin' methods?
 	if (pin == GPIO_INVALID) {
-		scheduleMsg(logger, "invalid pin name [%s]", pinName);
+		efiPrintf("invalid pin name [%s]", pinName);
 		return;
 	}
 	CONFIG(fsioOutputPins)[index] = pin;
-	scheduleMsg(logger, "FSIO output pin #%d [%s]", (index + 1), hwPortname(pin));
-	scheduleMsg(logger, "please writeconfig and reboot for pin to take effect");
+	efiPrintf("FSIO output pin #%d [%s]", (index + 1), hwPortname(pin));
+	efiPrintf("please writeconfig and reboot for pin to take effect");
 	showFsioInfo();
 }
 #endif /* EFI_PROD_CODE */
@@ -368,7 +368,7 @@ static void runFsioCalculation(int index DECLARE_ENGINE_PARAMETER_SUFFIX) {
 	} else {
 		int value = (int) fvalue;
 		if (value != enginePins.fsioOutputs[index].getLogicValue()) {
-			//		scheduleMsg(logger, "setting %s %s", getIo_pin_e(pin), boolToString(value));
+			//		efiPrintf("setting %s %s", getIo_pin_e(pin), boolToString(value));
 			enginePins.fsioOutputs[index].setValue(value);
 		}
 	}
@@ -416,10 +416,10 @@ static void setPinState(const char * msg, OutputPin *pin, LEElement *element DEC
 		if (pin->isInitialized() && value != pin->getLogicValue()) {
 
 			for (int i = 0;i < calc.currentCalculationLogPosition;i++) {
-				scheduleMsg(logger, "calc %d: action %s value %.2f", i, action2String(calc.calcLogAction[i]), calc.calcLogValue[i]);
+				efiPrintf("calc %d: action %s value %.2f", i, action2String(calc.calcLogAction[i]), calc.calcLogValue[i]);
 			}
 
-			scheduleMsg(logger, "setPin %s %s", msg, value ? "on" : "off");
+			efiPrintf("setPin %s %s", msg, value ? "on" : "off");
 			pin->setValue(value);
 		}
 	}
@@ -430,14 +430,14 @@ static void setPinState(const char * msg, OutputPin *pin, LEElement *element DEC
 static void setFsioFrequency(int index, int frequency) {
 	index--;
 	if (index < 0 || index >= FSIO_COMMAND_COUNT) {
-		scheduleMsg(logger, "invalid FSIO index: %d", index);
+		efiPrintf("invalid FSIO index: %d", index);
 		return;
 	}
 	CONFIG(fsioFrequency)[index] = frequency;
 	if (frequency == 0) {
-		scheduleMsg(logger, "FSIO output #%d@%s set to on/off mode", index + 1, hwPortname(CONFIG(fsioOutputPins)[index]));
+		efiPrintf("FSIO output #%d@%s set to on/off mode", index + 1, hwPortname(CONFIG(fsioOutputPins)[index]));
 	} else {
-		scheduleMsg(logger, "Setting FSIO frequency %dHz on #%d@%s", frequency, index + 1, hwPortname(CONFIG(fsioOutputPins)[index]));
+		efiPrintf("Setting FSIO frequency %dHz on #%d@%s", frequency, index + 1, hwPortname(CONFIG(fsioOutputPins)[index]));
 	}
 }
 #endif /* EFI_PROD_CODE */
@@ -566,18 +566,18 @@ void runFsio(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 static void showFsio(const char *msg, LEElement *element) {
 #if EFI_PROD_CODE || EFI_SIMULATOR
 	if (msg != NULL)
-		scheduleMsg(logger, "%s:", msg);
+		efiPrintf("%s:", msg);
 	while (element->action != LE_METHOD_RETURN) {
-		scheduleMsg(logger, "action %d: fValue=%.2f", element->action, element->fValue);
+		efiPrintf("action %d: fValue=%.2f", element->action, element->fValue);
 		element++;
 	}
-	scheduleMsg(logger, "<end>");
+	efiPrintf("<end>");
 #endif
 }
 
 static void showFsioInfo(void) {
 #if EFI_PROD_CODE || EFI_SIMULATOR
-	scheduleMsg(logger, "sys used %d/user used %d", sysPool.getSize(), userPool.getSize());
+	efiPrintf("sys used %d/user used %d", sysPool.getSize(), userPool.getSize());
 	showFsio("a/c", acRelayLogic);
 	showFsio("fuel", fuelPumpLogic);
 	showFsio("fan", radiatorFanLogic);
@@ -586,7 +586,7 @@ static void showFsioInfo(void) {
 	for (int i = 0; i < CAM_INPUTS_COUNT ; i++) {
 		brain_pin_e pin = engineConfiguration->auxPidPins[i];
 		if (isBrainPinValid(pin)) {
-			scheduleMsg(logger, "VVT pid #%d [%s]", (i + 1),
+			efiPrintf("VVT pid #%d [%s]", (i + 1),
 					hwPortname(pin));
 
 		}
@@ -603,24 +603,24 @@ static void showFsioInfo(void) {
 			 */
 			int freq = CONFIG(fsioFrequency)[i];
 			const char *modeMessage = freq == 0 ? " (on/off mode)" : "";
-			scheduleMsg(logger, "FSIO #%d [%s] at %s@%dHz%s value=%.2f", (i + 1), exp,
+			efiPrintf("FSIO #%d [%s] at %s@%dHz%s value=%.2f", (i + 1), exp,
 					hwPortname(CONFIG(fsioOutputPins)[i]),
 					freq, modeMessage,
 					engine->fsioState.fsioLastValue[i]);
-//			scheduleMsg(logger, "user-defined #%d value=%.2f", i, engine->engineConfigurationPtr2->fsioLastValue[i]);
+//			efiPrintf("user-defined #%d value=%.2f", i, engine->engineConfigurationPtr2->fsioLastValue[i]);
 			showFsio(NULL, state.fsioLogics[i]);
 		}
 	}
 	for (int i = 0; i < FSIO_COMMAND_COUNT; i++) {
 		float v = CONFIG(fsio_setting)[i];
 		if (!cisnan(v)) {
-			scheduleMsg(logger, "user property #%d: %.2f", i + 1, v);
+			efiPrintf("user property #%d: %.2f", i + 1, v);
 		}
 	}
 	for (int i = 0; i < FSIO_COMMAND_COUNT; i++) {
 		brain_pin_e inputPin = CONFIG(fsioDigitalInputs)[i];
 		if (isBrainPinValid(inputPin)) {
-			scheduleMsg(logger, "FSIO digital input #%d: %s", i, hwPortname(inputPin));
+			efiPrintf("FSIO digital input #%d: %s", i, hwPortname(inputPin));
 		}
 	}
 #endif
@@ -633,7 +633,7 @@ static void setFsioSetting(float humanIndexF, float value) {
 #if EFI_PROD_CODE || EFI_SIMULATOR
 	int index = (int)humanIndexF - 1;
 	if (index < 0 || index >= FSIO_COMMAND_COUNT) {
-		scheduleMsg(logger, "invalid FSIO index: %d", (int)humanIndexF);
+		efiPrintf("invalid FSIO index: %d", (int)humanIndexF);
 		return;
 	}
 	engineConfiguration->fsio_setting[index] = value;
@@ -644,16 +644,16 @@ static void setFsioSetting(float humanIndexF, float value) {
 void setFsioExpression(const char *indexStr, const char *quotedLine DECLARE_CONFIG_PARAMETER_SUFFIX) {
 	int index = atoi(indexStr) - 1;
 	if (index < 0 || index >= FSIO_COMMAND_COUNT) {
-		scheduleMsg(logger, "invalid FSIO index: %d", index);
+		efiPrintf("invalid FSIO index: %d", index);
 		return;
 	}
 	char * l = unquote((char*) quotedLine);
 	if (strlen(l) > LE_COMMAND_LENGTH - 1) {
-		scheduleMsg(logger, "Too long %d", strlen(l));
+		efiPrintf("Too long %d", strlen(l));
 		return;
 	}
 
-	scheduleMsg(logger, "setting user out #%d to [%s]", index + 1, l);
+	efiPrintf("setting user out #%d to [%s]", index + 1, l);
 	strcpy(config->fsioFormulas[index], l);
 }
 
@@ -668,14 +668,14 @@ void applyFsioExpression(const char *indexStr, const char *quotedLine DECLARE_EN
 static void rpnEval(char *line) {
 #if EFI_PROD_CODE || EFI_SIMULATOR
 	line = unquote(line);
-	scheduleMsg(logger, "Parsing [%s]", line);
+	efiPrintf("Parsing [%s]", line);
 	evalPool.reset();
 	LEElement * e = evalPool.parseExpression(line);
 	if (e == NULL) {
-		scheduleMsg(logger, "parsing failed");
+		efiPrintf("parsing failed");
 	} else {
 		float result = evalCalc.evaluate("eval", 0, e PASS_ENGINE_PARAMETER_SUFFIX);
-		scheduleMsg(logger, "Evaluate result: %.2f", result);
+		efiPrintf("Evaluate result: %.2f", result);
 	}
 #endif
 }

--- a/firmware/controllers/engine_controller.cpp
+++ b/firmware/controllers/engine_controller.cpp
@@ -105,8 +105,6 @@ EXTERN_ENGINE;
 
 #if !EFI_UNIT_TEST
 
-static LoggingWithStorage logger("Engine Controller");
-
 /**
  * Would love to pass reference to configuration object into constructor but C++ does allow attributes after parenthesized initializer
  */
@@ -306,12 +304,12 @@ static void printAnalogChannelInfoExt(const char *name, adc_channel_e hwChannel,
 		float dividerCoeff) {
 #if HAL_USE_ADC
 	if (!isAdcChannelValid(hwChannel)) {
-		scheduleMsg(&logger, "ADC is not assigned for %s", name);
+		efiPrintf("ADC is not assigned for %s", name);
 		return;
 	}
 
 	float voltage = adcVoltage * dividerCoeff;
-	scheduleMsg(&logger, "%s ADC%d %s %s adc=%.2f/input=%.2fv/divider=%.2f", name, hwChannel, getAdc_channel_mode_e(getAdcMode(hwChannel)),
+	efiPrintf("%s ADC%d %s %s adc=%.2f/input=%.2fv/divider=%.2f", name, hwChannel, getAdc_channel_mode_e(getAdcMode(hwChannel)),
 			getPinNameByAdcChannel(name, hwChannel, pinNameBuffer), adcVoltage, voltage, dividerCoeff);
 #endif /* HAL_USE_ADC */
 }
@@ -323,7 +321,7 @@ static void printAnalogChannelInfo(const char *name, adc_channel_e hwChannel) {
 }
 
 static void printAnalogInfo(void) {
-	scheduleMsg(&logger, "analogInputDividerCoefficient: %.2f", engineConfiguration->analogInputDividerCoefficient);
+	efiPrintf("analogInputDividerCoefficient: %.2f", engineConfiguration->analogInputDividerCoefficient);
 
 	printAnalogChannelInfo("hip9011", engineConfiguration->hipOutputChannel);
 	printAnalogChannelInfo("fuel gauge", engineConfiguration->fuelLevelSensor);
@@ -371,7 +369,7 @@ static void getShort(int offset) {
 	/**
 	 * this response is part of rusEfi console API
 	 */
-	scheduleMsg(&logger, "short%s%d is %d", CONSOLE_DATA_PROTOCOL_TAG, offset, value);
+	efiPrintf("short%s%d is %d", CONSOLE_DATA_PROTOCOL_TAG, offset, value);
 }
 
 static void getByte(int offset) {
@@ -382,7 +380,7 @@ static void getByte(int offset) {
 	/**
 	 * this response is part of rusEfi console API
 	 */
-	scheduleMsg(&logger, "byte%s%d is %d", CONSOLE_DATA_PROTOCOL_TAG, offset, value);
+	efiPrintf("byte%s%d is %d", CONSOLE_DATA_PROTOCOL_TAG, offset, value);
 }
 
 static void onConfigurationChanged() {
@@ -398,7 +396,7 @@ static void onConfigurationChanged() {
 static void setBit(const char *offsetStr, const char *bitStr, const char *valueStr) {
 	int offset = atoi(offsetStr);
 	if (absI(offset) == absI(ERROR_CODE)) {
-		scheduleMsg(&logger, "invalid offset [%s]", offsetStr);
+		efiPrintf("invalid offset [%s]", offsetStr);
 		return;
 	}
 	if (isOutOfBounds(offset)) {
@@ -406,12 +404,12 @@ static void setBit(const char *offsetStr, const char *bitStr, const char *valueS
 	}
 	int bit = atoi(bitStr);
 	if (absI(bit) == absI(ERROR_CODE)) {
-		scheduleMsg(&logger, "invalid bit [%s]", bitStr);
+		efiPrintf("invalid bit [%s]", bitStr);
 		return;
 	}
 	int value = atoi(valueStr);
 	if (absI(value) == absI(ERROR_CODE)) {
-		scheduleMsg(&logger, "invalid value [%s]", valueStr);
+		efiPrintf("invalid value [%s]", valueStr);
 		return;
 	}
 	int *ptr = (int *) (&((char *) engineConfiguration)[offset]);
@@ -419,7 +417,7 @@ static void setBit(const char *offsetStr, const char *bitStr, const char *valueS
 	/**
 	 * this response is part of rusEfi console API
 	 */
-	scheduleMsg(&logger, "bit%s%d/%d is %d", CONSOLE_DATA_PROTOCOL_TAG, offset, bit, value);
+	efiPrintf("bit%s%d/%d is %d", CONSOLE_DATA_PROTOCOL_TAG, offset, bit, value);
 	onConfigurationChanged();
 }
 
@@ -449,7 +447,7 @@ static void getBit(int offset, int bit) {
 	/**
 	 * this response is part of rusEfi console API
 	 */
-	scheduleMsg(&logger, "bit%s%d/%d is %d", CONSOLE_DATA_PROTOCOL_TAG, offset, bit, value);
+	efiPrintf("bit%s%d/%d is %d", CONSOLE_DATA_PROTOCOL_TAG, offset, bit, value);
 }
 
 static void getInt(int offset) {
@@ -460,7 +458,7 @@ static void getInt(int offset) {
 	/**
 	 * this response is part of rusEfi console API
 	 */
-	scheduleMsg(&logger, "int%s%d is %d", CONSOLE_DATA_PROTOCOL_TAG, offset, value);
+	efiPrintf("int%s%d is %d", CONSOLE_DATA_PROTOCOL_TAG, offset, value);
 }
 
 static void setInt(const int offset, const int value) {
@@ -480,20 +478,20 @@ static void getFloat(int offset) {
 	/**
 	 * this response is part of rusEfi console API
 	 */
-	scheduleMsg(&logger, "float%s%d is %.5f", CONSOLE_DATA_PROTOCOL_TAG, offset, value);
+	efiPrintf("float%s%d is %.5f", CONSOLE_DATA_PROTOCOL_TAG, offset, value);
 }
 
 static void setFloat(const char *offsetStr, const char *valueStr) {
 	int offset = atoi(offsetStr);
 	if (absI(offset) == absI(ERROR_CODE)) {
-		scheduleMsg(&logger, "invalid offset [%s]", offsetStr);
+		efiPrintf("invalid offset [%s]", offsetStr);
 		return;
 	}
 	if (isOutOfBounds(offset))
 		return;
 	float value = atoff(valueStr);
 	if (cisnan(value)) {
-		scheduleMsg(&logger, "invalid value [%s]", valueStr);
+		efiPrintf("invalid value [%s]", valueStr);
 		return;
 	}
 	float *ptr = (float *) (&((char *) engineConfiguration)[offset]);
@@ -519,7 +517,7 @@ static void initConfigActions(void) {
 // todo: move this logic somewhere else?
 static void getKnockInfo(void) {
 	adc_channel_e hwChannel = engineConfiguration->externalKnockSenseAdc;
-	scheduleMsg(&logger, "externalKnockSenseAdc on ADC", getPinNameByAdcChannel("knock", hwChannel, pinNameBuffer));
+	efiPrintf("externalKnockSenseAdc on ADC", getPinNameByAdcChannel("knock", hwChannel, pinNameBuffer));
 
 	engine->printKnockState();
 }

--- a/firmware/controllers/engine_controller.cpp
+++ b/firmware/controllers/engine_controller.cpp
@@ -525,7 +525,7 @@ static void getKnockInfo(void) {
 
 // this method is used by real firmware and simulator and unit test
 void commonInitEngineController(Logging *sharedLogger DECLARE_ENGINE_PARAMETER_SUFFIX) {
-	initInterpolation(sharedLogger);
+	initInterpolation();
 
 #if EFI_SIMULATOR
 	printf("commonInitEngineController\n");
@@ -582,7 +582,7 @@ void commonInitEngineController(Logging *sharedLogger DECLARE_ENGINE_PARAMETER_S
 
 	initButtonShift(PASS_ENGINE_PARAMETER_SIGNATURE);
 
-	initButtonDebounce(sharedLogger);
+	initButtonDebounce();
 	initStartStopButton(PASS_ENGINE_PARAMETER_SIGNATURE);
 
 #if EFI_ELECTRONIC_THROTTLE_BODY

--- a/firmware/controllers/engine_cycle/main_trigger_callback.cpp
+++ b/firmware/controllers/engine_cycle/main_trigger_callback.cpp
@@ -303,11 +303,11 @@ void InjectionEvent::onTriggerTooth(size_t trgEventIndex, int rpm, efitick_t now
 		printf("scheduling injection angle=%.2f/delay=%.2f injectionDuration=%.2f\r\n", injectionStart.angleOffsetFromTriggerEvent, NT2US(startTime - nowNt), injectionDuration);
 #endif
 #if EFI_DEFAILED_LOGGING
-	scheduleMsg(logger, "handleFuel pin=%s eventIndex %d duration=%.2fms %d", outputs[0]->name,
+	efiPrintf("handleFuel pin=%s eventIndex %d duration=%.2fms %d", outputs[0]->name,
 			injEventIndex,
 			injectionDuration,
 			getRevolutionCounter());
-	scheduleMsg(logger, "handleFuel pin=%s delay=%.2f %d", outputs[0]->name, NT2US(startTime - nowNt),
+	efiPrintf("handleFuel pin=%s delay=%.2f %d", outputs[0]->name, NT2US(startTime - nowNt),
 			getRevolutionCounter());
 #endif /* EFI_DEFAILED_LOGGING */
 }
@@ -348,7 +348,7 @@ static void handleFuel(const bool limitedFuel, uint32_t trgEventIndex, int rpm, 
 
 #if FUEL_MATH_EXTREME_LOGGING
 	if (printFuelDebug) {
-		scheduleMsg(logger, "handleFuel ind=%d %d", trgEventIndex, getRevolutionCounter());
+		efiPrintf("handleFuel ind=%d %d", trgEventIndex, getRevolutionCounter());
 	}
 #endif /* FUEL_MATH_EXTREME_LOGGING */
 
@@ -539,8 +539,8 @@ static void showMainInfo(Engine *engine) {
 #if EFI_PROD_CODE
 	int rpm = GET_RPM();
 	float el = getFuelingLoad(PASS_ENGINE_PARAMETER_SIGNATURE);
-	scheduleMsg(logger, "rpm %d engine_load %.2f", rpm, el);
-	scheduleMsg(logger, "fuel %.2fms timing %.2f", ENGINE(injectionDuration), engine->engineState.timingAdvance);
+	efiPrintf("rpm %d engine_load %.2f", rpm, el);
+	efiPrintf("fuel %.2fms timing %.2f", ENGINE(injectionDuration), engine->engineState.timingAdvance);
 #endif /* EFI_PROD_CODE */
 }
 
@@ -551,7 +551,7 @@ void initMainEventListener(Logging *sharedLogger DECLARE_ENGINE_PARAMETER_SUFFIX
 #if EFI_PROD_CODE
 	addConsoleActionP("maininfo", (VoidPtr) showMainInfo, engine);
 
-	scheduleMsg(logger, "initMainLoop: %d", currentTimeMillis());
+	efiPrintf("initMainLoop: %d", currentTimeMillis());
 #endif
 
 

--- a/firmware/controllers/engine_cycle/map_averaging.cpp
+++ b/firmware/controllers/engine_cycle/map_averaging.cpp
@@ -315,7 +315,7 @@ void mapAveragingTriggerCallback(
 }
 
 static void showMapStats(void) {
-	scheduleMsg(logger, "per revolution %d", measurementsPerRevolution);
+	efiPrintf("per revolution %d", measurementsPerRevolution);
 }
 
 #if EFI_PROD_CODE

--- a/firmware/controllers/engine_cycle/rpm_calculator.cpp
+++ b/firmware/controllers/engine_cycle/rpm_calculator.cpp
@@ -209,7 +209,7 @@ void RpmCalculator::setStopped() {
 		assignRpmValue(0);
 		// needed by 'useNoiselessTriggerDecoder'
 		engine->triggerCentral.noiseFilter.resetAccumSignalData();
-		scheduleMsg(logger, "engine stopped");
+		efiPrintf("engine stopped");
 	}
 	state = STOPPED;
 }
@@ -308,7 +308,7 @@ void rpmShaftPositionCallback(trigger_event_e ckpSignalType,
 		instantRpm = minF(instantRpm, CONFIG(cranking.rpm) - 1);
 		rpmState->assignRpmValue(instantRpm);
 #if 0
-		scheduleMsg(logger, "** RPM: idx=%d sig=%d iRPM=%d", index, ckpSignalType, instantRpm);
+		efiPrintf("** RPM: idx=%d sig=%d iRPM=%d", index, ckpSignalType, instantRpm);
 #endif
 	}
 }

--- a/firmware/controllers/engine_cycle/spark_logic.cpp
+++ b/firmware/controllers/engine_cycle/spark_logic.cpp
@@ -48,7 +48,7 @@ static void fireSparkBySettingPinLow(IgnitionEvent *event, IgnitionOutputPin *ou
 #endif /* EFI_UNIT_TEST */
 
 #if SPARK_EXTREME_LOGGING
-	scheduleMsg(logger, "spark goes low  %d %s %d current=%d cnt=%d id=%d", getRevolutionCounter(), output->name, (int)getTimeNowUs(),
+	efiPrintf("spark goes low  %d %s %d current=%d cnt=%d id=%d", getRevolutionCounter(), output->name, (int)getTimeNowUs(),
 			output->currentLogicValue, output->outOfOrder, event->sparkId);
 #endif /* SPARK_EXTREME_LOGGING */
 
@@ -125,7 +125,7 @@ static void prepareCylinderIgnitionSchedule(angle_t dwellAngleDuration, floatms_
 	if (printFuelDebug) {
 		printf("addIgnitionEvent %s ind=%d\n", output->name, event->dwellPosition.triggerEventIndex);
 	}
-	//	scheduleMsg(logger, "addIgnitionEvent %s ind=%d", output->name, event->dwellPosition->eventIndex);
+	//	efiPrintf("addIgnitionEvent %s ind=%d", output->name, event->dwellPosition->eventIndex);
 #endif /* FUEL_MATH_EXTREME_LOGGING */
 }
 
@@ -232,7 +232,7 @@ static void startDwellByTurningSparkPinHigh(IgnitionEvent *event, IgnitionOutput
 
 
 #if SPARK_EXTREME_LOGGING
-	scheduleMsg(logger, "spark goes high %d %s %d current=%d cnt=%d id=%d", getRevolutionCounter(), output->name, (int)getTimeNowUs(),
+	efiPrintf("spark goes high %d %s %d current=%d cnt=%d id=%d", getRevolutionCounter(), output->name, (int)getTimeNowUs(),
 			output->currentLogicValue, output->outOfOrder, event->sparkId);
 #endif /* SPARK_EXTREME_LOGGING */
 
@@ -317,7 +317,7 @@ bool scheduleOrQueue(AngleBasedEvent *event,
 		bool isPending = assertNotInIgnitionList(ENGINE(angleBasedEventsHead), event);
 		if (isPending) {
 #if SPARK_EXTREME_LOGGING
-			scheduleMsg(logger, "isPending thus not adding to queue index=%d rev=%d now=%d", trgEventIndex, getRevolutionCounter(), (int)getTimeNowUs());
+			efiPrintf("isPending thus not adding to queue index=%d rev=%d now=%d", trgEventIndex, getRevolutionCounter(), (int)getTimeNowUs());
 #endif /* SPARK_EXTREME_LOGGING */
 		} else {
 			LL_APPEND2(ENGINE(angleBasedEventsHead), event, nextToothEvent);
@@ -345,7 +345,7 @@ static void handleSparkEvent(bool limitedSpark, uint32_t trgEventIndex, Ignition
 	ignitionErrorDetection.add(isIgnitionError);
 	if (isIgnitionError) {
 #if EFI_PROD_CODE
-		scheduleMsg(logger, "Negative spark delay=%.1f deg", angleOffset);
+		efiPrintf("Negative spark delay=%.1f deg", angleOffset);
 #endif /* EFI_PROD_CODE */
 		return;
 	}
@@ -357,7 +357,7 @@ static void handleSparkEvent(bool limitedSpark, uint32_t trgEventIndex, Ignition
 	 */
 	if (!limitedSpark) {
 #if SPARK_EXTREME_LOGGING
-		scheduleMsg(logger, "scheduling sparkUp ind=%d %d %s now=%d %d later id=%d", trgEventIndex, getRevolutionCounter(), event->getOutputForLoggins()->name, (int)getTimeNowUs(), (int)angleOffset,
+		efiPrintf("scheduling sparkUp ind=%d %d %s now=%d %d later id=%d", trgEventIndex, getRevolutionCounter(), event->getOutputForLoggins()->name, (int)getTimeNowUs(), (int)angleOffset,
 				event->sparkId);
 #endif /* SPARK_EXTREME_LOGGING */
 
@@ -386,11 +386,11 @@ static void handleSparkEvent(bool limitedSpark, uint32_t trgEventIndex, Ignition
 
 	if (scheduled) {
 #if SPARK_EXTREME_LOGGING
-		scheduleMsg(logger, "scheduling sparkDown ind=%d %d %s now=%d later id=%d", trgEventIndex, getRevolutionCounter(), event->getOutputForLoggins()->name, (int)getTimeNowUs(), event->sparkId);
+		efiPrintf("scheduling sparkDown ind=%d %d %s now=%d later id=%d", trgEventIndex, getRevolutionCounter(), event->getOutputForLoggins()->name, (int)getTimeNowUs(), event->sparkId);
 #endif /* FUEL_MATH_EXTREME_LOGGING */
 	} else {
 #if SPARK_EXTREME_LOGGING
-		scheduleMsg(logger, "to queue sparkDown ind=%d %d %s now=%d for id=%d", trgEventIndex, getRevolutionCounter(), event->getOutputForLoggins()->name, (int)getTimeNowUs(), event->sparkEvent.position.triggerEventIndex);
+		efiPrintf("to queue sparkDown ind=%d %d %s now=%d for id=%d", trgEventIndex, getRevolutionCounter(), event->getOutputForLoggins()->name, (int)getTimeNowUs(), event->sparkEvent.position.triggerEventIndex);
 #endif /* SPARK_EXTREME_LOGGING */
 	}
 
@@ -469,7 +469,7 @@ static void scheduleAllSparkEventsUntilNextTriggerTooth(uint32_t trgEventIndex, 
 			scheduling_s * sDown = &current->scheduling;
 
 #if SPARK_EXTREME_LOGGING
-	scheduleMsg(logger, "time to invoke ind=%d %d %d", trgEventIndex, getRevolutionCounter(), (int)getTimeNowUs());
+	efiPrintf("time to invoke ind=%d %d %d", trgEventIndex, getRevolutionCounter(), (int)getTimeNowUs());
 #endif /* SPARK_EXTREME_LOGGING */
 
 			scheduleByAngle(

--- a/firmware/controllers/flash_main.cpp
+++ b/firmware/controllers/flash_main.cpp
@@ -60,7 +60,7 @@ static void flashWriteThread(void*) {
 #endif // EFI_FLASH_WRITE_THREAD
 
 void setNeedToWriteConfiguration(void) {
-	scheduleMsg(logger, "Scheduling configuration write");
+	efiPrintf("Scheduling configuration write");
 	needToWriteConfiguration = true;
 
 #if EFI_FLASH_WRITE_THREAD
@@ -99,7 +99,7 @@ int eraseAndFlashCopy(flashaddr_t storageAddress, const TStorage& data)
 }
 
 void writeToFlashNow(void) {
-	scheduleMsg(logger, "Writing pending configuration...");
+	efiPrintf("Writing pending configuration...");
 
 	// Set up the container
 	persistentState.size = sizeof(persistentState);
@@ -114,9 +114,9 @@ void writeToFlashNow(void) {
 	bool isSuccess = (result1 == FLASH_RETURN_SUCCESS) && (result2 == FLASH_RETURN_SUCCESS);
 
 	if (isSuccess) {
-		scheduleMsg(logger, "FLASH_SUCCESS");
+		efiPrintf("FLASH_SUCCESS");
 	} else {
-		scheduleMsg(logger, "Flashing failed");
+		efiPrintf("Flashing failed");
 	}
 	assertEngineReference();
 
@@ -145,7 +145,7 @@ typedef enum {
 } persisted_configuration_state_e;
 
 static persisted_configuration_state_e doReadConfiguration(flashaddr_t address, Logging * logger) {
-	scheduleMsg(logger, "readFromFlash %x", address);
+	efiPrintf("readFromFlash %x", address);
 	intFlashRead(address, (char *) &persistentState, sizeof(persistentState));
 
 	if (!isValidCrc(&persistentState)) {
@@ -165,7 +165,7 @@ static persisted_configuration_state_e readConfiguration(Logging* logger) {
 	efiAssert(CUSTOM_ERR_ASSERT, getCurrentRemainingStack() > EXPECTED_REMAINING_STACK, "read f", PC_ERROR);
 	persisted_configuration_state_e result = doReadConfiguration(getFlashAddrFirstCopy(), logger);
 	if (result != PC_OK) {
-		scheduleMsg(logger, "Reading second configuration copy");
+		efiPrintf("Reading second configuration copy");
 		result = doReadConfiguration(getFlashAddrSecondCopy(), logger);
 	}
 
@@ -192,11 +192,11 @@ void readFromFlash() {
 	persisted_configuration_state_e result = readConfiguration(logger);
 
 	if (result == CRC_FAILED) {
-		scheduleMsg(logger, "Need to reset flash to default due to CRC");
+		efiPrintf("Need to reset flash to default due to CRC");
 	} else if (result == INCOMPATIBLE_VERSION) {
-		scheduleMsg(logger, "Resetting due to version mismatch but preserving engine type [%d]", engineConfiguration->engineType);
+		efiPrintf("Resetting due to version mismatch but preserving engine type [%d]", engineConfiguration->engineType);
 	} else {
-		scheduleMsg(logger, "Read valid configuration from flash!");
+		efiPrintf("Read valid configuration from flash!");
 	}
 }
 

--- a/firmware/controllers/math/pid_auto_tune.cpp
+++ b/firmware/controllers/math/pid_auto_tune.cpp
@@ -90,7 +90,7 @@ void PID_AutoTune::SetLookbackSec(int value)
 
 double inline PID_AutoTune::fastArcTan(double x)
 {
-  // source: “Efficient approximations for the arctangent function”, Rajan, S. Sichun Wang Inkol, R. Joyal, A., May 2006
+  // source: ï¿½Efficient approximations for the arctangent functionï¿½, Rajan, S. Sichun Wang Inkol, R. Joyal, A., May 2006
   //return CONST_PI / 4.0 * x - x * (abs(x) - 1.0) * (0.2447 + 0.0663 * abs(x));
 
   // source: "Understanding Digital Signal Processing", 2nd Ed, Richard G. Lyons, eq. 13-107
@@ -115,7 +115,7 @@ double PID_AutoTune::calculatePhaseLag(double inducedAmplitude)
 
 void PID_AutoTune::setState(PidAutoTune_AutoTunerState state) {
 	this->state = state;
-	scheduleMsg(logger, "setState %s", getPidAutoTune_AutoTunerState(state));
+	efiPrintf("setState %s", getPidAutoTune_AutoTunerState(state));
 #if EFI_UNIT_TEST
 	if (verboseMode)
 		printf("setState %s\r\n", getPidAutoTune_AutoTunerState(state));
@@ -124,7 +124,7 @@ void PID_AutoTune::setState(PidAutoTune_AutoTunerState state) {
 
 void PID_AutoTune::setPeakType(PidAutoTune_Peak peakType) {
 	this->peakType = peakType;
-	scheduleMsg(logger, "setPeakType %s", getPidAutoTune_Peak(peakType));
+	efiPrintf("setPeakType %s", getPidAutoTune_Peak(peakType));
 #if EFI_UNIT_TEST
 	if (verboseMode)
 		printf("peakType %s\r\n", getPidAutoTune_Peak(peakType));
@@ -168,7 +168,7 @@ bool PID_AutoTune::Runtime(Logging *logger)
     }
     else
     {
-    	scheduleMsg(logger, "starting...");
+    	efiPrintf("starting...");
     	setState(RELAY_STEP_UP);
     }
   }
@@ -180,7 +180,7 @@ bool PID_AutoTune::Runtime(Logging *logger)
 	  if (verboseMode)
 		  printf("too soon for new input %d %d %d\r\n", now, lastTime, sampleTime);
 #endif /* EFI_UNIT_TEST */
-	scheduleMsg(logger, "AT skipping now=%d %d %d", now, lastTime, sampleTime);
+	efiPrintf("AT skipping now=%d %d %d", now, lastTime, sampleTime);
 
     return false;
   }
@@ -200,13 +200,13 @@ bool PID_AutoTune::Runtime(Logging *logger)
   // check input and change relay state if necessary
   if ((state == RELAY_STEP_UP) && (refVal > setpoint + workingNoiseBand))
   {
-	  scheduleMsg(logger, "noise crossed up %f s=%f n=%f", refVal, setpoint, workingNoiseBand);
+	  efiPrintf("noise crossed up %f s=%f n=%f", refVal, setpoint, workingNoiseBand);
 	  setState(RELAY_STEP_DOWN);
     justChanged = true;
   }
   else if ((state == RELAY_STEP_DOWN) && (refVal < setpoint - workingNoiseBand))
   {
-	  scheduleMsg(logger, "noise crossed down %f s=%f n=%f", refVal, setpoint, workingNoiseBand);
+	  efiPrintf("noise crossed down %f s=%f n=%f", refVal, setpoint, workingNoiseBand);
 	  setState(RELAY_STEP_UP);
     justChanged = true;
   }
@@ -330,7 +330,7 @@ bool PID_AutoTune::Runtime(Logging *logger)
 #if defined (AUTOTUNE_RELAY_BIAS)
     setOutput(outputStart + workingOstep + relayBias);
 #else
-	  scheduleMsg(logger, "AT adding %f", workingOutputstep);
+	  efiPrintf("AT adding %f", workingOutputstep);
     setOutput(outputStart + workingOutputstep);
 #endif
 
@@ -341,7 +341,7 @@ bool PID_AutoTune::Runtime(Logging *logger)
 #if defined (AUTOTUNE_RELAY_BIAS)
 	  setOutput(outputStart - workingOstep + relayBias);
 #else
-	  scheduleMsg(logger, "AT subtracting %f", workingOutputstep);
+	  efiPrintf("AT subtracting %f", workingOutputstep);
 	  setOutput(outputStart - workingOutputstep);
 #endif
 
@@ -371,7 +371,7 @@ bool PID_AutoTune::Runtime(Logging *logger)
   if (inputCount <= nLookBack)
   {
     lastInputs[nLookBack - inputCount] = refVal;
-	  scheduleMsg(logger, "AT need more data %d %d", inputCount, nLookBack);
+	  efiPrintf("AT need more data %d %d", inputCount, nLookBack);
 #if EFI_UNIT_TEST
 	  if (verboseMode) {
 		  printf("need more data %d %d\r\n", inputCount, nLookBack);
@@ -398,7 +398,7 @@ bool PID_AutoTune::Runtime(Logging *logger)
     lastInputs[i + 1] = val;
   }
   lastInputs[0] = refVal;
-  scheduleMsg(logger, "isMin=%d isMax=%d", isMin, isMax);
+  efiPrintf("isMin=%d isMax=%d", isMin, isMax);
 
   // for AMIGOf tuning rule, perform an initial
   // step change to calculate process gain K_process
@@ -538,7 +538,7 @@ bool PID_AutoTune::Runtime(Logging *logger)
   if (justChanged)
   {
     peakCount++;
-    scheduleMsg(logger, "peakCount=%d", peakCount);
+    efiPrintf("peakCount=%d", peakCount);
 
 
 #if defined (AUTOTUNE_DEBUG)
@@ -634,7 +634,7 @@ bool PID_AutoTune::Runtime(Logging *logger)
 #endif
 
     // source for AMIGOf PI auto tuning method:
-    // "Revisiting the Ziegler-Nichols tuning rules for PI control —
+    // "Revisiting the Ziegler-Nichols tuning rules for PI control ï¿½
     //  Part II. The frequency response method."
     // T. Hagglund and K. J. Astrom
     // Asian Journal of Control, Vol. 6, No. 4, pp. 469-482, December 2004
@@ -648,14 +648,14 @@ bool PID_AutoTune::Runtime(Logging *logger)
       Serial.println(phaseLag / CONST_PI * 180.0);
 #endif
 
-      // check that phase lag is within acceptable bounds, ideally between 120° and 140°
-      // but 115° to 145° will just about do, and might converge quicker
+      // check that phase lag is within acceptable bounds, ideally between 120ï¿½ and 140ï¿½
+      // but 115ï¿½ to 145ï¿½ will just about do, and might converge quicker
       if (abs(phaseLag - CONST_PI * 130.0 / 180.0) > (CONST_PI * 15.0 / 180.0))
       {
         // phase lag outside the desired range
         // set noiseBand to new estimate
-        // aiming for 135° = 0.75 * pi (radians)
-        // sin(135°) = sqrt(2)/2
+        // aiming for 135ï¿½ = 0.75 * pi (radians)
+        // sin(135ï¿½) = sqrt(2)/2
         // NB noiseBand = 0.5 * hysteresis
         newWorkingNoiseBand = 0.5 * inducedAmplitude * CONST_SQRT2_DIV_2;
 
@@ -723,7 +723,7 @@ bool PID_AutoTune::Runtime(Logging *logger)
 
   // autotune algorithm has terminated
   // reset autotuner variables
-  scheduleMsg(logger, "AT done");
+  efiPrintf("AT done");
   setOutput( outputStart);
 
   if (state == FAILED)
@@ -790,7 +790,7 @@ bool PID_AutoTune::Runtime(Logging *logger)
 #if EFI_UNIT_TEST
 		printf("Happy end AMIGOF_PI!\r\n");
 #endif /* EFI_UNIT_TEST */
-	scheduleMsg(logger, "output %f", output);
+	efiPrintf("output %f", output);
     // converged
     return true;
   }
@@ -824,7 +824,7 @@ float PID_AutoTune::GetKd() const
 void PID_AutoTune::setOutput(float output) {
 	this->output = output;
 
-	scheduleMsg(logger, "setOutput %f %s", output, getPidAutoTune_AutoTunerState(state));
+	efiPrintf("setOutput %f %s", output, getPidAutoTune_AutoTunerState(state));
 
 #if EFI_UNIT_TEST
 	if (verboseMode) {

--- a/firmware/controllers/settings.cpp
+++ b/firmware/controllers/settings.cpp
@@ -62,7 +62,7 @@ static Logging logger("settings control", LOGGING_BUFFER, sizeof(LOGGING_BUFFER)
 EXTERN_ENGINE;
 
 void printSpiState(Logging *logger, const engine_configuration_s *engineConfiguration) {
-	scheduleMsg(logger, "spi 1=%s/2=%s/3=%s/4=%s",
+	efiPrintf("spi 1=%s/2=%s/3=%s/4=%s",
 		boolToString(engineConfiguration->is_enabled_spi_1),
 		boolToString(engineConfiguration->is_enabled_spi_2),
 		boolToString(engineConfiguration->is_enabled_spi_3),

--- a/firmware/controllers/settings.cpp
+++ b/firmware/controllers/settings.cpp
@@ -72,36 +72,36 @@ void printSpiState(Logging *logger, const engine_configuration_s *engineConfigur
 extern engine_configuration_s *engineConfiguration;
 
 static void printOutputs(const engine_configuration_s *engineConfiguration) {
-	scheduleMsg(&logger, "injectionPins: mode %s", getPin_output_mode_e(engineConfiguration->injectionPinMode));
+	efiPrintf("injectionPins: mode %s", getPin_output_mode_e(engineConfiguration->injectionPinMode));
 	for (size_t i = 0; i < engineConfiguration->specs.cylindersCount; i++) {
 		brain_pin_e brainPin = engineConfiguration->injectionPins[i];
-		scheduleMsg(&logger, "injection #%d @ %s", (1 + i), hwPortname(brainPin));
+		efiPrintf("injection #%d @ %s", (1 + i), hwPortname(brainPin));
 	}
 
-	scheduleMsg(&logger, "ignitionPins: mode %s", getPin_output_mode_e(engineConfiguration->ignitionPinMode));
+	efiPrintf("ignitionPins: mode %s", getPin_output_mode_e(engineConfiguration->ignitionPinMode));
 	for (size_t i = 0; i < engineConfiguration->specs.cylindersCount; i++) {
 		brain_pin_e brainPin = engineConfiguration->ignitionPins[i];
-		scheduleMsg(&logger, "ignition #%d @ %s", (1 + i), hwPortname(brainPin));
+		efiPrintf("ignition #%d @ %s", (1 + i), hwPortname(brainPin));
 	}
 
-	scheduleMsg(&logger, "idlePin: mode %s @ %s freq=%d", getPin_output_mode_e(engineConfiguration->idle.solenoidPinMode),
+	efiPrintf("idlePin: mode %s @ %s freq=%d", getPin_output_mode_e(engineConfiguration->idle.solenoidPinMode),
 			hwPortname(engineConfiguration->idle.solenoidPin), engineConfiguration->idle.solenoidFrequency);
-	scheduleMsg(&logger, "malfunctionIndicator: %s mode=%s", hwPortname(engineConfiguration->malfunctionIndicatorPin),
+	efiPrintf("malfunctionIndicator: %s mode=%s", hwPortname(engineConfiguration->malfunctionIndicatorPin),
 			getPin_output_mode_e(engineConfiguration->malfunctionIndicatorPinMode));
 
-	scheduleMsg(&logger, "fuelPumpPin: mode %s @ %s", getPin_output_mode_e(engineConfiguration->fuelPumpPinMode),
+	efiPrintf("fuelPumpPin: mode %s @ %s", getPin_output_mode_e(engineConfiguration->fuelPumpPinMode),
 			hwPortname(engineConfiguration->fuelPumpPin));
 
-	scheduleMsg(&logger, "fanPin: mode %s @ %s", getPin_output_mode_e(engineConfiguration->fanPinMode),
+	efiPrintf("fanPin: mode %s @ %s", getPin_output_mode_e(engineConfiguration->fanPinMode),
 			hwPortname(engineConfiguration->fanPin));
 
-	scheduleMsg(&logger, "mainRelay: mode %s @ %s", getPin_output_mode_e(engineConfiguration->mainRelayPinMode),
+	efiPrintf("mainRelay: mode %s @ %s", getPin_output_mode_e(engineConfiguration->mainRelayPinMode),
 			hwPortname(engineConfiguration->mainRelayPin));
 
-	scheduleMsg(&logger, "starterRelay: mode %s @ %s", getPin_output_mode_e(engineConfiguration->starterRelayDisablePinMode),
+	efiPrintf("starterRelay: mode %s @ %s", getPin_output_mode_e(engineConfiguration->starterRelayDisablePinMode),
 			hwPortname(engineConfiguration->starterRelayDisablePin));
 
-	scheduleMsg(&logger, "alternator field: mode %s @ %s",
+	efiPrintf("alternator field: mode %s @ %s",
 			getPin_output_mode_e(engineConfiguration->alternatorControlPinMode),
 			hwPortname(engineConfiguration->alternatorControlPin));
 }
@@ -154,61 +154,61 @@ const char* getConfigurationName(engine_type_e engineType) {
  */
 void printConfiguration(const engine_configuration_s *engineConfiguration) {
 
-	scheduleMsg(&logger, "Template %s/%d trigger %s/%s/%d", getConfigurationName(engineConfiguration->engineType),
+	efiPrintf("Template %s/%d trigger %s/%s/%d", getConfigurationName(engineConfiguration->engineType),
 			engineConfiguration->engineType, getTrigger_type_e(engineConfiguration->trigger.type),
 			getEngine_load_mode_e(engineConfiguration->fuelAlgorithm), engineConfiguration->fuelAlgorithm);
 
 
-	scheduleMsg(&logger, "configurationVersion=%d", engine->getGlobalConfigurationVersion());
+	efiPrintf("configurationVersion=%d", engine->getGlobalConfigurationVersion());
 
-	scheduleMsg(&logger, "rpmHardLimit: %d/operationMode=%d", engineConfiguration->rpmHardLimit,
+	efiPrintf("rpmHardLimit: %d/operationMode=%d", engineConfiguration->rpmHardLimit,
 			engine->getOperationMode(PASS_ENGINE_PARAMETER_SIGNATURE));
 
-	scheduleMsg(&logger, "globalTriggerAngleOffset=%.2f", engineConfiguration->globalTriggerAngleOffset);
+	efiPrintf("globalTriggerAngleOffset=%.2f", engineConfiguration->globalTriggerAngleOffset);
 
-	scheduleMsg(&logger, "=== cranking ===");
-	scheduleMsg(&logger, "crankingRpm: %d", engineConfiguration->cranking.rpm);
-	scheduleMsg(&logger, "cranking injection %s", getInjection_mode_e(engineConfiguration->crankingInjectionMode));
+	efiPrintf("=== cranking ===");
+	efiPrintf("crankingRpm: %d", engineConfiguration->cranking.rpm);
+	efiPrintf("cranking injection %s", getInjection_mode_e(engineConfiguration->crankingInjectionMode));
 
 	if (engineConfiguration->useConstantDwellDuringCranking) {
-		scheduleMsg(&logger, "ignitionDwellForCrankingMs=%.2f", engineConfiguration->ignitionDwellForCrankingMs);
+		efiPrintf("ignitionDwellForCrankingMs=%.2f", engineConfiguration->ignitionDwellForCrankingMs);
 	} else {
-		scheduleMsg(&logger, "cranking charge charge angle=%.2f fire at %.2f", engineConfiguration->crankingChargeAngle,
+		efiPrintf("cranking charge charge angle=%.2f fire at %.2f", engineConfiguration->crankingChargeAngle,
 				engineConfiguration->crankingTimingAngle);
 	}
 
-	scheduleMsg(&logger, "=== ignition ===");
+	efiPrintf("=== ignition ===");
 
-	scheduleMsg(&logger, "ignitionMode: %s/enabled=%s", getIgnition_mode_e(engineConfiguration->ignitionMode),
+	efiPrintf("ignitionMode: %s/enabled=%s", getIgnition_mode_e(engineConfiguration->ignitionMode),
 			boolToString(engineConfiguration->isIgnitionEnabled));
-	scheduleMsg(&logger, "timingMode: %s", getTiming_mode_e(engineConfiguration->timingMode));
+	efiPrintf("timingMode: %s", getTiming_mode_e(engineConfiguration->timingMode));
 	if (engineConfiguration->timingMode == TM_FIXED) {
-		scheduleMsg(&logger, "fixedModeTiming: %d", (int) engineConfiguration->fixedModeTiming);
+		efiPrintf("fixedModeTiming: %d", (int) engineConfiguration->fixedModeTiming);
 	}
 
-	scheduleMsg(&logger, "=== injection ===");
-	scheduleMsg(&logger, "injection %s offset=%.2f/enabled=%s", getInjection_mode_e(engineConfiguration->injectionMode),
+	efiPrintf("=== injection ===");
+	efiPrintf("injection %s offset=%.2f/enabled=%s", getInjection_mode_e(engineConfiguration->injectionMode),
 			(double) engineConfiguration->extraInjectionOffset, boolToString(engineConfiguration->isInjectionEnabled));
 
 	printOutputs(engineConfiguration);
 
-	scheduleMsg(&logger, "map_avg=%s/wa=%s",
+	efiPrintf("map_avg=%s/wa=%s",
 			boolToString(engineConfiguration->isMapAveragingEnabled),
 			boolToString(engineConfiguration->isWaveAnalyzerEnabled));
 
-	scheduleMsg(&logger, "isManualSpinningMode=%s/isCylinderCleanupEnabled=%s",
+	efiPrintf("isManualSpinningMode=%s/isCylinderCleanupEnabled=%s",
 			boolToString(engineConfiguration->isManualSpinningMode),
 			boolToString(engineConfiguration->isCylinderCleanupEnabled));
 
-	scheduleMsg(&logger, "clutchUp@%s: %s", hwPortname(engineConfiguration->clutchUpPin),
+	efiPrintf("clutchUp@%s: %s", hwPortname(engineConfiguration->clutchUpPin),
 			boolToString(engine->clutchUpState));
-	scheduleMsg(&logger, "clutchDown@%s: %s", hwPortname(engineConfiguration->clutchDownPin),
+	efiPrintf("clutchDown@%s: %s", hwPortname(engineConfiguration->clutchDownPin),
 			boolToString(engine->clutchDownState));
 
-	scheduleMsg(&logger, "digitalPotentiometerSpiDevice %d", engineConfiguration->digitalPotentiometerSpiDevice);
+	efiPrintf("digitalPotentiometerSpiDevice %d", engineConfiguration->digitalPotentiometerSpiDevice);
 
 	for (int i = 0; i < DIGIPOT_COUNT; i++) {
-		scheduleMsg(&logger, "digitalPotentiometer CS%d %s", i,
+		efiPrintf("digitalPotentiometer CS%d %s", i,
 				hwPortname(engineConfiguration->digitalPotentiometerChipSelect[i]));
 	}
 #if EFI_PROD_CODE
@@ -302,27 +302,27 @@ static void printTpsSenser(const char *msg, SensorType sensor, int16_t min, int1
 	auto raw = Sensor::getRaw(sensor);
 
 	if (!tps.Valid) {
-		scheduleMsg(&logger, "TPS not valid");
+		efiPrintf("TPS not valid");
 	}
 
 	char pinNameBuffer[16];
 
-	scheduleMsg(&logger, "tps min (closed) %d/max (full) %d v=%.2f @%s", min, max,
+	efiPrintf("tps min (closed) %d/max (full) %d v=%.2f @%s", min, max,
 			raw, getPinNameByAdcChannel(msg, channel, pinNameBuffer));
 
 
-	scheduleMsg(&logger, "current 10bit=%d value=%.2f", convertVoltageTo10bitADC(raw), tps.Value);
+	efiPrintf("current 10bit=%d value=%.2f", convertVoltageTo10bitADC(raw), tps.Value);
 }
 
 void printTPSInfo(void) {
-	scheduleMsg(&logger, "pedal up %f / down %f",
+	efiPrintf("pedal up %f / down %f",
 			engineConfiguration->throttlePedalUpVoltage,
 			engineConfiguration->throttlePedalWOTVoltage);
 
 	auto pps = Sensor::get(SensorType::AcceleratorPedal);
 
 	if (!pps.Valid) {
-		scheduleMsg(&logger, "PPS not valid");
+		efiPrintf("PPS not valid");
 	}
 
 	printTpsSenser("TPS", SensorType::Tps1, engineConfiguration->tpsMin, engineConfiguration->tpsMax, engineConfiguration->tps1_1AdcChannel);
@@ -333,10 +333,10 @@ static void printTemperatureInfo(void) {
 #if EFI_ANALOG_SENSORS
 	Sensor::showAllSensorInfo();
 
-	scheduleMsg(&logger, "fan=%s @ %s", boolToString(enginePins.fanRelay.getLogicValue()),
+	efiPrintf("fan=%s @ %s", boolToString(enginePins.fanRelay.getLogicValue()),
 			hwPortname(engineConfiguration->fanPin));
 
-	scheduleMsg(&logger, "A/C relay=%s @ %s", boolToString(enginePins.acRelay.getLogicValue()),
+	efiPrintf("A/C relay=%s @ %s", boolToString(enginePins.acRelay.getLogicValue()),
 			hwPortname(engineConfiguration->acRelayPin));
 
 #endif /* EFI_ANALOG_SENSORS */
@@ -371,13 +371,13 @@ static void setRpmHardLimit(int value) {
 
 static void setCrankingIACExtra(float percent) {
 	engineConfiguration->crankingIACposition = percent;
-	scheduleMsg(&logger, "cranking_iac %.2f", percent);
+	efiPrintf("cranking_iac %.2f", percent);
 
 }
 
 static void setCrankingFuel(float timeMs) {
 	engineConfiguration->cranking.baseFuel = timeMs;
-	scheduleMsg(&logger, "cranking_fuel %.2f", timeMs);
+	efiPrintf("cranking_fuel %.2f", timeMs);
 
 	printTemperatureInfo();
 }
@@ -438,7 +438,7 @@ static void setTriggerType(int value) {
 	engineConfiguration->trigger.type = (trigger_type_e) value;
 	incrementGlobalConfigurationVersion(PASS_ENGINE_PARAMETER_SIGNATURE);
 	doPrintConfiguration();
-	scheduleMsg(&logger, "Do you need to also invoke set operation_mode X?");
+	efiPrintf("Do you need to also invoke set operation_mode X?");
 	engine->resetEngineSnifferIfInTestMode();
 }
 
@@ -452,14 +452,14 @@ static void setInjectorLag(float voltage, float value) {
 
 static void setToothedWheel(int total, int skipped DECLARE_ENGINE_PARAMETER_SUFFIX) {
 	if (total < 1 || skipped >= total) {
-		scheduleMsg(&logger, "invalid parameters %d %d", total, skipped);
+		efiPrintf("invalid parameters %d %d", total, skipped);
 		return;
 	}
 	engineConfiguration->trigger.type = TT_TOOTHED_WHEEL;
 	engineConfiguration->trigger.customTotalToothCount = total;
 	engineConfiguration->trigger.customSkippedToothCount = skipped;
 
-	scheduleMsg(&logger, "toothed: total=%d/skipped=%d", total, skipped);
+	efiPrintf("toothed: total=%d/skipped=%d", total, skipped);
 	setToothedWheelConfiguration(&engine->triggerCentral.triggerShape, total, skipped, engineConfiguration->ambiguousOperationMode);
 //	initializeTriggerWaveform(&logger, engineConfiguration, engineConfiguration2);
 	incrementGlobalConfigurationVersion(PASS_ENGINE_PARAMETER_SIGNATURE);
@@ -475,13 +475,13 @@ static void setCrankingChargeAngle(float value) {
 static void setGlobalFuelCorrection(float value) {
 	if (value < 0.01 || value > 50)
 		return;
-	scheduleMsg(&logger, "setting fuel mult=%.2f", value);
+	efiPrintf("setting fuel mult=%.2f", value);
 	engineConfiguration->globalFuelCorrection = value;
 }
 
 static void setFanSetting(float onTempC, float offTempC) {
 	if (onTempC <= offTempC) {
-		scheduleMsg(&logger, "ON temp [%.2f] should be above OFF temp [%.2f]", onTempC, offTempC);
+		efiPrintf("ON temp [%.2f] should be above OFF temp [%.2f]", onTempC, offTempC);
 		return;
 	}
 	engineConfiguration->fanOnTemperature = onTempC;
@@ -490,7 +490,7 @@ static void setFanSetting(float onTempC, float offTempC) {
 
 static void setWholeTimingMap(float value) {
 	// todo: table helper?
-	scheduleMsg(&logger, "Setting whole timing map to %.2f", value);
+	efiPrintf("Setting whole timing map to %.2f", value);
 	for (int l = 0; l < IGN_LOAD_COUNT; l++) {
 		for (int r = 0; r < IGN_RPM_COUNT; r++) {
 			config->ignitionTable[l][r] = value;
@@ -499,22 +499,22 @@ static void setWholeTimingMap(float value) {
 }
 
 static void setWholePhaseMapCmd(float value) {
-	scheduleMsg(&logger, "Setting whole injection phase map to %.2f", value);
+	efiPrintf("Setting whole injection phase map to %.2f", value);
 #if IGN_LOAD_COUNT == DEFAULT_IGN_LOAD_COUNT
 	setMap(config->injectionPhase, value);
 #endif
 }
 
 static void setWholeTimingMapCmd(float value) {
-	scheduleMsg(&logger, "Setting whole timing advance map to %.2f", value);
+	efiPrintf("Setting whole timing advance map to %.2f", value);
 	setWholeTimingMap(value);
 	engine->resetEngineSnifferIfInTestMode();
 }
 
 static void setWholeVeCmd(float value) {
-	scheduleMsg(&logger, "Setting whole VE map to %.2f", value);
+	efiPrintf("Setting whole VE map to %.2f", value);
 	if (engineConfiguration->fuelAlgorithm != LM_SPEED_DENSITY) {
-		scheduleMsg(&logger, "WARNING: setting VE map not in SD mode is pointless");
+		efiPrintf("WARNING: setting VE map not in SD mode is pointless");
 	}
 	setMap(config->veTable, value);
 	engine->resetEngineSnifferIfInTestMode();
@@ -543,10 +543,10 @@ static void setIgnitionPin(const char *indexStr, const char *pinName) {
 	brain_pin_e pin = parseBrainPin(pinName);
 	// todo: extract method - code duplication with other 'set_xxx_pin' methods?
 	if (pin == GPIO_INVALID) {
-		scheduleMsg(&logger, "invalid pin name [%s]", pinName);
+		efiPrintf("invalid pin name [%s]", pinName);
 		return;
 	}
-	scheduleMsg(&logger, "setting ignition pin[%d] to %s please save&restart", index, hwPortname(pin));
+	efiPrintf("setting ignition pin[%d] to %s please save&restart", index, hwPortname(pin));
 	engineConfiguration->ignitionPins[index] = pin;
 	incrementGlobalConfigurationVersion(PASS_ENGINE_PARAMETER_SIGNATURE);
 }
@@ -555,20 +555,20 @@ static void setIgnitionPin(const char *indexStr, const char *pinName) {
 static void readPin(const char *pinName) {
 	brain_pin_e pin = parseBrainPin(pinName);
 	if (pin == GPIO_INVALID) {
-		scheduleMsg(&logger, "invalid pin name [%s]", pinName);
+		efiPrintf("invalid pin name [%s]", pinName);
 		return;
 	}
 	int physicalValue = palReadPad(getHwPort("read", pin), getHwPin("read", pin));
-	scheduleMsg(&logger, "pin %s value %d", hwPortname(pin), physicalValue);
+	efiPrintf("pin %s value %d", hwPortname(pin), physicalValue);
 }
 
 static void setIndividualPin(const char *pinName, brain_pin_e *targetPin, const char *name) {
 	brain_pin_e pin = parseBrainPin(pinName);
 	if (pin == GPIO_INVALID) {
-		scheduleMsg(&logger, "invalid pin name [%s]", pinName);
+		efiPrintf("invalid pin name [%s]", pinName);
 		return;
 	}
-	scheduleMsg(&logger, "setting %s pin to %s please save&restart", name, hwPortname(pin));
+	efiPrintf("setting %s pin to %s please save&restart", name, hwPortname(pin));
 	*targetPin = pin;
 	incrementGlobalConfigurationVersion(PASS_ENGINE_PARAMETER_SIGNATURE);
 }
@@ -638,10 +638,10 @@ static void setInjectionPin(const char *indexStr, const char *pinName) {
 	brain_pin_e pin = parseBrainPin(pinName);
 	// todo: extract method - code duplication with other 'set_xxx_pin' methods?
 	if (pin == GPIO_INVALID) {
-		scheduleMsg(&logger, "invalid pin name [%s]", pinName);
+		efiPrintf("invalid pin name [%s]", pinName);
 		return;
 	}
-	scheduleMsg(&logger, "setting injection pin[%d] to %s please save&restart", index, hwPortname(pin));
+	efiPrintf("setting injection pin[%d] to %s please save&restart", index, hwPortname(pin));
 	engineConfiguration->injectionPins[index] = pin;
 	incrementGlobalConfigurationVersion(PASS_ENGINE_PARAMETER_SIGNATURE);
 }
@@ -659,10 +659,10 @@ static void setTriggerInputPin(const char *indexStr, const char *pinName) {
 	brain_pin_e pin = parseBrainPin(pinName);
 	// todo: extract method - code duplication with other 'set_xxx_pin' methods?
 	if (pin == GPIO_INVALID) {
-		scheduleMsg(&logger, "invalid pin name [%s]", pinName);
+		efiPrintf("invalid pin name [%s]", pinName);
 		return;
 	}
-	scheduleMsg(&logger, "setting trigger pin[%d] to %s please save&restart", index, hwPortname(pin));
+	efiPrintf("setting trigger pin[%d] to %s please save&restart", index, hwPortname(pin));
 	engineConfiguration->triggerInputPins[index] = pin;
 	incrementGlobalConfigurationVersion(PASS_ENGINE_PARAMETER_SIGNATURE);
 }
@@ -685,10 +685,10 @@ static void setEgtCSPin(const char *indexStr, const char *pinName) {
 		return;
 	brain_pin_e pin = parseBrainPin(pinName);
 	if (pin == GPIO_INVALID) {
-		scheduleMsg(&logger, "invalid pin name [%s]", pinName);
+		efiPrintf("invalid pin name [%s]", pinName);
 		return;
 	}
-	scheduleMsg(&logger, "setting EGT CS pin[%d] to %s please save&restart", index, hwPortname(pin));
+	efiPrintf("setting EGT CS pin[%d] to %s please save&restart", index, hwPortname(pin));
 	engineConfiguration->max31855_cs[index] = pin;
 	incrementGlobalConfigurationVersion(PASS_ENGINE_PARAMETER_SIGNATURE);
 }
@@ -699,10 +699,10 @@ static void setTriggerSimulatorPin(const char *indexStr, const char *pinName) {
 		return;
 	brain_pin_e pin = parseBrainPin(pinName);
 	if (pin == GPIO_INVALID) {
-		scheduleMsg(&logger, "invalid pin name [%s]", pinName);
+		efiPrintf("invalid pin name [%s]", pinName);
 		return;
 	}
-	scheduleMsg(&logger, "setting trigger simulator pin[%d] to %s please save&restart", index, hwPortname(pin));
+	efiPrintf("setting trigger simulator pin[%d] to %s please save&restart", index, hwPortname(pin));
 	engineConfiguration->triggerSimulatorPins[index] = pin;
 	incrementGlobalConfigurationVersion(PASS_ENGINE_PARAMETER_SIGNATURE);
 }
@@ -713,35 +713,35 @@ static void setTriggerSimulatorPin(const char *indexStr, const char *pinName) {
 static void setAnalogInputPin(const char *sensorStr, const char *pinName) {
 	brain_pin_e pin = parseBrainPin(pinName);
 	if (pin == GPIO_INVALID) {
-		scheduleMsg(&logger, "invalid pin name [%s]", pinName);
+		efiPrintf("invalid pin name [%s]", pinName);
 		return;
 	}
 	adc_channel_e channel = getAdcChannel(pin);
 	if (channel == EFI_ADC_ERROR) {
-		scheduleMsg(&logger, "Error with [%s]", pinName);
+		efiPrintf("Error with [%s]", pinName);
 		return;
 	}
 	if (strEqual("map", sensorStr)) {
 		engineConfiguration->map.sensor.hwChannel = channel;
-		scheduleMsg(&logger, "setting MAP to %s/%d", pinName, channel);
+		efiPrintf("setting MAP to %s/%d", pinName, channel);
 	} else if (strEqual("pps", sensorStr)) {
 		engineConfiguration->throttlePedalPositionAdcChannel = channel;
-		scheduleMsg(&logger, "setting PPS to %s/%d", pinName, channel);
+		efiPrintf("setting PPS to %s/%d", pinName, channel);
 	} else if (strEqual("afr", sensorStr)) {
 		engineConfiguration->afr.hwChannel = channel;
-		scheduleMsg(&logger, "setting AFR to %s/%d", pinName, channel);
+		efiPrintf("setting AFR to %s/%d", pinName, channel);
 	} else if (strEqual("clt", sensorStr)) {
 		engineConfiguration->clt.adcChannel = channel;
-		scheduleMsg(&logger, "setting CLT to %s/%d", pinName, channel);
+		efiPrintf("setting CLT to %s/%d", pinName, channel);
 	} else if (strEqual("iat", sensorStr)) {
 		engineConfiguration->iat.adcChannel = channel;
-		scheduleMsg(&logger, "setting IAT to %s/%d", pinName, channel);
+		efiPrintf("setting IAT to %s/%d", pinName, channel);
 	} else if (strEqual("tps", sensorStr)) {
 		engineConfiguration->tps1_1AdcChannel = channel;
-		scheduleMsg(&logger, "setting TPS1 to %s/%d", pinName, channel);
+		efiPrintf("setting TPS1 to %s/%d", pinName, channel);
 	} else if (strEqual("tps2", sensorStr)) {
 		engineConfiguration->tps2_1AdcChannel = channel;
-		scheduleMsg(&logger, "setting TPS2 to %s/%d", pinName, channel);
+		efiPrintf("setting TPS2 to %s/%d", pinName, channel);
 	}
 	incrementGlobalConfigurationVersion(PASS_ENGINE_PARAMETER_SIGNATURE);
 }
@@ -754,10 +754,10 @@ static void setLogicInputPin(const char *indexStr, const char *pinName) {
 	}
 	brain_pin_e pin = parseBrainPin(pinName);
 	if (pin == GPIO_INVALID) {
-		scheduleMsg(&logger, "invalid pin name [%s]", pinName);
+		efiPrintf("invalid pin name [%s]", pinName);
 		return;
 	}
-	scheduleMsg(&logger, "setting logic input pin[%d] to %s please save&restart", index, hwPortname(pin));
+	efiPrintf("setting logic input pin[%d] to %s please save&restart", index, hwPortname(pin));
 	engineConfiguration->logicAnalyzerPins[index] = pin;
 	incrementGlobalConfigurationVersion(PASS_ENGINE_PARAMETER_SIGNATURE);
 }
@@ -765,10 +765,10 @@ static void setLogicInputPin(const char *indexStr, const char *pinName) {
 static void showPinFunction(const char *pinName) {
 	brain_pin_e pin = parseBrainPin(pinName);
 	if (pin == GPIO_INVALID) {
-		scheduleMsg(&logger, "invalid pin name [%s]", pinName);
+		efiPrintf("invalid pin name [%s]", pinName);
 		return;
 	}
-	scheduleMsg(&logger, "Pin %s: [%s]", pinName, getPinFunction(pin));
+	efiPrintf("Pin %s: [%s]", pinName, getPinFunction(pin));
 }
 
 #endif /* EFI_PROD_CODE */
@@ -784,7 +784,7 @@ static void setTimingMap(const char * rpmStr, const char *loadStr, const char *v
 	loadIndex = loadIndex < 0 ? 0 : loadIndex;
 
 	config->ignitionTable[loadIndex][rpmIndex] = value;
-	scheduleMsg(&logger, "Setting timing map entry %d:%d to %.2f", rpmIndex, loadIndex, value);
+	efiPrintf("Setting timing map entry %d:%d to %.2f", rpmIndex, loadIndex, value);
 }
 
 static void setSpiMode(int index, bool mode) {
@@ -799,7 +799,7 @@ static void setSpiMode(int index, bool mode) {
 		engineConfiguration->is_enabled_spi_3 = mode;
 		break;
 	default:
-		scheduleMsg(&logger, "invalid spi index %d", index);
+		efiPrintf("invalid spi index %d", index);
 		return;
 	}
 	printSpiState(&logger, engineConfiguration);
@@ -911,10 +911,10 @@ static void enableOrDisable(const char *param, bool isEnabled) {
 	} else if (strEqualCaseInsensitive(param, "cylinder_cleanup")) {
 		engineConfiguration->isCylinderCleanupEnabled = isEnabled;
 	} else {
-		scheduleMsg(&logger, "unexpected [%s]", param);
+		efiPrintf("unexpected [%s]", param);
 		return; // well, MISRA would not like this 'return' here :(
 	}
-	scheduleMsg(&logger, "[%s] %s", param, isEnabled ? "enabled" : "disabled");
+	efiPrintf("[%s] %s", param, isEnabled ? "enabled" : "disabled");
 }
 
 static void enable(const char *param) {
@@ -945,7 +945,7 @@ static void printAllInfo(void) {
 	printTemperatureInfo();
 	printTPSInfo();
 #if EFI_ENGINE_SNIFFER
-	scheduleMsg(&logger, "waveChartUsedSize=%d", waveChartUsedSize);
+	efiPrintf("waveChartUsedSize=%d", waveChartUsedSize);
 #endif
 }
 
@@ -1024,7 +1024,7 @@ static void getValue(const char *paramStr) {
 		const plain_get_integer_s *currentI = &getI_plain[0];
 		while (currentI < getI_plain + sizeof(getI_plain)/sizeof(getI_plain[0])) {
 			if (strEqualCaseInsensitive(paramStr, currentI->token)) {
-				scheduleMsg(&logger, "%s value: %d", currentI->token, *currentI->value);
+				efiPrintf("%s value: %d", currentI->token, *currentI->value);
 				return;
 			}
 			currentI++;
@@ -1035,7 +1035,7 @@ static void getValue(const char *paramStr) {
 	while (currentF < getF_plain + sizeof(getF_plain)/sizeof(getF_plain[0])) {
 		if (strEqualCaseInsensitive(paramStr, currentF->token)) {
 			float value = *currentF->value;
-			scheduleMsg(&logger, "%s value: %.2f", currentF->token, value);
+			efiPrintf("%s value: %.2f", currentF->token, value);
 			return;
 		}
 		currentF++;
@@ -1046,33 +1046,33 @@ static void getValue(const char *paramStr) {
 
 
 	if (strEqualCaseInsensitive(paramStr, "isCJ125Enabled")) {
-		scheduleMsg(&logger, "isCJ125Enabled=%d", engineConfiguration->isCJ125Enabled);
+		efiPrintf("isCJ125Enabled=%d", engineConfiguration->isCJ125Enabled);
 #if EFI_PROD_CODE
 	} else if (strEqualCaseInsensitive(paramStr, "bor")) {
 		showBor();
 #endif /* EFI_PROD_CODE */
 	} else if (strEqualCaseInsensitive(paramStr, "tps_min")) {
-		scheduleMsg(&logger, "tps_min=%d", engineConfiguration->tpsMin);
+		efiPrintf("tps_min=%d", engineConfiguration->tpsMin);
 	} else if (strEqualCaseInsensitive(paramStr, "trigger_only_front")) {
-		scheduleMsg(&logger, "trigger_only_front=%d", engineConfiguration->useOnlyRisingEdgeForTrigger);
+		efiPrintf("trigger_only_front=%d", engineConfiguration->useOnlyRisingEdgeForTrigger);
 	} else if (strEqualCaseInsensitive(paramStr, "tps_max")) {
-		scheduleMsg(&logger, "tps_max=%d", engineConfiguration->tpsMax);
+		efiPrintf("tps_max=%d", engineConfiguration->tpsMax);
 	} else if (strEqualCaseInsensitive(paramStr, "global_trigger_offset_angle")) {
-		scheduleMsg(&logger, "global_trigger_offset=%.2f", engineConfiguration->globalTriggerAngleOffset);
+		efiPrintf("global_trigger_offset=%.2f", engineConfiguration->globalTriggerAngleOffset);
 	} else if (strEqualCaseInsensitive(paramStr, "trigger_hw_input")) {
-		scheduleMsg(&logger, "trigger_hw_input=%s", boolToString(engine->hwTriggerInputEnabled));
+		efiPrintf("trigger_hw_input=%s", boolToString(engine->hwTriggerInputEnabled));
 	} else if (strEqualCaseInsensitive(paramStr, "is_enabled_spi_1")) {
-		scheduleMsg(&logger, "is_enabled_spi_1=%s", boolToString(engineConfiguration->is_enabled_spi_1));
+		efiPrintf("is_enabled_spi_1=%s", boolToString(engineConfiguration->is_enabled_spi_1));
 	} else if (strEqualCaseInsensitive(paramStr, "is_enabled_spi_2")) {
-		scheduleMsg(&logger, "is_enabled_spi_2=%s", boolToString(engineConfiguration->is_enabled_spi_2));
+		efiPrintf("is_enabled_spi_2=%s", boolToString(engineConfiguration->is_enabled_spi_2));
 	} else if (strEqualCaseInsensitive(paramStr, "is_enabled_spi_3")) {
-		scheduleMsg(&logger, "is_enabled_spi_3=%s", boolToString(engineConfiguration->is_enabled_spi_3));
+		efiPrintf("is_enabled_spi_3=%s", boolToString(engineConfiguration->is_enabled_spi_3));
 	} else if (strEqualCaseInsensitive(paramStr, "vvtCamSensorUseRise")) {
-		scheduleMsg(&logger, "vvtCamSensorUseRise=%s", boolToString(engineConfiguration->vvtCamSensorUseRise));
+		efiPrintf("vvtCamSensorUseRise=%s", boolToString(engineConfiguration->vvtCamSensorUseRise));
 	} else if (strEqualCaseInsensitive(paramStr, "invertCamVVTSignal")) {
-		scheduleMsg(&logger, "invertCamVVTSignal=%s", boolToString(engineConfiguration->invertCamVVTSignal));
+		efiPrintf("invertCamVVTSignal=%s", boolToString(engineConfiguration->invertCamVVTSignal));
 	} else if (strEqualCaseInsensitive(paramStr, "isHip9011Enabled")) {
-		scheduleMsg(&logger, "isHip9011Enabled=%d", engineConfiguration->isHip9011Enabled);
+		efiPrintf("isHip9011Enabled=%d", engineConfiguration->isHip9011Enabled);
 	}
 
 #if EFI_RTC
@@ -1081,7 +1081,7 @@ static void getValue(const char *paramStr) {
 	}
 #endif
 	else {
-		scheduleMsg(&logger, "Invalid Parameter: %s", paramStr);
+		efiPrintf("Invalid Parameter: %s", paramStr);
 	}
 }
 

--- a/firmware/controllers/system/efi_gpio.cpp
+++ b/firmware/controllers/system/efi_gpio.cpp
@@ -32,7 +32,6 @@ extern WaveChart waveChart;
 
 // todo: clean this mess, this should become 'static'/private
 EnginePins enginePins;
-static Logging* logger;
 
 pin_output_mode_e DEFAULT_OUTPUT = OM_DEFAULT;
 pin_output_mode_e INVERTED_OUTPUT = OM_INVERTED;
@@ -589,8 +588,7 @@ uint8_t criticalErrorLedState;
 #define LED_ERROR_BRAIN_PIN_MODE DEFAULT_OUTPUT
 #endif /* LED_ERROR_BRAIN_PIN_MODE */
 
-void initPrimaryPins(Logging *sharedLogger) {
-	logger = sharedLogger;
+void initPrimaryPins() {
 #if EFI_PROD_CODE
 	enginePins.errorLedPin.initPin("led: CRITICAL status", LED_CRITICAL_ERROR_BRAIN_PIN, &(LED_ERROR_BRAIN_PIN_MODE));
 	criticalErrorLedPort = getHwPort("CRITICAL", LED_CRITICAL_ERROR_BRAIN_PIN);

--- a/firmware/controllers/system/efi_gpio.cpp
+++ b/firmware/controllers/system/efi_gpio.cpp
@@ -202,7 +202,7 @@ void EnginePins::debug() {
 #if EFI_PROD_CODE
 	RegisteredOutputPin * pin = registeredOutputHead;
 	while (pin != nullptr) {
-		scheduleMsg(logger, "%s %d", pin->registrationName, pin->currentLogicValue);
+		efiPrintf("%s %d", pin->registrationName, pin->currentLogicValue);
 		pin = pin->next;
 	}
 #endif // EFI_PROD_CODE
@@ -341,7 +341,7 @@ bool NamedOutputPin::stop() {
 #if EFI_GPIO_HARDWARE
 	if (isInitialized() && getLogicValue()) {
 		setValue(false);
-		scheduleMsg(logger, "turning off %s", name);
+		efiPrintf("turning off %s", name);
 		return true;
 	}
 #endif /* EFI_GPIO_HARDWARE */
@@ -567,7 +567,7 @@ void OutputPin::deInit() {
 	ext = false;
 #endif // (BOARD_EXT_GPIOCHIPS > 0)
 
-	scheduleMsg(logger, "unregistering %s", hwPortname(brainPin));
+	efiPrintf("unregistering %s", hwPortname(brainPin));
 
 #if EFI_GPIO_HARDWARE && EFI_PROD_CODE
 	efiSetPadUnused(brainPin);

--- a/firmware/controllers/system/efi_gpio.h
+++ b/firmware/controllers/system/efi_gpio.h
@@ -14,7 +14,7 @@
 #include "engine_configuration.h"
 #include "smart_gpio.h"
 
-void initPrimaryPins(Logging *sharedLogger);
+void initPrimaryPins();
 void initOutputPins(DECLARE_ENGINE_PARAMETER_SIGNATURE);
 
 #if EFI_GPIO_HARDWARE

--- a/firmware/controllers/system/timer/pwm_generator_logic.cpp
+++ b/firmware/controllers/system/timer/pwm_generator_logic.cpp
@@ -113,7 +113,7 @@ static efitick_t getNextSwitchTimeNt(PwmConfig *state) {
 	float switchTime = state->mode == PM_NORMAL ? state->multiChannelStateSequence.getSwitchTime(state->safe.phaseIndex) : 1;
 	float periodNt = state->safe.periodNt;
 #if DEBUG_PWM
-	scheduleMsg(&logger, "iteration=%d switchTime=%.2f period=%.2f", iteration, switchTime, period);
+	efiPrintf("iteration=%d switchTime=%.2f period=%.2f", iteration, switchTime, period);
 #endif /* DEBUG_PWM */
 
 	/**
@@ -123,7 +123,7 @@ static efitick_t getNextSwitchTimeNt(PwmConfig *state) {
 	uint32_t timeToSwitchNt = (uint32_t)((iteration + switchTime) * periodNt);
 
 #if DEBUG_PWM
-	scheduleMsg(&logger, "start=%d timeToSwitch=%d", state->safe.start, timeToSwitch);
+	efiPrintf("start=%d timeToSwitch=%d", state->safe.start, timeToSwitch);
 #endif /* DEBUG_PWM */
 	return state->safe.startNt + timeToSwitchNt;
 }
@@ -170,7 +170,7 @@ void PwmConfig::handleCycleStart() {
 
 			forceCycleStart = false;
 #if DEBUG_PWM
-			scheduleMsg(&logger, "state reset start=%d iteration=%d", state->safe.start, state->safe.iteration);
+			efiPrintf("state reset start=%d iteration=%d", state->safe.start, state->safe.iteration);
 #endif
 		}
 }
@@ -184,8 +184,8 @@ efitick_t PwmConfig::togglePwmState() {
 	}
 
 #if DEBUG_PWM
-	scheduleMsg(&logger, "togglePwmState phaseIndex=%d iteration=%d", safe.phaseIndex, safe.iteration);
-	scheduleMsg(&logger, "period=%.2f safe.period=%.2f", period, safe.periodNt);
+	efiPrintf("togglePwmState phaseIndex=%d iteration=%d", safe.phaseIndex, safe.iteration);
+	efiPrintf("period=%.2f safe.period=%.2f", period, safe.periodNt);
 #endif
 
 	if (cisnan(periodNt)) {
@@ -224,7 +224,7 @@ efitick_t PwmConfig::togglePwmState() {
 
 	efitick_t nextSwitchTimeNt = getNextSwitchTimeNt(this);
 #if DEBUG_PWM
-	scheduleMsg(&logger, "%s: nextSwitchTime %d", state->name, nextSwitchTime);
+	efiPrintf("%s: nextSwitchTime %d", state->name, nextSwitchTime);
 #endif /* DEBUG_PWM */
 
 	// If we're very far behind schedule, restart the cycle fresh to avoid scheduling a huge pile of events all at once

--- a/firmware/controllers/trigger/decoders/trigger_structure.cpp
+++ b/firmware/controllers/trigger/decoders/trigger_structure.cpp
@@ -472,7 +472,7 @@ void TriggerWaveform::initializeTriggerWaveform(Logging *logger, operation_mode_
 
 #if EFI_PROD_CODE
 	efiAssertVoid(CUSTOM_ERR_6641, getCurrentRemainingStack() > EXPECTED_REMAINING_STACK, "init t");
-	scheduleMsg(logger, "initializeTriggerWaveform(%s/%d)", getTrigger_type_e(triggerConfig->type), (int) triggerConfig->type);
+	efiPrintf("initializeTriggerWaveform(%s/%d)", getTrigger_type_e(triggerConfig->type), (int) triggerConfig->type);
 #endif
 
 	shapeDefinitionError = false;

--- a/firmware/controllers/trigger/trigger_central.cpp
+++ b/firmware/controllers/trigger/trigger_central.cpp
@@ -520,7 +520,7 @@ void TriggerCentral::handleShaftSignal(trigger_event_e signal, efitick_t timesta
 		ScopePerf perf(PE::ShaftPositionListeners);
 
 #if TRIGGER_EXTREME_LOGGING
-	scheduleMsg(logger, "trigger %d %d %d", triggerIndexForListeners, getRevolutionCounter(), (int)getTimeNowUs());
+	efiPrintf("trigger %d %d %d", triggerIndexForListeners, getRevolutionCounter(), (int)getTimeNowUs());
 #endif /* TRIGGER_EXTREME_LOGGING */
 
 		rpmShaftPositionCallback(signal, triggerIndexForListeners, timestamp PASS_ENGINE_PARAMETER_SUFFIX);
@@ -549,11 +549,11 @@ static void triggerShapeInfo(void) {
 #if EFI_PROD_CODE || EFI_SIMULATOR
 	TriggerWaveform *shape = &engine->triggerCentral.triggerShape;
 	TriggerFormDetails *triggerFormDetails = &engine->triggerCentral.triggerFormDetails;
-	scheduleMsg(logger, "useRise=%s", boolToString(TRIGGER_WAVEFORM(useRiseEdge)));
-	scheduleMsg(logger, "gap from %.2f to %.2f", TRIGGER_WAVEFORM(syncronizationRatioFrom[0]), TRIGGER_WAVEFORM(syncronizationRatioTo[0]));
+	efiPrintf("useRise=%s", boolToString(TRIGGER_WAVEFORM(useRiseEdge)));
+	efiPrintf("gap from %.2f to %.2f", TRIGGER_WAVEFORM(syncronizationRatioFrom[0]), TRIGGER_WAVEFORM(syncronizationRatioTo[0]));
 
 	for (size_t i = 0; i < shape->getSize(); i++) {
-		scheduleMsg(logger, "event %d %.2f", i, triggerFormDetails->eventAngles[i]);
+		efiPrintf("event %d %.2f", i, triggerFormDetails->eventAngles[i]);
 	}
 #endif
 }
@@ -574,84 +574,84 @@ void triggerInfo(void) {
 
 
 #if (HAL_TRIGGER_USE_PAL == TRUE) && (PAL_USE_CALLBACKS == TRUE)
-		scheduleMsg(logger, "trigger PAL mode %d", engine->hwTriggerInputEnabled);
+		efiPrintf("trigger PAL mode %d", engine->hwTriggerInputEnabled);
 #else
 
 #if HAL_USE_ICU == TRUE
-	scheduleMsg(logger, "trigger ICU hw: %d %d %d", icuRisingCallbackCounter, icuFallingCallbackCounter, engine->hwTriggerInputEnabled);
+	efiPrintf("trigger ICU hw: %d %d %d", icuRisingCallbackCounter, icuFallingCallbackCounter, engine->hwTriggerInputEnabled);
 #endif /* HAL_USE_ICU */
 
 #endif /* HAL_TRIGGER_USE_PAL */
 
-	scheduleMsg(logger, "Template %s (%d) trigger %s (%d) useRiseEdge=%s onlyFront=%s useOnlyFirstChannel=%s tdcOffset=%.2f",
+	efiPrintf("Template %s (%d) trigger %s (%d) useRiseEdge=%s onlyFront=%s useOnlyFirstChannel=%s tdcOffset=%.2f",
 			getConfigurationName(engineConfiguration->engineType), engineConfiguration->engineType,
 			getTrigger_type_e(engineConfiguration->trigger.type), engineConfiguration->trigger.type,
 			boolToString(TRIGGER_WAVEFORM(useRiseEdge)), boolToString(engineConfiguration->useOnlyRisingEdgeForTrigger),
 			boolToString(engineConfiguration->trigger.useOnlyFirstChannel), TRIGGER_WAVEFORM(tdcPosition));
 
 	if (engineConfiguration->trigger.type == TT_TOOTHED_WHEEL) {
-		scheduleMsg(logger, "total %d/skipped %d", engineConfiguration->trigger.customTotalToothCount,
+		efiPrintf("total %d/skipped %d", engineConfiguration->trigger.customTotalToothCount,
 				engineConfiguration->trigger.customSkippedToothCount);
 	}
 
-	scheduleMsg(logger, "trigger#1 event counters up=%d/down=%d", engine->triggerCentral.getHwEventCounter(0),
+	efiPrintf("trigger#1 event counters up=%d/down=%d", engine->triggerCentral.getHwEventCounter(0),
 			engine->triggerCentral.getHwEventCounter(1));
 
 	if (ts->needSecondTriggerInput) {
-		scheduleMsg(logger, "trigger#2 event counters up=%d/down=%d", engine->triggerCentral.getHwEventCounter(2),
+		efiPrintf("trigger#2 event counters up=%d/down=%d", engine->triggerCentral.getHwEventCounter(2),
 				engine->triggerCentral.getHwEventCounter(3));
 	}
-	scheduleMsg(logger, "expected cycle events %d/%d/%d", TRIGGER_WAVEFORM(expectedEventCount[0]),
+	efiPrintf("expected cycle events %d/%d/%d", TRIGGER_WAVEFORM(expectedEventCount[0]),
 			TRIGGER_WAVEFORM(expectedEventCount[1]), TRIGGER_WAVEFORM(expectedEventCount[2]));
 
-	scheduleMsg(logger, "trigger type=%d/need2ndChannel=%s", engineConfiguration->trigger.type,
+	efiPrintf("trigger type=%d/need2ndChannel=%s", engineConfiguration->trigger.type,
 			boolToString(TRIGGER_WAVEFORM(needSecondTriggerInput)));
-	scheduleMsg(logger, "expected duty #0=%.2f/#1=%.2f", TRIGGER_WAVEFORM(expectedDutyCycle[0]), TRIGGER_WAVEFORM(expectedDutyCycle[1]));
+	efiPrintf("expected duty #0=%.2f/#1=%.2f", TRIGGER_WAVEFORM(expectedDutyCycle[0]), TRIGGER_WAVEFORM(expectedDutyCycle[1]));
 
-	scheduleMsg(logger, "synchronizationNeeded=%s/isError=%s/total errors=%d ord_err=%d/total revolutions=%d/self=%s",
+	efiPrintf("synchronizationNeeded=%s/isError=%s/total errors=%d ord_err=%d/total revolutions=%d/self=%s",
 			boolToString(ts->isSynchronizationNeeded),
 			boolToString(isTriggerDecoderError()), engine->triggerCentral.triggerState.totalTriggerErrorCounter,
 			engine->triggerCentral.triggerState.orderingErrorCounter, engine->triggerCentral.triggerState.getTotalRevolutionCounter(),
 			boolToString(engine->directSelfStimulation));
 
 	if (TRIGGER_WAVEFORM(isSynchronizationNeeded)) {
-		scheduleMsg(logger, "gap from %.2f to %.2f", TRIGGER_WAVEFORM(syncronizationRatioFrom[0]), TRIGGER_WAVEFORM(syncronizationRatioTo[0]));
+		efiPrintf("gap from %.2f to %.2f", TRIGGER_WAVEFORM(syncronizationRatioFrom[0]), TRIGGER_WAVEFORM(syncronizationRatioTo[0]));
 	}
 
 #endif /* EFI_PROD_CODE || EFI_SIMULATOR */
 
 #if EFI_PROD_CODE
 	if (HAVE_CAM_INPUT()) {
-		scheduleMsg(logger, "VVT input: %s mode %s", hwPortname(engineConfiguration->camInputs[0]),
+		efiPrintf("VVT input: %s mode %s", hwPortname(engineConfiguration->camInputs[0]),
 				getVvt_mode_e(engineConfiguration->vvtMode[0]));
-		scheduleMsg(logger, "VVT event counters: %d/%d", engine->triggerCentral.vvtEventRiseCounter, engine->triggerCentral.vvtEventFallCounter);
+		efiPrintf("VVT event counters: %d/%d", engine->triggerCentral.vvtEventRiseCounter, engine->triggerCentral.vvtEventFallCounter);
 
 	}
 
-	scheduleMsg(logger, "primary trigger input: %s", hwPortname(CONFIG(triggerInputPins)[0]));
-	scheduleMsg(logger, "primary trigger simulator: %s %s freq=%d",
+	efiPrintf("primary trigger input: %s", hwPortname(CONFIG(triggerInputPins)[0]));
+	efiPrintf("primary trigger simulator: %s %s freq=%d",
 			hwPortname(CONFIG(triggerSimulatorPins)[0]),
 			getPin_output_mode_e(CONFIG(triggerSimulatorPinModes)[0]),
 			CONFIG(triggerSimulatorFrequency));
 
 	if (ts->needSecondTriggerInput) {
-		scheduleMsg(logger, "secondary trigger input: %s", hwPortname(CONFIG(triggerInputPins)[1]));
+		efiPrintf("secondary trigger input: %s", hwPortname(CONFIG(triggerInputPins)[1]));
 #if EFI_EMULATE_POSITION_SENSORS
-		scheduleMsg(logger, "secondary trigger simulator: %s %s phase=%d",
+		efiPrintf("secondary trigger simulator: %s %s phase=%d",
 				hwPortname(CONFIG(triggerSimulatorPins)[1]),
 				getPin_output_mode_e(CONFIG(triggerSimulatorPinModes)[1]), triggerSignal.safe.phaseIndex);
 #endif /* EFI_EMULATE_POSITION_SENSORS */
 	}
-//	scheduleMsg(logger, "3rd trigger simulator: %s %s", hwPortname(CONFIG(triggerSimulatorPins)[2]),
+//	efiPrintf("3rd trigger simulator: %s %s", hwPortname(CONFIG(triggerSimulatorPins)[2]),
 //			getPin_output_mode_e(CONFIG(triggerSimulatorPinModes)[2]));
 
-	scheduleMsg(logger, "trigger error extra LED: %s %s", hwPortname(CONFIG(triggerErrorPin)),
+	efiPrintf("trigger error extra LED: %s %s", hwPortname(CONFIG(triggerErrorPin)),
 			getPin_output_mode_e(CONFIG(triggerErrorPinMode)));
-	scheduleMsg(logger, "primary logic input: %s", hwPortname(CONFIG(logicAnalyzerPins)[0]));
-	scheduleMsg(logger, "secondary logic input: %s", hwPortname(CONFIG(logicAnalyzerPins)[1]));
+	efiPrintf("primary logic input: %s", hwPortname(CONFIG(logicAnalyzerPins)[0]));
+	efiPrintf("secondary logic input: %s", hwPortname(CONFIG(logicAnalyzerPins)[1]));
 
 
-	scheduleMsg(logger, "totalTriggerHandlerMaxTime=%d", triggerMaxDuration);
+	efiPrintf("totalTriggerHandlerMaxTime=%d", triggerMaxDuration);
 
 #endif /* EFI_PROD_CODE */
 }
@@ -691,7 +691,7 @@ void onConfigurationChangeTriggerCallback(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 	#endif
 	}
 #if EFI_DEFAILED_LOGGING
-	scheduleMsg(logger, "isTriggerConfigChanged=%d", engine->isTriggerConfigChanged);
+	efiPrintf("isTriggerConfigChanged=%d", engine->isTriggerConfigChanged);
 #endif /* EFI_DEFAILED_LOGGING */
 
 	// we do not want to miss two updates in a row

--- a/firmware/controllers/trigger/trigger_decoder.cpp
+++ b/firmware/controllers/trigger/trigger_decoder.cpp
@@ -551,7 +551,7 @@ void TriggerState::decodeTriggerEvent(
 				int rpm = GET_RPM();
 				floatms_t engineCycleDuration = getEngineCycleDuration(rpm PASS_ENGINE_PARAMETER_SUFFIX);
 				int time = currentCycle.totalTimeNt[0];
-				scheduleMsg(logger, "%s duty %f %d",
+				efiPrintf("%s duty %f %d",
 						name,
 						time / engineCycleDuration,
 						time
@@ -566,10 +566,10 @@ void TriggerState::decodeTriggerEvent(
 
 					float gap = 1.0 * toothDurations[i] / toothDurations[i + 1];
 					if (cisnan(gap)) {
-						scheduleMsg(logger, "index=%d NaN gap, you have noise issues?",
+						efiPrintf("index=%d NaN gap, you have noise issues?",
 								i);
 					} else {
-						scheduleMsg(logger, "%s rpm=%d time=%d index=%d: gap=%.3f expected from %.3f to %.3f error=%s",
+						efiPrintf("%s rpm=%d time=%d index=%d: gap=%.3f expected from %.3f to %.3f error=%s",
 								triggerConfiguration.PrintPrefix,
 								GET_RPM(),
 							/* cast is needed to make sure we do not put 64 bit value to stack*/ (int)getTimeNowSeconds(),
@@ -724,10 +724,6 @@ uint32_t TriggerState::findTriggerZeroEventIndex(
 			syncIndex, *this, shape);
 
 	return syncIndex % shape.getSize();
-}
-
-void initTriggerDecoderLogger(Logging *sharedLogger) {
-	logger = sharedLogger;
 }
 
 #endif /* EFI_SHAFT_POSITION_INPUT */

--- a/firmware/controllers/trigger/trigger_decoder.h
+++ b/firmware/controllers/trigger/trigger_decoder.h
@@ -220,8 +220,6 @@ angle_t getEngineCycle(operation_mode_e operationMode);
 
 class Engine;
 
-void initTriggerDecoderLogger(Logging *sharedLogger);
-
 void calculateTriggerSynchPoint(
 	TriggerWaveform& shape,
 	TriggerState& state

--- a/firmware/controllers/trigger/trigger_emulator_algo.cpp
+++ b/firmware/controllers/trigger/trigger_emulator_algo.cpp
@@ -106,13 +106,13 @@ void setTriggerEmulatorRPM(int rpm DECLARE_ENGINE_PARAMETER_SUFFIX) {
 	}
 	engine->resetEngineSnifferIfInTestMode();
 
-	scheduleMsg(logger, "Emulating position sensor(s). RPM=%d", rpm);
+	efiPrintf("Emulating position sensor(s). RPM=%d", rpm);
 }
 
 static void updateTriggerWaveformIfNeeded(PwmConfig *state) {
 	if (atTriggerVersion < engine->triggerCentral.triggerShape.version) {
 		atTriggerVersion = engine->triggerCentral.triggerShape.version;
-		scheduleMsg(logger, "Stimulator: updating trigger shape: %d/%d %d", atTriggerVersion,
+		efiPrintf("Stimulator: updating trigger shape: %d/%d %d", atTriggerVersion,
 				engine->getGlobalConfigurationVersion(), currentTimeMillis());
 
 

--- a/firmware/development/hw_layer/poten.cpp
+++ b/firmware/development/hw_layer/poten.cpp
@@ -80,7 +80,7 @@ static void sendToPot(Mcp42010Driver *driver, int channel, int value) {
 void setPotResistance(Mcp42010Driver *driver, int channel, int resistance) {
 	int value = getPotStep(resistance);
 
-	scheduleMsg(logger, "Sending to potentiometer%d: %d for R=%d", channel, value, resistance);
+	efiPrintf("Sending to potentiometer%d: %d for R=%d", channel, value, resistance);
 	sendToPot(driver, channel, value);
 }
 
@@ -98,7 +98,7 @@ void initPotentiometers(Logging *sharedLogger DECLARE_ENGINE_PARAMETER_SUFFIX) {
 	logger = sharedLogger;
 #if EFI_POTENTIOMETER
 	if (CONFIG(digitalPotentiometerSpiDevice) == SPI_NONE) {
-		scheduleMsg(logger, "digiPot spi disabled");
+		efiPrintf("digiPot spi disabled");
 		return;
 	}
 	turnOnSpi(CONFIG(digitalPotentiometerSpiDevice));

--- a/firmware/development/logic_analyzer.cpp
+++ b/firmware/development/logic_analyzer.cpp
@@ -128,7 +128,7 @@ static void initWave(const char *name, int index) {
 		reader->hw->setPeriodCallback((VoidInt)(void*) waIcuPeriodCallback, (void*) reader);
 	}
 
-	scheduleMsg(logger, "wave%d input on %s", index, hwPortname(brainPin));
+	efiPrintf("wave%d input on %s", index, hwPortname(brainPin));
 }
 
 WaveReader::WaveReader() {
@@ -220,7 +220,7 @@ void printWave(Logging *logging) {
 }
 
 void showWaveInfo(void) {
-	scheduleMsg(logger, "logic input #1: %d/%d", readers[0].fallEventCounter, readers[0].riseEventCounter);
+	efiPrintf("logic input #1: %d/%d", readers[0].fallEventCounter, readers[0].riseEventCounter);
 }
 
 void initWaveAnalyzer(Logging *sharedLogger) {

--- a/firmware/development/rfi_perftest.cpp
+++ b/firmware/development/rfi_perftest.cpp
@@ -44,7 +44,7 @@ static void testSystemCalls(const int count) {
 	time = currentTimeMillis() - start;
 	if (result != 0) {
 		// Finished 100000 iterations of 'chTimeNow()' in 33ms
-		scheduleMsg(logger, "Finished %d iterations of 'chTimeNow()' in %dms", count, time);
+		efiPrintf("Finished %d iterations of 'chTimeNow()' in %dms", count, time);
 	}
 
 	start = currentTimeMillis();
@@ -58,7 +58,7 @@ static void testSystemCalls(const int count) {
 	time = currentTimeMillis() - start;
 	if (result != 0) {
 		// Finished 100000 iterations of 'chTimeNow()' with chSysLock in 144ms
-		scheduleMsg(logger, "Finished %d iterations of 'chTimeNow()' with chSysLock in %dms", count, time);
+		efiPrintf("Finished %d iterations of 'chTimeNow()' with chSysLock in %dms", count, time);
 	}
 
 	start = currentTimeMillis();
@@ -66,7 +66,7 @@ static void testSystemCalls(const int count) {
 		result += currentTimeMillis();
 	time = currentTimeMillis() - start;
 	if (result != 0)
-		scheduleMsg(logger, "Finished %d iterations of 'currentTimeMillis' in %dms", count, time);
+		efiPrintf("Finished %d iterations of 'currentTimeMillis' in %dms", count, time);
 }
 
 static Engine testEngine;
@@ -79,14 +79,14 @@ static void testRusefiMethods(const int count) {
 
 	time = currentTimeMillis() - start;
 	if (tempi != 0)
-		scheduleMsg(logger, "Finished %d iterations of getBaseFuel in %dms", count, time);
+		efiPrintf("Finished %d iterations of getBaseFuel in %dms", count, time);
 
 //	start = currentTimeMillis();
 //	for (int i = 0; i < count; i++)
 //		tempi += getInjectionDuration(1200, NULL); // todo
 //	time = currentTimeMillis() - start;
 //	if (tempi != 0)
-//		scheduleMsg(logger, "Finished %d iterations of getFuelMs in %dms", count, time);
+//		efiPrintf("Finished %d iterations of getFuelMs in %dms", count, time);
 
 	start = currentTimeMillis();
 	for (int i = 0; i < count; i++) {
@@ -95,7 +95,7 @@ static void testRusefiMethods(const int count) {
 	}
 	time = currentTimeMillis() - start;
 	if (tempi != 0)
-		scheduleMsg(logger, "Finished %d iterations of updateSlowSensors in %dms", count, time);
+		efiPrintf("Finished %d iterations of updateSlowSensors in %dms", count, time);
 }
 
 static void testMath(const int count) {
@@ -108,7 +108,7 @@ static void testMath(const int count) {
 	}
 	time = currentTimeMillis() - start;
 	if (temp64 != 0) {
-		scheduleMsg(logger, "Finished %d iterations of int64_t summation in %dms", count, time);
+		efiPrintf("Finished %d iterations of int64_t summation in %dms", count, time);
 	}
 
 	temp64 = 1;
@@ -118,14 +118,14 @@ static void testMath(const int count) {
 	}
 	time = currentTimeMillis() - start;
 	if (temp64 == 0) {
-		scheduleMsg(logger, "Finished %d iterations of int64_t multiplication in %dms", count, time);
+		efiPrintf("Finished %d iterations of int64_t multiplication in %dms", count, time);
 	}
 
 	start = currentTimeMillis();
 	for (int i = 0; i < count; i++)
 		;
 	time = currentTimeMillis() - start;
-	scheduleMsg(logger, "Finished %d iterations of empty loop in %dms", count, time);
+	efiPrintf("Finished %d iterations of empty loop in %dms", count, time);
 
 	uint32_t tempi = 1;
 	start = currentTimeMillis();
@@ -137,7 +137,7 @@ static void testMath(const int count) {
 		// 11ms is 1848000 ticks
 		// 18.48 ticks per iteration
 		// Finished 100000 iterations of uint32_t summation in 11ms
-		scheduleMsg(logger, "Finished %d iterations of uint32_t summation in %dms", count, time);
+		efiPrintf("Finished %d iterations of uint32_t summation in %dms", count, time);
 	}
 
 	start = currentTimeMillis();
@@ -148,7 +148,7 @@ static void testMath(const int count) {
 	time = currentTimeMillis() - start;
 	if (tempi != 0) {
 		// Finished 100000 iterations of uint32_t division in 16ms
-		scheduleMsg(logger, "Finished %d iterations of uint32_t division in %dms", count, time);
+		efiPrintf("Finished %d iterations of uint32_t division in %dms", count, time);
 	}
 
 	start = currentTimeMillis();
@@ -159,7 +159,7 @@ static void testMath(const int count) {
 	time = currentTimeMillis() - start;
 	if (temp64 == 0) {
 		//  Finished 100000 iterations of int64_t summation in 21ms
-		scheduleMsg(logger, "Finished %d iterations of int64_t summation in %dms", count, time);
+		efiPrintf("Finished %d iterations of int64_t summation in %dms", count, time);
 	}
 
 	start = currentTimeMillis();
@@ -170,7 +170,7 @@ static void testMath(const int count) {
 	time = currentTimeMillis() - start;
 	if (temp64 != 0) {
 		// Finished 100000 iterations of int64_t division in 181ms
-		scheduleMsg(logger, "Finished %d iterations of int64_t division in %dms", count, time);
+		efiPrintf("Finished %d iterations of int64_t division in %dms", count, time);
 	}
 
 	start = currentTimeMillis();
@@ -180,7 +180,7 @@ static void testMath(const int count) {
 	}
 	time = currentTimeMillis() - start;
 	if (tempf != 0) {
-		scheduleMsg(logger, "Finished %d iterations of float summation in %dms", count, time);
+		efiPrintf("Finished %d iterations of float summation in %dms", count, time);
 	}
 
 	start = currentTimeMillis();
@@ -193,7 +193,7 @@ static void testMath(const int count) {
 		//  ms =  ticks
 		//  ticks per iteration
 		// Finished 100000 iterations of float division in ms
-		scheduleMsg(logger, "Finished %d iterations of float multiplication in %dms", count, time);
+		efiPrintf("Finished %d iterations of float multiplication in %dms", count, time);
 	}
 
 	start = currentTimeMillis();
@@ -206,7 +206,7 @@ static void testMath(const int count) {
 		// 65 ms = 10920000 ticks
 		// 109.2 ticks per iteration
 		// Finished 100000 iterations of float division in 65ms
-		scheduleMsg(logger, "Finished %d iterations of float division in %dms", count, time);
+		efiPrintf("Finished %d iterations of float division in %dms", count, time);
 	}
 
 	start = currentTimeMillis();
@@ -217,7 +217,7 @@ static void testMath(const int count) {
 	time = currentTimeMillis() - start;
 	if (tempf != 0) {
 		// Finished 100000 iterations of float log in 191ms
-		scheduleMsg(logger, "Finished %d iterations of float log in %dms", count, time);
+		efiPrintf("Finished %d iterations of float log in %dms", count, time);
 	}
 
 	start = currentTimeMillis();
@@ -227,7 +227,7 @@ static void testMath(const int count) {
 	time = currentTimeMillis() - start;
 	if (tempd != 0) {
 		// Finished 100000 iterations of double summation in 80ms
-		scheduleMsg(logger, "Finished %d iterations of double summation in %dms", count, time);
+		efiPrintf("Finished %d iterations of double summation in %dms", count, time);
 	}
 
 	start = currentTimeMillis();
@@ -237,7 +237,7 @@ static void testMath(const int count) {
 	time = currentTimeMillis() - start;
 	if (tempd != 0) {
 		// Finished 100000 iterations of double division in 497ms
-		scheduleMsg(logger, "Finished %d iterations of double division in %dms", count, time);
+		efiPrintf("Finished %d iterations of double division in %dms", count, time);
 	}
 
 	start = currentTimeMillis();
@@ -248,12 +248,12 @@ static void testMath(const int count) {
 	time = currentTimeMillis() - start;
 	if (tempd != 0) {
 		// Finished 100000 iterations of double log in 242ms
-		scheduleMsg(logger, "Finished %d iterations of double log in %dms", count, time);
+		efiPrintf("Finished %d iterations of double log in %dms", count, time);
 	}
 }
 
 static void runTests(const int count) {
-	scheduleMsg(logger, "Running tests: %d", count);
+	efiPrintf("Running tests: %d", count);
 	testRusefiMethods(count / 10);
 	testSystemCalls(count);
 	testMath(count);
@@ -268,12 +268,12 @@ static int rtcStartTime;
 #include "chrtclib.h"
 
 static void timeInfo(void) {
-	scheduleMsg(logger, "chTimeNow as seconds = %d", getTimeNowSeconds());
-	scheduleMsg(logger, "hal seconds = %d", halTime.get() / (long)CORE_CLOCK);
+	efiPrintf("chTimeNow as seconds = %d", getTimeNowSeconds());
+	efiPrintf("hal seconds = %d", halTime.get() / (long)CORE_CLOCK);
 
 #if EFI_RTC
 	int unix = rtcGetTimeUnixSec(&RTCD1) - rtcStartTime;
-	scheduleMsg(logger, "unix seconds = %d", unix);
+	efiPrintf("unix seconds = %d", unix);
 #endif
 }
 

--- a/firmware/hw_layer/debounce.cpp
+++ b/firmware/hw_layer/debounce.cpp
@@ -11,7 +11,6 @@
 #include "hardware.h"
 
 ButtonDebounce* ButtonDebounce::s_firstDebounce = nullptr;
-static Logging *logger;
 
 ButtonDebounce::ButtonDebounce(const char *name)
 	: m_name(name)
@@ -126,9 +125,7 @@ void ButtonDebounce::debug() {
     }
 }
 
-void initButtonDebounce(Logging *sharedLogger) {
-	logger = sharedLogger;
-
+void initButtonDebounce() {
 #if !EFI_UNIT_TEST
 	addConsoleAction("debounce", ButtonDebounce::debug);
 #endif /* EFI_UNIT_TEST */

--- a/firmware/hw_layer/debounce.cpp
+++ b/firmware/hw_layer/debounce.cpp
@@ -118,8 +118,8 @@ void ButtonDebounce::debug() {
     ButtonDebounce *listItem = s_firstDebounce;
     while (listItem != nullptr) {
 #if EFI_PROD_CODE || EFI_UNIT_TEST
-        scheduleMsg(logger, "%s timeLast %d", listItem->m_name, listItem->timeLast);
-        scheduleMsg(logger, "physical state %d value %d", efiReadPin(listItem->active_pin), listItem->storedValue);
+        efiPrintf("%s timeLast %d", listItem->m_name, listItem->timeLast);
+        efiPrintf("physical state %d value %d", efiReadPin(listItem->active_pin), listItem->storedValue);
 #endif
 
         listItem = listItem->nextDebounce;

--- a/firmware/hw_layer/debounce.h
+++ b/firmware/hw_layer/debounce.h
@@ -39,4 +39,4 @@ private:
     static ButtonDebounce* s_firstDebounce;
 };
 
-void initButtonDebounce(Logging *sharedLogger);
+void initButtonDebounce();

--- a/firmware/hw_layer/digital_input/trigger/trigger_input_comp.cpp
+++ b/firmware/hw_layer/digital_input/trigger/trigger_input_comp.cpp
@@ -44,7 +44,7 @@ static void setHysteresis(COMPDriver *comp, int sign) {
 		toothCnt = 0;
 		prevNt = nowNt;
 #ifdef TRIGGER_COMP_EXTREME_LOGGING
-		scheduleMsg(logger, "* f=%f d=%d", curVrFreqNt * 1000.0f, dacHysteresisDelta);
+		efiPrintf("* f=%f d=%d", curVrFreqNt * 1000.0f, dacHysteresisDelta);
 #endif /* TRIGGER_COMP_EXTREME_LOGGING */
 	}
 #endif /* EFI_TRIGGER_COMP_ADAPTIVE_HYSTERESIS */
@@ -114,7 +114,7 @@ static int getDacValue(uint8_t voltage DECLARE_ENGINE_PARAMETER_SUFFIX) {
 void startTriggerInputPins(void) {
 	//efiAssertVoid(CUSTOM_ERR_, !isCompEnabled, "isCompEnabled");
 	if (isCompEnabled) {
-		scheduleMsg(logger, "startTIPins(): already enabled!");
+		efiPrintf("startTIPins(): already enabled!");
 		return;
 	}
 
@@ -130,10 +130,10 @@ void startTriggerInputPins(void) {
 	float saturatedToothDurationUs = 60.0f * US_PER_SECOND_F / satRpm / hystUpdatePeriodNumEvents;
 	saturatedVrFreqNt = 1.0f / US2NT(saturatedToothDurationUs);
 	
-	scheduleMsg(logger, "startTIPins(): cDac=%d hystMin=%d hystMax=%d satRpm=%.0f satFreq*1k=%f period=%d", 
+	efiPrintf("startTIPins(): cDac=%d hystMin=%d hystMax=%d satRpm=%.0f satFreq*1k=%f period=%d", 
 		centeredDacValue, dacHysteresisMin, dacHysteresisMax, satRpm, saturatedVrFreqNt * 1000.0f, hystUpdatePeriodNumEvents);
 #ifdef EFI_TRIGGER_COMP_ADAPTIVE_HYSTERESIS
-	scheduleMsg(logger, "startTIPins(): ADAPTIVE_HYSTERESIS enabled!");
+	efiPrintf("startTIPins(): ADAPTIVE_HYSTERESIS enabled!");
 #endif /* EFI_TRIGGER_COMP_ADAPTIVE_HYSTERESIS */
 		
 	int channel = EFI_COMP_TRIGGER_CHANNEL; // todo: use getInputCaptureChannel(hwPin);
@@ -153,11 +153,11 @@ void startTriggerInputPins(void) {
 
 void stopTriggerInputPins(void) {
 	if (!isCompEnabled) {
-		scheduleMsg(logger, "stopTIPins(): already disabled!");
+		efiPrintf("stopTIPins(): already disabled!");
 		return;
 	}
 
-	scheduleMsg(logger, "stopTIPins();");
+	efiPrintf("stopTIPins();");
 
 	compDisable(EFI_COMP_PRIMARY_DEVICE);
 	isCompEnabled = false;

--- a/firmware/hw_layer/digital_input/trigger/trigger_input_exti.cpp
+++ b/firmware/hw_layer/digital_input/trigger/trigger_input_exti.cpp
@@ -89,7 +89,7 @@ static void cam_callback(void *arg) {
 int extiTriggerTurnOnInputPin(const char *msg, int index, bool isTriggerShaft) {
 	brain_pin_e brainPin = isTriggerShaft ? CONFIG(triggerInputPins)[index] : engineConfiguration->camInputs[index];
 
-	scheduleMsg(logger, "extiTriggerTurnOnInputPin %s %s", msg, hwPortname(brainPin));
+	efiPrintf("extiTriggerTurnOnInputPin %s %s", msg, hwPortname(brainPin));
 
 	/* TODO:
 	 * * do not set to both edges if we need only one

--- a/firmware/hw_layer/hardware.cpp
+++ b/firmware/hw_layer/hardware.cpp
@@ -484,7 +484,7 @@ void initHardwareNoConfig(Logging *l) {
 	/**
 	 * We need the LED_ERROR pin even before we read configuration
 	 */
-	initPrimaryPins(sharedLogger);
+	initPrimaryPins();
 
 	// it's important to initialize this pretty early in the game before any scheduling usages
 	initSingleTimerExecutorHardware();

--- a/firmware/hw_layer/hardware.cpp
+++ b/firmware/hw_layer/hardware.cpp
@@ -454,13 +454,13 @@ void applyNewHardwareSettings(void) {
 }
 
 void setBor(int borValue) {
-	scheduleMsg(sharedLogger, "setting BOR to %d", borValue);
+	efiPrintf("setting BOR to %d", borValue);
 	BOR_Set((BOR_Level_t)borValue);
 	showBor();
 }
 
 void showBor(void) {
-	scheduleMsg(sharedLogger, "BOR=%d", (int)BOR_Get());
+	efiPrintf("BOR=%d", (int)BOR_Get());
 }
 
 // This function initializes hardware that can do so before configuration is loaded
@@ -470,7 +470,7 @@ void initHardwareNoConfig(Logging *l) {
 	efiAssertVoid(CUSTOM_EC_NULL, engineConfiguration!=NULL, "engineConfiguration");
 	
 
-	scheduleMsg(sharedLogger, "initHardware()");
+	efiPrintf("initHardware()");
 
 	initPinRepository();
 
@@ -605,7 +605,7 @@ void initHardware() {
 
 	calcFastAdcIndexes();
 
-	scheduleMsg(sharedLogger, "initHardware() OK!");
+	efiPrintf("initHardware() OK!");
 }
 
 #endif /* EFI_PROD_CODE */

--- a/firmware/hw_layer/lcd/lcd_HD44780.cpp
+++ b/firmware/hw_layer/lcd/lcd_HD44780.cpp
@@ -186,12 +186,12 @@ void lcd_HD44780_print_string(const char* string) {
 
 //getHwPin(CONFIG(HD44780_db7))
 static void lcdInfo(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
-	scheduleMsg(logger, "HD44780 RS=%s", hwPortname(CONFIG(HD44780_rs)));
-	scheduleMsg(logger, "HD44780 E=%s", hwPortname(CONFIG(HD44780_e)));
-	scheduleMsg(logger, "HD44780 D4=%s", hwPortname(CONFIG(HD44780_db4)));
-	scheduleMsg(logger, "HD44780 D5=%s", hwPortname(CONFIG(HD44780_db5)));
-	scheduleMsg(logger, "HD44780 D6=%s", hwPortname(CONFIG(HD44780_db6)));
-	scheduleMsg(logger, "HD44780 D7=%s", hwPortname(CONFIG(HD44780_db7)));
+	efiPrintf("HD44780 RS=%s", hwPortname(CONFIG(HD44780_rs)));
+	efiPrintf("HD44780 E=%s", hwPortname(CONFIG(HD44780_e)));
+	efiPrintf("HD44780 D4=%s", hwPortname(CONFIG(HD44780_db4)));
+	efiPrintf("HD44780 D5=%s", hwPortname(CONFIG(HD44780_db5)));
+	efiPrintf("HD44780 D6=%s", hwPortname(CONFIG(HD44780_db6)));
+	efiPrintf("HD44780 D7=%s", hwPortname(CONFIG(HD44780_db7)));
 }
 
 void stopHD44780_pins() {
@@ -237,7 +237,7 @@ void lcd_HD44780_init(Logging *sharedLogger) {
 		return;
 	}
 
-	scheduleMsg(logger, "lcd_HD44780_init %d", engineConfiguration->displayMode);
+	efiPrintf("lcd_HD44780_init %d", engineConfiguration->displayMode);
 
 	if (!lcd_HD44780_is_enabled())
 		return;
@@ -267,7 +267,7 @@ void lcd_HD44780_init(Logging *sharedLogger) {
 	lcd_HD44780_write_command(LCD_HD44780_DISPLAY_ON);
 
 	lcd_HD44780_set_position(0, 0);
-	scheduleMsg(logger, "lcd_HD44780_init() done");
+	efiPrintf("lcd_HD44780_init() done");
 }
 
 void lcdShowPanicMessage(char *message) {

--- a/firmware/hw_layer/max31855.cpp
+++ b/firmware/hw_layer/max31855.cpp
@@ -39,11 +39,11 @@ static void showEgtInfo(void) {
 #if EFI_PROD_CODE
 	printSpiState(logger, engineConfiguration);
 
-	scheduleMsg(logger, "EGT spi: %d", CONFIG(max31855spiDevice));
+	efiPrintf("EGT spi: %d", CONFIG(max31855spiDevice));
 
 	for (int i = 0; i < EGT_CHANNEL_COUNT; i++) {
 		if (isBrainPinValid(CONFIG(max31855_cs)[i])) {
-			scheduleMsg(logger, "%d ETG @ %s", i, hwPortname(CONFIG(max31855_cs)[i]));
+			efiPrintf("%d ETG @ %s", i, hwPortname(CONFIG(max31855_cs)[i]));
 		}
 	}
 #endif
@@ -120,24 +120,24 @@ uint16_t getEgtValue(int egtChannel) {
 static void egtRead(void) {
 
 	if (driver == NULL) {
-		scheduleMsg(logger, "No SPI selected for EGT");
+		efiPrintf("No SPI selected for EGT");
 		return;
 	}
 
-	scheduleMsg(logger, "Reading egt");
+	efiPrintf("Reading egt");
 
 	uint32_t egtPacket = readEgtPacket(0);
 
 	max_32855_code code = getResultCode(egtPacket);
 
-	scheduleMsg(logger, "egt %x code=%d %s", egtPacket, code, getMcCode(code));
+	efiPrintf("egt %x code=%d %s", egtPacket, code, getMcCode(code));
 
 	if (code != MC_INVALID) {
 		int refBits = ((egtPacket & 0xFFFF) / 16); // bits 15:4
 		float refTemp = refBits / 16.0;
-		scheduleMsg(logger, "reference temperature %.2f", refTemp);
+		efiPrintf("reference temperature %.2f", refTemp);
 
-		scheduleMsg(logger, "EGT temperature %d", GET_TEMPERATURE_C(egtPacket));
+		efiPrintf("EGT temperature %d", GET_TEMPERATURE_C(egtPacket));
 	}
 }
 

--- a/firmware/hw_layer/mc33816.cpp
+++ b/firmware/hw_layer/mc33816.cpp
@@ -62,21 +62,21 @@ static bool validateChipId() {
 
 static void showStats() {
 	if (!isInitializaed) {
-		scheduleMsg(logger, "WAITINIG FOR VBatt...");
+		efiPrintf("WAITINIG FOR VBatt...");
 	}
 	// x9D is product code or something, and 43 is the revision?
-	scheduleMsg(logger, "MC 0x%x %s", mcChipId, validateChipId() ? "hooray!" : "not hooray :(");
+	efiPrintf("MC 0x%x %s", mcChipId, validateChipId() ? "hooray!" : "not hooray :(");
 
     if (isBrainPinValid(CONFIG(mc33816_flag0))) {
-    	scheduleMsg(logger, "flag0 before %d after %d", flag0before, flag0after);
+    	efiPrintf("flag0 before %d after %d", flag0before, flag0after);
 
-    	scheduleMsg(logger, "flag0 right now %d", efiReadPin(CONFIG(mc33816_flag0)));
+    	efiPrintf("flag0 right now %d", efiReadPin(CONFIG(mc33816_flag0)));
 
     } else {
-    	scheduleMsg(logger, "No flag0 pin selected");
+    	efiPrintf("No flag0 pin selected");
     }
-    scheduleMsg(logger, "MC voltage %d", CONFIG(mc33_hvolt));
-    scheduleMsg(logger, "MC driver status 0x%x", mcDriverStatus);
+    efiPrintf("MC voltage %d", CONFIG(mc33_hvolt));
+    efiPrintf("MC driver status 0x%x", mcDriverStatus);
 }
 
 static void mcRestart();
@@ -469,13 +469,13 @@ static void mcRestart() {
 	flag0before = false;
 	flag0after = false;
 
-	scheduleMsg(logger, "MC Restart");
+	efiPrintf("MC Restart");
 	showStats();
 
 	driven.setValue(0); // ensure driven is off
 
 	if (Sensor::get(SensorType::BatteryVoltage).value_or(VBAT_FALLBACK_VALUE) < LOW_VBATT) {
-		scheduleMsg(logger, "GDI not Restarting until we see VBatt");
+		efiPrintf("GDI not Restarting until we see VBatt");
 		return;
 	}
 

--- a/firmware/hw_layer/sensors/cj125_logic.cpp
+++ b/firmware/hw_layer/sensors/cj125_logic.cpp
@@ -23,7 +23,7 @@ void CJ125::SetHeater(float value DECLARE_ENGINE_PARAMETER_SUFFIX) {
 	float maxDuty = (Sensor::get(SensorType::BatteryVoltage).value_or(VBAT_FALLBACK_VALUE) > CJ125_HEATER_LIMITING_VOLTAGE) ? CJ125_HEATER_LIMITING_RATE : 1.0f;
 	heaterDuty = (value < CJ125_HEATER_MIN_DUTY) ? 0.0f : minF(maxF(value, 0.0f), maxDuty);
 #ifdef CJ125_DEBUG
-	scheduleMsg(logger, "cjSetHeater: %.2f", heaterDuty);
+	efiPrintf("cjSetHeater: %.2f", heaterDuty);
 #endif
 	// a little trick to disable PWM if needed.
 	// todo: this should be moved to wboHeaterControl.setPwmDutyCycle()
@@ -69,9 +69,9 @@ static void printDiagCode(Logging * logging, const char *msg, int code, const ch
 
 void CJ125::printDiag() {
 	if (diag == CJ125_DIAG_NORM) {
-		scheduleMsg(logger, "cj125: diag Looks great!");
+		efiPrintf("cj125: diag Looks great!");
 	} else {
-		scheduleMsg(logger, "cj125: diag NOT GOOD");
+		efiPrintf("cj125: diag NOT GOOD");
 		printDiagCode(logger, "VM", diag, LOW_VOLTAGE);
 		printDiagCode(logger, "UN", diag >> 2, LOW_VOLTAGE);
 		printDiagCode(logger, "IA", diag >> 4, LOW_VOLTAGE);
@@ -99,14 +99,14 @@ bool CJ125::cjIdentify(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 	int init2 = spi->ReadRegister(INIT_REG2_RD);
 
 	diag = spi->ReadRegister(DIAG_REG_RD);
-	scheduleMsg(logger, "cj125: Check ident=0x%x diag=0x%x init1=0x%x init2=0x%x", ident, diag, init1, init2);
+	efiPrintf("cj125: Check ident=0x%x diag=0x%x init1=0x%x init2=0x%x", ident, diag, init1, init2);
 	if (ident != CJ125_IDENT) {
-		scheduleMsg(logger, "cj125: Error! Wrong ident! Cannot communicate with CJ125!");
+		efiPrintf("cj125: Error! Wrong ident! Cannot communicate with CJ125!");
 		setError(CJ125_ERROR_WRONG_IDENT PASS_ENGINE_PARAMETER_SUFFIX);
 		return false;
 	}
 	if (init1 != CJ125_INIT1_NORMAL_17 || init2 != CJ125_INIT2_DIAG) {
-		scheduleMsg(logger, "cj125: Error! Cannot set init registers! Cannot communicate with CJ125!");
+		efiPrintf("cj125: Error! Cannot set init registers! Cannot communicate with CJ125!");
 		setError(CJ125_ERROR_WRONG_IDENT PASS_ENGINE_PARAMETER_SUFFIX);
 		return false;
 	}

--- a/firmware/hw_layer/sensors/hip9011.cpp
+++ b/firmware/hw_layer/sensors/hip9011.cpp
@@ -440,7 +440,7 @@ void initHip9011(Logging *sharedLogger) {
 	/* load settings */
 	instance.prescaler = CONFIG(hip9011PrescalerAndSDO);
 
-	scheduleMsg(logger, "Starting HIP9011/TPIC8101 driver");
+	efiPrintf("Starting HIP9011/TPIC8101 driver");
 
 	chThdCreateStatic(hipThreadStack, sizeof(hipThreadStack), PRIO_HIP9011, (tfunc_t)(void*) hipThread, NULL);
 
@@ -453,52 +453,52 @@ void initHip9011(Logging *sharedLogger) {
 
 static void showHipInfo(void) {
 	if (!CONFIG(isHip9011Enabled)) {
-		scheduleMsg(logger, "hip9011 driver not active");
+		efiPrintf("hip9011 driver not active");
 		return;
 	}
 
-	scheduleMsg(logger, "HIP9011: enabled %s state %s",
+	efiPrintf("HIP9011: enabled %s state %s",
 		boolToString(CONFIG(isHip9011Enabled)),
 		getHip_state_e(instance.state));
 
-	scheduleMsg(logger, " Advanced mode: enabled %d used %d",
+	efiPrintf(" Advanced mode: enabled %d used %d",
 		CONFIG(useTpicAdvancedMode),
 		instance.adv_mode);
 
-	scheduleMsg(logger, " Input Ch %d (cylinder %d next %d)",
+	efiPrintf(" Input Ch %d (cylinder %d next %d)",
 		instance.channelIdx,
 		instance.cylinderNumber,
 		instance.expectedCylinderNumber);
 
-	scheduleMsg(logger, " Cyl bore %.2fmm freq %.2fkHz band idx 0x%x",
+	efiPrintf(" Cyl bore %.2fmm freq %.2fkHz band idx 0x%x",
 		engineConfiguration->cylinderBore,
 		instance.getBand(PASS_HIP_PARAMS),
 		instance.bandIdx);
 
-	scheduleMsg(logger, " Integrator idx 0x%x",
+	efiPrintf(" Integrator idx 0x%x",
 		instance.intergratorIdx);
 
-	scheduleMsg(logger, " Gain %.2f idx 0x%x",
+	efiPrintf(" Gain %.2f idx 0x%x",
 		engineConfiguration->hip9011Gain,
 		instance.gainIdx);
 
-	scheduleMsg(logger, " PaSDO=0x%x",
+	efiPrintf(" PaSDO=0x%x",
 		instance.prescaler);
 
-	scheduleMsg(logger, " knockVThreshold=%.2f knockCount=%d maxKnockSubDeg=%.2f",
+	efiPrintf(" knockVThreshold=%.2f knockCount=%d maxKnockSubDeg=%.2f",
 		engineConfiguration->knockVThreshold,
 		engine->knockCount,
 		engineConfiguration->maxKnockSubDeg);
 
-	scheduleMsg(logger, " Adc input %s (%.2f V)",
+	efiPrintf(" Adc input %s (%.2f V)",
 		getAdc_channel_e(engineConfiguration->hipOutputChannel),
 		getVoltage("hipinfo", engineConfiguration->hipOutputChannel));
 
-	scheduleMsg(logger, " IntHold %s (mode 0x%x)",
+	efiPrintf(" IntHold %s (mode 0x%x)",
 		hwPortname(CONFIG(hip9011IntHoldPin)),
 		CONFIG(hip9011IntHoldPinMode));
 
-	scheduleMsg(logger, " Spi %s CS %s (mode 0x%x)",
+	efiPrintf(" Spi %s CS %s (mode 0x%x)",
 		getSpi_device_e(engineConfiguration->hip9011SpiDevice),
 		hwPortname(CONFIG(hip9011CsPin)),
 		CONFIG(hip9011CsPinMode));
@@ -507,19 +507,19 @@ static void showHipInfo(void) {
 	printSpiConfig(logger, "hip9011", CONFIG(hip9011SpiDevice));
 #endif /* EFI_PROD_CODE */
 
-	scheduleMsg(logger, " SPI good response %d incorrect response %d",
+	efiPrintf(" SPI good response %d incorrect response %d",
 		instance.correctResponsesCount,
 		instance.invalidResponsesCount);
 
-	scheduleMsg(logger, " hip %.2f vmax=%.2f",
+	efiPrintf(" hip %.2f vmax=%.2f",
 		engine->knockVolts,
 		hipValueMax);
 
-	scheduleMsg(logger, " Window start %.2f end %.2f",
+	efiPrintf(" Window start %.2f end %.2f",
 		engineConfiguration->knockDetectionWindowStart,
 		engineConfiguration->knockDetectionWindowEnd);
 
-	scheduleMsg(logger, " Counters: samples %d overruns %d sync miss %d",
+	efiPrintf(" Counters: samples %d overruns %d sync miss %d",
 		instance.samples, instance.overrun, instance.unsync);
 
 	hipValueMax = 0;

--- a/firmware/hw_layer/trigger_input_adc.cpp
+++ b/firmware/hw_layer/trigger_input_adc.cpp
@@ -88,7 +88,7 @@ static void setHysteresis(int sign) {
 		toothCnt = 0;
 		prevNt = nowNt;
 #ifdef TRIGGER_COMP_EXTREME_LOGGING
-		scheduleMsg(logger, "* f=%f d=%d", curVrFreqNt * 1000.0f, dacHysteresisDelta);
+		efiPrintf("* f=%f d=%d", curVrFreqNt * 1000.0f, dacHysteresisDelta);
 #endif /* TRIGGER_COMP_EXTREME_LOGGING */
 	}
 #endif /* EFI_TRIGGER_COMP_ADAPTIVE_HYSTERESIS */
@@ -244,7 +244,7 @@ static int turnOnTriggerInputPin(const char *msg, int index, bool isTriggerShaft
 	float saturatedToothDurationUs = 60.0f * US_PER_SECOND_F / satRpm / hystUpdatePeriodNumEvents;
 	saturatedVrFreqNt = 1.0f / US2NT(saturatedToothDurationUs);
 	
-	scheduleMsg(logger, "startTIPins(): cDac=%d hystMin=%d hystMax=%d satRpm=%.0f satFreq*1k=%f period=%d", 
+	efiPrintf("startTIPins(): cDac=%d hystMin=%d hystMax=%d satRpm=%.0f satFreq*1k=%f period=%d", 
 		centeredDacValue, dacHysteresisMin, dacHysteresisMax, satRpm, saturatedVrFreqNt * 1000.0f, hystUpdatePeriodNumEvents);
 #endif
 
@@ -254,7 +254,7 @@ static int turnOnTriggerInputPin(const char *msg, int index, bool isTriggerShaft
 	triggerInputPin = getHwPin("trg", brainPin);
 
 	ioline_t pal_line = PAL_LINE(triggerInputPort, triggerInputPin);
-	scheduleMsg(logger, "turnOnTriggerInputPin %s l=%d", hwPortname(brainPin), pal_line);
+	efiPrintf("turnOnTriggerInputPin %s l=%d", hwPortname(brainPin), pal_line);
 	
 	efiExtiEnablePin(msg, brainPin, PAL_EVENT_MODE_BOTH_EDGES, isTriggerShaft ? shaft_callback : cam_callback, (void *)pal_line);
 	
@@ -275,7 +275,7 @@ void startTriggerInputPins(void) {
 
 
 void stopTriggerInputPins(void) {
-	scheduleMsg(logger, "stopTIPins();");
+	efiPrintf("stopTIPins();");
 
 #if 0
 	for (int i = 0; i < TRIGGER_SUPPORTED_CHANNELS; i++) {

--- a/firmware/hw_layer/vehicle_speed.cpp
+++ b/firmware/hw_layer/vehicle_speed.cpp
@@ -57,14 +57,14 @@ static void vsAnaWidthCallback(void) {
 }
 
 static void speedInfo(void) {
-	scheduleMsg(logger, "VSS input at %s",
+	efiPrintf("VSS input at %s",
 			hwPortname(CONFIG(vehicleSpeedSensorInputPin)));
 
-	scheduleMsg(logger, "c=%.2f eventCounter=%d speed=%.2f",
+	efiPrintf("c=%.2f eventCounter=%d speed=%.2f",
 			engineConfiguration->vehicleSpeedCoef,
 			engine->engineState.vssEventCounter,
 			getVehicleSpeed());
-	scheduleMsg(logger, "vss diff %d", vssDiff);
+	efiPrintf("vss diff %d", vssDiff);
 }
 
 bool hasVehicleSpeedSensor() {

--- a/firmware/rusefi.cpp
+++ b/firmware/rusefi.cpp
@@ -156,7 +156,7 @@ void rebootNow(void) {
  * Once day we will write graceful shutdown, but that would be one day.
  */
 static void scheduleReboot(void) {
-	scheduleMsg(&sharedLogger, "Rebooting in 3 seconds...");
+	efiPrintf("Rebooting in 3 seconds...");
 	chibios_rt::CriticalSectionLocker csl;
 	chVTSetI(&resetTimer, TIME_MS2I(3000), (vtfunc_t) rebootNow, NULL);
 }
@@ -183,15 +183,6 @@ void runRusEfi(void) {
 
 	addConsoleAction(CMD_REBOOT, scheduleReboot);
 	addConsoleAction(CMD_REBOOT_DFU, jump_to_bootloader);
-
-#if EFI_SHAFT_POSITION_INPUT
-	/**
-	 * This is so early because we want to init logger
-	 * which would be used while finding trigger sync index
-	 * while reading configuration
-	 */
-	initTriggerDecoderLogger(&sharedLogger);
-#endif /* EFI_SHAFT_POSITION_INPUT */
 
 	/**
 	 * we need to initialize table objects before default configuration can set values
@@ -263,7 +254,7 @@ void runRusEfi(void) {
 		runSchedulingPrecisionTestIfNeeded();
 	}
 
-	scheduleMsg(&sharedLogger, "Running main loop");
+	efiPrintf("Running main loop");
 	main_loop_started = true;
 	/**
 	 * This loop is the closes we have to 'main loop' - but here we only publish the status. The main logic of engine

--- a/firmware/util/cli_registry.cpp
+++ b/firmware/util/cli_registry.cpp
@@ -25,8 +25,6 @@
 // todo: support \t as well
 #define SPACE_CHAR ' '
 
-static Logging * logging;
-
 static int consoleActionCount = 0;
 static TokenCallback consoleActions[CONSOLE_MAX_ACTIONS] CCM_OPTIONAL;
 
@@ -170,20 +168,20 @@ static int getParameterCount(action_type_e parameterType) {
 void helpCommand(void) {
 
 #if EFI_PROD_CODE || EFI_SIMULATOR
-	scheduleMsg(logging, "%d actions available", consoleActionCount);
+	efiPrintf("%d actions available", consoleActionCount);
 	for (int i = 0; i < consoleActionCount; i++) {
 		TokenCallback *current = &consoleActions[i];
-		scheduleMsg(logging, "  %s: %d parameters", current->token, getParameterCount(current->parameterType));
+		efiPrintf("  %s: %d parameters", current->token, getParameterCount(current->parameterType));
 	}
 #endif
-	scheduleMsg(logging, "For more visit http://rusefi.com/wiki/index.php?title=Manual:Software:dev_console_commands");
+	efiPrintf("For more visit http://rusefi.com/wiki/index.php?title=Manual:Software:dev_console_commands");
 }
 
 /**
  * @brief This is just a test function
  */
 static void echo(int value) {
-	scheduleMsg(logging, "got value: %d", value);
+	efiPrintf("got value: %d", value);
 }
 
 char *unquote(char *line) {
@@ -342,7 +340,7 @@ void handleActionWithParameter(TokenCallback *current, char *parameter) {
 		int value1 = atoi(parameter);
 		if (absI(value1) == ERROR_CODE) {
 #if EFI_PROD_CODE || EFI_SIMULATOR
-			scheduleMsg(logging, "not an integer [%s]", parameter);
+			efiPrintf("not an integer [%s]", parameter);
 #endif
 			return;
 		}
@@ -350,7 +348,7 @@ void handleActionWithParameter(TokenCallback *current, char *parameter) {
 		int value2 = atoi(parameter);
 		if (absI(value2) == ERROR_CODE) {
 #if EFI_PROD_CODE || EFI_SIMULATOR
-			scheduleMsg(logging, "not an integer [%s]", parameter);
+			efiPrintf("not an integer [%s]", parameter);
 #endif
 			return;
 		}
@@ -371,7 +369,7 @@ void handleActionWithParameter(TokenCallback *current, char *parameter) {
 	if (current->parameterType == FLOAT_PARAMETER) {
 		float value = atoff(parameter);
 		if (cisnan(value)) {
-			scheduleMsg(logging, "invalid float [%s]", parameter);
+			efiPrintf("invalid float [%s]", parameter);
 			return;
 		}
 		VoidFloat callbackF = (VoidFloat) current->callback;
@@ -388,7 +386,7 @@ void handleActionWithParameter(TokenCallback *current, char *parameter) {
 		REPLACE_SPACES_WITH_ZERO;
 		float value1 = atoff(parameter);
 		if (cisnan(value1)) {
-			scheduleMsg(logging, "invalid float [%s]", parameter);
+			efiPrintf("invalid float [%s]", parameter);
 			return;
 		}
 
@@ -396,7 +394,7 @@ void handleActionWithParameter(TokenCallback *current, char *parameter) {
 		float value2 = atoff(parameter);
 
 		if (cisnan(value2)) {
-			scheduleMsg(logging, "invalid float [%s]", parameter);
+			efiPrintf("invalid float [%s]", parameter);
 			return;
 		}
 	if (current->parameterType == FLOAT_FLOAT_PARAMETER) {
@@ -417,7 +415,7 @@ void handleActionWithParameter(TokenCallback *current, char *parameter) {
 		int value1 = atoi(parameter);
 		if (absI(value1) == ERROR_CODE) {
 #if EFI_PROD_CODE || EFI_SIMULATOR
-			scheduleMsg(logging, "not an integer [%s]", parameter);
+			efiPrintf("not an integer [%s]", parameter);
 #endif
 			return;
 		}
@@ -425,7 +423,7 @@ void handleActionWithParameter(TokenCallback *current, char *parameter) {
 		float value2 = atoff(parameter);
 
 		if (cisnan(value2)) {
-			scheduleMsg(logging, "invalid float [%s]", parameter);
+			efiPrintf("invalid float [%s]", parameter);
 			return;
 		}
 		
@@ -437,7 +435,7 @@ void handleActionWithParameter(TokenCallback *current, char *parameter) {
 
 	int value = atoi(parameter);
 	if (absI(value) == ERROR_CODE) {
-		scheduleMsg(logging, "invalid integer [%s]", parameter);
+		efiPrintf("invalid integer [%s]", parameter);
 		return;
 	}
 
@@ -492,7 +490,7 @@ char *validateSecureLine(char *line) {
 		char *divider = line;
 		while (*divider != '!') {
 			if (*divider == '\0') {
-				scheduleMsg(logging, "Divider not found [%s]", line);
+				efiPrintf("Divider not found [%s]", line);
 				return NULL;
 			}
 			divider++;
@@ -502,7 +500,7 @@ char *validateSecureLine(char *line) {
 		line = divider;
 		int actualLength = strlen(line);
 		if (expectedLength != actualLength) {
-			scheduleMsg(logging, "Error detected: expected %d but got %d in [%s]", expectedLength, actualLength, line);
+			efiPrintf("Error detected: expected %d but got %d in [%s]", expectedLength, actualLength, line);
 			return NULL;
 		}
 	}
@@ -561,18 +559,18 @@ void handleConsoleLine(char *line) {
 	if (lineLength > 100) {
 		// todo: better max size logic
 		// todo: better reaction to excessive line
-		scheduleMsg(logging, "Long line?");
+		efiPrintf("Long line?");
 		return;
 	}
 
 	bool isKnownComman = handleConsoleLineInternal(line, lineLength);
 
 	if (!isKnownComman) {
-		scheduleMsg(logging, "unknown command [%s]", line);
+		efiPrintf("unknown command [%s]", line);
 		return;
 	}
 
 #if EFI_PROD_CODE || EFI_SIMULATOR
-	scheduleMsg(logging, "confirmation_%s:%d", line, lineLength);
+	efiPrintf("confirmation_%s:%d", line, lineLength);
 #endif
 }

--- a/firmware/util/efilib.cpp
+++ b/firmware/util/efilib.cpp
@@ -237,7 +237,7 @@ float atoff(const char *param) {
 	char *string = todofixthismesswithcopy;
 	if (indexOf(string, 'n') != -1 || indexOf(string, 'N') != -1) {
 #if ! EFI_SIMULATOR
-		scheduleMsg(nullptr, "NAN from [%s]", string);
+		efiPrintf("NAN from [%s]", string);
 #endif
 		return (float) NAN;
 	}

--- a/firmware/util/math/interpolation.cpp
+++ b/firmware/util/math/interpolation.cpp
@@ -25,8 +25,6 @@ int needInterpolationLogging(void) {
 
 #define BINARY_PERF true
 
-Logging * logger;
-
 #if BINARY_PERF && ! EFI_UNIT_TEST
 
 #define COUNT 10000
@@ -202,8 +200,7 @@ void setCurveValue(float bins[], float values[], int size, float key, float valu
 	values[index] = value;
 }
 
-void initInterpolation(Logging *sharedLogger) {
-	logger = sharedLogger;
+void initInterpolation() {
 #if BINARY_PERF && ! EFI_UNIT_TEST
 	addConsoleAction("binarytest", testBinary);
 #endif

--- a/firmware/util/math/interpolation.cpp
+++ b/firmware/util/math/interpolation.cpp
@@ -58,14 +58,14 @@ static void testBinary(void) {
 			}
 			timeNew = getTimeNowLowerNt() - start;
 		}
-		scheduleMsg(logger, "for v=%d old=%d ticks", v, timeOld);
-		scheduleMsg(logger, "for v=%d new=%d ticks", v, timeNew);
+		efiPrintf("for v=%d old=%d ticks", v, timeOld);
+		efiPrintf("for v=%d new=%d ticks", v, timeNew);
 
 		totalOld += timeOld;
 		totalNew += timeNew;
 	}
-	scheduleMsg(logger, "totalOld=%d ticks", totalOld);
-	scheduleMsg(logger, "totalNew=%d ticks", totalNew);
+	efiPrintf("totalOld=%d ticks", totalOld);
+	efiPrintf("totalNew=%d ticks", totalNew);
 
 }
 

--- a/firmware/util/math/interpolation.h
+++ b/firmware/util/math/interpolation.h
@@ -306,7 +306,7 @@ float interpolate3d(const char *msg, float x, const kType xBin[], int xBinSize, 
 	return interpolateMsg(msg, keyMin, keyMinValue, keyMax, keyMaxValue, y);
 }
 void setCurveValue(float bins[], float values[], int size, float key, float value);
-void initInterpolation(Logging *sharedLogger);
+void initInterpolation();
 
 class FastInterpolation {
 public:

--- a/simulator/simulator/rusEfiFunctionalTest.cpp
+++ b/simulator/simulator/rusEfiFunctionalTest.cpp
@@ -94,15 +94,6 @@ void rusEfiFunctionalTest(void) {
 	itoa10(versionBuffer, (int)getRusEfiVersion());
 	printToConsole(versionBuffer);
 
-#if EFI_SHAFT_POSITION_INPUT
-	/**
-	 * This is so early because we want to init logger
-	 * which would be used while finding trigger sync index
-	 * while reading configuration
-	 */
-	initTriggerDecoderLogger(&sharedLogger);
-#endif /* EFI_SHAFT_POSITION_INPUT */
-
 	engine->setConfig();
 
 	initializeConsole();


### PR DESCRIPTION
This PR replaces most instances of scheduleMsg with efiPrintf (omitting the no longer used first parameter), and cleans up a few now-unused `LoggingWithStorage` or parameters passing in a `Logging` object.