### PR TITLE
explicitly test PTC thermistors

### DIFF
--- a/firmware/controllers/sensors/converters/thermistor_func.cpp
+++ b/firmware/controllers/sensors/converters/thermistor_func.cpp
@@ -27,7 +27,7 @@ SensorResult ThermistorFunc::convert(float ohms) const {
 
 	// bounds check result - please don't try to run rusEfi when colder than -50C
 	// high end limit is required as this could be an oil temp sensor
-	if (celsius < -50 || celsius > 200) {
+	if (celsius < -50 || celsius > 250) {
 		return unexpected;
 	}
 

--- a/unit_tests/tests/sensor/therm_func.cpp
+++ b/unit_tests/tests/sensor/therm_func.cpp
@@ -34,3 +34,22 @@ TEST(thermistor, ThermistorNeon) {
 	assertEqualsM("B", 0.0003, tf.m_b);
 	ASSERT_NEAR(0.0, tf.m_c, EPS4D);
 }
+
+TEST(thermistor, PtcAirCooledMotorcycle) {
+	// data from https://static.chipdip.ru/lib/033/DOC001033132.pdf
+	thermistor_conf_s tc = {0, 100, 200, 486, 975, 1679, 0};
+
+	ThermistorFunc tf;
+	tf.configure(tc);
+
+	// calibrated points should be almost perfect
+	ASSERT_NEAR(tf.convert(486).value_or(0), 0, 0.1);
+	ASSERT_NEAR(tf.convert(975).value_or(0), 100, 0.1);
+	ASSERT_NEAR(tf.convert(1679).value_or(0), 200, 0.1);
+
+	// Other points should be pretty good
+	ASSERT_NEAR(tf.convert(414).value_or(0), -20, 2);
+	ASSERT_NEAR(tf.convert(704).value_or(0), 50, 2);
+	ASSERT_NEAR(tf.convert(1300).value_or(0), 150, 2);
+	ASSERT_NEAR(tf.convert(1846).value_or(0), 220, 2);
+}


### PR DESCRIPTION
write a test to make sure ptc thermistors work too

also increases the maximum valid temperature somewhat, since air cooled engines can run HOT