### PR TITLE
Assorted todos

### DIFF
--- a/firmware/controllers/algo/fuel/fuel_computer.cpp
+++ b/firmware/controllers/algo/fuel/fuel_computer.cpp
@@ -21,7 +21,6 @@ mass_t FuelComputerBase::getCycleFuel(mass_t airmass, int rpm, float load) const
 FuelComputer::FuelComputer(const ValueProvider3D& lambdaTable) : m_lambdaTable(&lambdaTable) {}
 
 float FuelComputer::getStoichiometricRatio() const {
-	// TODO: vary this with ethanol content/configured setting/whatever
 	float primary = (float)CONFIG(stoichRatioPrimary) / PACK_MULT_AFR_CFG;
 
 	// Config compatibility: this field may be zero on ECUs with old defaults

--- a/firmware/controllers/algo/fuel/injector_model.cpp
+++ b/firmware/controllers/algo/fuel/injector_model.cpp
@@ -20,8 +20,8 @@ constexpr float convertToGramsPerSecond(float ccPerMinute) {
 expected<float> InjectorModel::getAbsoluteRailPressure() const {
 	switch (CONFIG(injectorCompensationMode)) {
 		case ICM_FixedRailPressure:
-			// TODO: should this add baro pressure instead of 1atm?
-			return (CONFIG(fuelReferencePressure) + 101.325f);
+			// Add barometric pressure, as "fixed" really means "fixed pressure above atmosphere"
+			return CONFIG(fuelReferencePressure) + Sensor::get(SensorType::BarometricPressure).value_or(101.325f);
 		case ICM_SensedRailPressure:
 			if (!Sensor::hasSensor(SensorType::FuelPressureInjector)) {
 				firmwareError(OBD_PCM_Processor_Fault, "Fuel pressure compensation is set to use a pressure sensor, but none is configured.");

--- a/firmware/hw_layer/drivers/gpio/mc33972.cpp
+++ b/firmware/hw_layer/drivers/gpio/mc33972.cpp
@@ -133,8 +133,6 @@ static int mc33972_spi_w(mc33972_priv *chip, uint32_t tx)
 	/* Slave Select assertion. */
 	spiSelect(spi);
 	/* Atomic transfer operations. */
-	/* TODO: check why spiExchange transfers invalid data on STM32F7xx, DMA issue? */
-	//spiExchange(spi, 3, txb, rxb);
 	for (i = 0; i < 3; i++)
 		rxb[i] = spiPolledExchange(spi, txb[i]);
 	/* Slave Select de-assertion. */
@@ -156,15 +154,7 @@ static int mc33972_spi_w(mc33972_priv *chip, uint32_t tx)
 
 static int mc33972_update_status(mc33972_priv *chip)
 {
-	int ret;
-
-	/* TODO: lock? */
-
-	ret = mc33972_spi_w(chip, CMD_STATUS);
-	
-	/* TODO: unlock? */
-
-	return ret;
+	return mc33972_spi_w(chip, CMD_STATUS);
 }
 
 static int mc33972_update_pullups(mc33972_priv *chip)


### PR DESCRIPTION
Address some todos around the code.  All minor.

The lock comments removed are OK because those functions are only ever called from one thread.