### PR TITLE
More pinout fixes

### DIFF
--- a/misc/pinout-gen/script.js
+++ b/misc/pinout-gen/script.js
@@ -17,10 +17,12 @@ function addRow(table, pin, pdiv) {
   tdata.textContent = pin.type
   fdata.textContent = pin.function;
   cdata.textContent = pin.color
-  row.addEventListener('click', function(table, pin, pdiv) {
-    clickPin(table.parentElement.parentElement.parentElement.querySelector(".info-table tbody"), pin, pdiv);
-    table.parentElement.parentElement.parentElement.scrollIntoView()
-  }.bind(null, table, pin, pdiv));
+  if (pdiv) {
+    row.addEventListener('click', function(table, pin, pdiv) {
+      clickPin(table.parentElement.parentElement.parentElement.querySelector(".info-table tbody"), pin, pdiv);
+      table.parentElement.parentElement.parentElement.scrollIntoView()
+    }.bind(null, table, pin, pdiv));
+  }
   table.appendChild(clone);
 }
 
@@ -67,8 +69,10 @@ window.addEventListener('load', function() {
             break;
           }
         }
-        addRow(fullTable, connector.pins[i], pdiv);
-        if (!pinfo.x) continue;
+        if (!pinfo.x) {
+          addRow(fullTable, connector.pins[i], null);
+          continue;
+        }
         var closest = 1000000;
         for (var ii = 0; ii < connector.info.pins.length; ii++) {
           var tinfo = connector.info.pins[ii];
@@ -103,6 +107,7 @@ window.addEventListener('load', function() {
         pdiv.style.marginLeft = "-" + (width / 2) + "%";
         pdiv.style.fontSize = (height / 7.5) + "vw";
         cdiv.appendChild(pdiv);
+        addRow(fullTable, connector.pins[i], pdiv);
       }
     }.bind(null, connector, sdiv, img));
     img.src = connector.info.image.file;

--- a/misc/pinout-gen/script.js
+++ b/misc/pinout-gen/script.js
@@ -105,7 +105,7 @@ window.addEventListener('load', function() {
         pdiv.style.width = width + "%";
         pdiv.style.marginTop = "-" + (width / 2) + "%";
         pdiv.style.marginLeft = "-" + (width / 2) + "%";
-        pdiv.style.fontSize = (height / 7.5) + "vw";
+        pdiv.style.fontSize = (height * 1.8) + "px";
         cdiv.appendChild(pdiv);
         addRow(fullTable, connector.pins[i], pdiv);
       }


### PR DESCRIPTION
The last fix caused a new bug. If you clicked on a row, the wrong pin was highlighted. This fixes that.

This also tries a new formula for the pin marker text size.