### PR TITLE
remove stateChangeCallback from simplepwm

### DIFF
--- a/firmware/controllers/actuators/alternator_controller.cpp
+++ b/firmware/controllers/actuators/alternator_controller.cpp
@@ -70,9 +70,8 @@ class AlternatorController : public PeriodicTimerController {
 
 		// todo: migrate this to FSIO
 		bool alternatorShouldBeEnabledAtCurrentRpm = GET_RPM() > engineConfiguration->cranking.rpm;
-		bool isAlternatorControlEnabled = CONFIG(isAlternatorControlEnabled) && alternatorShouldBeEnabledAtCurrentRpm;
 
-		if (!isAlternatorControlEnabled) {
+		if (!CONFIG(isAlternatorControlEnabled) || !alternatorShouldBeEnabledAtCurrentRpm) {
 			// we need to avoid accumulating iTerm while engine is not running
 			pidReset();
 

--- a/firmware/controllers/actuators/alternator_controller.cpp
+++ b/firmware/controllers/actuators/alternator_controller.cpp
@@ -162,7 +162,7 @@ void initAlternatorCtrl(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 				"Alternator control",
 				&engine->executor,
 				&enginePins.alternatorPin,
-				engineConfiguration->alternatorPwmFrequency, 0.1, (pwm_gen_callback*)applyAlternatorPinState);
+				engineConfiguration->alternatorPwmFrequency, 0);
 	}
 	instance.Start();
 }

--- a/firmware/controllers/algo/engine.h
+++ b/firmware/controllers/algo/engine.h
@@ -185,10 +185,6 @@ public:
 	 * this is based on sensorChartMode and sensorSnifferRpmThreshold settings
 	 */
 	sensor_chart_e sensorChartMode = SC_OFF;
-	/**
-	 * based on current RPM and isAlternatorControlEnabled setting
-	 */
-	bool isAlternatorControlEnabled = false;
 
 	bool slowCallBackWasInvoked = false;
 

