### PR TITLE
TS communication minor fixes

### DIFF
--- a/firmware/console/binary/tunerstudio.cpp
+++ b/firmware/console/binary/tunerstudio.cpp
@@ -444,13 +444,7 @@ static void tsProcessOne(TsChannelBase* tsChannel) {
 
 	if (!tsChannel->isReady()) {
 		chThdSleepMilliseconds(10);
-		tsChannel->wasReady = false;
 		return;
-	}
-
-	if (!tsChannel->wasReady) {
-		tsChannel->wasReady = true;
-//			scheduleSimpleMsg(&logger, "ts channel is now ready ", hTimeNow());
 	}
 
 	tsState.totalCounter++;

--- a/firmware/console/binary/tunerstudio_io.h
+++ b/firmware/console/binary/tunerstudio_io.h
@@ -48,8 +48,6 @@ public:
 	 */
 	char scratchBuffer[BLOCKING_FACTOR + 30];
 
-	bool wasReady = false;
-
 private:
 	void writeCrcPacketSmall(uint8_t responseCode, const uint8_t* buf, size_t size);
 	void writeCrcPacketLarge(uint8_t responseCode, const uint8_t* buf, size_t size);

--- a/firmware/console/console_io.cpp
+++ b/firmware/console/console_io.cpp
@@ -49,8 +49,8 @@ EXTERN_ENGINE;
 
 bool consoleByteArrived = false;
 
-void onDataArrived(void) {
-	consoleByteArrived = true;
+void onDataArrived(bool valid) {
+	consoleByteArrived = valid;
 }
 
 CommandHandler console_line_callback;

--- a/firmware/console/console_io.h
+++ b/firmware/console/console_io.h
@@ -21,4 +21,4 @@ typedef void (*CommandHandler)(char *);
 
 void consoleOutputBuffer(const uint8_t *buf, int size);
 void startConsole(CommandHandler console_line_callback_p);
-void onDataArrived(void);
+void onDataArrived(bool valid);

--- a/firmware/console/status_loop.cpp
+++ b/firmware/console/status_loop.cpp
@@ -404,7 +404,6 @@ extern int totalLoggedBytes;
 				offTimeMs = 50;
 				onTimeMs = 450;
 			} else if (consoleByteArrived) {
-				consoleByteArrived = false;
 				offTimeMs = 100;
 				onTimeMs = 33;
 #if EFI_INTERNAL_FLASH


### PR DESCRIPTION
Some related to https://github.com/rusefi/rusefi/issues/2839 , but does not fix it.

- do not stop "communication" blinking in case TS command executes too long. CRC calculation command previously sometimes cause communication LED to switch to slow blinking for a one period. 