### PR TITLE
hoist hwHandleShaftSignal

### DIFF
--- a/firmware/controllers/trigger/trigger_central.h
+++ b/firmware/controllers/trigger/trigger_central.h
@@ -87,7 +87,7 @@ public:
 
 void triggerInfo(void);
 void handleShaftSignal2(trigger_event_e signal, efitick_t timestamp DECLARE_ENGINE_PARAMETER_SUFFIX);
-void hwHandleShaftSignal(trigger_event_e signal, efitick_t timestamp);
+void hwHandleShaftSignal(bool isPrimary, bool isRising, efitick_t timestamp DECLARE_ENGINE_PARAMETER_SUFFIX);
 void hwHandleVvtCamSignal(trigger_value_e front, efitick_t timestamp, int index DECLARE_ENGINE_PARAMETER_SUFFIX);
 
 void initTriggerCentral();

--- a/firmware/hw_layer/digital_input/trigger/trigger_input_comp.cpp
+++ b/firmware/hw_layer/digital_input/trigger/trigger_input_comp.cpp
@@ -54,25 +54,24 @@ static void comp_shaft_callback(COMPDriver *comp) {
 	
 	uint32_t status = comp_lld_get_status(comp);
 	int isPrimary = (comp == EFI_COMP_PRIMARY_DEVICE);
-	if (!isPrimary && !TRIGGER_WAVEFORM(needSecondTriggerInput)) {
-		return;
-	}
-	trigger_event_e signal;
+
+	bool rise = false;
+
 	if (status & COMP_IRQ_RISING) {
-		signal = isPrimary ? (engineConfiguration->invertPrimaryTriggerSignal ? SHAFT_PRIMARY_FALLING : SHAFT_PRIMARY_RISING) : 
-			(engineConfiguration->invertSecondaryTriggerSignal ? SHAFT_SECONDARY_FALLING : SHAFT_SECONDARY_RISING);
-		hwHandleShaftSignal(signal, stamp);
+		rise = true;
+
 		// shift the threshold down a little bit to avoid false-triggering (threshold hysteresis)
 		setHysteresis(comp, -1);
 	}
 
 	if (status & COMP_IRQ_FALLING) {
-		signal = isPrimary ? (engineConfiguration->invertPrimaryTriggerSignal ? SHAFT_PRIMARY_RISING : SHAFT_PRIMARY_FALLING) : 
-			(engineConfiguration->invertSecondaryTriggerSignal ? SHAFT_SECONDARY_RISING : SHAFT_SECONDARY_FALLING);
-		hwHandleShaftSignal(signal, stamp);
+		rise = false;
+
 		// shift the threshold up a little bit to avoid false-triggering (threshold hysteresis)
 		setHysteresis(comp, 1);
 	}
+
+	hwHandleShaftSignal(isPrimary, rise, stamp);
 }
 
 // todo: add cam support?