--- a/firmware/controllers/system/timer/pwm_generator_logic.cpp
+++ b/firmware/controllers/system/timer/pwm_generator_logic.cpp
@@ -359,11 +359,11 @@ void startSimplePwm(SimplePwm *state, const char *msg, ExecutorInterface *execut
 void startSimplePwmExt(SimplePwm *state, const char *msg,
 		ExecutorInterface *executor,
 		brain_pin_e brainPin, OutputPin *output, float frequency,
-		float dutyCycle, pwm_gen_callback *stateChangeCallback) {
+		float dutyCycle) {
 
 	output->initPin(msg, brainPin);
 
-	startSimplePwm(state, msg, executor, output, frequency, dutyCycle, stateChangeCallback);
+	startSimplePwm(state, msg, executor, output, frequency, dutyCycle);
 }
 
 void startSimplePwmHard(SimplePwm *state, const char *msg,

--- a/firmware/controllers/system/timer/pwm_generator_logic.cpp
+++ b/firmware/controllers/system/timer/pwm_generator_logic.cpp
@@ -334,31 +334,6 @@ void PwmConfig::weComplexInit(const char *msg, ExecutorInterface *executor,
 	timerCallback(this);
 }
 
-/**
- * This method controls the actual hardware pins
- *
- * This method takes ~350 ticks.
- */
-static void applyPinState(int stateIndex, PwmConfig *state) /* pwm_gen_callback */ {
-#if EFI_PROD_CODE
-	if (!engine->isPwmEnabled) {
-		for (int channelIndex = 0; channelIndex < state->multiChannelStateSequence.waveCount; channelIndex++) {
-			OutputPin *output = state->outputPins[channelIndex];
-			output->setValue(0);
-		}
-		return;
-	}
-#endif // EFI_PROD_CODE
-
-	efiAssertVoid(CUSTOM_ERR_6663, stateIndex < PWM_PHASE_MAX_COUNT, "invalid stateIndex");
-	efiAssertVoid(CUSTOM_ERR_6664, state->multiChannelStateSequence.waveCount <= PWM_PHASE_MAX_WAVE_PER_PWM, "invalid waveCount");
-	for (int channelIndex = 0; channelIndex < state->multiChannelStateSequence.waveCount; channelIndex++) {
-		OutputPin *output = state->outputPins[channelIndex];
-		int value = state->multiChannelStateSequence.getChannelState(channelIndex, stateIndex);
-		output->setValue(value);
-	}
-}
-
 void startSimplePwm(SimplePwm *state, const char *msg, ExecutorInterface *executor,
 		OutputPin *output, float frequency, float dutyCycle) {
 	efiAssertVoid(CUSTOM_ERR_PWM_STATE_ASSERT, state != NULL, "state");
@@ -412,7 +387,7 @@ void startSimplePwmHard(SimplePwm *state, const char *msg,
  *
  * This method takes ~350 ticks.
  */
-static void applyPinState(int stateIndex, PwmConfig *state) /* pwm_gen_callback */ {
+void applyPinState(int stateIndex, PwmConfig *state) /* pwm_gen_callback */ {
 #if EFI_PROD_CODE
 	if (!engine->isPwmEnabled) {
 		for (int channelIndex = 0; channelIndex < state->multiChannelStateSequence.waveCount; channelIndex++) {

--- a/firmware/controllers/system/timer/pwm_generator_logic.h
+++ b/firmware/controllers/system/timer/pwm_generator_logic.h
@@ -145,7 +145,7 @@ void applyPinState(int stateIndex, PwmConfig* state) /* pwm_gen_callback */;
 void startSimplePwm(SimplePwm *state, const char *msg,
 		ExecutorInterface *executor,
 		OutputPin *output,
-		float frequency, float dutyCycle, pwm_gen_callback *stateChangeCallback = (pwm_gen_callback*)applyPinState);
+		float frequency, float dutyCycle);
 
 /**
  * initialize GPIO pin and start a one-channel software PWM driver.

--- a/firmware/controllers/system/timer/pwm_generator_logic.h
+++ b/firmware/controllers/system/timer/pwm_generator_logic.h
@@ -156,7 +156,7 @@ void startSimplePwmExt(SimplePwm *state,
 		const char *msg,
 		ExecutorInterface *executor,
 		brain_pin_e brainPin, OutputPin *output,
-		float frequency, float dutyCycle, pwm_gen_callback *stateChangeCallback = (pwm_gen_callback*)applyPinState);
+		float frequency, float dutyCycle);
 
 void startSimplePwmHard(SimplePwm *state, const char *msg,
 		ExecutorInterface *executor,

--- a/firmware/hw_layer/sensors/cj125.cpp
+++ b/firmware/hw_layer/sensors/cj125.cpp
@@ -628,7 +628,7 @@ void initCJ125(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 	if (!cjStartSpi(PASS_ENGINE_PARAMETER_SIGNATURE))
 		return;
 	efiPrintf("cj125: Starting heater control");
-	globalInstance.StartHeaterControl((pwm_gen_callback*)applyPinState PASS_ENGINE_PARAMETER_SUFFIX);
+	globalInstance.StartHeaterControl(PASS_ENGINE_PARAMETER_SIGNATURE);
 	cjStart(PASS_ENGINE_PARAMETER_SIGNATURE);
 	
 #ifdef CJ125_DEBUG

--- a/firmware/hw_layer/sensors/cj125_logic.cpp
+++ b/firmware/hw_layer/sensors/cj125_logic.cpp
@@ -41,12 +41,12 @@ bool CJ125::isWorkingState(void) const {
 	return state != CJ125_ERROR && state != CJ125_INIT && state != CJ125_IDLE;
 }
 
-void CJ125::StartHeaterControl(pwm_gen_callback *stateChangeCallback DECLARE_ENGINE_PARAMETER_SUFFIX) {
+void CJ125::StartHeaterControl(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 	// todo: use custom pin state method, turn pin off while not running
 	startSimplePwmExt(&wboHeaterControl, "wboHeaterPin",
 			&engine->executor,
 			CONFIG(wboHeaterPin),
-			&wboHeaterPin, CJ125_HEATER_PWM_FREQ, 0.0f, stateChangeCallback);
+			&wboHeaterPin, CJ125_HEATER_PWM_FREQ, 0.0f);
 	SetIdleHeater(PASS_ENGINE_PARAMETER_SIGNATURE);
 }
 

--- a/firmware/hw_layer/sensors/cj125_logic.h
+++ b/firmware/hw_layer/sensors/cj125_logic.h
@@ -99,7 +99,7 @@ public:
 	bool isWorkingState(void) const;
 	void SetHeater(float value DECLARE_ENGINE_PARAMETER_SUFFIX);
 	void SetIdleHeater(DECLARE_ENGINE_PARAMETER_SIGNATURE);
-	void StartHeaterControl(pwm_gen_callback *stateChangeCallback DECLARE_ENGINE_PARAMETER_SUFFIX);
+	void StartHeaterControl(DECLARE_ENGINE_PARAMETER_SIGNATURE);
 	bool cjIdentify(DECLARE_ENGINE_PARAMETER_SIGNATURE);
 	void printDiag();
 	void calibrate(DECLARE_ENGINE_PARAMETER_SIGNATURE);

--- a/unit_tests/tests/sensor/test_cj125.cpp
+++ b/unit_tests/tests/sensor/test_cj125.cpp
@@ -8,10 +8,6 @@
 #include "cj125_logic.h"
 #include "engine_test_helper.h"
 
-static void applyHeaterPinState(PwmConfig *state, int stateIndex) {
-
-}
-
 class TestSpi : public Cj125SpiStream {
 public:
 	MOCK_METHOD1(ReadRegister, uint8_t(uint8_t));
@@ -27,7 +23,7 @@ TEST(testCJ125, testInitialState) {
 
 	WITH_ENGINE_TEST_HELPER(FORD_ASPIRE_1996);
 
-	cj.StartHeaterControl((pwm_gen_callback*)&applyHeaterPinState PASS_ENGINE_PARAMETER_SUFFIX);
+	cj.StartHeaterControl(PASS_ENGINE_PARAMETER_SIGNATURE);
 	ASSERT_EQ(cj.heaterDuty, CJ125_HEATER_IDLE_RATE);
 
 	TestSpi mock;


### PR DESCRIPTION
Simplify where we don't need it.  Everybody can use the standard "just turn the pin on or off" callback.

related to #2643 and probably eventually resurrection of #1393