### PR TITLE
boring parts of idle pr #2745

### DIFF
--- a/firmware/controllers/actuators/idle_thread.cpp
+++ b/firmware/controllers/actuators/idle_thread.cpp
@@ -590,8 +590,9 @@ void setDefaultIdleParameters(DECLARE_CONFIG_PARAMETER_SIGNATURE) {
 #if ! EFI_UNIT_TEST
 
 void onConfigurationChangeIdleCallback(engine_configuration_s *previousConfiguration) {
-	shouldResetPid = !getIdlePid(PASS_ENGINE_PARAMETER_SIGNATURE)->isSame(&previousConfiguration->idleRpmPid);
-	mustResetPid = shouldResetPid;
+	if (getIdlePid(PASS_ENGINE_PARAMETER_SIGNATURE)->isSame(&previousConfiguration->idleRpmPid)) {
+		mustResetPid = true;
+	}
 }
 
 void setTargetIdleRpm(int value) {

--- a/firmware/controllers/actuators/idle_thread.cpp
+++ b/firmware/controllers/actuators/idle_thread.cpp
@@ -390,9 +390,6 @@ static percent_t automaticIdleController(float tpsPos, float rpm, int targetRpm,
 	percent_t newValue = idlePid->getOutput(targetRpm, rpm, SLOW_CALLBACK_PERIOD_MS / 1000.0f);
 	engine->engineState.idle.idleState = PID_VALUE;
 
-	// the state of PID has been changed, so we might reset it now, but only when needed (see idlePidDeactivationTpsThreshold)
-	mightResetPid = true;
-
 	// Apply PID Multiplier if used
 	if (CONFIG(useIacPidMultTable)) {
 		float engineLoad = getFuelingLoad(PASS_ENGINE_PARAMETER_SIGNATURE);

--- a/firmware/controllers/actuators/idle_thread.cpp
+++ b/firmware/controllers/actuators/idle_thread.cpp
@@ -346,7 +346,7 @@ static percent_t automaticIdleController(float tpsPos, float rpm, int targetRpm,
 		// Don't store old I and D terms if PID doesn't work anymore.
 		// Otherwise they will affect the idle position much later, when the throttle is closed.
 		// we reset only if I-term is negative, because the positive I-term is good - it keeps RPM from dropping too low
-		if (getIdlePid(PASS_ENGINE_PARAMETER_SIGNATURE)->getIntegration() <= 0 || mustResetPid) {
+		if (idlePid->getIntegration() <= 0 || mustResetPid) {
 			idlePid->reset();
 		}
 


### PR DESCRIPTION
pull out the boring parts of #2745:

- simplify reset flags (it's totally fine to reset PID more than once. It's just not worth the code complexity of 3 different flags tracking PID reset)
- only call getIdlePid once (easier to read!)
- code style