### PR TITLE
explicit compiler version check

### DIFF
--- a/firmware/main.cpp
+++ b/firmware/main.cpp
@@ -11,6 +11,7 @@
 #include "os_access.h"
 #include "rusefi.h"
 #include "mpu_util.h"
+#include "version_check.h"
 
 int main(void) {
 	/*

--- a/firmware/version_check.h
+++ b/firmware/version_check.h
@@ -1,0 +1,13 @@
+// This file asserts that the compiler is appropriate for rusEFI use.
+
+#pragma once
+
+// non-MCU builds are significantly more tolerant
+#if EFI_PROD_CODE
+
+static constexpr auto gccVersion = (__GNUC__ * 100) + (__GNUC_MINOR__ * 10) + ( __GNUC_PATCHLEVEL__ );
+
+// Firmware builds require at least GCC 9.3.1
+static_assert(gccVersion >= 931, "GCC compiler >= 9.3.1 required");
+
+#endif


### PR DESCRIPTION
Fail hard (and obvious) if you tried a compiler that might not work.

fixes #2671 