### PR TITLE
make getAirmass const

### DIFF
--- a/firmware/controllers/algo/airmass/airmass.cpp
+++ b/firmware/controllers/algo/airmass/airmass.cpp
@@ -4,9 +4,9 @@
 
 EXTERN_ENGINE;
 
-AirmassModelBase::AirmassModelBase(const ValueProvider3D& veTable) : m_veTable(&veTable) {}
+AirmassVeModelBase::AirmassVeModelBase(const ValueProvider3D& veTable) : m_veTable(&veTable) {}
 
-float AirmassModelBase::getVeLoadAxis(float passedLoad) const {
+float AirmassVeModelBase::getVeLoadAxis(float passedLoad) const {
 	switch(CONFIG(veOverrideMode)) {
 		case VE_None: return passedLoad;
 		case VE_MAP: return Sensor::get(SensorType::Map).value_or(0);
@@ -15,7 +15,7 @@ float AirmassModelBase::getVeLoadAxis(float passedLoad) const {
 	}
 }
 
-float AirmassModelBase::getVe(int rpm, float load) const {
+float AirmassVeModelBase::getVe(int rpm, float load) const {
 	efiAssert(OBD_PCM_Processor_Fault, m_veTable != nullptr, "VE table null", 0);
 
 	// Override the load value if necessary

--- a/firmware/controllers/algo/airmass/airmass.h
+++ b/firmware/controllers/algo/airmass/airmass.h
@@ -9,12 +9,15 @@ struct AirmassResult {
 	float EngineLoadPercent = 100;
 };
 
-class AirmassModelBase {
+struct AirmassModelBase {
+	virtual AirmassResult getAirmass(int rpm) const = 0;
+};
+
+class AirmassVeModelBase : public AirmassModelBase {
 public:
 	DECLARE_ENGINE_PTR;
 
-	explicit AirmassModelBase(const ValueProvider3D& veTable);
-	virtual AirmassResult getAirmass(int rpm) = 0;
+	explicit AirmassVeModelBase(const ValueProvider3D& veTable);
 
 protected:
 	// Retrieve the user-calibrated volumetric efficiency from the table

--- a/firmware/controllers/algo/airmass/alphan_airmass.cpp
+++ b/firmware/controllers/algo/airmass/alphan_airmass.cpp
@@ -1,7 +1,7 @@
 #include "alphan_airmass.h"
 #include "sensor.h"
 
-AirmassResult AlphaNAirmass::getAirmass(int rpm) {
+AirmassResult AlphaNAirmass::getAirmass(int rpm) const {
 	auto tps = Sensor::get(SensorType::Tps1);
 
 	if (!tps.Valid) {

--- a/firmware/controllers/algo/airmass/alphan_airmass.h
+++ b/firmware/controllers/algo/airmass/alphan_airmass.h
@@ -6,5 +6,5 @@ class AlphaNAirmass : public SpeedDensityBase {
 public:
 	explicit AlphaNAirmass(const ValueProvider3D& veTable) : SpeedDensityBase(veTable) {}
 
-	AirmassResult getAirmass(int rpm) override;
+	AirmassResult getAirmass(int rpm) const override;
 };

--- a/firmware/controllers/algo/airmass/maf_airmass.cpp
+++ b/firmware/controllers/algo/airmass/maf_airmass.cpp
@@ -5,7 +5,7 @@
 
 EXTERN_ENGINE;
 
-AirmassResult MafAirmass::getAirmass(int rpm) {
+AirmassResult MafAirmass::getAirmass(int rpm) const {
 	float maf = Sensor::get(SensorType::Maf).value_or(0) + engine->engineLoadAccelEnrichment.getEngineLoadEnrichment(PASS_ENGINE_PARAMETER_SIGNATURE);
 	return getAirmassImpl(maf, rpm);
 }

--- a/firmware/controllers/algo/airmass/maf_airmass.h
+++ b/firmware/controllers/algo/airmass/maf_airmass.h
@@ -2,11 +2,11 @@
 
 #include "airmass.h"
 
-class MafAirmass final : public AirmassModelBase {
+class MafAirmass final : public AirmassVeModelBase {
 public:
-	explicit MafAirmass(const ValueProvider3D& veTable) : AirmassModelBase(veTable) {}
+	explicit MafAirmass(const ValueProvider3D& veTable) : AirmassVeModelBase(veTable) {}
 
-	AirmassResult getAirmass(int rpm) override;
+	AirmassResult getAirmass(int rpm) const override;
 
 	// Compute airmass based on flow & engine speed
 	AirmassResult getAirmassImpl(float massAirFlow, int rpm) const;

--- a/firmware/controllers/algo/airmass/speed_density_airmass.cpp
+++ b/firmware/controllers/algo/airmass/speed_density_airmass.cpp
@@ -5,7 +5,7 @@
 
 EXTERN_ENGINE;
 
-AirmassResult SpeedDensityAirmass::getAirmass(int rpm) {
+AirmassResult SpeedDensityAirmass::getAirmass(int rpm) const {
 	ScopePerf perf(PE::GetSpeedDensityFuel);
 
 	/**

--- a/firmware/controllers/algo/airmass/speed_density_airmass.h
+++ b/firmware/controllers/algo/airmass/speed_density_airmass.h
@@ -9,7 +9,7 @@ public:
 		, m_mapEstimationTable(&mapEstimationTable)
 	{}
 
-	AirmassResult getAirmass(int rpm) override;
+	AirmassResult getAirmass(int rpm) const override;
 
 	float getMap(int rpm) const;
 

--- a/firmware/controllers/algo/airmass/speed_density_base.cpp
+++ b/firmware/controllers/algo/airmass/speed_density_base.cpp
@@ -25,7 +25,7 @@ float idealGasLaw(float volume, float pressure, float temperature) {
 	return volume * pressure / (AIR_R * temperature);
 }
 
-float SpeedDensityBase::getAirmassImpl(float ve, float manifoldPressure, float temperature DECLARE_ENGINE_PARAMETER_SUFFIX) {
+/*static*/ float SpeedDensityBase::getAirmassImpl(float ve, float manifoldPressure, float temperature DECLARE_ENGINE_PARAMETER_SUFFIX) {
 	float cycleAir = ve * idealGasLaw(CONFIG(specs.displacement), manifoldPressure, temperature);
 	return cycleAir / CONFIG(specs.cylindersCount);
 }

--- a/firmware/controllers/algo/airmass/speed_density_base.h
+++ b/firmware/controllers/algo/airmass/speed_density_base.h
@@ -13,9 +13,9 @@
 
 float idealGasLaw(float volume, float pressure, float temperature);
 
-class SpeedDensityBase : public AirmassModelBase {
+class SpeedDensityBase : public AirmassVeModelBase {
 protected:
-	explicit SpeedDensityBase(const ValueProvider3D& veTable) : AirmassModelBase(veTable) {}
+	explicit SpeedDensityBase(const ValueProvider3D& veTable) : AirmassVeModelBase(veTable) {}
 
 public:
 	static float getAirmassImpl(float ve, float manifoldPressure, float temperature DECLARE_ENGINE_PARAMETER_SUFFIX);

--- a/firmware/controllers/algo/engine.h
+++ b/firmware/controllers/algo/engine.h
@@ -35,7 +35,7 @@
 #define SLOW_CALLBACK_PERIOD_MS 50
 
 class RpmCalculator;
-class AirmassModelBase;
+struct AirmassModelBase;
 
 #define MAF_DECODING_CACHE_SIZE 256
 

--- a/firmware/controllers/algo/fuel_math.cpp
+++ b/firmware/controllers/algo/fuel_math.cpp
@@ -165,8 +165,8 @@ static SpeedDensityAirmass sdAirmass(veMap, mapEstimationTable);
 static MafAirmass mafAirmass(veMap);
 static AlphaNAirmass alphaNAirmass(veMap);
 
-AirmassModelBase* getAirmassModel(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
-	switch (CONFIG(fuelAlgorithm)) {
+AirmassModelBase* getAirmassModel(engine_load_mode_e mode DECLARE_ENGINE_PARAMETER_SUFFIX) {
+	switch (mode) {
 		case LM_SPEED_DENSITY: return &sdAirmass;
 		case LM_REAL_MAF: return &mafAirmass;
 		case LM_ALPHA_N: return &alphaNAirmass;
@@ -188,7 +188,7 @@ static float getBaseFuelMass(int rpm DECLARE_ENGINE_PARAMETER_SUFFIX) {
 	ScopePerf perf(PE::GetBaseFuel);
 
 	// airmass modes - get airmass first, then convert to fuel
-	auto model = getAirmassModel(PASS_ENGINE_PARAMETER_SIGNATURE);
+	auto model = getAirmassModel(CONFIG(fuelAlgorithm) PASS_ENGINE_PARAMETER_SUFFIX);
 	efiAssert(CUSTOM_ERR_ASSERT, model != nullptr, "Invalid airmass mode", 0.0f);
 
 	auto airmass = model->getAirmass(rpm);

--- a/firmware/controllers/algo/fuel_math.h
+++ b/firmware/controllers/algo/fuel_math.h
@@ -7,8 +7,8 @@
 
 #pragma once
 
-#include "engine.h"
-#include "airmass.h"
+#include "engine_ptr.h"
+#include "rusefi_types.h"
 
 void initFuelMap(DECLARE_ENGINE_PARAMETER_SIGNATURE);
 
@@ -31,3 +31,6 @@ floatms_t getInjectionMass(int rpm DECLARE_ENGINE_PARAMETER_SUFFIX);
 percent_t getInjectorDutyCycle(int rpm DECLARE_ENGINE_PARAMETER_SUFFIX);
 
 float getStandardAirCharge(DECLARE_ENGINE_PARAMETER_SIGNATURE);
+
+struct AirmassModelBase;
+AirmassModelBase* getAirmassModel(engine_load_mode_e mode DECLARE_ENGINE_PARAMETER_SUFFIX);

--- a/unit_tests/mocks.h
+++ b/unit_tests/mocks.h
@@ -59,13 +59,13 @@ public:
 	MOCK_METHOD(void, scheduleForLater, (scheduling_s *scheduling, int delayUs, action_s action), (override));
 };
 
-class MockAirmass : public AirmassModelBase {
+class MockAirmass : public AirmassVeModelBase {
 public:
-	MockAirmass() : AirmassModelBase(veTable) {}
+	MockAirmass() : AirmassVeModelBase(veTable) {}
 
 	MockVp3d veTable;
 
-	MOCK_METHOD(AirmassResult, getAirmass, (int rpm), (override));
+	MOCK_METHOD(AirmassResult, getAirmass, (int rpm), (const, override));
 };
 
 class MockInjectorModel2 : public IInjectorModel {

--- a/unit_tests/tests/ignition_injection/test_fuel_math.cpp
+++ b/unit_tests/tests/ignition_injection/test_fuel_math.cpp
@@ -112,10 +112,10 @@ TEST(AirmassModes, VeOverride) {
 		EXPECT_CALL(veTable, getValue(_, 30.0f)).WillOnce(Return(0));
 	}
 
-	struct DummyAirmassModel : public AirmassModelBase {
-		DummyAirmassModel(const ValueProvider3D& veTable) : AirmassModelBase(veTable) {}
+	struct DummyAirmassModel : public AirmassVeModelBase {
+		DummyAirmassModel(const ValueProvider3D& veTable) : AirmassVeModelBase(veTable) {}
 
-		AirmassResult getAirmass(int rpm) override {
+		AirmassResult getAirmass(int rpm) const override {
 			// Default load value 10, will be overriden
 			getVe(rpm, 10.0f);
 


### PR DESCRIPTION
That function can be `const`.  Tangentially related to #2693.

Also breaks out an interface for AirmassModelBase that doesn't have built-in VE logic.