### PR TITLE
hip9011

### DIFF
--- a/firmware/config/boards/hellen/cypress/config/controllers/algo/auto_generated_enums.cpp
+++ b/firmware/config/boards/hellen/cypress/config/controllers/algo/auto_generated_enums.cpp
@@ -1,7 +1,7 @@
 #include "global.h"
 #include "rusefi_enums.h"
 #include "rusefi_hw_enums.h"
-// was generated automatically by rusEFI tool  from rusefi_hw_enums.h // was generated automatically by rusEFI tool  from rusefi_enums.h // by enum2string.jar tool on Tue May 04 14:13:02 UTC 2021
+// was generated automatically by rusEFI tool  from rusefi_hw_enums.h // was generated automatically by rusEFI tool  from rusefi_enums.h // by enum2string.jar tool on Sat May 08 16:52:30 MSK 2021
 // see also gen_config_and_enums.bat
 
 
@@ -1067,23 +1067,6 @@ case GPPWM_GreaterThan:
   return "GPPWM_GreaterThan";
 case GPPWM_LessThan:
   return "GPPWM_LessThan";
-  }
- return NULL;
-}
-const char *getHip_state_e(hip_state_e value){
-switch(value) {
-case IS_INTEGRATING:
-  return "IS_INTEGRATING";
-case IS_SENDING_SPI_COMMAND:
-  return "IS_SENDING_SPI_COMMAND";
-case NOT_READY:
-  return "NOT_READY";
-case READY_TO_INTEGRATE:
-  return "READY_TO_INTEGRATE";
-case WAITING_FOR_ADC_TO_SKIP:
-  return "WAITING_FOR_ADC_TO_SKIP";
-case WAITING_FOR_RESULT_ADC:
-  return "WAITING_FOR_RESULT_ADC";
   }
  return NULL;
 }

--- a/firmware/config/boards/hellen/cypress/config/controllers/algo/auto_generated_enums.h
+++ b/firmware/config/boards/hellen/cypress/config/controllers/algo/auto_generated_enums.h
@@ -1,4 +1,4 @@
-// was generated automatically by rusEFI tool  from rusefi_hw_enums.h // was generated automatically by rusEFI tool  from rusefi_enums.h // by enum2string.jar tool on Fri Apr 30 05:39:10 UTC 2021
+// was generated automatically by rusEFI tool  from rusefi_hw_enums.h // was generated automatically by rusEFI tool  from rusefi_enums.h // by enum2string.jar tool on Sat May 08 16:52:30 MSK 2021
 // see also gen_config_and_enums.bat
 
 
@@ -30,7 +30,6 @@ const char *getEtb_function_e(etb_function_e value);
 const char *getGear_e(gear_e value);
 const char *getGppwm_channel_e(gppwm_channel_e value);
 const char *getGppwm_compare_mode_e(gppwm_compare_mode_e value);
-const char *getHip_state_e(hip_state_e value);
 const char *getIdle_mode_e(idle_mode_e value);
 const char *getIdle_state_e(idle_state_e value);
 const char *getIgnition_mode_e(ignition_mode_e value);

--- a/firmware/config/boards/kinetis/config/controllers/algo/auto_generated_enums.cpp
+++ b/firmware/config/boards/kinetis/config/controllers/algo/auto_generated_enums.cpp
@@ -1,7 +1,7 @@
 #include "global.h"
 #include "rusefi_enums.h"
 #include "rusefi_hw_enums.h"
-// was generated automatically by rusEFI tool  from rusefi_hw_enums.h // was generated automatically by rusEFI tool  from rusefi_enums.h // by enum2string.jar tool on Tue May 04 14:13:02 UTC 2021
+// was generated automatically by rusEFI tool  from rusefi_hw_enums.h // was generated automatically by rusEFI tool  from rusefi_enums.h // by enum2string.jar tool on Sat May 08 16:52:29 MSK 2021
 // see also gen_config_and_enums.bat
 
 
