### PR TITLE
Consolidate hwHandleShaftSignal

### DIFF
--- a/firmware/controllers/trigger/trigger_central.cpp
+++ b/firmware/controllers/trigger/trigger_central.cpp
@@ -292,9 +292,11 @@ uint32_t triggerDuration;
 uint32_t triggerMaxDuration = 0;
 
 /**
- * this method is invoked only by real hardware call-backs
+ * This function is called by all trigger inputs:
+ *  - Hardware triggers
+ *  - Trigger simulator (on ECU)
+ *  - Trigger replay from CSV (unit tests)
  */
-
 void hwHandleShaftSignal(int signalIndex, bool isRising, efitick_t timestamp DECLARE_ENGINE_PARAMETER_SUFFIX) {
 	ScopePerf perf(PE::HandleShaftSignal);
 #if VR_HW_CHECK_MODE

--- a/firmware/controllers/trigger/trigger_central.cpp
+++ b/firmware/controllers/trigger/trigger_central.cpp
@@ -296,6 +296,7 @@ uint32_t triggerMaxDuration = 0;
  */
 
 void hwHandleShaftSignal(int signalIndex, bool isRising, efitick_t timestamp DECLARE_ENGINE_PARAMETER_SUFFIX) {
+	ScopePerf perf(PE::HandleShaftSignal);
 #if VR_HW_CHECK_MODE
 	// some boards do not have hardware VR input LEDs which makes such boards harder to validate
 	// from experience we know that assembly mistakes happen and quality control is required
@@ -314,15 +315,6 @@ void hwHandleShaftSignal(int signalIndex, bool isRising, efitick_t timestamp DEC
 
 	palWritePad(criticalErrorLedPort, criticalErrorLedPin, 0);
 #endif // VR_HW_CHECK_MODE
-
-	handleShaftSignal2(signalIndex, isRising, timestamp PASS_ENGINE_PARAMETER_SUFFIX);
-}
-
-/**
- * this method is invoked by both real hardware and self-stimulator
- */
-void handleShaftSignal2(int signalIndex, bool isRising, efitick_t timestamp DECLARE_ENGINE_PARAMETER_SUFFIX) {
-	ScopePerf perf(PE::HandleShaftSignal);
 
 	bool isPrimary = signalIndex == 0;
 	if (!isPrimary && !TRIGGER_WAVEFORM(needSecondTriggerInput)) {

--- a/firmware/controllers/trigger/trigger_central.cpp
+++ b/firmware/controllers/trigger/trigger_central.cpp
@@ -295,7 +295,7 @@ uint32_t triggerMaxDuration = 0;
  * this method is invoked only by real hardware call-backs
  */
 
-void hwHandleShaftSignal(trigger_event_e signal, efitick_t timestamp DECLARE_ENGINE_PARAMETER_SUFFIX) {
+void hwHandleShaftSignal(int signalIndex, bool isRising, efitick_t timestamp DECLARE_ENGINE_PARAMETER_SUFFIX) {
 #if VR_HW_CHECK_MODE
 	// some boards do not have hardware VR input LEDs which makes such boards harder to validate
 	// from experience we know that assembly mistakes happen and quality control is required
@@ -315,21 +315,36 @@ void hwHandleShaftSignal(trigger_event_e signal, efitick_t timestamp DECLARE_ENG
 	palWritePad(criticalErrorLedPort, criticalErrorLedPin, 0);
 #endif // VR_HW_CHECK_MODE
 
-	handleShaftSignal2(signal, timestamp PASS_ENGINE_PARAMETER_SUFFIX);
-
+	handleShaftSignal2(signalIndex, isRising, timestamp PASS_ENGINE_PARAMETER_SUFFIX);
 }
 
 /**
  * this method is invoked by both real hardware and self-stimulator
  */
-void handleShaftSignal2(trigger_event_e signal, efitick_t timestamp DECLARE_ENGINE_PARAMETER_SUFFIX) {
+void handleShaftSignal2(int signalIndex, bool isRising, efitick_t timestamp DECLARE_ENGINE_PARAMETER_SUFFIX) {
 	ScopePerf perf(PE::HandleShaftSignal);
+
+	bool isPrimary = signalIndex == 0;
+	if (!isPrimary && !TRIGGER_WAVEFORM(needSecondTriggerInput)) {
+		return;
+	}
+
+	trigger_event_e signal;
+	// todo: add support for 3rd channel
+	if (isRising) {
+		signal = isPrimary ?
+					(engineConfiguration->invertPrimaryTriggerSignal ? SHAFT_PRIMARY_FALLING : SHAFT_PRIMARY_RISING) :
+					(engineConfiguration->invertSecondaryTriggerSignal ? SHAFT_SECONDARY_FALLING : SHAFT_SECONDARY_RISING);
+	} else {
+		signal = isPrimary ?
+					(engineConfiguration->invertPrimaryTriggerSignal ? SHAFT_PRIMARY_RISING : SHAFT_PRIMARY_FALLING) :
+					(engineConfiguration->invertSecondaryTriggerSignal ? SHAFT_SECONDARY_RISING : SHAFT_SECONDARY_FALLING);
+	}
 
 	// Don't accept trigger input in case of some problems
 	if (!engine->limpManager.allowTriggerInput()) {
 		return;
 	}
-
 
 #if EFI_TOOTH_LOGGER
 	// Log to the Tunerstudio tooth logger

--- a/firmware/controllers/trigger/trigger_central.h
+++ b/firmware/controllers/trigger/trigger_central.h
@@ -86,8 +86,8 @@ public:
 };
 
 void triggerInfo(void);
-void handleShaftSignal2(trigger_event_e signal, efitick_t timestamp DECLARE_ENGINE_PARAMETER_SUFFIX);
-void hwHandleShaftSignal(trigger_event_e signal, efitick_t timestamp DECLARE_ENGINE_PARAMETER_SUFFIX);
+void handleShaftSignal2(int signalIndex, bool isRising, efitick_t timestamp DECLARE_ENGINE_PARAMETER_SUFFIX);
+void hwHandleShaftSignal(int signalIndex, bool isRising, efitick_t timestamp DECLARE_ENGINE_PARAMETER_SUFFIX);
 void hwHandleVvtCamSignal(trigger_value_e front, efitick_t timestamp, int index DECLARE_ENGINE_PARAMETER_SUFFIX);
 
 void initTriggerCentral();

--- a/firmware/controllers/trigger/trigger_central.h
+++ b/firmware/controllers/trigger/trigger_central.h
@@ -86,7 +86,6 @@ public:
 };
 
 void triggerInfo(void);
-void handleShaftSignal2(int signalIndex, bool isRising, efitick_t timestamp DECLARE_ENGINE_PARAMETER_SUFFIX);
 void hwHandleShaftSignal(int signalIndex, bool isRising, efitick_t timestamp DECLARE_ENGINE_PARAMETER_SUFFIX);
 void hwHandleVvtCamSignal(trigger_value_e front, efitick_t timestamp, int index DECLARE_ENGINE_PARAMETER_SUFFIX);
 

--- a/firmware/controllers/trigger/trigger_emulator_algo.cpp
+++ b/firmware/controllers/trigger/trigger_emulator_algo.cpp
@@ -55,13 +55,8 @@ void TriggerEmulatorHelper::handleEmulatorCallback(const int size, const MultiCh
 	for (size_t i = 0; i < PWM_PHASE_MAX_WAVE_PER_PWM; i++) {
 		if (needEvent(stateIndex, size, multiChannelStateSequence, i)) {
 			pin_state_t currentValue = multiChannelStateSequence.getChannelState(/*phaseIndex*/i, stateIndex);
-			
-			constexpr trigger_event_e riseEvents[] = { SHAFT_PRIMARY_RISING, SHAFT_SECONDARY_RISING, SHAFT_3RD_RISING };
-			constexpr trigger_event_e fallEvents[] = { SHAFT_PRIMARY_FALLING, SHAFT_SECONDARY_FALLING, SHAFT_3RD_FALLING };
 
-			trigger_event_e event = (currentValue ? riseEvents : fallEvents)[i];
-
-			handleShaftSignal2(event, stamp PASS_ENGINE_PARAMETER_SUFFIX);
+			handleShaftSignal2(i, currentValue, stamp PASS_ENGINE_PARAMETER_SUFFIX);
 		}
 	}
 }

--- a/firmware/controllers/trigger/trigger_emulator_algo.cpp
+++ b/firmware/controllers/trigger/trigger_emulator_algo.cpp
@@ -56,7 +56,7 @@ void TriggerEmulatorHelper::handleEmulatorCallback(const int size, const MultiCh
 		if (needEvent(stateIndex, size, multiChannelStateSequence, i)) {
 			pin_state_t currentValue = multiChannelStateSequence.getChannelState(/*phaseIndex*/i, stateIndex);
 
-			handleShaftSignal2(i, currentValue, stamp PASS_ENGINE_PARAMETER_SUFFIX);
+			hwHandleShaftSignal(i, currentValue, stamp PASS_ENGINE_PARAMETER_SUFFIX);
 		}
 	}
 }

--- a/firmware/hw_layer/digital_input/trigger/trigger_input_comp.cpp
+++ b/firmware/hw_layer/digital_input/trigger/trigger_input_comp.cpp
@@ -54,22 +54,16 @@ static void comp_shaft_callback(COMPDriver *comp) {
 	
 	uint32_t status = comp_lld_get_status(comp);
 	int isPrimary = (comp == EFI_COMP_PRIMARY_DEVICE);
-	if (!isPrimary && !TRIGGER_WAVEFORM(needSecondTriggerInput)) {
-		return;
-	}
+
 	trigger_event_e signal;
 	if (status & COMP_IRQ_RISING) {
-		signal = isPrimary ? (engineConfiguration->invertPrimaryTriggerSignal ? SHAFT_PRIMARY_FALLING : SHAFT_PRIMARY_RISING) : 
-			(engineConfiguration->invertSecondaryTriggerSignal ? SHAFT_SECONDARY_FALLING : SHAFT_SECONDARY_RISING);
-		hwHandleShaftSignal(signal, stamp);
+		hwHandleShaftSignal(isPrimary ? 0 : 1, true, stamp);
 		// shift the threshold down a little bit to avoid false-triggering (threshold hysteresis)
 		setHysteresis(comp, -1);
 	}
 
 	if (status & COMP_IRQ_FALLING) {
-		signal = isPrimary ? (engineConfiguration->invertPrimaryTriggerSignal ? SHAFT_PRIMARY_RISING : SHAFT_PRIMARY_FALLING) : 
-			(engineConfiguration->invertSecondaryTriggerSignal ? SHAFT_SECONDARY_RISING : SHAFT_SECONDARY_FALLING);
-		hwHandleShaftSignal(signal, stamp);
+		hwHandleShaftSignal(isPrimary ? 0 : 1, false, stamp);
 		// shift the threshold up a little bit to avoid false-triggering (threshold hysteresis)
 		setHysteresis(comp, 1);
 	}

--- a/firmware/hw_layer/digital_input/trigger/trigger_input_exti.cpp
+++ b/firmware/hw_layer/digital_input/trigger/trigger_input_exti.cpp
@@ -41,24 +41,7 @@ static void shaft_callback(void *arg) {
 	// todo: support for 3rd trigger input channel
 	// todo: start using real event time from HW event, not just software timer?
 
-	bool isPrimary = index == 0;
-	if (!isPrimary && !TRIGGER_WAVEFORM(needSecondTriggerInput)) {
-		return;
-	}
-
-	trigger_event_e signal;
-	// todo: add support for 3rd channel
-	if (rise) {
-		signal = isPrimary ?
-					(engineConfiguration->invertPrimaryTriggerSignal ? SHAFT_PRIMARY_FALLING : SHAFT_PRIMARY_RISING) :
-					(engineConfiguration->invertSecondaryTriggerSignal ? SHAFT_SECONDARY_FALLING : SHAFT_SECONDARY_RISING);
-	} else {
-		signal = isPrimary ?
-					(engineConfiguration->invertPrimaryTriggerSignal ? SHAFT_PRIMARY_RISING : SHAFT_PRIMARY_FALLING) :
-					(engineConfiguration->invertSecondaryTriggerSignal ? SHAFT_SECONDARY_RISING : SHAFT_SECONDARY_FALLING);
-	}
-
-	hwHandleShaftSignal(signal, stamp);
+	hwHandleShaftSignal(index, rise, stamp);
 }
 
 static void cam_callback(void *arg) {

--- a/firmware/hw_layer/digital_input/trigger/trigger_input_icu.cpp
+++ b/firmware/hw_layer/digital_input/trigger/trigger_input_icu.cpp
@@ -68,16 +68,10 @@ static void shaftRisingCallback(bool isPrimary) {
 	TRIGGER_BAIL_IF_SELF_STIM
 #endif
 	icuRisingCallbackCounter++;
-// todo: support for 3rd trigger input channel
 
-	if (!isPrimary && !TRIGGER_WAVEFORM(needSecondTriggerInput)) {
-		return;
-	}
 	//	icucnt_t last_width = icuGetWidth(icup); so far we are fine with system time
-	// todo: add support for 3rd channel
-	trigger_event_e signal = isPrimary ? (engineConfiguration->invertPrimaryTriggerSignal ? SHAFT_PRIMARY_FALLING : SHAFT_PRIMARY_RISING) : (engineConfiguration->invertSecondaryTriggerSignal ? SHAFT_SECONDARY_FALLING : SHAFT_SECONDARY_RISING);
 
-	hwHandleShaftSignal(signal, stamp);
+	hwHandleShaftSignal(isPrimary ? 0 : 1, true, stamp);
 }
 
 static void shaftFallingCallback(bool isPrimary) {
@@ -90,14 +84,7 @@ static void shaftFallingCallback(bool isPrimary) {
 
 	icuFallingCallbackCounter++;
 
-	if (!isPrimary && !TRIGGER_WAVEFORM(needSecondTriggerInput)) {
-		return;
-	}
-
-	// todo: add support for 3rd channel
-	trigger_event_e signal =
-			isPrimary ? (engineConfiguration->invertPrimaryTriggerSignal ? SHAFT_PRIMARY_RISING : SHAFT_PRIMARY_FALLING) : (engineConfiguration->invertSecondaryTriggerSignal ? SHAFT_SECONDARY_RISING : SHAFT_SECONDARY_FALLING);
-	hwHandleShaftSignal(signal, stamp);
+	hwHandleShaftSignal(isPrimary ? 0 : 1, false, stamp);
 }
 
 /*==========================================================================*/

--- a/firmware/hw_layer/trigger_input_adc.cpp
+++ b/firmware/hw_layer/trigger_input_adc.cpp
@@ -112,20 +112,8 @@ static void onTriggerChanged(efitick_t stamp, bool isPrimary, bool isRising) {
 	// todo: support for 3rd trigger input channel
 	// todo: start using real event time from HW event, not just software timer?
 
-	if (!isPrimary && !TRIGGER_WAVEFORM(needSecondTriggerInput)) {
-		return;
-	}
-	trigger_event_e signal;
-	if (isRising) {
-		signal = isPrimary ? (engineConfiguration->invertPrimaryTriggerSignal ? SHAFT_PRIMARY_FALLING : SHAFT_PRIMARY_RISING) : 
-			(engineConfiguration->invertSecondaryTriggerSignal ? SHAFT_SECONDARY_FALLING : SHAFT_SECONDARY_RISING);
-	}
-	else {
-		signal = isPrimary ? (engineConfiguration->invertPrimaryTriggerSignal ? SHAFT_PRIMARY_RISING : SHAFT_PRIMARY_FALLING) : 
-			(engineConfiguration->invertSecondaryTriggerSignal ? SHAFT_SECONDARY_RISING : SHAFT_SECONDARY_FALLING);
-	}
 	// call the main trigger handler
-	hwHandleShaftSignal(signal, stamp);
+	hwHandleShaftSignal(isPrimary ? 0 : 1, isRising, stamp);
 #endif
 }
 

--- a/unit_tests/logicdata_csv_reader.cpp
+++ b/unit_tests/logicdata_csv_reader.cpp
@@ -62,10 +62,9 @@ void CsvReader::processLine(EngineTestHelper *eth) {
 		if (currentState[index] == newState[index]) {
 			continue;
 		}
-		trigger_event_e event =
-				(newState[index] ? riseEvents : fallEvents)[index];
+
 		efitick_t nowNt = getTimeNowNt();
-		handleShaftSignal2(event, nowNt PASS_ENGINE_PARAMETER_SUFFIX);
+		handleShaftSignal2(index, newState[index], nowNt PASS_ENGINE_PARAMETER_SUFFIX);
 
 		currentState[index] = newState[index];
 	}

--- a/unit_tests/logicdata_csv_reader.cpp
+++ b/unit_tests/logicdata_csv_reader.cpp
@@ -64,7 +64,7 @@ void CsvReader::processLine(EngineTestHelper *eth) {
 		}
 
 		efitick_t nowNt = getTimeNowNt();
-		handleShaftSignal2(index, newState[index], nowNt PASS_ENGINE_PARAMETER_SUFFIX);
+		hwHandleShaftSignal(index, newState[index], nowNt PASS_ENGINE_PARAMETER_SUFFIX);
 
 		currentState[index] = newState[index];
 	}


### PR DESCRIPTION
- Move logic to translate [index, rise] -> trigger_event_e to a single place, instead of 4 duplicates of the same logic
- No more handleShaftSignal2: everyone now calls hwHandleShaftSignal directly (including tests!)
- 