### PR TITLE
fix instant rpm

### DIFF
--- a/firmware/controllers/engine_cycle/rpm_calculator.cpp
+++ b/firmware/controllers/engine_cycle/rpm_calculator.cpp
@@ -278,11 +278,14 @@ void rpmShaftPositionCallback(trigger_event_e ckpSignalType,
 
 				rpmState->setRpmValue(rpm > UNREALISTIC_RPM ? NOISY_RPM : rpm);
 			}
+		} else {
+			// we are here only once trigger is synchronized for the first time
+			// while transitioning  from 'spinning' to 'running'
+			engine->triggerCentral.triggerState.movePreSynchTimestamps(PASS_ENGINE_PARAMETER_SIGNATURE);
 		}
 
 		rpmState->onNewEngineCycle();
 	}
-
 
 #if EFI_SENSOR_CHART
 	// this 'index==0' case is here so that it happens after cycle callback so
@@ -293,13 +296,6 @@ void rpmShaftPositionCallback(trigger_event_e ckpSignalType,
 		scAddData(crankAngle, signal);
 	}
 #endif /* EFI_SENSOR_CHART */
-
-	if (rpmState->isSpinningUp()) {
-		// we are here only once trigger is synchronized for the first time
-		// while transitioning  from 'spinning' to 'running'
-		// Replace 'normal' RPM with instant RPM for the initial spin-up period
-		engine->triggerCentral.triggerState.movePreSynchTimestamps(PASS_ENGINE_PARAMETER_SIGNATURE);
-	}
 
 	// Always update instant RPM even when not spinning up
 	engine->triggerCentral.triggerState.updateInstantRpm(&engine->triggerCentral.triggerFormDetails, nowNt PASS_ENGINE_PARAMETER_SUFFIX);

--- a/unit_tests/tests/trigger/test_real_cranking_miata_NA.cpp
+++ b/unit_tests/tests/trigger/test_real_cranking_miata_NA.cpp
@@ -44,6 +44,8 @@ TEST(cranking, realCrankingFromFile) {
 	while (reader.haveMore()) {
 		reader.processLine(&eth);
 	}
-	ASSERT_EQ( 0, eth.recentWarnings()->getCount())<< "warningCounter#realCranking";
-	ASSERT_EQ( 560, GET_RPM())<< reader.lineIndex;
+
+	// TODO: we should avoid this warning
+	ASSERT_EQ(1, eth.recentWarnings()->getCount())<< "warningCounter#realCranking";
+	ASSERT_EQ(560, GET_RPM())<< reader.lineIndex;
 }

--- a/unit_tests/tests/trigger/test_real_cranking_miata_NA.cpp
+++ b/unit_tests/tests/trigger/test_real_cranking_miata_NA.cpp
@@ -46,6 +46,7 @@ TEST(cranking, realCrankingFromFile) {
 	}
 
 	// TODO: we should avoid this warning
+	// See https://github.com/rusefi/rusefi/issues/2889
 	ASSERT_EQ(1, eth.recentWarnings()->getCount())<< "warningCounter#realCranking";
 	ASSERT_EQ(560, GET_RPM())<< reader.lineIndex;
 }

--- a/unit_tests/tests/trigger/test_real_cranking_miata_na6.cpp
+++ b/unit_tests/tests/trigger/test_real_cranking_miata_na6.cpp
@@ -64,26 +64,26 @@ TEST(cranking, hardcodedRealCranking) {
 	/* 17 */ EVENT(/* timestamp*/1.30114225, T_PRIMARY, /*value*/true);
 	EXPECT_EQ(219, GET_RPM());
 	/* 18 */ EVENT(/* timestamp*/1.3341915, T_SECONDARY, /*value*/false);
-	EXPECT_EQ(88, GET_RPM());
+	EXPECT_EQ(228, GET_RPM());
 	/* 19 */ EVENT(/* timestamp*/1.383534, T_SECONDARY, /*value*/true);
-	EXPECT_EQ( 67,  GET_RPM());
+	EXPECT_EQ( 248,  GET_RPM());
 
 	// WHY DOES RPM GO SO LOW HERE?
 	// It doesn't look like it drops in the logic analyzer trace (hint: it doesn't, there's a bug)
 
 	// second synch
 	/* 22 */ EVENT(/* timestamp*/1.45352675, T_PRIMARY, /*value*/true);
-	EXPECT_EQ(33, GET_RPM());
+	EXPECT_EQ(224, GET_RPM());
 	/* 23 */ EVENT(/* timestamp*/1.46291525, T_SECONDARY, /*value*/false);
-	EXPECT_EQ(38, GET_RPM());
+	EXPECT_EQ(231, GET_RPM());
 	/* 25 */ EVENT(/* timestamp*/1.49939025, T_PRIMARY, /*value*/false);
-	EXPECT_EQ(54, GET_RPM());
+	EXPECT_EQ(239, GET_RPM());
 	/* 27 */ EVENT(/* timestamp*/1.511785, T_SECONDARY, /*value*/true);
-	EXPECT_EQ(57, GET_RPM());
+	EXPECT_EQ(234, GET_RPM());
 	/* 28 */ EVENT(/* timestamp*/1.5908545, T_SECONDARY, /*value*/false);
-	EXPECT_EQ(57, GET_RPM());
+	EXPECT_EQ(231, GET_RPM());
 	/* 31 */ EVENT(/* timestamp*/1.6399845, T_SECONDARY, /*value*/true);
-	EXPECT_EQ(35, GET_RPM());
+	EXPECT_EQ(234, GET_RPM());
 	/* 32 */ EVENT(/* timestamp*/1.70975875, T_PRIMARY, /*value*/true);
 	EXPECT_EQ(233, GET_RPM());
 	/* 33 */ EVENT(/* timestamp*/1.7194455, T_SECONDARY, /*value*/false);


### PR DESCRIPTION
fix #2885 

call movePreSynchTimestamps exactly once, on the first sync