@@ -863,23 +863,6 @@ case GPPWM_GreaterThan:
   return "GPPWM_GreaterThan";
 case GPPWM_LessThan:
   return "GPPWM_LessThan";
-  }
- return NULL;
-}
-const char *getHip_state_e(hip_state_e value){
-switch(value) {
-case IS_INTEGRATING:
-  return "IS_INTEGRATING";
-case IS_SENDING_SPI_COMMAND:
-  return "IS_SENDING_SPI_COMMAND";
-case NOT_READY:
-  return "NOT_READY";
-case READY_TO_INTEGRATE:
-  return "READY_TO_INTEGRATE";
-case WAITING_FOR_ADC_TO_SKIP:
-  return "WAITING_FOR_ADC_TO_SKIP";
-case WAITING_FOR_RESULT_ADC:
-  return "WAITING_FOR_RESULT_ADC";
   }
  return NULL;
 }

--- a/firmware/config/boards/kinetis/config/controllers/algo/auto_generated_enums.h
+++ b/firmware/config/boards/kinetis/config/controllers/algo/auto_generated_enums.h
@@ -1,4 +1,4 @@
-// was generated automatically by rusEFI tool  from rusefi_hw_enums.h // was generated automatically by rusEFI tool  from rusefi_enums.h // by enum2string.jar tool on Fri Apr 30 05:39:10 UTC 2021
+// was generated automatically by rusEFI tool  from rusefi_hw_enums.h // was generated automatically by rusEFI tool  from rusefi_enums.h // by enum2string.jar tool on Sat May 08 16:52:29 MSK 2021
 // see also gen_config_and_enums.bat
 
 
@@ -30,7 +30,6 @@ const char *getEtb_function_e(etb_function_e value);
 const char *getGear_e(gear_e value);
 const char *getGppwm_channel_e(gppwm_channel_e value);
 const char *getGppwm_compare_mode_e(gppwm_compare_mode_e value);
-const char *getHip_state_e(hip_state_e value);
 const char *getIdle_mode_e(idle_mode_e value);
 const char *getIdle_state_e(idle_state_e value);
 const char *getIgnition_mode_e(ignition_mode_e value);

--- a/firmware/config/boards/subaru_eg33/config/controllers/algo/auto_generated_enums.cpp
+++ b/firmware/config/boards/subaru_eg33/config/controllers/algo/auto_generated_enums.cpp
@@ -1,7 +1,7 @@
 #include "global.h"
 #include "rusefi_enums.h"
 #include "rusefi_hw_enums.h"
-// was generated automatically by rusEFI tool  from rusefi_hw_enums.h // was generated automatically by rusEFI tool  from rusefi_enums.h // by enum2string.jar tool on Tue May 04 14:13:03 UTC 2021
+// was generated automatically by rusEFI tool  from rusefi_hw_enums.h // was generated automatically by rusEFI tool  from rusefi_enums.h // by enum2string.jar tool on Sat May 08 16:45:49 MSK 2021
 // see also gen_config_and_enums.bat
 
 
@@ -1063,23 +1063,6 @@ case GPPWM_GreaterThan:
   return "GPPWM_GreaterThan";
 case GPPWM_LessThan:
   return "GPPWM_LessThan";
-  }
- return NULL;
-}
-const char *getHip_state_e(hip_state_e value){
-switch(value) {
-case IS_INTEGRATING:
-  return "IS_INTEGRATING";
-case IS_SENDING_SPI_COMMAND:
-  return "IS_SENDING_SPI_COMMAND";
-case NOT_READY:
-  return "NOT_READY";
-case READY_TO_INTEGRATE:
-  return "READY_TO_INTEGRATE";
-case WAITING_FOR_ADC_TO_SKIP:
-  return "WAITING_FOR_ADC_TO_SKIP";
-case WAITING_FOR_RESULT_ADC:
-  return "WAITING_FOR_RESULT_ADC";
   }
  return NULL;
 }