--- a/firmware/hw_layer/digital_input/trigger/trigger_input_exti.cpp
+++ b/firmware/hw_layer/digital_input/trigger/trigger_input_exti.cpp
@@ -42,23 +42,8 @@ static void shaft_callback(void *arg) {
 	// todo: start using real event time from HW event, not just software timer?
 
 	bool isPrimary = index == 0;
-	if (!isPrimary && !TRIGGER_WAVEFORM(needSecondTriggerInput)) {
-		return;
-	}
 
-	trigger_event_e signal;
-	// todo: add support for 3rd channel
-	if (rise) {
-		signal = isPrimary ?
-					(engineConfiguration->invertPrimaryTriggerSignal ? SHAFT_PRIMARY_FALLING : SHAFT_PRIMARY_RISING) :
-					(engineConfiguration->invertSecondaryTriggerSignal ? SHAFT_SECONDARY_FALLING : SHAFT_SECONDARY_RISING);
-	} else {
-		signal = isPrimary ?
-					(engineConfiguration->invertPrimaryTriggerSignal ? SHAFT_PRIMARY_RISING : SHAFT_PRIMARY_FALLING) :
-					(engineConfiguration->invertSecondaryTriggerSignal ? SHAFT_SECONDARY_RISING : SHAFT_SECONDARY_FALLING);
-	}
-
-	hwHandleShaftSignal(signal, stamp);
+	hwHandleShaftSignal(isPrimary, rise, stamp);
 }
 
 static void cam_callback(void *arg) {

--- a/firmware/hw_layer/digital_input/trigger/trigger_input_icu.cpp
+++ b/firmware/hw_layer/digital_input/trigger/trigger_input_icu.cpp
@@ -70,14 +70,9 @@ static void shaftRisingCallback(bool isPrimary) {
 	icuRisingCallbackCounter++;
 // todo: support for 3rd trigger input channel
 
-	if (!isPrimary && !TRIGGER_WAVEFORM(needSecondTriggerInput)) {
-		return;
-	}
 	//	icucnt_t last_width = icuGetWidth(icup); so far we are fine with system time
 	// todo: add support for 3rd channel
-	trigger_event_e signal = isPrimary ? (engineConfiguration->invertPrimaryTriggerSignal ? SHAFT_PRIMARY_FALLING : SHAFT_PRIMARY_RISING) : (engineConfiguration->invertSecondaryTriggerSignal ? SHAFT_SECONDARY_FALLING : SHAFT_SECONDARY_RISING);
-
-	hwHandleShaftSignal(signal, stamp);
+	hwHandleShaftSignal(isPrimary, true, stamp);
 }
 
 static void shaftFallingCallback(bool isPrimary) {
@@ -90,14 +85,7 @@ static void shaftFallingCallback(bool isPrimary) {
 
 	icuFallingCallbackCounter++;
 
-	if (!isPrimary && !TRIGGER_WAVEFORM(needSecondTriggerInput)) {
-		return;
-	}
-
-	// todo: add support for 3rd channel
-	trigger_event_e signal =
-			isPrimary ? (engineConfiguration->invertPrimaryTriggerSignal ? SHAFT_PRIMARY_RISING : SHAFT_PRIMARY_FALLING) : (engineConfiguration->invertSecondaryTriggerSignal ? SHAFT_SECONDARY_RISING : SHAFT_SECONDARY_FALLING);
-	hwHandleShaftSignal(signal, stamp);
+	hwHandleShaftSignal(isPrimary, false, stamp);
 }
 
 /*==========================================================================*/

--- a/firmware/hw_layer/trigger_input_adc.cpp
+++ b/firmware/hw_layer/trigger_input_adc.cpp
@@ -112,20 +112,8 @@ static void onTriggerChanged(efitick_t stamp, bool isPrimary, bool isRising) {
 	// todo: support for 3rd trigger input channel
 	// todo: start using real event time from HW event, not just software timer?
 
-	if (!isPrimary && !TRIGGER_WAVEFORM(needSecondTriggerInput)) {
-		return;
-	}
-	trigger_event_e signal;
-	if (isRising) {
-		signal = isPrimary ? (engineConfiguration->invertPrimaryTriggerSignal ? SHAFT_PRIMARY_FALLING : SHAFT_PRIMARY_RISING) : 
-			(engineConfiguration->invertSecondaryTriggerSignal ? SHAFT_SECONDARY_FALLING : SHAFT_SECONDARY_RISING);
-	}
-	else {
-		signal = isPrimary ? (engineConfiguration->invertPrimaryTriggerSignal ? SHAFT_PRIMARY_RISING : SHAFT_PRIMARY_FALLING) : 
-			(engineConfiguration->invertSecondaryTriggerSignal ? SHAFT_SECONDARY_RISING : SHAFT_SECONDARY_FALLING);
-	}
 	// call the main trigger handler
-	hwHandleShaftSignal(signal, stamp);
+	hwHandleShaftSignal(isRising, isPrimary, stamp);
 #endif
 }
 

--- a/unit_tests/logicdata_csv_reader.h
+++ b/unit_tests/logicdata_csv_reader.h
@@ -11,7 +11,7 @@ public:
 	FILE *fp;
 	char buffer[255];
 
-	bool currentState[2];
+	bool lastState[2];
 
 	int triggerCount = 2;
 

--- a/unit_tests/tests/trigger/test_real_volkswagen.cpp
+++ b/unit_tests/tests/trigger/test_real_volkswagen.cpp
@@ -23,7 +23,6 @@ TEST(crankingVW, vwRealCrankingFromFile) {
 		reader.processLine(&eth);
 	}
 
-	ASSERT_EQ( 3, eth.recentWarnings()->getCount())<< "warningCounter#vwRealCranking";
-	ASSERT_EQ( 1683, GET_RPM())<< reader.lineIndex;
-
+	ASSERT_EQ(1, eth.recentWarnings()->getCount()) << "warningCounter#vwRealCranking";
+	ASSERT_EQ(1683, GET_RPM()) << reader.lineIndex;
 }


### PR DESCRIPTION
Simplify hwHandleShaftSignal logic - we don't need the logic duplicated everywhere to decide which signal maps to primary/secondary rise/fall.

As a result, we can now call that from `CsvReader::processLine`.