### PR TITLE
save table config space, store lua script in config

### DIFF
--- a/firmware/controllers/algo/rusefi_types.h
+++ b/firmware/controllers/algo/rusefi_types.h
@@ -81,6 +81,7 @@ typedef float percent_t;
 
 typedef void (*Void)(void);
 
+typedef char lua_script_t[LUA_SCRIPT_SIZE];
 typedef char error_message_t[ERROR_BUFFER_SIZE];
 
 typedef char vehicle_info_t[VEHICLE_INFO_SIZE];
@@ -91,9 +92,9 @@ typedef brain_pin_e egt_cs_array_t[EGT_CHANNEL_COUNT];
 
 typedef uint8_t lambda_table_t[FUEL_LOAD_COUNT][FUEL_RPM_COUNT];
 // todo: merge these two types together? but these tables have different TS parameters like ranges etc
-typedef float fuel_table_t[FUEL_LOAD_COUNT][FUEL_RPM_COUNT];
+typedef uint16_t ve_table_t[FUEL_LOAD_COUNT][FUEL_RPM_COUNT];
 typedef uint16_t map_estimate_table_t[FUEL_LOAD_COUNT][FUEL_RPM_COUNT];
-typedef float ignition_table_t[IGN_LOAD_COUNT][IGN_RPM_COUNT];
+typedef int16_t ignition_table_t[IGN_LOAD_COUNT][IGN_RPM_COUNT];
 typedef int16_t ignition_tps_table_t[IGN_LOAD_COUNT][IGN_RPM_COUNT];
 typedef uint8_t pedal_to_tps_t[PEDAL_TO_TPS_SIZE][PEDAL_TO_TPS_SIZE];
 typedef uint8_t iac_pid_mult_t[IAC_PID_MULT_SIZE][IAC_PID_MULT_SIZE];
@@ -124,8 +125,6 @@ typedef float cfg_float_t_1f;
 
 typedef brain_pin_e brain_input_pin_e;
 typedef brain_pin_e switch_input_pin_e;
-
-typedef fuel_table_t ve_table_t;
 
 typedef void (*VoidPtr)(void*);
 

--- a/firmware/controllers/lua/lua.cpp
+++ b/firmware/controllers/lua/lua.cpp
@@ -81,6 +81,7 @@ public:
 		if (m_ptr) {
 			efiPrintf("LUA: Tearing down instance...");
 			lua_close(m_ptr);
+			efiAssertVoid(OBD_PCM_Processor_Fault, memoryUsed == 0, "Lua memory leak: %d bytes used after teardown", memoryUsed);
 		}
 	}
 
