### PR TITLE
make the cranking idle implementation match what the UI claims

### DIFF
--- a/firmware/controllers/actuators/idle_thread.cpp
+++ b/firmware/controllers/actuators/idle_thread.cpp
@@ -229,9 +229,14 @@ IIdleController::Phase IdleController::determinePhase(int rpm, int targetRpm, Se
 }
 
 float IdleController::getCrankingOpenLoop(float clt) const {
-	return 
-		CONFIG(crankingIACposition)		// Base cranking position (cranking page)
-		 * interpolate2d(clt, config->cltCrankingCorrBins, config->cltCrankingCorr);
+	float mult =
+		CONFIG(overrideCrankingIacSetting)
+		// Override to separate table
+	 	? interpolate2d(clt, config->cltCrankingCorrBins, config->cltCrankingCorr)
+		// Otherwise use plain running table
+		: interpolate2d(clt, config->cltIdleCorrBins, config->cltIdleCorr);
+
+	return CONFIG(crankingIACposition) * mult;
 }
 
 float IdleController::getRunningOpenLoop(float clt, SensorResult tps) const {
@@ -256,9 +261,7 @@ float IdleController::getRunningOpenLoop(float clt, SensorResult tps) const {
 
 float IdleController::getOpenLoop(Phase phase, float clt, SensorResult tps) const {
 	float running = getRunningOpenLoop(clt, tps);
-
-	// Cranking value is either its own table, or the running value if not overriden
-	float cranking = CONFIG(overrideCrankingIacSetting) ? getCrankingOpenLoop(clt) : running;
+	float cranking = getCrankingOpenLoop(clt);
 
 	// if we're cranking, nothing more to do.
 	if (phase == Phase::Cranking) {


### PR DESCRIPTION
Found while testing #2745.  Makes getOpenLoop do the right thing in case `overrideCrankingIacSetting` is set to false.

nb: this code path is not currently called by master, but will be after #2745 