### PR TITLE
pack scheduling_s

### DIFF
--- a/firmware/controllers/engine_controller.cpp
+++ b/firmware/controllers/engine_controller.cpp
@@ -702,7 +702,7 @@ void initEngineContoller(DECLARE_ENGINE_PARAMETER_SUFFIX) {
  * UNUSED_SIZE constants.
  */
 #ifndef RAM_UNUSED_SIZE
-#define RAM_UNUSED_SIZE 3000
+#define RAM_UNUSED_SIZE 4000
 #endif
 #ifndef CCM_UNUSED_SIZE
 #define CCM_UNUSED_SIZE 2000

--- a/firmware/controllers/system/timer/scheduler.h
+++ b/firmware/controllers/system/timer/scheduler.h
@@ -12,6 +12,7 @@ typedef void (*schfunc_t)(void *);
 
 class action_s {
 public:
+	// Default constructor constructs null action (ie, implicit bool conversion returns false)
 	action_s() = default;
 
 	// Allow implicit conversion from schfunc_t to action_s
@@ -27,6 +28,10 @@ public:
 	schfunc_t getCallback() const;
 	void * getArgument() const;
 
+	operator bool() const {
+		return callback != nullptr;
+	}
+
 private:
 	schfunc_t callback = nullptr;
 	void *param = nullptr;
@@ -35,6 +40,7 @@ private:
 /**
  * This structure holds information about an event scheduled in the future: when to execute what callback with what parameters
  */
+#pragma pack(push, 4)
 struct scheduling_s {
 #if EFI_SIGNAL_EXECUTOR_SLEEP
 	virtual_timer_t timer;
@@ -44,7 +50,6 @@ struct scheduling_s {
 	 * timestamp represented as 64-bit value of ticks since MCU start
 	 */
 	volatile efitime_t momentX = 0;
-	bool isScheduled = false;
 
 	/**
 	 * Scheduler implementation uses a sorted linked list of these scheduling records.
@@ -53,6 +58,7 @@ struct scheduling_s {
 
 	action_s action;
 };
+#pragma pack(pop)
 
 struct ExecutorInterface {
 	/**


### PR DESCRIPTION
This change cuts `sizeof(scheduling_s)` from 24 to 20.  Saves ~750 bytes of memory.

Saves 4 bytes by using the action itself instead of a separate `isScheduled` bit.