### PR TITLE
Add check for error

### DIFF
--- a/misc/jenkins/generate_pinouts/gen_upload_pinouts.sh
+++ b/misc/jenkins/generate_pinouts/gen_upload_pinouts.sh
@@ -21,6 +21,9 @@ for c in $CONNECTORS; do
   fi
   file $DIR/index.html
   IMG=$(yq r $c 'info.image.file')
+  if [ $? -ne 0 ]; then
+    exit 1;
+  fi
   echo "IMG "$IMG
   if [ $IMG ]; then
     cp $(dirname $c)/$IMG $DIR


### PR DESCRIPTION
This will fix #2609. It's still possible for there to be yaml errors, as we don't check for errors at generation time. The only time an error will show up at generation time is if it prevents getting the file name for the image.