### PR TITLE
assign specific int values to SensorType

### DIFF
--- a/firmware/controllers/sensors/sensor_type.h
+++ b/firmware/controllers/sensors/sensor_type.h
@@ -20,54 +20,54 @@
  */
 enum class SensorType : unsigned char {
 	Invalid = 0,
-	Clt,
-	Iat,
-	Rpm,
-	Map,
-	Maf,
+	Clt = 1,
+	Iat = 2,
+	Rpm = 3,
+	Map = 4,
+	Maf = 5,
 
-	OilPressure,
+	OilPressure = 6,
 
-	FuelPressureLow, // in kPa
-	FuelPressureHigh, // in kPa
-	FuelPressureInjector,
+	FuelPressureLow = 7, // in kPa
+	FuelPressureHigh = 8, // in kPa
+	FuelPressureInjector = 9,
 
 	// This is the "resolved" position, potentially composited out of the following two
-	Tps1,
+	Tps1 = 10,
 	// This is the first sensor
-	Tps1Primary,
+	Tps1Primary = 11,
 	// This is the second sensor
-	Tps1Secondary,
+	Tps1Secondary = 12,
 
-	Tps2,
-	Tps2Primary,
-	Tps2Secondary,
+	Tps2 = 13,
+	Tps2Primary = 14,
+	Tps2Secondary = 15,
 
 	// Redundant and combined sensors for acc pedal
-	AcceleratorPedal,
-	AcceleratorPedalPrimary,
-	AcceleratorPedalSecondary,
+	AcceleratorPedal = 16,
+	AcceleratorPedalPrimary = 17,
+	AcceleratorPedalSecondary = 18,
 
 	// This maps to the pedal if we have one, and Tps1 if not.
-	DriverThrottleIntent,
+	DriverThrottleIntent = 19,
 
-	AuxTemp1,
-	AuxTemp2,
+	AuxTemp1 = 20,
+	AuxTemp2 = 21,
 
-	Lambda1,
-	Lambda2,
+	Lambda1 = 22,
+	Lambda2 = 23,
 
-	WastegatePosition,
-	IdlePosition,
+	WastegatePosition = 24,
+	IdlePosition = 25,
 
-	FuelEthanolPercent,
+	FuelEthanolPercent = 26,
 
-	BatteryVoltage,
+	BatteryVoltage = 27,
 
-	BarometricPressure,
+	BarometricPressure = 28,
 
-	FuelLevel,
+	FuelLevel = 29,
 
 	// Leave me at the end!
-	PlaceholderLast
+	PlaceholderLast = 30,
 };


### PR DESCRIPTION
Set explicit values for sensor types, since Lua has no concept of an enum.  These now must stay in the same order so as to not break Lua scripts.