--- a/firmware/config/boards/subaru_eg33/config/controllers/algo/auto_generated_enums.h
+++ b/firmware/config/boards/subaru_eg33/config/controllers/algo/auto_generated_enums.h
@@ -1,4 +1,4 @@
-// was generated automatically by rusEFI tool  from rusefi_hw_enums.h // was generated automatically by rusEFI tool  from rusefi_enums.h // by enum2string.jar tool on Fri Apr 30 05:39:11 UTC 2021
+// was generated automatically by rusEFI tool  from rusefi_hw_enums.h // was generated automatically by rusEFI tool  from rusefi_enums.h // by enum2string.jar tool on Sat May 08 16:45:49 MSK 2021
 // see also gen_config_and_enums.bat
 
 
@@ -30,7 +30,6 @@ const char *getEtb_function_e(etb_function_e value);
 const char *getGear_e(gear_e value);
 const char *getGppwm_channel_e(gppwm_channel_e value);
 const char *getGppwm_compare_mode_e(gppwm_compare_mode_e value);
-const char *getHip_state_e(hip_state_e value);
 const char *getIdle_mode_e(idle_mode_e value);
 const char *getIdle_state_e(idle_state_e value);
 const char *getIgnition_mode_e(ignition_mode_e value);

--- a/firmware/controllers/algo/auto_generated_enums.cpp
+++ b/firmware/controllers/algo/auto_generated_enums.cpp
@@ -1,7 +1,7 @@
 #include "global.h"
 #include "rusefi_enums.h"
 #include "rusefi_hw_enums.h"
-// was generated automatically by rusEFI tool  from rusefi_hw_enums.h // was generated automatically by rusEFI tool  from rusefi_enums.h // by enum2string.jar tool on Tue May 04 14:13:01 UTC 2021
+// was generated automatically by rusEFI tool  from rusefi_hw_enums.h // was generated automatically by rusEFI tool  from rusefi_enums.h // by enum2string.jar tool on Sat May 08 16:52:29 MSK 2021
 // see also gen_config_and_enums.bat
 
 
@@ -1039,23 +1039,6 @@ case GPPWM_GreaterThan:
   return "GPPWM_GreaterThan";
 case GPPWM_LessThan:
   return "GPPWM_LessThan";
-  }
- return NULL;
-}
-const char *getHip_state_e(hip_state_e value){
-switch(value) {
-case IS_INTEGRATING:
-  return "IS_INTEGRATING";
-case IS_SENDING_SPI_COMMAND:
-  return "IS_SENDING_SPI_COMMAND";
-case NOT_READY:
-  return "NOT_READY";
-case READY_TO_INTEGRATE:
-  return "READY_TO_INTEGRATE";
-case WAITING_FOR_ADC_TO_SKIP:
-  return "WAITING_FOR_ADC_TO_SKIP";
-case WAITING_FOR_RESULT_ADC:
-  return "WAITING_FOR_RESULT_ADC";
   }
  return NULL;
 }

--- a/firmware/controllers/algo/auto_generated_enums.h
+++ b/firmware/controllers/algo/auto_generated_enums.h
@@ -1,4 +1,4 @@
-// was generated automatically by rusEFI tool  from rusefi_hw_enums.h // was generated automatically by rusEFI tool  from rusefi_enums.h // by enum2string.jar tool on Fri Apr 30 05:39:09 UTC 2021
+// was generated automatically by rusEFI tool  from rusefi_hw_enums.h // was generated automatically by rusEFI tool  from rusefi_enums.h // by enum2string.jar tool on Sat May 08 16:52:29 MSK 2021
 // see also gen_config_and_enums.bat
 
 
