### PR TITLE
move ADC pin initialization

### DIFF
--- a/firmware/hw_layer/adc/adc_inputs.cpp
+++ b/firmware/hw_layer/adc/adc_inputs.cpp
@@ -463,32 +463,11 @@ static void configureInputs(void) {
 
 	addChannel("Baro Press", engineConfiguration->baroSensor.hwChannel, ADC_SLOW);
 
-	addChannel("TPS 1 Primary", engineConfiguration->tps1_1AdcChannel, ADC_SLOW);
-	addChannel("TPS 1 Secondary", engineConfiguration->tps1_2AdcChannel, ADC_SLOW);
-	addChannel("TPS 2 Primary", engineConfiguration->tps2_1AdcChannel, ADC_SLOW);
-	addChannel("TPS 2 Secondary", engineConfiguration->tps2_2AdcChannel, ADC_SLOW);
-
-	addChannel("Wastegate Position", engineConfiguration->wastegatePositionSensor, ADC_SLOW);
-	addChannel("Idle Position Sensor", engineConfiguration->idlePositionSensor, ADC_SLOW);
-
-	addChannel("Fuel Level", engineConfiguration->fuelLevelSensor, ADC_SLOW);
-	addChannel("Acc Pedal1", engineConfiguration->throttlePedalPositionAdcChannel, ADC_SLOW);
-	addChannel("Acc Pedal2", engineConfiguration->throttlePedalPositionSecondAdcChannel, ADC_SLOW);
-	addChannel("VBatt", engineConfiguration->vbattAdcChannel, ADC_SLOW);
 	// not currently used	addChannel("Vref", engineConfiguration->vRefAdcChannel, ADC_SLOW);
-	addChannel("CLT", engineConfiguration->clt.adcChannel, ADC_SLOW);
-	addChannel("IAT", engineConfiguration->iat.adcChannel, ADC_SLOW);
-	addChannel("AUX Temp 1", engineConfiguration->auxTempSensor1.adcChannel, ADC_SLOW);
-	addChannel("AUX Temp 2", engineConfiguration->auxTempSensor2.adcChannel, ADC_SLOW);
 
 	addChannel("AUXF#1", engineConfiguration->auxFastSensor1_adcChannel, ADC_FAST);
 
 	addChannel("AFR", engineConfiguration->afr.hwChannel, ADC_SLOW);
-	addChannel("Oil Pressure", engineConfiguration->oilPressure.hwChannel, ADC_SLOW);
-
-	addChannel("LFP", engineConfiguration->lowPressureFuel.hwChannel, ADC_SLOW);
-	addChannel("HFP", engineConfiguration->highPressureFuel.hwChannel, ADC_SLOW);
-
 
 	if (CONFIG(isCJ125Enabled)) {
 		addChannel("CJ125 UR", engineConfiguration->cj125ur, ADC_SLOW);

--- a/firmware/hw_layer/adc/adc_subscription.cpp
+++ b/firmware/hw_layer/adc/adc_subscription.cpp
@@ -48,6 +48,7 @@ void AdcSubscription::SubscribeSensor(FunctionalSensor &sensor,
 
 	// Ensure that enough entries are available
 	if (s_nextEntry >= std::size(s_entries)) {
+		firmwareError(CUSTOM_INVALID_ADC, "too many ADC subscriptions");
 		return;
 	}
 

--- a/firmware/hw_layer/adc/adc_subscription.cpp
+++ b/firmware/hw_layer/adc/adc_subscription.cpp
@@ -5,8 +5,6 @@
 #include "perf_trace.h"
 #include "biquad.h"
 
-#include <iterator>
-
 EXTERN_ENGINE;
 
 #if EFI_UNIT_TEST
@@ -47,7 +45,7 @@ void AdcSubscription::SubscribeSensor(FunctionalSensor &sensor,
 	}
 
 	// Ensure that enough entries are available
-	if (s_nextEntry >= std::size(s_entries)) {
+	if (s_nextEntry >= efi::size(s_entries)) {
 		firmwareError(CUSTOM_INVALID_ADC, "too many ADC subscriptions");
 		return;
 	}

--- a/firmware/hw_layer/adc/adc_subscription.cpp
+++ b/firmware/hw_layer/adc/adc_subscription.cpp
@@ -40,10 +40,19 @@ void AdcSubscription::SubscribeSensor(FunctionalSensor &sensor,
 		return;
 	}
 
-	// bounds check
+	const char* name = sensor.getSensorName();
+	if (/*type-limited (int)setting < 0 || */(int)channel >= HW_MAX_ADC_INDEX) {
+		firmwareError(CUSTOM_INVALID_ADC, "Invalid ADC setting %s", name);
+		return;
+	}
+
+	// Ensure that enough entries are available
 	if (s_nextEntry >= std::size(s_entries)) {
 		return;
 	}
+
+	// Enable the input pin
+	efiSetPadMode(name, getAdcChannelBrainPin(name, channel), PAL_MODE_INPUT_ANALOG);
 
 	// if 0, default to the board's divider coefficient
 	if (voltsPerAdcVolt == 0) {

--- a/firmware/hw_layer/adc/adc_subscription.cpp
+++ b/firmware/hw_layer/adc/adc_subscription.cpp
@@ -29,7 +29,7 @@ struct AdcSubscriptionEntry {
 };
 
 static size_t s_nextEntry = 0;
-static AdcSubscriptionEntry s_entries[8];
+static AdcSubscriptionEntry s_entries[16];
 
 void AdcSubscription::SubscribeSensor(FunctionalSensor &sensor,
 									  adc_channel_e channel,


### PR DESCRIPTION
- Move pin init to adc subscription, progress towards #2636
- Increase number of available ADC subscription entries, fixes #2632
- Fatal error if we run out of ADC subscription entries would have helped diagnose #2632