@@ -233,9 +234,7 @@ static bool runOneLua() {
 	// Reset default tick rate
 	luaTickPeriodMs = 100;
 
-	auto scriptStr = "function onTick() end";
-
-	if (!loadScript(ls, scriptStr)) {
+	if (!loadScript(ls, config->luaScript)) {
 		return false;
 	}
 

--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -64,7 +64,7 @@
 ! Any time an incompatible change is made to the configuration format stored in flash,
 ! update this string to the current date! It is required to also update TS_SIGNATURE above
 ! when this happens.
-#define FLASH_DATA_VERSION 10003
+#define FLASH_DATA_VERSION 10004
 
 ! all the sub-structures are going to be nested within the primary structure, that's
 ! needed to get a proper TunerStudio file
@@ -194,6 +194,8 @@ struct_no_prefix engine_configuration_s
 #define LOAD_1_BYTE_PACKING_MULT 2
 #define PACK_MULT_AFR_CFG 10
 #define PACK_MULT_LAMBDA_CFG 147
+#define PACK_MULT_VE_CFG 50
+#define PACK_MULT_IGN_CFG 20
 #define PACK_MULT_FUEL_MASS 100
 #define PACK_MULT_FUEL_FLOW 200
 #define FSIO_TABLE_8 8
@@ -220,7 +222,7 @@ struct_no_prefix engine_configuration_s
 #define PACK_MULT_MAP_ESTIMATE 100
 
 custom map_estimate_table_t	2*@@FUEL_RPM_COUNT@@x@@FUEL_LOAD_COUNT@@ array,   U16,   @OFFSET@, [@@FUEL_RPM_COUNT@@x@@FUEL_LOAD_COUNT@@],"kPa",      {1/@@PACK_MULT_MAP_ESTIMATE@@},     0,      0.0,   100.0,   2
-custom ve_table_t 4*@@FUEL_RPM_COUNT@@x@@FUEL_LOAD_COUNT@@ array,   F32,   @OFFSET@, [@@FUEL_RPM_COUNT@@x@@FUEL_LOAD_COUNT@@],"%", 1, 0, 0, 999.0, 2
+custom ve_table_t 2*@@FUEL_RPM_COUNT@@x@@FUEL_LOAD_COUNT@@ array,   U16,   @OFFSET@, [@@FUEL_RPM_COUNT@@x@@FUEL_LOAD_COUNT@@],"%", {1/@@PACK_MULT_VE_CFG@@}, 0, 0, 1000, 2
 custom lambda_table_t @@FUEL_RPM_COUNT@@x@@FUEL_LOAD_COUNT@@ array,   U08,   @OFFSET@, [@@FUEL_RPM_COUNT@@x@@FUEL_LOAD_COUNT@@],"deg",	   {1/@@PACK_MULT_LAMBDA_CFG@@},     0,        0.6,  1.5,     2
 custom afr_table_t @@FUEL_RPM_COUNT@@x@@FUEL_LOAD_COUNT@@ array,   U08,   @OFFSET@, [@@FUEL_RPM_COUNT@@x@@FUEL_LOAD_COUNT@@],"deg",	   {1/@@PACK_MULT_AFR_CFG@@},     0,        0,  25.0,     1
 
@@ -234,9 +236,9 @@ custom tps_tps_table_t	4*@@TPS_TPS_ACCEL_TABLE@@x@@TPS_TPS_ACCEL_TABLE@@ array, 
 custom baro_corr_table_t 4*@@BARO_CORR_SIZE@@x@@BARO_CORR_SIZE@@ array,   F32,   @OFFSET@, [@@BARO_CORR_SIZE@@x@@BARO_CORR_SIZE@@],"ratio", 1, 0, 0, 2.0, 2
 
 
-custom ignition_table_t	4*@@IGN_RPM_COUNT@@x@@IGN_LOAD_COUNT@@ array,   F32,   @OFFSET@, [@@IGN_RPM_COUNT@@x@@IGN_LOAD_COUNT@@],"deg",	   1,     0,     -20, 90,    2
+custom ignition_table_t	2*@@IGN_RPM_COUNT@@x@@IGN_LOAD_COUNT@@ array,   S16,   @OFFSET@, [@@IGN_RPM_COUNT@@x@@IGN_LOAD_COUNT@@],"deg", {1/@@PACK_MULT_IGN_CFG@@},     0,     -20, 90,    2
 
-custom angle_table_t	4*@@IGN_RPM_COUNT@@x@@IGN_LOAD_COUNT@@ array,   F32,   @OFFSET@, [@@IGN_RPM_COUNT@@x@@IGN_LOAD_COUNT@@],"deg",	   1,     0,     -720,  720,    2
+custom angle_table_t	2*@@IGN_RPM_COUNT@@x@@IGN_LOAD_COUNT@@ array,   S16,   @OFFSET@, [@@IGN_RPM_COUNT@@x@@IGN_LOAD_COUNT@@],"deg", {1/@@PACK_MULT_IGN_CFG@@},     0,     -720,  720, 2
 custom pedal_to_tps_t	@@PEDAL_TO_TPS_SIZE@@x@@PEDAL_TO_TPS_SIZE@@ array,   U08,   @OFFSET@, [@@PEDAL_TO_TPS_SIZE@@x@@PEDAL_TO_TPS_SIZE@@],"%",	   1,     0,     0,  100,    0
 
 custom iac_pid_mult_t	@@IAC_PID_MULT_SIZE@@x@@IAC_PID_MULT_SIZE@@ array,   U08,   @OFFSET@, [@@IAC_PID_MULT_SIZE@@x@@IAC_PID_MULT_SIZE@@],"%",	   1,     0,     0,  999,    2
@@ -1048,7 +1050,6 @@ custom maf_sensor_type_e 4 bits, S32, @OFFSET@, [0:1], @@maf_sensor_type_e_enum@
 
 	uint16_t[FUEL_LEVEL_TABLE_COUNT] fuelLevelBins;;"volt", {1/@@PACK_MULT_VOLTAGE@@}, 0, 0, 5, 3
 
-	int[59] unusedAtOldBoardConfigurationEnd;;"units", 1, 0, -20, 100, 0
 	uint16_t vehicleWeight;;"kg", 1, 0, 0, 10000, 0
 	brain_pin_e lps25BaroSensorScl
 	brain_pin_e lps25BaroSensorSda
@@ -1327,7 +1328,6 @@ float[MAP_ACCEL_TAPER] mapAccelTaperMult;;"mult",      1,     0,   0.0,    300, 
 	float[NARROW_BAND_WIDE_BAND_CONVERSION_SIZE] narrowToWideOxygen;;"ratio",      1,     0,      -40.0,    40.0,   2
 	vvt_mode_e[CAMS_PER_BANK iterate] vvtMode;set vvt_mode X
 	uint8_t[CAMS_PER_BANK_padding] vvtModePadding;;
-	uint8_t[22] unusedOldBiquad;;"units", 1, 0, -20, 100, 0
 	float[CLT_TIMING_CURVE_SIZE] cltTimingBins;CLT-based timing correction;"C",        1,     0,   -100.0,    250.0,  1
 	float[CLT_TIMING_CURVE_SIZE] cltTimingExtra;;"degree",      1,     0,      -400.0,    400.0,   0
 custom tle8888_mode_e 1 bits, U08, @OFFSET@, [0:1], "Auto", "SemiAuto", "Manual", "Hall"
@@ -1350,7 +1350,6 @@ tle8888_mode_e tle8888mode;
 	uint8_t[6] unused2508;;"units", 1, 0, -20, 100, 0
 	int16_t etbFreq;;"Hz",      1,     0,    0, @@ETB_HW_MAX_FREQUENCY@@,      0
 	pid_s etbWastegatePid;
-	uint8_t[4] unused2536;;"units", 1, 0, -20, 100, 0
 
 	custom cfg_float_t_1f 4 scalar,  F32,   @OFFSET@, 		"Val",	   1,	   0,       -20000000, 20000000,	  1
 	cfg_float_t_1f[IGNITION_PIN_COUNT iterate] timing_offset_cylinder;per-cylinder timing correction
@@ -1384,14 +1383,11 @@ tle8888_mode_e tle8888mode;
 
 
 	pid_s[CAMS_PER_BANK iterate] auxPid;
-	uint8_t[40] unused1366;;"units", 1, 0, -20, 100, 0
 
 	linear_sensor_s oilPressure;
 
 	spi_device_e accelerometerSpiDevice;
-	uint8_t[1] unusedAuxVoltage1_TODO_332;;"units", 1, 0, -20, 100, 0
-	uint8_t[1] unusedAuxVoltage2_TODO_332;;"units", 1, 0, -20, 100, 0
-	uint8_t[1] unusedSpiPadding5;;"units", 1, 0, -20, 100, 0
+	uint8_t[3] unusedAuxVoltage1_TODO_332;;"units", 1, 0, -20, 100, 0
 	float[FSIO_CURVE_16] fsioCurve1Bins;;"x",        1,     0,   -999,    1000.0,  3
 	float[FSIO_CURVE_16] fsioCurve1;;"y",      1,     0,      -999,    1000.0,   3
 	float[FSIO_CURVE_16] fsioCurve2Bins;;"x",        1,     0,   -999,    1000.0,  3
@@ -1432,7 +1428,7 @@ float[CLT_CURVE_SIZE] iacCoasting;    CLT-based idle position for coasting (used
 int8_t[CLT_LIMITER_CURVE_SIZE] cltRevLimitRpmBins;CLT-based target RPM for hard limit depending on CLT like on Lexus LFA;"C",        1,     0,   -70,    120,  0
 uint16_t[CLT_LIMITER_CURVE_SIZE] cltRevLimitRpm;See idleRpmPid;"",      1,     0,      0,    8000,   0
 
-uint8_t[524] unused3328;;"units", 1, 0, -20, 100, 0
+uint8_t[572] unused3328;;"units", 1, 0, -20, 100, 0
 
 float tChargeAirCoefMin;;"Min tCharge Coeff.",        1,     0,  0.0,    1.0,  4
 float tChargeAirCoefMax;;"Max tCharge Coeff.",        1,     0,  0.0,    1.0,  4
@@ -1451,7 +1447,6 @@ tChargeMode_e tChargeMode;
 	int16_t etb_iTermMin;iTerm min value;"",        1,     0,  -30000,    30000.0,  0
 	int16_t etb_iTermMax;iTerm max value;"",        1,     0,  -30000,    30000.0,  0
 	float etbDeadband;;"",        1,     0,  0,    100.0,  2
-	uint8_t[4] unused1059;;"units", 1, 0, -20, 100, 0
 
 	pid_s idleTimingPid;See useIdleTimingPidControl
 	uint8_t[2] unused3988;;"units", 1, 0, -20, 100, 0
@@ -1595,9 +1590,6 @@ fsio_table_8x8_u8t vvtTable2;
 float[FSIO_TABLE_8] vvtTable2LoadBins;;"L",       1,      0,      0.0,  255,   0
 float[FSIO_TABLE_8] vvtTable2RpmBins;RPM is float and not integer in order to use unified methods for interpolation;"RPM",    1,      0,      0.0,  25500.0,   2
 
-
-uint8_t[256] unused15136;;"units", 1, 0, -20, 100, 0
-
 ignition_table_t ignitionTable;
 float[IGN_LOAD_COUNT] ignitionLoadBins;;"Load",   1,   0.0,        0,  500.0,   2
 float[IGN_RPM_COUNT] ignitionRpmBins;;"RPM",	   1,   0.0,        0,  18000.0, 2
@@ -1635,6 +1627,10 @@ fsio_table_8x8_u8t fsioTable4;
 float[FSIO_TABLE_8] fsioTable4LoadBins;;"L",	   1,      0,      0.0,  255,   0
 float[FSIO_TABLE_8] fsioTable4RpmBins;RPM is float and not integer in order to use unified methods for interpolation;"RPM",	   1,      0,      0.0,  25500.0,   2
 
+
+#define LUA_SCRIPT_SIZE 2560
+custom lua_script_t @@LUA_SCRIPT_SIZE@@ string, ASCII, @OFFSET@, @@LUA_SCRIPT_SIZE@@
+lua_script_t luaScript;
 
 end_struct
 


### PR DESCRIPTION
- Remove some small unused blocks, consolidating at the end #1753
- Make many tables scaled int16 or uint16 instead of float (saves half the space!)
- Store Lua script (2.5k) at the end