@@ -30,7 +30,6 @@ const char *getEtb_function_e(etb_function_e value);
 const char *getGear_e(gear_e value);
 const char *getGppwm_channel_e(gppwm_channel_e value);
 const char *getGppwm_compare_mode_e(gppwm_compare_mode_e value);
-const char *getHip_state_e(hip_state_e value);
 const char *getIdle_mode_e(idle_mode_e value);
 const char *getIdle_state_e(idle_state_e value);
 const char *getIgnition_mode_e(ignition_mode_e value);

--- a/firmware/controllers/algo/rusefi_enums.h
+++ b/firmware/controllers/algo/rusefi_enums.h
@@ -932,31 +932,6 @@ typedef enum {
 } can_nbc_e;
 
 typedef enum {
-	NOT_READY,
-	/**
-	 * the step after this one is always IS_INTEGRATING
-	 * We only integrate if we have RPM
-	 */
-	READY_TO_INTEGRATE,
-	/**
-	 * the step after this one is always WAITING_FOR_ADC_TO_SKIP
-	 */
-	IS_INTEGRATING,
-	/**
-	 * the step after this one is always WAITING_FOR_RESULT_ADC
-	 */
-	WAITING_FOR_ADC_TO_SKIP,
-	/**
-	 * the step after this one is always IS_SENDING_SPI_COMMAND or READY_TO_INTEGRATE
-	 */
-	WAITING_FOR_RESULT_ADC,
-	/**
-	 * the step after this one is always READY_TO_INTEGRATE
-	 */
-	IS_SENDING_SPI_COMMAND,
-} hip_state_e;
-
-typedef enum {
 	TCHARGE_MODE_RPM_TPS = 0,
 	TCHARGE_MODE_AIR_INTERP = 1,
 	Force_4bytes_size_tChargeMode_e = ENUM_32_BITS,

--- a/firmware/hw_layer/sensors/hip9011.cpp
+++ b/firmware/hw_layer/sensors/hip9011.cpp
@@ -540,6 +540,15 @@ void initHip9011() {
 /* Debug functions.															*/
 /*==========================================================================*/
 
+static const char *hip_state_names[] =
+{
+	"Not ready/calculating",
+	"Ready for integration",
+	"Integrating",
+	"Waiting for first ADC sample",
+	"Waiting for second ADC sample"
+};
+
 static void showHipInfo(void) {
 	if (!CONFIG(isHip9011Enabled)) {
 		efiPrintf("hip9011 driver not active");
@@ -548,7 +557,7 @@ static void showHipInfo(void) {
 
 	efiPrintf("HIP9011: enabled %s state %s",
 		boolToString(CONFIG(isHip9011Enabled)),
-		getHip_state_e(instance.state));
+		hip_state_names[instance.state]);
 
 	efiPrintf(" Advanced mode: enabled %d used %d",
 		CONFIG(useTpicAdvancedMode),

--- a/firmware/hw_layer/sensors/hip9011_logic.h
+++ b/firmware/hw_layer/sensors/hip9011_logic.h
@@ -20,6 +20,19 @@
 #define GAIN_LOOKUP_SIZE 		64
 #define BAND_LOOKUP_SIZE 		64
 
+typedef enum {
+	/* initial state and state used during value read and calculations */
+	NOT_READY,
+	/* chip is configuread and ready for next integration */
+	READY_TO_INTEGRATE,
+	/* integration is in progress */
+	IS_INTEGRATING,
+	/* in default mode driver is waiting for first ADC callback */
+	WAITING_FOR_ADC_TO_SKIP,
+	/* in default mode driver is waiting for second ADC callback, saves it and switched to NOT_READY state */
+	WAITING_FOR_RESULT_ADC
+} hip_state_e;
+
 /**
  * this interface defines hardware communication layer for HIP9011 chip
  */


### PR DESCRIPTION
Move HIP states enum out of rusefi_enums.h
-this is internal driver stuff. No need to have it defined globaly.

Auto-generated configs and docs 