### PR TITLE
Destroy all shared logger

### DIFF
--- a/firmware/bootloader/src/main.cpp
+++ b/firmware/bootloader/src/main.cpp
@@ -18,7 +18,6 @@ extern "C"
 
 #include "dfu.h"
 
-LoggingWithStorage tsLogger("binary");
 static bool wasCommand = false;
 
 static THD_WORKING_AREA(waBootloaderSerial, 128);

--- a/firmware/controllers/actuators/alternator_controller.cpp
+++ b/firmware/controllers/actuators/alternator_controller.cpp
@@ -31,8 +31,6 @@
 
 EXTERN_ENGINE;
 
-static Logging *logger;
-
 static SimplePwm alternatorControl("alt");
 static PidIndustrial alternatorPid(&persistentState.persistentConfiguration.engineConfiguration.alternatorControl);
 
@@ -163,8 +161,7 @@ void onConfigurationChangeAlternatorCallback(engine_configuration_s *previousCon
 	shouldResetPid = !alternatorPid.isSame(&previousConfiguration->alternatorControl);
 }
 
-void initAlternatorCtrl(Logging *sharedLogger DECLARE_ENGINE_PARAMETER_SUFFIX) {
-	logger = sharedLogger;
+void initAlternatorCtrl(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 	addConsoleAction("altinfo", showAltInfo);
 	if (!isBrainPinValid(CONFIG(alternatorControlPin)))
 		return;

--- a/firmware/controllers/actuators/alternator_controller.h
+++ b/firmware/controllers/actuators/alternator_controller.h
@@ -11,7 +11,7 @@
 #pragma once
 
 #include "engine.h"
-void initAlternatorCtrl(Logging *sharedLogger);
+void initAlternatorCtrl();
 void startAlternatorPin(void);
 void stopAlternatorPin(void);
 void setAltPFactor(float p);

--- a/firmware/controllers/actuators/boost_control.cpp
+++ b/firmware/controllers/actuators/boost_control.cpp
@@ -27,7 +27,6 @@
 
 EXTERN_ENGINE;
 
-static Logging *logger;
 static boostOpenLoop_Map3D_t boostMapOpen("boostmapopen");
 static boostOpenLoop_Map3D_t boostMapClosed("boostmapclosed");
 static SimplePwm boostPwmControl("boost");
@@ -204,7 +203,7 @@ void onConfigurationChangeBoostCallback(engine_configuration_s *previousConfigur
 	boostController.onConfigurationChange(&previousConfiguration->boostPid);
 }
 
-void initBoostCtrl(Logging *sharedLogger DECLARE_ENGINE_PARAMETER_SUFFIX) {
+void initBoostCtrl(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 	// todo: why do we have 'isBoostControlEnabled' setting exactly?
 	// 'initAuxPid' is an example of a subsystem without explicit enable
 	if (!CONFIG(isBoostControlEnabled)) {
@@ -221,8 +220,6 @@ void initBoostCtrl(Logging *sharedLogger DECLARE_ENGINE_PARAMETER_SUFFIX) {
 	if (!isBrainPinValid(CONFIG(boostControlPin)) && !hasAnyEtbWastegate) {
 		return;
 	}
-
-	logger = sharedLogger;
 
 	// Set up open & closed loop tables
 	boostMapOpen.init(config->boostTableOpenLoop, config->boostTpsBins, config->boostRpmBins);

--- a/firmware/controllers/actuators/boost_control.h
+++ b/firmware/controllers/actuators/boost_control.h
@@ -43,7 +43,7 @@ private:
 };
 
 void startBoostPin();
-void initBoostCtrl(Logging *sharedLogger DECLARE_ENGINE_PARAMETER_SUFFIX);
+void initBoostCtrl(DECLARE_ENGINE_PARAMETER_SIGNATURE);
 void setDefaultBoostParameters(DECLARE_CONFIG_PARAMETER_SIGNATURE);
 void onConfigurationChangeBoostCallback(engine_configuration_s *previousConfiguration);
 

--- a/firmware/controllers/algo/accel_enrichment.cpp
+++ b/firmware/controllers/algo/accel_enrichment.cpp
@@ -36,8 +36,6 @@ EXTERN_ENGINE;
 
 tps_tps_Map3D_t tpsTpsMap("tpsTps");
 
-static Logging *logger = nullptr;
-
 void WallFuel::resetWF() {
 	wallFuel = 0;
 }
@@ -326,9 +324,6 @@ AccelEnrichment::AccelEnrichment() {
 #if ! EFI_UNIT_TEST
 
 static void accelInfo() {
-	if (!logger) {
-		return;
-	}
 //	efiPrintf("EL accel length=%d", mapInstance.cb.getSize());
 	efiPrintf("EL accel th=%.2f/mult=%.2f", engineConfiguration->engineLoadAccelEnrichmentThreshold, engineConfiguration->engineLoadAccelEnrichmentMultiplier);
 	efiPrintf("EL decel th=%.2f/mult=%.2f", engineConfiguration->engineLoadDecelEnleanmentThreshold, engineConfiguration->engineLoadDecelEnleanmentMultiplier);
@@ -400,8 +395,7 @@ void updateAccelParameters() {
 #endif /* ! EFI_UNIT_TEST */
 
 
-void initAccelEnrichment(Logging *sharedLogger DECLARE_ENGINE_PARAMETER_SUFFIX) {
-	logger = sharedLogger;
+void initAccelEnrichment(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 	tpsTpsMap.init(config->tpsTpsAccelTable, config->tpsTpsAccelFromRpmBins, config->tpsTpsAccelToRpmBins);
 
 #if ! EFI_UNIT_TEST

--- a/firmware/controllers/algo/accel_enrichment.h
+++ b/firmware/controllers/algo/accel_enrichment.h
@@ -77,7 +77,7 @@ public:
 	int invocationCounter = 0;
 };
 
-void initAccelEnrichment(Logging *sharedLogger DECLARE_ENGINE_PARAMETER_SUFFIX);
+void initAccelEnrichment(DECLARE_ENGINE_PARAMETER_SIGNATURE);
 
 void setEngineLoadAccelLen(int len);
 void setEngineLoadAccelThr(float value);

--- a/firmware/controllers/algo/engine.cpp
+++ b/firmware/controllers/algo/engine.cpp
@@ -103,7 +103,7 @@ trigger_type_e getVvtTriggerType(vvt_mode_e vvtMode) {
 	}
 }
 
-static void initVvtShape(Logging *logger, int camIndex, TriggerState &initState DECLARE_ENGINE_PARAMETER_SUFFIX) {
+static void initVvtShape(int camIndex, TriggerState &initState DECLARE_ENGINE_PARAMETER_SUFFIX) {
 	vvt_mode_e vvtMode = engineConfiguration->vvtMode[camIndex];
 	TriggerWaveform *shape = &ENGINE(triggerCentral).vvtShape[camIndex];
 
@@ -117,7 +117,7 @@ static void initVvtShape(Logging *logger, int camIndex, TriggerState &initState 
 		trigger_config_s config;
 		ENGINE(triggerCentral).vvtTriggerType[camIndex] = config.type = getVvtTriggerType(vvtMode);
 
-		shape->initializeTriggerWaveform(logger,
+		shape->initializeTriggerWaveform(
 				engineConfiguration->ambiguousOperationMode,
 				CONFIG(vvtCamSensorUseRise), &config);
 
@@ -128,7 +128,7 @@ static void initVvtShape(Logging *logger, int camIndex, TriggerState &initState 
 
 }
 
-void Engine::initializeTriggerWaveform(Logging *logger DECLARE_ENGINE_PARAMETER_SUFFIX) {
+void Engine::initializeTriggerWaveform(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 	static TriggerState initState;
 	INJECT_ENGINE_REFERENCE(&initState);
 
@@ -142,7 +142,7 @@ void Engine::initializeTriggerWaveform(Logging *logger DECLARE_ENGINE_PARAMETER_
 	// we have a confusing threading model so some synchronization would not hurt
 	chibios_rt::CriticalSectionLocker csl;
 
-	TRIGGER_WAVEFORM(initializeTriggerWaveform(logger,
+	TRIGGER_WAVEFORM(initializeTriggerWaveform(
 			engineConfiguration->ambiguousOperationMode,
 			engineConfiguration->useOnlyRisingEdgeForTrigger, &engineConfiguration->trigger));
 
@@ -159,8 +159,8 @@ void Engine::initializeTriggerWaveform(Logging *logger DECLARE_ENGINE_PARAMETER_
 	}
 
 
-	initVvtShape(logger, 0, initState PASS_ENGINE_PARAMETER_SUFFIX);
-	initVvtShape(logger, 1, initState PASS_ENGINE_PARAMETER_SUFFIX);
+	initVvtShape(0, initState PASS_ENGINE_PARAMETER_SUFFIX);
+	initVvtShape(1, initState PASS_ENGINE_PARAMETER_SUFFIX);
 
 
 	if (!TRIGGER_WAVEFORM(shapeDefinitionError)) {

--- a/firmware/controllers/algo/engine.h
+++ b/firmware/controllers/algo/engine.h
@@ -252,7 +252,7 @@ public:
 	void periodicSlowCallback(DECLARE_ENGINE_PARAMETER_SIGNATURE);
 	void updateSlowSensors(DECLARE_ENGINE_PARAMETER_SIGNATURE);
 	void updateSwitchInputs(DECLARE_ENGINE_PARAMETER_SIGNATURE);
-	void initializeTriggerWaveform(Logging *logger DECLARE_ENGINE_PARAMETER_SUFFIX);
+	void initializeTriggerWaveform(DECLARE_ENGINE_PARAMETER_SIGNATURE);
 
 	bool clutchUpState = false;
 	bool clutchDownState = false;
@@ -386,7 +386,7 @@ private:
 };
 
 void prepareShapes(DECLARE_ENGINE_PARAMETER_SIGNATURE);
-void applyNonPersistentConfiguration(Logging * logger DECLARE_ENGINE_PARAMETER_SUFFIX);
+void applyNonPersistentConfiguration(DECLARE_ENGINE_PARAMETER_SIGNATURE);
 void prepareOutputSignals(DECLARE_ENGINE_PARAMETER_SIGNATURE);
 
 void validateConfiguration(DECLARE_ENGINE_PARAMETER_SIGNATURE);

--- a/firmware/controllers/algo/engine_configuration.cpp
+++ b/firmware/controllers/algo/engine_configuration.cpp
@@ -1182,7 +1182,7 @@ void setDefaultFrankensoConfiguration(DECLARE_CONFIG_PARAMETER_SIGNATURE) {
 #define IGNORE_FLASH_CONFIGURATION false
 #endif
 
-void loadConfiguration(Logging* logger DECLARE_ENGINE_PARAMETER_SUFFIX) {
+void loadConfiguration(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 #ifdef CONFIG_RESET_SWITCH_PORT
 	// initialize the reset pin if necessary
 	palSetPadMode(CONFIG_RESET_SWITCH_PORT, CONFIG_RESET_SWITCH_PIN, PAL_MODE_INPUT_PULLUP);
@@ -1196,7 +1196,7 @@ void loadConfiguration(Logging* logger DECLARE_ENGINE_PARAMETER_SUFFIX) {
 #if EFI_INTERNAL_FLASH
 	if (SHOULD_IGNORE_FLASH() || IGNORE_FLASH_CONFIGURATION) {
 		engineConfiguration->engineType = DEFAULT_ENGINE_TYPE;
-		resetConfigurationExt(logger, engineConfiguration->engineType PASS_ENGINE_PARAMETER_SUFFIX);
+		resetConfigurationExt(engineConfiguration->engineType PASS_ENGINE_PARAMETER_SUFFIX);
 		writeToFlashNow();
 	} else {
 		// this call reads configuration from flash memory or sets default configuration
@@ -1206,14 +1206,14 @@ void loadConfiguration(Logging* logger DECLARE_ENGINE_PARAMETER_SUFFIX) {
 #else // not EFI_INTERNAL_FLASH
 	// This board doesn't load configuration, initialize the default
 	engineConfiguration->engineType = DEFAULT_ENGINE_TYPE;
-	resetConfigurationExt(logger, engineConfiguration->engineType PASS_ENGINE_PARAMETER_SUFFIX);
+	resetConfigurationExt(engineConfiguration->engineType PASS_ENGINE_PARAMETER_SUFFIX);
 #endif /* EFI_INTERNAL_FLASH */
 
 	// Force any board configuration options that humans shouldn't be able to change
 	setBoardConfigOverrides();
 }
 
-void resetConfigurationExt(Logging * logger, configuration_callback_t boardCallback, engine_type_e engineType DECLARE_ENGINE_PARAMETER_SUFFIX) {
+void resetConfigurationExt(configuration_callback_t boardCallback, engine_type_e engineType DECLARE_ENGINE_PARAMETER_SUFFIX) {
 	enginePins.reset(); // that's mostly important for functional tests
 	/**
 	 * Let's apply global defaults first
@@ -1474,7 +1474,7 @@ void resetConfigurationExt(Logging * logger, configuration_callback_t boardCallb
 	default:
 		firmwareError(CUSTOM_UNEXPECTED_ENGINE_TYPE, "Unexpected engine type: %d", engineType);
 	}
-	applyNonPersistentConfiguration(logger PASS_ENGINE_PARAMETER_SUFFIX);
+	applyNonPersistentConfiguration(PASS_ENGINE_PARAMETER_SIGNATURE);
 
 #if EFI_TUNER_STUDIO
 	syncTunerStudioCopy();
@@ -1485,8 +1485,8 @@ void emptyCallbackWithConfiguration(engine_configuration_s * engineConfiguration
 	UNUSED(engineConfiguration);
 }
 
-void resetConfigurationExt(Logging * logger, engine_type_e engineType DECLARE_ENGINE_PARAMETER_SUFFIX) {
-	resetConfigurationExt(logger, &emptyCallbackWithConfiguration, engineType PASS_ENGINE_PARAMETER_SUFFIX);
+void resetConfigurationExt(engine_type_e engineType DECLARE_ENGINE_PARAMETER_SUFFIX) {
+	resetConfigurationExt(&emptyCallbackWithConfiguration, engineType PASS_ENGINE_PARAMETER_SUFFIX);
 }
 
 void validateConfiguration(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
@@ -1504,7 +1504,7 @@ void validateConfiguration(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 	}
 }
 
-void applyNonPersistentConfiguration(Logging * logger DECLARE_ENGINE_PARAMETER_SUFFIX) {
+void applyNonPersistentConfiguration(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 #if EFI_PROD_CODE
 	efiAssertVoid(CUSTOM_APPLY_STACK, getCurrentRemainingStack() > EXPECTED_REMAINING_STACK, "apply c");
 	efiPrintf("applyNonPersistentConfiguration()");
@@ -1513,7 +1513,7 @@ void applyNonPersistentConfiguration(Logging * logger DECLARE_ENGINE_PARAMETER_S
 	assertEngineReference();
 
 #if EFI_ENGINE_CONTROL
-	ENGINE(initializeTriggerWaveform(logger PASS_ENGINE_PARAMETER_SUFFIX));
+	ENGINE(initializeTriggerWaveform(PASS_ENGINE_PARAMETER_SIGNATURE));
 #endif // EFI_ENGINE_CONTROL
 
 #if EFI_FSIO

--- a/firmware/controllers/algo/engine_configuration.h
+++ b/firmware/controllers/algo/engine_configuration.h
@@ -58,9 +58,9 @@ typedef void (*configuration_callback_t)(engine_configuration_s*);
 
 #ifdef __cplusplus
 // because of 'Logging' class parameter these functions are visible only to C++ code but C code
-void loadConfiguration(Logging* logger DECLARE_ENGINE_PARAMETER_SUFFIX);
-void resetConfigurationExt(Logging * logger, configuration_callback_t boardCallback, engine_type_e engineType DECLARE_ENGINE_PARAMETER_SUFFIX);
-void resetConfigurationExt(Logging * logger, engine_type_e engineType DECLARE_ENGINE_PARAMETER_SUFFIX);
+void loadConfiguration(DECLARE_ENGINE_PARAMETER_SIGNATURE);
+void resetConfigurationExt(configuration_callback_t boardCallback, engine_type_e engineType DECLARE_ENGINE_PARAMETER_SUFFIX);
+void resetConfigurationExt(engine_type_e engineType DECLARE_ENGINE_PARAMETER_SUFFIX);
 
 void rememberCurrentConfiguration(DECLARE_ENGINE_PARAMETER_SIGNATURE);
 #endif /* __cplusplus */

--- a/firmware/controllers/bench_test.cpp
+++ b/firmware/controllers/bench_test.cpp
@@ -60,7 +60,6 @@
 
 EXTERN_ENGINE;
 
-static Logging * logger;
 static bool isRunningBench = false;
 
 bool isRunningBenchTest(void) {
@@ -494,9 +493,7 @@ void executeTSCommand(uint16_t subsystem, uint16_t index) {
 	}
 }
 
-void initBenchTest(Logging *sharedLogger) {
-	logger = sharedLogger;
-
+void initBenchTest() {
 	addConsoleAction("fuelpumpbench", fuelPumpBench);
 	addConsoleAction("acrelaybench", acRelayBench);
 	addConsoleActionS("fuelpumpbench2", fuelPumpBenchExt);

--- a/firmware/controllers/bench_test.h
+++ b/firmware/controllers/bench_test.h
@@ -12,7 +12,7 @@
 
 #include "global.h"
 
-void initBenchTest(Logging *sharedLogger);
+void initBenchTest();
 
 bool isRunningBenchTest(void);
 

--- a/firmware/controllers/can/can_vss.cpp
+++ b/firmware/controllers/can/can_vss.cpp
@@ -17,7 +17,6 @@
 
 EXTERN_ENGINE;
 
-static Logging *logger;
 static bool isInit = false;
 static uint16_t filterCanID = 0;
 static efitick_t frameTime;
@@ -115,10 +114,8 @@ float getVehicleCanSpeed(void) {
     }
 }
 
-void initCanVssSupport(Logging *logger_ptr) {
-
+void initCanVssSupport() {
     addConsoleAction("canvssinfo", canVssInfo);
-    logger = logger_ptr;
 
     if (CONFIG(enableCanVss)) {
 

--- a/firmware/controllers/can/can_vss.h
+++ b/firmware/controllers/can/can_vss.h
@@ -8,7 +8,7 @@
 #pragma once
 
 float getVehicleCanSpeed(void);
-void initCanVssSupport(Logging *logger_ptr);
+void initCanVssSupport();
 void setCanVss(int type);
 
 #if EFI_CAN_SUPPORT

--- a/firmware/controllers/core/fsio_impl.cpp
+++ b/firmware/controllers/core/fsio_impl.cpp
@@ -115,7 +115,6 @@ static LEElement * starterRelayDisableLogic;
 static LEElement * mainRelayLogic;
 #endif /* EFI_MAIN_RELAY_CONTROL */
 
-static Logging *logger;
 #if EFI_PROD_CODE || EFI_SIMULATOR
 
 FsioResult getEngineValue(le_action_e action DECLARE_ENGINE_PARAMETER_SUFFIX) {
@@ -693,10 +692,8 @@ ValueProvider3D *getFSIOTable(int index) {
 	}
 }
 
-void initFsioImpl(Logging *sharedLogger DECLARE_ENGINE_PARAMETER_SUFFIX) {
-#if EFI_PROD_CODE || EFI_SIMULATOR
-	logger = sharedLogger;
-#else
+void initFsioImpl(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
+#if EFI_UNIT_TEST
 	// only unit test needs this
 	sysPool.reset();
 #endif

--- a/firmware/controllers/core/fsio_impl.h
+++ b/firmware/controllers/core/fsio_impl.h
@@ -39,7 +39,7 @@ expected<float> getEngineValue(le_action_e action DECLARE_ENGINE_PARAMETER_SUFFI
 void setFsio(int index, brain_pin_e pin, const char * exp DECLARE_CONFIG_PARAMETER_SUFFIX);
 void setFsioExt(int index, brain_pin_e pin, const char * exp, int pwmFrequency DECLARE_CONFIG_PARAMETER_SUFFIX);
 
-void initFsioImpl(Logging *sharedLogger DECLARE_ENGINE_PARAMETER_SUFFIX);
+void initFsioImpl(DECLARE_ENGINE_PARAMETER_SIGNATURE);
 void runFsio(DECLARE_ENGINE_PARAMETER_SIGNATURE);
 void setFsioExpression(const char *indexStr, const char *quotedLine DECLARE_CONFIG_PARAMETER_SUFFIX);
 void applyFsioExpression(const char *indexStr, const char *quotedLine DECLARE_ENGINE_PARAMETER_SUFFIX);

--- a/firmware/controllers/engine_controller.cpp
+++ b/firmware/controllers/engine_controller.cpp
@@ -524,7 +524,7 @@ static void getKnockInfo(void) {
 #endif /* EFI_UNIT_TEST */
 
 // this method is used by real firmware and simulator and unit test
-void commonInitEngineController(Logging *sharedLogger DECLARE_ENGINE_PARAMETER_SUFFIX) {
+void commonInitEngineController(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 	initInterpolation();
 
 #if EFI_SIMULATOR
@@ -568,10 +568,10 @@ void commonInitEngineController(Logging *sharedLogger DECLARE_ENGINE_PARAMETER_S
 
 	initSensors(PASS_ENGINE_PARAMETER_SIGNATURE);
 
-	initAccelEnrichment(sharedLogger PASS_ENGINE_PARAMETER_SUFFIX);
+	initAccelEnrichment(PASS_ENGINE_PARAMETER_SIGNATURE);
 
 #if EFI_FSIO
-	initFsioImpl(sharedLogger PASS_ENGINE_PARAMETER_SUFFIX);
+	initFsioImpl(PASS_ENGINE_PARAMETER_SIGNATURE);
 #endif /* EFI_FSIO */
 
 	initGpPwm(PASS_ENGINE_PARAMETER_SIGNATURE);
@@ -591,12 +591,12 @@ void commonInitEngineController(Logging *sharedLogger DECLARE_ENGINE_PARAMETER_S
 
 #if EFI_MAP_AVERAGING
 	if (engineConfiguration->isMapAveragingEnabled) {
-		initMapAveraging(sharedLogger PASS_ENGINE_PARAMETER_SUFFIX);
+		initMapAveraging(PASS_ENGINE_PARAMETER_SIGNATURE);
 	}
 #endif /* EFI_MAP_AVERAGING */
 
 #if EFI_BOOST_CONTROL
-	initBoostCtrl(sharedLogger PASS_ENGINE_PARAMETER_SUFFIX);
+	initBoostCtrl(PASS_ENGINE_PARAMETER_SIGNATURE);
 #endif /* EFI_BOOST_CONTROL */
 
 #if EFI_LAUNCH_CONTROL
@@ -608,17 +608,16 @@ void commonInitEngineController(Logging *sharedLogger DECLARE_ENGINE_PARAMETER_S
 	 * there is an implicit dependency on the fact that 'tachometer' listener is the 1st listener - this case
 	 * other listeners can access current RPM value
 	 */
-	initRpmCalculator(sharedLogger PASS_ENGINE_PARAMETER_SUFFIX);
+	initRpmCalculator(PASS_ENGINE_PARAMETER_SIGNATURE);
 #endif /* EFI_SHAFT_POSITION_INPUT */
 
 #if (EFI_ENGINE_CONTROL && EFI_SHAFT_POSITION_INPUT) || EFI_SIMULATOR || EFI_UNIT_TEST
 	if (CONFIG(isEngineControlEnabled)) {
-		initAuxValves(sharedLogger PASS_ENGINE_PARAMETER_SUFFIX);
+		initAuxValves(PASS_ENGINE_PARAMETER_SIGNATURE);
 		/**
 		 * This method adds trigger listener which actually schedules ignition
 		 */
-		initSparkLogic(sharedLogger);
-		initMainEventListener(sharedLogger PASS_ENGINE_PARAMETER_SUFFIX);
+		initMainEventListener(PASS_ENGINE_PARAMETER_SIGNATURE);
 #if EFI_HPFP
 		initHPFP(PASS_ENGINE_PARAMETER_SIGNATURE);
 #endif // EFI_HPFP
@@ -630,18 +629,18 @@ void commonInitEngineController(Logging *sharedLogger DECLARE_ENGINE_PARAMETER_S
 
 #if !EFI_UNIT_TEST
 
-void initEngineContoller(Logging *sharedLogger DECLARE_ENGINE_PARAMETER_SUFFIX) {
+void initEngineContoller(DECLARE_ENGINE_PARAMETER_SUFFIX) {
 	addConsoleAction("analoginfo", printAnalogInfo);
 
 #if EFI_PROD_CODE && EFI_ENGINE_CONTROL
-	initBenchTest(sharedLogger);
+	initBenchTest();
 #endif /* EFI_PROD_CODE && EFI_ENGINE_CONTROL */
 
-	commonInitEngineController(sharedLogger);
+	commonInitEngineController();
 
 #if EFI_LOGIC_ANALYZER
 	if (engineConfiguration->isWaveAnalyzerEnabled) {
-		initWaveAnalyzer(sharedLogger);
+		initWaveAnalyzer();
 	}
 #endif /* EFI_LOGIC_ANALYZER */
 
@@ -649,7 +648,7 @@ void initEngineContoller(Logging *sharedLogger DECLARE_ENGINE_PARAMETER_SUFFIX) 
 	/**
 	 * this uses SimplePwm which depends on scheduler, has to be initialized after scheduler
 	 */
-	initCJ125(sharedLogger PASS_ENGINE_PARAMETER_SUFFIX);
+	initCJ125(PASS_ENGINE_PARAMETER_SIGNATURE);
 #endif /* EFI_CJ125 */
 
 
@@ -667,7 +666,7 @@ void initEngineContoller(Logging *sharedLogger DECLARE_ENGINE_PARAMETER_SUFFIX) 
 #endif /* EFI_PWM_TESTER */
 
 #if EFI_ALTERNATOR_CONTROL
-	initAlternatorCtrl(sharedLogger PASS_ENGINE_PARAMETER_SUFFIX);
+	initAlternatorCtrl(PASS_ENGINE_PARAMETER_SIGNATURE);
 #endif /* EFI_ALTERNATOR_CONTROL */
 
 #if EFI_AUX_PID

--- a/firmware/controllers/engine_controller.h
+++ b/firmware/controllers/engine_controller.h
@@ -12,8 +12,8 @@
 
 char * getPinNameByAdcChannel(const char *msg, adc_channel_e hwChannel, char *buffer);
 void initPeriodicEvents(DECLARE_ENGINE_PARAMETER_SIGNATURE);
-void initEngineContoller(Logging *sharedLogger DECLARE_ENGINE_PARAMETER_SUFFIX);
-void commonInitEngineController(Logging *sharedLogger DECLARE_ENGINE_PARAMETER_SUFFIX);
+void initEngineContoller(DECLARE_ENGINE_PARAMETER_SIGNATURE);
+void commonInitEngineController(DECLARE_ENGINE_PARAMETER_SIGNATURE);
 void initStartStopButton(DECLARE_ENGINE_PARAMETER_SIGNATURE);
 
 void initDataStructures(DECLARE_ENGINE_PARAMETER_SIGNATURE);

--- a/firmware/controllers/engine_cycle/aux_valves.cpp
+++ b/firmware/controllers/engine_cycle/aux_valves.cpp
@@ -68,8 +68,7 @@ void auxPlainPinTurnOn(AuxActor *current) {
 			);
 	}
 
-void initAuxValves(Logging *sharedLogger DECLARE_ENGINE_PARAMETER_SUFFIX) {
-	UNUSED(sharedLogger);
+void initAuxValves(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 	if (!isBrainPinValid(engineConfiguration->auxValves[0])) {
 		return;
 	}

--- a/firmware/controllers/engine_cycle/aux_valves.h
+++ b/firmware/controllers/engine_cycle/aux_valves.h
@@ -9,6 +9,6 @@
 
 #include "engine.h"
 
-void initAuxValves(Logging *sharedLogger DECLARE_ENGINE_PARAMETER_SUFFIX);
+void initAuxValves(DECLARE_ENGINE_PARAMETER_SIGNATURE);
 void recalculateAuxValveTiming(DECLARE_ENGINE_PARAMETER_SIGNATURE);
 void auxPlainPinTurnOn(AuxActor *current);

--- a/firmware/controllers/engine_cycle/main_trigger_callback.cpp
+++ b/firmware/controllers/engine_cycle/main_trigger_callback.cpp
@@ -65,8 +65,6 @@ static const char *prevOutputName = nullptr;
 
 static InjectionEvent primeInjEvent;
 
-static Logging *logger;
-
 // todo: figure out if this even helps?
 //#if defined __GNUC__
 //#define RAM_METHOD_PREFIX __attribute__((section(".ram")))
@@ -544,8 +542,7 @@ static void showMainInfo(Engine *engine) {
 #endif /* EFI_PROD_CODE */
 }
 
-void initMainEventListener(Logging *sharedLogger DECLARE_ENGINE_PARAMETER_SUFFIX) {
-	logger = sharedLogger;
+void initMainEventListener(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 	efiAssertVoid(CUSTOM_ERR_6631, engine!=NULL, "null engine");
 
 #if EFI_PROD_CODE

--- a/firmware/controllers/engine_cycle/main_trigger_callback.h
+++ b/firmware/controllers/engine_cycle/main_trigger_callback.h
@@ -13,7 +13,7 @@
 
 #include "event_registry.h"
 
-void initMainEventListener(Logging *sharedLogger DECLARE_ENGINE_PARAMETER_SUFFIX);
+void initMainEventListener(DECLARE_ENGINE_PARAMETER_SIGNATURE);
 
 void mainTriggerCallback(uint32_t trgEventIndex, efitick_t edgeTimestamp DECLARE_ENGINE_PARAMETER_SUFFIX);
 

--- a/firmware/controllers/engine_cycle/map_averaging.cpp
+++ b/firmware/controllers/engine_cycle/map_averaging.cpp
@@ -44,7 +44,6 @@
 
 #define FAST_MAP_CHART_SKIP_FACTOR 16
 
-static Logging *logger;
 /**
  * this instance does not have a real physical pin - it's only used for engine sniffer
  */
@@ -339,9 +338,7 @@ float getMap(void) {
 }
 #endif /* EFI_PROD_CODE */
 
-void initMapAveraging(Logging *sharedLogger DECLARE_ENGINE_PARAMETER_SUFFIX) {
-	logger = sharedLogger;
-
+void initMapAveraging(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 #if !EFI_UNIT_TEST
 	addConsoleAction("faststat", showMapStats);
 #endif /* EFI_UNIT_TEST */

--- a/firmware/controllers/engine_cycle/map_averaging.h
+++ b/firmware/controllers/engine_cycle/map_averaging.h
@@ -15,7 +15,7 @@
 void mapAveragingAdcCallback(adcsample_t newValue);
 #endif
 
-void initMapAveraging(Logging *sharedLogger DECLARE_ENGINE_PARAMETER_SUFFIX);
+void initMapAveraging(DECLARE_ENGINE_PARAMETER_SIGNATURE);
 void refreshMapAveragingPreCalc(DECLARE_ENGINE_PARAMETER_SIGNATURE);
 
 void mapAveragingTriggerCallback(

--- a/firmware/controllers/engine_cycle/rpm_calculator.cpp
+++ b/firmware/controllers/engine_cycle/rpm_calculator.cpp
@@ -84,8 +84,6 @@ int RpmCalculator::getRpm() const {
 
 EXTERN_ENGINE;
 
-static Logging * logger;
-
 RpmCalculator::RpmCalculator() :
 		StoredValueSensor(SensorType::Rpm, 0)
 	{
@@ -374,10 +372,9 @@ float getCrankshaftAngleNt(efitick_t timeNt DECLARE_ENGINE_PARAMETER_SUFFIX) {
 	return rpm == 0 ? NAN : timeSinceZeroAngle / oneDegreeSeconds;
 }
 
-void initRpmCalculator(Logging *sharedLogger DECLARE_ENGINE_PARAMETER_SUFFIX) {
+void initRpmCalculator(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 	INJECT_ENGINE_REFERENCE(&ENGINE(rpmCalculator));
 
-	logger = sharedLogger;
 #if ! HW_CHECK_MODE
 	if (hasFirmwareError()) {
 		return;

--- a/firmware/controllers/engine_cycle/rpm_calculator.h
+++ b/firmware/controllers/engine_cycle/rpm_calculator.h
@@ -168,7 +168,7 @@ void tdcMarkCallback(
 /**
  * @brief   Initialize RPM calculator
  */
-void initRpmCalculator(Logging *sharedLogger DECLARE_ENGINE_PARAMETER_SUFFIX);
+void initRpmCalculator(DECLARE_ENGINE_PARAMETER_SIGNATURE);
 
 float getCrankshaftAngleNt(efitick_t timeNt DECLARE_ENGINE_PARAMETER_SUFFIX);
 

--- a/firmware/controllers/engine_cycle/spark_logic.cpp
+++ b/firmware/controllers/engine_cycle/spark_logic.cpp
@@ -516,10 +516,6 @@ void onTriggerEventSparkLogic(bool limitedSpark, uint32_t trgEventIndex, int rpm
 	}
 }
 
-void initSparkLogic(Logging *sharedLogger) {
-	logger = sharedLogger;
-}
-
 /**
  * Number of sparks per physical coil
  * @see getNumberOfInjections

--- a/firmware/controllers/engine_cycle/spark_logic.cpp
+++ b/firmware/controllers/engine_cycle/spark_logic.cpp
@@ -34,7 +34,6 @@ extern bool verboseMode;
 #endif // EFI_PRINTF_FUEL_DETAILS
 
 static cyclic_buffer<int> ignitionErrorDetection;
-static Logging *logger;
 
 static const char *prevSparkName = nullptr;
 

--- a/firmware/controllers/engine_cycle/spark_logic.h
+++ b/firmware/controllers/engine_cycle/spark_logic.h
@@ -10,7 +10,6 @@
 #include "engine.h"
 
 void onTriggerEventSparkLogic(bool limitedSpark, uint32_t trgEventIndex, int rpm, efitick_t edgeTimestamp DECLARE_ENGINE_PARAMETER_SUFFIX);
-void initSparkLogic(Logging *sharedLogger);
 void turnSparkPinHigh(IgnitionEvent *event);
 void fireSparkAndPrepareNextSchedule(IgnitionEvent *event);
 int getNumberOfSparks(ignition_mode_e mode DECLARE_ENGINE_PARAMETER_SUFFIX);

--- a/firmware/controllers/flash_main.h
+++ b/firmware/controllers/flash_main.h
@@ -11,7 +11,7 @@
 #include "engine.h"
 
 void readFromFlash();
-void initFlash(Logging *sharedLogger);
+void initFlash();
 
 /**
  * Because of hardware-related issues, stm32f4 chip is totally

--- a/firmware/controllers/settings.cpp
+++ b/firmware/controllers/settings.cpp
@@ -61,7 +61,7 @@ static Logging logger("settings control", LOGGING_BUFFER, sizeof(LOGGING_BUFFER)
 
 EXTERN_ENGINE;
 
-void printSpiState(Logging *logger, const engine_configuration_s *engineConfiguration) {
+void printSpiState(const engine_configuration_s *engineConfiguration) {
 	efiPrintf("spi 1=%s/2=%s/3=%s/4=%s",
 		boolToString(engineConfiguration->is_enabled_spi_1),
 		boolToString(engineConfiguration->is_enabled_spi_2),
@@ -213,7 +213,7 @@ void printConfiguration(const engine_configuration_s *engineConfiguration) {
 	}
 #if EFI_PROD_CODE
 
-	printSpiState(&logger, engineConfiguration);
+	printSpiState(engineConfiguration);
 
 #endif /* EFI_PROD_CODE */
 }
@@ -238,8 +238,8 @@ void setEngineType(int value) {
 	{
 		chibios_rt::CriticalSectionLocker csl;
 
-		engineConfiguration->engineType = (engine_type_e) value;
-		resetConfigurationExt(&logger, (engine_type_e) value PASS_ENGINE_PARAMETER_SUFFIX);
+		engineConfiguration->engineType = (engine_type_e)value;
+		resetConfigurationExt((engine_type_e)value PASS_ENGINE_PARAMETER_SUFFIX);
 		engine->resetEngineSnifferIfInTestMode();
 
 	#if EFI_INTERNAL_FLASH
@@ -461,7 +461,6 @@ static void setToothedWheel(int total, int skipped DECLARE_ENGINE_PARAMETER_SUFF
 
 	efiPrintf("toothed: total=%d/skipped=%d", total, skipped);
 	setToothedWheelConfiguration(&engine->triggerCentral.triggerShape, total, skipped, engineConfiguration->ambiguousOperationMode);
-//	initializeTriggerWaveform(&logger, engineConfiguration, engineConfiguration2);
 	incrementGlobalConfigurationVersion(PASS_ENGINE_PARAMETER_SIGNATURE);
 	doPrintConfiguration();
 }
@@ -802,7 +801,7 @@ static void setSpiMode(int index, bool mode) {
 		efiPrintf("invalid spi index %d", index);
 		return;
 	}
-	printSpiState(&logger, engineConfiguration);
+	printSpiState(engineConfiguration);
 }
 
 static void enableOrDisable(const char *param, bool isEnabled) {

--- a/firmware/controllers/settings.cpp
+++ b/firmware/controllers/settings.cpp
@@ -56,9 +56,6 @@ extern WaveChart waveChart;
 #define SETTINGS_LOGGING_BUFFER_SIZE 1000
 #endif /* SETTINGS_LOGGING_BUFFER_SIZE */
 
-static char LOGGING_BUFFER[SETTINGS_LOGGING_BUFFER_SIZE];
-static Logging logger("settings control", LOGGING_BUFFER, sizeof(LOGGING_BUFFER));
-
 EXTERN_ENGINE;
 
 void printSpiState(const engine_configuration_s *engineConfiguration) {

--- a/firmware/controllers/settings.h
+++ b/firmware/controllers/settings.h
@@ -8,10 +8,10 @@
 
 #pragma once
 
-#include "engine.h"
+#include "engine_configuration_generated_structures.h"
 
 void initSettings(void);
-void printSpiState(Logging *logger, const engine_configuration_s *engineConfiguration);
+void printSpiState(const engine_configuration_s *engineConfiguration);
 void printConfiguration(const engine_configuration_s *engineConfiguration);
 void scheduleStopEngine(void);
 void setCallFromPitStop(int durationMs);

--- a/firmware/controllers/system/efi_gpio.h
+++ b/firmware/controllers/system/efi_gpio.h
@@ -246,6 +246,6 @@ const char *portname(ioportid_t GPIOx);
 
 #endif /* EFI_GPIO_HARDWARE */
 
-void printSpiConfig(Logging *logging, const char *msg, spi_device_e device);
+void printSpiConfig(const char *msg, spi_device_e device);
 brain_pin_e parseBrainPin(const char *str);
 const char *hwPortname(brain_pin_e brainPin);

--- a/firmware/controllers/trigger/decoders/trigger_structure.cpp
+++ b/firmware/controllers/trigger/decoders/trigger_structure.cpp
@@ -468,7 +468,7 @@ void TriggerWaveform::setSecondTriggerSynchronizationGap(float syncRatio) {
 /**
  * External logger is needed because at this point our logger is not yet initialized
  */
-void TriggerWaveform::initializeTriggerWaveform(Logging *logger, operation_mode_e ambiguousOperationMode, bool useOnlyRisingEdgeForTrigger, const trigger_config_s *triggerConfig) {
+void TriggerWaveform::initializeTriggerWaveform(operation_mode_e ambiguousOperationMode, bool useOnlyRisingEdgeForTrigger, const trigger_config_s *triggerConfig) {
 
 #if EFI_PROD_CODE
 	efiAssertVoid(CUSTOM_ERR_6641, getCurrentRemainingStack() > EXPECTED_REMAINING_STACK, "init t");

--- a/firmware/controllers/trigger/decoders/trigger_structure.h
+++ b/firmware/controllers/trigger/decoders/trigger_structure.h
@@ -86,7 +86,7 @@ class Logging;
 class TriggerWaveform {
 public:
 	TriggerWaveform();
-	void initializeTriggerWaveform(Logging *logger, operation_mode_e ambiguousOperationMode,
+	void initializeTriggerWaveform(operation_mode_e ambiguousOperationMode,
 			bool useOnlyRisingEdgeForTrigger, const trigger_config_s *triggerConfig);
 	void setShapeDefinitionError(bool value);
 

--- a/firmware/controllers/trigger/trigger_central.cpp
+++ b/firmware/controllers/trigger/trigger_central.cpp
@@ -77,8 +77,6 @@ int TriggerCentral::getHwEventCounter(int index) const {
 
 EXTERN_ENGINE;
 
-static Logging *logger;
-
 angle_t TriggerCentral::getVVTPosition(uint8_t bankIndex, uint8_t camIndex) {
 	return vvtPosition[bankIndex][camIndex];
 }
@@ -686,7 +684,7 @@ void onConfigurationChangeTriggerCallback(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 		assertEngineReference();
 
 	#if EFI_ENGINE_CONTROL
-		ENGINE(initializeTriggerWaveform(logger PASS_ENGINE_PARAMETER_SUFFIX));
+		ENGINE(initializeTriggerWaveform(PASS_ENGINE_PARAMETER_SIGNATURE));
 		engine->triggerCentral.noiseFilter.resetAccumSignalData();
 	#endif
 	}
@@ -711,8 +709,7 @@ bool isTriggerConfigChanged(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 	return engine->isTriggerConfigChanged;
 }
 
-void initTriggerCentral(Logging *sharedLogger) {
-	logger = sharedLogger;
+void initTriggerCentral() {
 	strcpy((char*) shaft_signal_msg_index, "x_");
 
 #if EFI_ENGINE_SNIFFER

--- a/firmware/controllers/trigger/trigger_central.h
+++ b/firmware/controllers/trigger/trigger_central.h
@@ -87,7 +87,7 @@ void triggerInfo(void);
 void hwHandleShaftSignal(trigger_event_e signal, efitick_t timestamp);
 void hwHandleVvtCamSignal(trigger_value_e front, efitick_t timestamp, int index DECLARE_ENGINE_PARAMETER_SUFFIX);
 
-void initTriggerCentral(Logging *sharedLogger);
+void initTriggerCentral();
 
 int isSignalDecoderError(void);
 

--- a/firmware/controllers/trigger/trigger_decoder.cpp
+++ b/firmware/controllers/trigger/trigger_decoder.cpp
@@ -113,8 +113,6 @@ bool printTriggerTrace = false;
 float actualSynchGap;
 #endif /* ! EFI_PROD_CODE */
 
-static Logging * logger = nullptr;
-
 void TriggerWaveform::initializeSyncPoint(TriggerState& state,
 			const TriggerConfiguration& triggerConfiguration,
 			const trigger_config_s& triggerConfig) {

--- a/firmware/controllers/trigger/trigger_emulator_algo.cpp
+++ b/firmware/controllers/trigger/trigger_emulator_algo.cpp
@@ -83,7 +83,6 @@ static float pwmSwitchTimesBuffer[PWM_PHASE_MAX_COUNT];
 
 PwmConfig triggerSignal(pwmSwitchTimesBuffer, sr);
 
-static Logging *logger;
 static int atTriggerVersion = 0;
 
 #if EFI_ENGINE_SNIFFER
@@ -185,9 +184,7 @@ void disableTriggerStimulator() {
 	hasInitTriggerEmulator = false;
 }
 
-void initTriggerEmulatorLogic(Logging *sharedLogger DECLARE_ENGINE_PARAMETER_SUFFIX) {
-	logger = sharedLogger;
-
+void initTriggerEmulatorLogic(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 	addConsoleActionI(CMD_RPM, setTriggerEmulatorRPM);
 }
 
@@ -199,12 +196,12 @@ void onConfigurationChangeRpmEmulatorCallback(engine_configuration_s *previousCo
 	setTriggerEmulatorRPM(engineConfiguration->triggerSimulatorFrequency);
 }
 
-void initTriggerEmulator(Logging *sharedLogger DECLARE_ENGINE_PARAMETER_SUFFIX) {
-	scheduleMsg(sharedLogger, "Emulating %s", getConfigurationName(engineConfiguration->engineType));
+void initTriggerEmulator(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
+	efiPrintf("Emulating %s", getConfigurationName(engineConfiguration->engineType));
 
 	startTriggerEmulatorPins();
 
-	initTriggerEmulatorLogic(sharedLogger);
+	initTriggerEmulatorLogic();
 }
 
 void startTriggerEmulatorPins() {

--- a/firmware/controllers/trigger/trigger_emulator_algo.h
+++ b/firmware/controllers/trigger/trigger_emulator_algo.h
@@ -9,11 +9,10 @@
 
 #include "engine.h"
 
-class Logging;
 class PwmConfig;
 class MultiChannelStateSequence;
 
-void initTriggerEmulator(Logging *sharedLogger DECLARE_ENGINE_PARAMETER_SUFFIX);
+void initTriggerEmulator(DECLARE_ENGINE_PARAMETER_SIGNATURE);
 void startTriggerEmulatorPins();
 void stopTriggerEmulatorPins();
 void setTriggerEmulatorRPM(int value DECLARE_ENGINE_PARAMETER_SUFFIX);
@@ -30,7 +29,7 @@ public:
 	void handleEmulatorCallback(PwmConfig *state, int stateIndex);
 };
 
-void initTriggerEmulatorLogic(Logging *sharedLogger DECLARE_ENGINE_PARAMETER_SUFFIX);
+void initTriggerEmulatorLogic(DECLARE_ENGINE_PARAMETER_SIGNATURE);
 
 int getPreviousIndex(const int currentIndex, const int size);
 bool needEvent(const int currentIndex, const int size, const MultiChannelStateSequence& mcss, int channelIndex);

--- a/firmware/development/engine_emulator.cpp
+++ b/firmware/development/engine_emulator.cpp
@@ -11,26 +11,18 @@
 #include "global.h"
 #include "engine_emulator.h"
 
-#include "advance_map.h"
-#include "fuel_math.h"
-
-#include "status_loop.h"
-#include "logic_analyzer.h"
-#include "pin_repository.h"
-#include "pwm_generator_logic.h"
-
 #include "poten.h"
 #include "trigger_emulator_algo.h"
 
 EXTERN_ENGINE;
 
-void initEngineEmulator(Logging *sharedLogger DECLARE_ENGINE_PARAMETER_SUFFIX) {
+void initEngineEmulator(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 	if (hasFirmwareError())
 		return;
 
 #if EFI_POTENTIOMETER && HAL_USE_SPI
-	initPotentiometers(sharedLogger PASS_ENGINE_PARAMETER_SUFFIX);
+	initPotentiometers(PASS_ENGINE_PARAMETER_SIGNATURE);
 #endif /* EFI_POTENTIOMETER && HAL_USE_SPI*/
 
-	initTriggerEmulator(sharedLogger PASS_ENGINE_PARAMETER_SUFFIX);
+	initTriggerEmulator(PASS_ENGINE_PARAMETER_SIGNATURE);
 }

--- a/firmware/development/engine_emulator.h
+++ b/firmware/development/engine_emulator.h
@@ -7,6 +7,6 @@
 
 #pragma once
 
-#include "engine.h"
-void initEngineEmulator(Logging *sharedLogger DECLARE_ENGINE_PARAMETER_SUFFIX);
+#include "engine_ptr.h"
+void initEngineEmulator(DECLARE_ENGINE_PARAMETER_SIGNATURE);
 

--- a/firmware/development/hw_layer/poten.cpp
+++ b/firmware/development/hw_layer/poten.cpp
@@ -51,8 +51,6 @@ EXTERN_ENGINE;
 #define SPI_POT_CONFIG SPI_CR1_BR_2 | SPI_CR1_BR_1 | SPI_CR1_DFF
 #endif /* defined(STM32F4XX) */
 
-static Logging * logger;
-
 #if EFI_POTENTIOMETER
 static Mcp42010Driver potConfig[DIGIPOT_COUNT];
 
@@ -94,8 +92,7 @@ static void setPotValue1(int value) {
 
 #endif /* EFI_POTENTIOMETER */
 
-void initPotentiometers(Logging *sharedLogger DECLARE_ENGINE_PARAMETER_SUFFIX) {
-	logger = sharedLogger;
+void initPotentiometers(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 #if EFI_POTENTIOMETER
 	if (CONFIG(digitalPotentiometerSpiDevice) == SPI_NONE) {
 		efiPrintf("digiPot spi disabled");

--- a/firmware/development/hw_layer/poten.h
+++ b/firmware/development/hw_layer/poten.h
@@ -20,7 +20,7 @@ typedef struct {
 } Mcp42010Driver;
 
 //void initPotentiometer(Mcp42010Driver *driver, SPIDriver *spi, ioportid_t port, ioportmask_t pin);
-void initPotentiometers(Logging *sharedLogger DECLARE_ENGINE_PARAMETER_SUFFIX);
+void initPotentiometers(DECLARE_ENGINE_PARAMETER_SIGNATURE);
 void setPotResistance(Mcp42010Driver *driver, int channel, int resistance);
 
 #endif

--- a/firmware/development/logic_analyzer.cpp
+++ b/firmware/development/logic_analyzer.cpp
@@ -45,8 +45,6 @@ static volatile efitimeus_t previousEngineCycleTimeUs = 0;
 static int waveReaderCount = 0;
 static WaveReader readers[MAX_ICU_COUNT];
 
-static Logging * logger;
-
 static void ensureInitialized(WaveReader *reader) {
 	/*may be*/UNUSED(reader);
 	efiAssertVoid(CUSTOM_ERR_6654, reader->hw != NULL && reader->hw->started, "wave analyzer NOT INITIALIZED");
@@ -223,8 +221,7 @@ void showWaveInfo(void) {
 	efiPrintf("logic input #1: %d/%d", readers[0].fallEventCounter, readers[0].riseEventCounter);
 }
 
-void initWaveAnalyzer(Logging *sharedLogger) {
-	logger = sharedLogger;
+void initWaveAnalyzer() {
 	if (hasFirmwareError()) {
 		return;
 	}

--- a/firmware/development/logic_analyzer.h
+++ b/firmware/development/logic_analyzer.h
@@ -50,7 +50,7 @@ public:
 	volatile efitimeus_t last_wave_high_widthUs = 0; // time period in systimer ticks
 };
 
-void initWaveAnalyzer(Logging *sharedLogger);
+void initWaveAnalyzer();
 void startLogicAnalyzerPins();
 void stopLogicAnalyzerPins();
 void printWave(Logging *logging);

--- a/firmware/development/rfi_perftest.cpp
+++ b/firmware/development/rfi_perftest.cpp
@@ -22,8 +22,6 @@
 #if EFI_PERF_METRICS
 #include "test.h"
 
-static Logging* logger;
-
 static void testSystemCalls(const int count) {
 	time_t start, time;
 	long result = 0;
@@ -297,8 +295,7 @@ static void runChibioTest(void) {
 	TestThread(getConsoleChannel());
 }
 
-void initTimePerfActions(Logging *sharedLogger) {
-	logger = sharedLogger;
+void initTimePerfActions() {
 #if EFI_RTC
 	rtcStartTime = rtcGetTimeUnixSec(&RTCD1);
 #endif

--- a/firmware/development/rfi_perftest.h
+++ b/firmware/development/rfi_perftest.h
@@ -9,4 +9,4 @@
 
 #include "global.h"
 
-void initTimePerfActions(Logging *sharedLogger);
+void initTimePerfActions();

--- a/firmware/hw_layer/digital_input/trigger/trigger_input.cpp
+++ b/firmware/hw_layer/digital_input/trigger/trigger_input.cpp
@@ -19,11 +19,11 @@ EXTERN_ENGINE;
 #if (HAL_USE_ICU == TRUE) || (HAL_TRIGGER_USE_PAL == TRUE)
 
 #if (HAL_USE_ICU == TRUE)
-	void icuTriggerTurnOnInputPins(Logging *sharedLogger);
+	void icuTriggerTurnOnInputPins();
 	int  icuTriggerTurnOnInputPin(const char *msg, int index, bool isTriggerShaft);
 	void icuTriggerTurnOffInputPin(brain_pin_e brainPin);
 #else
-	#define icuTriggerTurnOnInputPins(sharedLogger) ((void)0)
+	#define icuTriggerTurnOnInputPins() ((void)0)
 	int  icuTriggerTurnOnInputPin(const char *msg, int index, bool isTriggerShaft) {
 		UNUSED(msg);
 		UNUSED(index);
@@ -35,11 +35,11 @@ EXTERN_ENGINE;
 #endif
 
 #if (HAL_TRIGGER_USE_PAL == TRUE)
-	void extiTriggerTurnOnInputPins(Logging *sharedLogger);
+	void extiTriggerTurnOnInputPins();
 	int  extiTriggerTurnOnInputPin(const char *msg, int index, bool isTriggerShaft);
 	void extiTriggerTurnOffInputPin(brain_pin_e brainPin);
 #else
-	#define extiTriggerTurnOnInputPins(sharedLogger) ((void)0)
+	#define extiTriggerTurnOnInputPins() ((void)0)
 	int  extiTriggerTurnOnInputPin(const char *msg, int index, bool isTriggerShaft) {
 		UNUSED(msg);
 		UNUSED(index);
@@ -161,10 +161,10 @@ void startTriggerInputPins(void) {
 	}
 }
 
-void turnOnTriggerInputPins(Logging *sharedLogger) {
+void turnOnTriggerInputPins() {
 	/* init all trigger HW available */
-	icuTriggerTurnOnInputPins(sharedLogger);
-	extiTriggerTurnOnInputPins(sharedLogger);
+	icuTriggerTurnOnInputPins();
+	extiTriggerTurnOnInputPins();
 
 	applyNewTriggerInputPins();
 }

--- a/firmware/hw_layer/digital_input/trigger/trigger_input.h
+++ b/firmware/hw_layer/digital_input/trigger/trigger_input.h
@@ -28,7 +28,7 @@
 
 #define TRIGGER_SUPPORTED_CHANNELS 2
 
-void turnOnTriggerInputPins(Logging *sharedLogger);
+void turnOnTriggerInputPins();
 void applyNewTriggerInputPins(void);
 void startTriggerInputPins(void);
 void stopTriggerInputPins(void);

--- a/firmware/hw_layer/digital_input/trigger/trigger_input_comp.cpp
+++ b/firmware/hw_layer/digital_input/trigger/trigger_input_comp.cpp
@@ -18,8 +18,6 @@
 
 EXTERN_ENGINE;
 
-static Logging *logger;
-
 static volatile int centeredDacValue = 127;
 static volatile int toothCnt = 0;
 static volatile int dacHysteresisMin = 1;	// = 5V * 1/256 (8-bit DAC) = ~20mV
@@ -98,8 +96,7 @@ static COMPConfig comp_shaft_cfg = {
 
 static bool isCompEnabled = false;
 
-void turnOnTriggerInputPins(Logging *sharedLogger) {
-	logger = sharedLogger;
+void turnOnTriggerInputPins() {
 	compInit();
 	compStart(EFI_COMP_PRIMARY_DEVICE, &comp_shaft_cfg);
 

--- a/firmware/hw_layer/digital_input/trigger/trigger_input_exti.cpp
+++ b/firmware/hw_layer/digital_input/trigger/trigger_input_exti.cpp
@@ -21,8 +21,6 @@
 	#error "PAL_USE_CALLBACKS should be enabled to use HAL_TRIGGER_USE_PAL"
 #endif
 
-static Logging *logger;
-
 EXTERN_ENGINE;
 
 static ioline_t shaftLines[TRIGGER_SUPPORTED_CHANNELS];
@@ -109,8 +107,7 @@ void extiTriggerTurnOffInputPin(brain_pin_e brainPin) {
 	efiExtiDisablePin(brainPin);
 }
 
-void extiTriggerTurnOnInputPins(Logging *sharedLogger) {
-	logger = sharedLogger;
+void extiTriggerTurnOnInputPins() {
 }
 
 #endif /* (EFI_SHAFT_POSITION_INPUT && (HAL_TRIGGER_USE_PAL == TRUE)) */

--- a/firmware/hw_layer/digital_input/trigger/trigger_input_icu.cpp
+++ b/firmware/hw_layer/digital_input/trigger/trigger_input_icu.cpp
@@ -25,8 +25,6 @@ int icuFallingCallbackCounter = 0;
 
 EXTERN_ENGINE;
 
-static Logging *logger;
-
 static void vvtRisingCallback(void *arg) {
 	efitick_t now = getTimeNowNt();
 	TRIGGER_BAIL_IF_DISABLED

--- a/firmware/hw_layer/digital_input/trigger/trigger_input_icu.cpp
+++ b/firmware/hw_layer/digital_input/trigger/trigger_input_icu.cpp
@@ -136,7 +136,6 @@ void icuTriggerTurnOffInputPin(brain_pin_e brainPin) {
 	stopDigitalCapture("trigger", brainPin);
 }
 
-void icuTriggerTurnOnInputPins(Logging *sharedLogger) {
-	logger = sharedLogger;
+void icuTriggerTurnOnInputPins() {
 }
 #endif /* (EFI_SHAFT_POSITION_INPUT && (HAL_USE_ICU == TRUE)) */

--- a/firmware/hw_layer/hardware.cpp
+++ b/firmware/hw_layer/hardware.cpp
@@ -137,8 +137,6 @@ SPIDriver * getSpiDevice(spi_device_e spiDevice) {
 }
 #endif
 
-static Logging *sharedLogger;
-
 #if EFI_PROD_CODE
 
 #define TPS_IS_SLOW -1
@@ -271,7 +269,7 @@ static void adcConfigListener(Engine *engine) {
 	calcFastAdcIndexes();
 }
 
-void turnOnHardware(Logging *sharedLogger) {
+static void turnOnHardware() {
 #if EFI_FASTER_UNIFORM_ADC
 	for (int i = 0; i < ADC_MAX_CHANNELS_COUNT; i++) {
 		averagedSamples[i] = 0;
@@ -280,7 +278,7 @@ void turnOnHardware(Logging *sharedLogger) {
 #endif /* EFI_FASTER_UNIFORM_ADC */
 
 #if EFI_SHAFT_POSITION_INPUT
-	turnOnTriggerInputPins(sharedLogger);
+	turnOnTriggerInputPins();
 #endif /* EFI_SHAFT_POSITION_INPUT */
 }
 
@@ -464,9 +462,8 @@ void showBor(void) {
 }
 
 // This function initializes hardware that can do so before configuration is loaded
-void initHardwareNoConfig(Logging *l) {
+void initHardwareNoConfig() {
 	efiAssertVoid(CUSTOM_IH_STACK, getCurrentRemainingStack() > EXPECTED_REMAINING_STACK, "init h");
-	sharedLogger = l;
 	efiAssertVoid(CUSTOM_EC_NULL, engineConfiguration!=NULL, "engineConfiguration");
 	
 
@@ -492,12 +489,12 @@ void initHardwareNoConfig(Logging *l) {
 	initRtc();
 
 #if EFI_INTERNAL_FLASH
-	initFlash(sharedLogger);
+	initFlash();
 #endif
 
 #if EFI_SHAFT_POSITION_INPUT
 	// todo: figure out better startup logic
-	initTriggerCentral(sharedLogger);
+	initTriggerCentral();
 #endif /* EFI_SHAFT_POSITION_INPUT */
 
 #if EFI_FILE_LOGGING
@@ -507,7 +504,7 @@ void initHardwareNoConfig(Logging *l) {
 
 void initHardware() {
 #if EFI_HD44780_LCD
-	lcd_HD44780_init(sharedLogger);
+	lcd_HD44780_init();
 	if (hasFirmwareError())
 		return;
 
@@ -547,11 +544,11 @@ void initHardware() {
 #endif /* EFI_ENGINE_CONTROL */
 
 #if EFI_MC33816
-	initMc33816(sharedLogger);
+	initMc33816();
 #endif /* EFI_MC33816 */
 
 #if EFI_MAX_31855
-	initMax31855(sharedLogger, CONFIG(max31855spiDevice), CONFIG(max31855_cs));
+	initMax31855(CONFIG(max31855spiDevice), CONFIG(max31855_cs));
 #endif /* EFI_MAX_31855 */
 
 #if EFI_CAN_SUPPORT
@@ -561,10 +558,10 @@ void initHardware() {
 //	init_adc_mcp3208(&adcState, &SPID2);
 //	requestAdcValue(&adcState, 0);
 
-	turnOnHardware(sharedLogger);
+	turnOnHardware();
 
 #if EFI_HIP_9011
-	initHip9011(sharedLogger);
+	initHip9011();
 #endif /* EFI_HIP_9011 */
 
 #if EFI_MEMS
@@ -588,11 +585,11 @@ void initHardware() {
 #endif /* EFI_AUX_SERIAL */
 
 #if EFI_VEHICLE_SPEED
-	initVehicleSpeed(sharedLogger);
+	initVehicleSpeed();
 #endif // EFI_VEHICLE_SPEED
 
 #if EFI_CAN_SUPPORT
-	initCanVssSupport(sharedLogger);
+	initCanVssSupport();
 #endif // EFI_CAN_SUPPORT
 
 #if EFI_CDM_INTEGRATION
@@ -600,7 +597,7 @@ void initHardware() {
 #endif // EFI_CDM_INTEGRATION
 
 #if (HAL_USE_PAL && EFI_JOYSTICK)
-	initJoystick(sharedLogger);
+	initJoystick();
 #endif /* HAL_USE_PAL && EFI_JOYSTICK */
 
 	calcFastAdcIndexes();

--- a/firmware/hw_layer/hardware.h
+++ b/firmware/hw_layer/hardware.h
@@ -51,7 +51,7 @@ brain_pin_e getSckPin(spi_device_e device);
 void applyNewHardwareSettings(void);
 
 // Initialize hardware that doesn't require configuration to be loaded
-void initHardwareNoConfig(Logging *l);
+void initHardwareNoConfig();
 
 // Initialize hardware with configuration loaded
 void initHardware();

--- a/firmware/hw_layer/lcd/lcd_HD44780.cpp
+++ b/firmware/hw_layer/lcd/lcd_HD44780.cpp
@@ -19,8 +19,6 @@
 
 EXTERN_ENGINE;
 
-static Logging *logger;
-
 enum {
 	LCD_HD44780_DISPLAY_CLEAR = 0x01,
 	LCD_HD44780_SHIFT_CURSOR_RIGHT = 0x06,
@@ -222,9 +220,7 @@ void startHD44780_pins() {
 	}
 }
 
-void lcd_HD44780_init(Logging *sharedLogger) {
-	logger = sharedLogger;
-
+void lcd_HD44780_init() {
 	addConsoleAction("lcdinfo", lcdInfo);
 
 	if (engineConfiguration->displayMode == DM_NONE) {

--- a/firmware/hw_layer/lcd/lcd_HD44780.h
+++ b/firmware/hw_layer/lcd/lcd_HD44780.h
@@ -14,7 +14,7 @@ extern "C"
 
 void startHD44780_pins();
 void stopHD44780_pins();
-void lcd_HD44780_init(Logging *sharedLogger);
+void lcd_HD44780_init();
 void lcd_HD44780_set_position(uint8_t row, uint8_t column);
 void lcd_HD44780_print_char(char data);
 void lcd_HD44780_print_string(const char *string);

--- a/firmware/hw_layer/max31855.cpp
+++ b/firmware/hw_layer/max31855.cpp
@@ -29,15 +29,13 @@
 
 static SPIDriver *driver;
 
-static Logging* logger;
-
 static SPIConfig spiConfig[EGT_CHANNEL_COUNT];
 
 EXTERN_ENGINE;
 
 static void showEgtInfo(void) {
 #if EFI_PROD_CODE
-	printSpiState(logger, engineConfiguration);
+	printSpiState(engineConfiguration);
 
 	efiPrintf("EGT spi: %d", CONFIG(max31855spiDevice));
 
@@ -141,14 +139,12 @@ static void egtRead(void) {
 	}
 }
 
-void initMax31855(Logging *sharedLogger, spi_device_e device, egt_cs_array_t max31855_cs) {
+void initMax31855(spi_device_e device, egt_cs_array_t max31855_cs) {
 	driver = getSpiDevice(device);
 	if (driver == NULL) {
 		// error already reported
 		return;
 	}
-
-	logger = sharedLogger;
 
 	// todo:spi device is now enabled separately - should probably be enabled here
 

--- a/firmware/hw_layer/max31855.h
+++ b/firmware/hw_layer/max31855.h
@@ -11,7 +11,7 @@
 #include "engine_configuration.h"
 
 #if HAL_USE_SPI
-void initMax31855(Logging *sharedLogger, spi_device_e device, egt_cs_array_t max31855_cs);
+void initMax31855(spi_device_e device, egt_cs_array_t max31855_cs);
 #endif /* HAL_USE_SPI */
 
 uint16_t getEgtValue(int egtChannel);

--- a/firmware/hw_layer/mc33816.cpp
+++ b/firmware/hw_layer/mc33816.cpp
@@ -41,7 +41,6 @@ static bool flag0after = false;
 
 static unsigned short mcChipId;
 static unsigned short mcDriverStatus;
-static Logging* logger;
 
 static SPIConfig spiCfg = { .circular = false,
 		.end_cb = NULL,
@@ -415,9 +414,7 @@ static void download_register(int r_target) {
 
 static bool haveMc33816 = false;
 
-void initMc33816(Logging *sharedLogger) {
-	logger = sharedLogger;
-
+void initMc33816() {
 	//
 	// see setTest33816EngineConfiguration for default configuration
 	// Pins

--- a/firmware/hw_layer/mc33816.h
+++ b/firmware/hw_layer/mc33816.h
@@ -7,8 +7,6 @@
 
 #pragma once
 
-#include "global.h"
-
 const int MC_CK = 6; // PLL x24 / CLK_DIV 4 = 6Mhz
 
 const int MAX_SPI_MODE_A_TRANSFER_SIZE = 31;  //max size for register config transfer
@@ -26,6 +24,5 @@ enum {
 	REG_DIAG
 };
 
-void initMc33816(Logging *logger);
+void initMc33816();
 void initMc33816IfNeeded();
-

--- a/firmware/hw_layer/mmc_card.cpp
+++ b/firmware/hw_layer/mmc_card.cpp
@@ -130,7 +130,7 @@ static void sdStatistics(void) {
 	printMmcPinout();
 	efiPrintf("SD enabled=%s status=%s", boolToString(CONFIG(isSdCardEnabled)),
 			sdStatus);
-	printSpiConfig(nullptr, "SD", mmcSpiDevice);
+	printSpiConfig("SD", mmcSpiDevice);
 	if (isSdCardAlive()) {
 		efiPrintf("filename=%s size=%d", logName, totalLoggedBytes);
 	}

--- a/firmware/hw_layer/pin_repository.cpp
+++ b/firmware/hw_layer/pin_repository.cpp
@@ -146,7 +146,7 @@ static void reportPins(void) {
 	efiPrintf("Total pins count: %d", pinRepository.totalPinsUsed);
 }
 
-void printSpiConfig(Logging *logging, const char *msg, spi_device_e device) {
+void printSpiConfig(const char *msg, spi_device_e device) {
 #if HAL_USE_SPI
 	scheduleMsg(logging, "%s %s mosi=%s", msg, getSpi_device_e(device), hwPortname(getMosiPin(device)));
 	scheduleMsg(logging, "%s %s miso=%s", msg, getSpi_device_e(device), hwPortname(getMisoPin(device)));

--- a/firmware/hw_layer/sensors/cj125.cpp
+++ b/firmware/hw_layer/sensors/cj125.cpp
@@ -37,8 +37,6 @@ EXTERN_ENGINE;
 #include "backup_ram.h"
 #include "pin_repository.h"
 
-static Logging *logger;
-
 static CJ125 globalInstance;
 
 #if ! EFI_UNIT_TEST
@@ -243,7 +241,7 @@ static void cjSetI(float value) {
 static void cjInfo() {
 	cjPrintState();
 #if HAL_USE_SPI
-	printSpiConfig(logger, "cj125", CONFIG(cj125SpiDevice));
+	printSpiConfig("cj125", CONFIG(cj125SpiDevice));
 #endif /* HAL_USE_SPI */
 }
 
@@ -604,10 +602,8 @@ void cjPostState(TunerStudioOutputChannels *tsOutputChannels) {
 }
 #endif /* EFI_TUNER_STUDIO */
 
-void initCJ125(Logging *sharedLogger DECLARE_ENGINE_PARAMETER_SUFFIX) {
-	logger = sharedLogger;
+void initCJ125(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 	globalInstance.spi = &spi;
-	globalInstance.logger = sharedLogger;
 
 	if (!CONFIG(isCJ125Enabled)) {
 		globalInstance.errorCode = CJ125_ERROR_DISABLED;

--- a/firmware/hw_layer/sensors/cj125.h
+++ b/firmware/hw_layer/sensors/cj125.h
@@ -102,7 +102,7 @@
 void cjPostState(TunerStudioOutputChannels *tsOutputChannels);
 #endif /* EFI_TUNER_STUDIO */
 
-void initCJ125(Logging *shared DECLARE_ENGINE_PARAMETER_SUFFIX);
+void initCJ125(DECLARE_ENGINE_PARAMETER_SIGNATURE);
 
 void cjRestart(void);
 void cjStartCalibration(void);

--- a/firmware/hw_layer/sensors/cj125_logic.cpp
+++ b/firmware/hw_layer/sensors/cj125_logic.cpp
@@ -50,19 +50,19 @@ void CJ125::StartHeaterControl(pwm_gen_callback *stateChangeCallback DECLARE_ENG
 	SetIdleHeater(PASS_ENGINE_PARAMETER_SIGNATURE);
 }
 
-static void printDiagCode(Logging * logging, const char *msg, int code, const char *code1message) {
+static void printDiagCode(const char *msg, int code, const char *code1message) {
 	switch(code & 0x3) {
 	case 0:
-		scheduleMsg(logging, "%s Short to GND", msg);
+		efiPrintf("%s Short to GND", msg);
 		return;
 	case 1:
-		scheduleMsg(logging, "%s %s", msg, code1message);
+		efiPrintf("%s %s", msg, code1message);
 		return;
 	case 2:
-		scheduleMsg(logging, "%s Short to Vbatt", msg);
+		efiPrintf("%s Short to Vbatt", msg);
 		return;
 	case 3:
-		scheduleMsg(logging, "%s LOOKS GOOD", msg);
+		efiPrintf("%s LOOKS GOOD", msg);
 		return;
 	}
 }
@@ -72,10 +72,10 @@ void CJ125::printDiag() {
 		efiPrintf("cj125: diag Looks great!");
 	} else {
 		efiPrintf("cj125: diag NOT GOOD");
-		printDiagCode(logger, "VM", diag, LOW_VOLTAGE);
-		printDiagCode(logger, "UN", diag >> 2, LOW_VOLTAGE);
-		printDiagCode(logger, "IA", diag >> 4, LOW_VOLTAGE);
-		printDiagCode(logger, "HR", diag >> 6, "open load");
+		printDiagCode("VM", diag, LOW_VOLTAGE);
+		printDiagCode("UN", diag >> 2, LOW_VOLTAGE);
+		printDiagCode("IA", diag >> 4, LOW_VOLTAGE);
+		printDiagCode("HR", diag >> 6, "open load");
 /* todo: do we want to throw CRITICAL on diag start-up error? probably not?
 		firmwareError(CUSTOM_ERR_CJ125_DIAG, "CJ125 is not well");
 */

--- a/firmware/hw_layer/sensors/cj125_logic.h
+++ b/firmware/hw_layer/sensors/cj125_logic.h
@@ -55,7 +55,6 @@ class CJ125 {
 public:
 	CJ125();
 	Cj125SpiStream *spi = nullptr;
-	Logging *logger = nullptr;
 
 	SimplePwm wboHeaterControl;
 

--- a/firmware/hw_layer/sensors/hip9011.cpp
+++ b/firmware/hw_layer/sensors/hip9011.cpp
@@ -83,8 +83,6 @@ HIP9011 instance(&hardware);
 
 static scheduling_s endTimer;
 
-static Logging *logger;
-
 // SPI_CR1_BR_1 // 5MHz
 // SPI_CR1_CPHA Clock Phase
 // todo: nicer method which would mention SPI speed explicitly?
@@ -418,9 +416,7 @@ void startHip9001_pins() {
 	Cs.initPin("hip CS", CONFIG(hip9011CsPin), &CONFIG(hip9011CsPinMode));
 }
 
-void initHip9011(Logging *sharedLogger) {
-	logger = sharedLogger;
-
+void initHip9011() {
 	if (!CONFIG(isHip9011Enabled))
 		return;
 
@@ -504,7 +500,7 @@ static void showHipInfo(void) {
 		CONFIG(hip9011CsPinMode));
 
 #if EFI_PROD_CODE
-	printSpiConfig(logger, "hip9011", CONFIG(hip9011SpiDevice));
+	printSpiConfig("hip9011", CONFIG(hip9011SpiDevice));
 #endif /* EFI_PROD_CODE */
 
 	efiPrintf(" SPI good response %d incorrect response %d",

--- a/firmware/hw_layer/sensors/hip9011.h
+++ b/firmware/hw_layer/sensors/hip9011.h
@@ -10,7 +10,7 @@
 
 #define HIP_THREAD_PERIOD 100
 
-void initHip9011(Logging *sharedLogger);
+void initHip9011();
 void startHip9001_pins();
 void stopHip9001_pins();
 #if HAL_USE_ADC

--- a/firmware/hw_layer/sensors/joystick.cpp
+++ b/firmware/hw_layer/sensors/joystick.cpp
@@ -32,7 +32,6 @@ static int joyD = 0;
 // 50ms
 #define NT_EVENT_GAP US2NT(50 *1000)
 
-static Logging *sharedLogger;
 static efitick_t lastEventTime = 0;
 
 static bool isJitter() {
@@ -111,12 +110,11 @@ void startJoystickPins() {
 	efiSetPadModeWithoutOwnershipAcquisition("joy D", CONFIG(joystickDPin), PAL_MODE_INPUT_PULLUP);
 }
 
-void initJoystick(Logging *shared) {
+void initJoystick() {
 	int channel;
 	addConsoleAction("joystickinfo", joystickInfo);
 	if (!isJoystickEnabled())
 		return;
-	sharedLogger = shared;
 
 	channel = getHwPin("joy", CONFIG(joystickCenterPin));
 	efiExtiEnablePin("joy", CONFIG(joystickCenterPin), PAL_EVENT_MODE_RISING_EDGE, (palcallback_t)(void *)extCallback, (void *)channel);

--- a/firmware/hw_layer/sensors/joystick.h
+++ b/firmware/hw_layer/sensors/joystick.h
@@ -18,6 +18,6 @@ typedef enum {
 } joystick_button_e;
 
 void onJoystick(joystick_button_e button);
-void initJoystick(Logging *shared);
+void initJoystick();
 void startJoystickPins();
 void stopJoystickPins();

--- a/firmware/hw_layer/trigger_input_adc.cpp
+++ b/firmware/hw_layer/trigger_input_adc.cpp
@@ -20,9 +20,7 @@ extern "C" void toggleLed(int led, int mode);
 #define BOARD_MOD1_PORT GPIOD
 #define BOARD_MOD1_PIN 5
 
-EXTERN_ENGINE
-;
-static Logging *logger;
+EXTERN_ENGINE;
 
 #if 0
 static volatile int centeredDacValue = 127;
@@ -181,9 +179,7 @@ static void comp_cam_callback(COMPDriver *comp) {
 }
 #endif
 
-void turnOnTriggerInputPins(Logging *sharedLogger) {
-	logger = sharedLogger;
-
+void turnOnTriggerInputPins() {
 	applyNewTriggerInputPins();
 }
 

--- a/firmware/hw_layer/vehicle_speed.cpp
+++ b/firmware/hw_layer/vehicle_speed.cpp
@@ -17,8 +17,6 @@
 
 EXTERN_ENGINE;
 
-static Logging *logger;
-
 static efitick_t lastSignalTimeNt = 0;
 static efitick_t vssDiff = 0;
 
@@ -103,8 +101,7 @@ void startVSSPins(void) {
 #endif /* HAL_VSS_USE_PAL, HAL_USE_ICU */
 }
 
-void initVehicleSpeed(Logging *l) {
-	logger = l;
+void initVehicleSpeed() {
 	addConsoleAction("speedinfo", speedInfo);
 	startVSSPins();
 }

--- a/firmware/hw_layer/vehicle_speed.h
+++ b/firmware/hw_layer/vehicle_speed.h
@@ -13,7 +13,7 @@
  * @return vehicle speed, in kilometers per hour
  */
 float getVehicleSpeed(void);
-void initVehicleSpeed(Logging *logger);
+void initVehicleSpeed();
 void setMockVehicleSpeed(float speedKPH);
 bool hasVehicleSpeedSensor();
 void stopVSSPins(void);

--- a/firmware/rusefi.cpp
+++ b/firmware/rusefi.cpp
@@ -136,8 +136,6 @@
 #include "engine_emulator.h"
 #endif /* EFI_ENGINE_EMULATOR */
 
-LoggingWithStorage sharedLogger("main");
-
 bool main_loop_started = false;
 
 static char panicMessage[200];
@@ -190,10 +188,10 @@ void runRusEfi(void) {
 	initDataStructures(PASS_ENGINE_PARAMETER_SIGNATURE);
 
 	// Perform hardware initialization that doesn't need configuration
-	initHardwareNoConfig(&sharedLogger);
+	initHardwareNoConfig();
 
 	// Read configuration from flash memory
-	loadConfiguration(&sharedLogger PASS_ENGINE_PARAMETER_SUFFIX);
+	loadConfiguration(PASS_ENGINE_PARAMETER_SIGNATURE);
 
 #if EFI_USB_SERIAL
 	startUsbConsole();
@@ -237,17 +235,17 @@ void runRusEfi(void) {
 		 * Now let's initialize actual engine control logic
 		 * todo: should we initialize some? most? controllers before hardware?
 		 */
-		initEngineContoller(&sharedLogger PASS_ENGINE_PARAMETER_SIGNATURE);
+		initEngineContoller(PASS_ENGINE_PARAMETER_SIGNATURE);
 
 		// This has to happen after RegisteredOutputPins are init'd: otherwise no change will be detected, and no init will happen
 		rememberCurrentConfiguration(PASS_ENGINE_PARAMETER_SIGNATURE);
 
 	#if EFI_PERF_METRICS
-		initTimePerfActions(&sharedLogger);
+		initTimePerfActions();
 	#endif
 			
 	#if EFI_ENGINE_EMULATOR
-		initEngineEmulator(&sharedLogger PASS_ENGINE_PARAMETER_SIGNATURE);
+		initEngineEmulator(PASS_ENGINE_PARAMETER_SIGNATURE);
 	#endif
 		startStatusThreads();
 

--- a/simulator/simulator/rusEfiFunctionalTest.cpp
+++ b/simulator/simulator/rusEfiFunctionalTest.cpp
@@ -104,13 +104,13 @@ void rusEfiFunctionalTest(void) {
 
 	// todo: reduce code duplication with initEngineContoller
 
-	resetConfigurationExt(NULL, FORD_ESCORT_GT PASS_ENGINE_PARAMETER_SUFFIX);
+	resetConfigurationExt(FORD_ESCORT_GT PASS_ENGINE_PARAMETER_SUFFIX);
 	enableTriggerStimulator();
 
 	commonInitEngineController(&sharedLogger);
 
-	initTriggerCentral(&sharedLogger);
-	initTriggerEmulator(&sharedLogger PASS_ENGINE_PARAMETER_SUFFIX);
+	initTriggerCentral();
+	initTriggerEmulator(PASS_ENGINE_PARAMETER_SIGNATURE);
 
 	startStatusThreads();
 

--- a/simulator/simulator/rusEfiFunctionalTest.cpp
+++ b/simulator/simulator/rusEfiFunctionalTest.cpp
@@ -37,8 +37,6 @@ EXTERN_ENGINE;
 
 extern WaveChart waveChart;
 
-LoggingWithStorage sharedLogger("simulator");
-
 int getRemainingStack(thread_t *otp) {
 	return 99999;
 }
@@ -107,7 +105,7 @@ void rusEfiFunctionalTest(void) {
 	resetConfigurationExt(FORD_ESCORT_GT PASS_ENGINE_PARAMETER_SUFFIX);
 	enableTriggerStimulator();
 
-	commonInitEngineController(&sharedLogger);
+	commonInitEngineController();
 
 	initTriggerCentral();
 	initTriggerEmulator(PASS_ENGINE_PARAMETER_SIGNATURE);

--- a/unit_tests/engine_test_helper.cpp
+++ b/unit_tests/engine_test_helper.cpp
@@ -81,11 +81,11 @@ EngineTestHelper::EngineTestHelper(engine_type_e engineType, configuration_callb
 
 	initDataStructures(PASS_ENGINE_PARAMETER_SIGNATURE);
 
-	resetConfigurationExt(NULL, configurationCallback, engineType PASS_ENGINE_PARAMETER_SUFFIX);
+	resetConfigurationExt(configurationCallback, engineType PASS_ENGINE_PARAMETER_SUFFIX);
 
 	enginePins.startPins(PASS_ENGINE_PARAMETER_SIGNATURE);
 
-	commonInitEngineController(NULL PASS_ENGINE_PARAMETER_SUFFIX);
+	commonInitEngineController(PASS_ENGINE_PARAMETER_SIGNATURE);
 
 	engineConfiguration->mafAdcChannel = EFI_ADC_10;
 	engine->engineState.mockAdcState.setMockVoltage(EFI_ADC_10, 0 PASS_ENGINE_PARAMETER_SUFFIX);
@@ -323,7 +323,7 @@ void EngineTestHelper::applyTriggerWaveform() {
 	Engine *engine = &this->engine;
 	EXPAND_Engine
 
-	ENGINE(initializeTriggerWaveform(NULL PASS_ENGINE_PARAMETER_SUFFIX));
+	ENGINE(initializeTriggerWaveform(PASS_ENGINE_PARAMETER_SIGNATURE));
 
 	incrementGlobalConfigurationVersion(PASS_ENGINE_PARAMETER_SIGNATURE);
 }

--- a/unit_tests/main.cpp
+++ b/unit_tests/main.cpp
@@ -29,8 +29,6 @@ efitick_t getTimeNowNt(void) {
 	return getTimeNowUs() * US_TO_NT_MULTIPLIER;
 }
 
-LoggingWithStorage sharedLogger("main");
-
 bool verboseMode = false;
 
 GTEST_API_ int main(int argc, char **argv) {

--- a/unit_tests/tests/ignition_injection/test_fuel_map.cpp
+++ b/unit_tests/tests/ignition_injection/test_fuel_map.cpp
@@ -142,7 +142,7 @@ TEST(misc, testAngleResolver) {
 
 	TriggerWaveform * ts = &engine->triggerCentral.triggerShape;
 	TriggerFormDetails *triggerFormDetails = &engine->triggerCentral.triggerFormDetails;
-	engine->initializeTriggerWaveform(NULL PASS_ENGINE_PARAMETER_SUFFIX);
+	engine->initializeTriggerWaveform(PASS_ENGINE_PARAMETER_SIGNATURE);
 
 	assertEqualsM("index 2", 52.76, triggerFormDetails->eventAngles[3]); // this angle is relation to synch point
 	assertEqualsM("time 2", 0.3233, ts->wave.getSwitchTime(2));

--- a/unit_tests/tests/test_accel_enrichment.cpp
+++ b/unit_tests/tests/test_accel_enrichment.cpp
@@ -104,8 +104,7 @@ TEST(fuel, testAccelEnrichmentFractionalTps) {
 		}
 	}
 
-	LoggingWithStorage logger("test");
-	initAccelEnrichment(&logger PASS_ENGINE_PARAMETER_SUFFIX);
+	initAccelEnrichment(PASS_ENGINE_PARAMETER_SIGNATURE);
 
 	engine->rpmCalculator.setRpmValue(600);
 	engine->periodicFastCallback(PASS_ENGINE_PARAMETER_SIGNATURE);

--- a/unit_tests/tests/test_hardware_reinit.cpp
+++ b/unit_tests/tests/test_hardware_reinit.cpp
@@ -12,6 +12,6 @@ TEST(hardware, reinit) {
 	ButtonDebounce::startConfigurationList();
 
 
-	resetConfigurationExt(nullptr, nullptr, DODGE_NEON_1995 PASS_ENGINE_PARAMETER_SUFFIX);
-	resetConfigurationExt(nullptr, nullptr, MIATA_NA6_MAP PASS_ENGINE_PARAMETER_SUFFIX);
+	resetConfigurationExt(nullptr, DODGE_NEON_1995 PASS_ENGINE_PARAMETER_SUFFIX);
+	resetConfigurationExt(nullptr, MIATA_NA6_MAP PASS_ENGINE_PARAMETER_SUFFIX);
 }

--- a/unit_tests/tests/trigger/test_all_triggers.cpp
+++ b/unit_tests/tests/trigger/test_all_triggers.cpp
@@ -64,7 +64,7 @@ TEST_P(AllTriggersFixture, TestTrigger) {
 
 	TriggerWaveform *shape = &engine->triggerCentral.triggerShape;
 	TriggerFormDetails *triggerFormDetails = &engine->triggerCentral.triggerFormDetails;
-	engine->initializeTriggerWaveform(NULL PASS_ENGINE_PARAMETER_SUFFIX);
+	engine->initializeTriggerWaveform(PASS_ENGINE_PARAMETER_SIGNATURE);
 
 	ASSERT_FALSE(shape->shapeDefinitionError) << "Trigger shapeDefinitionError";
 

--- a/unit_tests/tests/trigger/test_trigger_decoder.cpp
+++ b/unit_tests/tests/trigger/test_trigger_decoder.cpp
@@ -518,7 +518,7 @@ TEST(misc, testTriggerDecoder) {
 
 		eth.persistentConfig.engineConfiguration.useOnlyRisingEdgeForTrigger = false;
 		eth.persistentConfig.engineConfiguration.sensorChartMode = SC_DETAILED_RPM;
-		applyNonPersistentConfiguration(NULL PASS_ENGINE_PARAMETER_SUFFIX);
+		applyNonPersistentConfiguration(PASS_ENGINE_PARAMETER_SIGNATURE);
 
 	}
 	testTriggerDecoder2("miata 1990", MIATA_1990, 11, 0.2985, 0.3890);
@@ -534,7 +534,7 @@ TEST(misc, testTriggerDecoder) {
 		printf("!!!!!!!!!!!!!!!!!! Now trying with only rising edges !!!!!!!!!!!!!!!!!\r\n");
 		engineConfiguration->useOnlyRisingEdgeForTrigger = true;
 
-		applyNonPersistentConfiguration(NULL PASS_ENGINE_PARAMETER_SUFFIX);
+		applyNonPersistentConfiguration(PASS_ENGINE_PARAMETER_SIGNATURE);
 		prepareShapes(PASS_ENGINE_PARAMETER_SIGNATURE);
 	}
 


### PR DESCRIPTION
No longer need to pass around instances of a `Logger` to everybody who needs one.