### PR TITLE
misc

### DIFF
--- a/firmware/config/boards/subaru_eg33/board_configuration.cpp
+++ b/firmware/config/boards/subaru_eg33/board_configuration.cpp
@@ -242,8 +242,7 @@ void setBoardDefaultConfiguration(void) {
 
 	/* This board also has AC clutch output: */
 	engineConfiguration->acRelayPin = TLE6240_PIN_15;
-	engineConfiguration->acCutoffLowRpm = 400;
-	engineConfiguration->acCutoffHighRpm = 3000;
+	engineConfiguration->maxAcRpm = 3000;
 	engineConfiguration->acIdleRpmBump = 200;
 
 	engineConfiguration->isCJ125Enabled = false;

--- a/firmware/config/engines/me7pnp.cpp
+++ b/firmware/config/engines/me7pnp.cpp
@@ -184,8 +184,6 @@ void vag_18_Turbo(DECLARE_CONFIG_PARAMETER_SIGNATURE) {
 	//Configuration 3 : 2 Wires
 
 	engineConfiguration->acRelayPin = GPIO_UNASSIGNED;
-	engineConfiguration->acCutoffLowRpm = 400;
-	engineConfiguration->acCutoffHighRpm = 4500;
 	engineConfiguration->acIdleRpmBump = 200;
 	// TODO: AC driver request input PE13 and AC compressor input-output PE7
 

--- a/firmware/controllers/algo/engine_configuration.cpp
+++ b/firmware/controllers/algo/engine_configuration.cpp
@@ -498,7 +498,6 @@ static void setDefaultEngineConfiguration(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 	engineConfiguration->canSleepPeriodMs = 50;
 	engineConfiguration->canReadEnabled = true;
 	engineConfiguration->canWriteEnabled = true;
-	engineConfiguration->canNbcType = CAN_BUS_MAZDA_RX8;
 
 	// Don't enable, but set default address
 	engineConfiguration->verboseCanBaseAddress = CAN_DEFAULT_BASE;
@@ -516,8 +515,9 @@ static void setDefaultEngineConfiguration(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 	engineConfiguration->idlePidRpmDeadZone = 50;
 	engineConfiguration->startOfCrankingPrimingPulse = 0;
 
-	engineConfiguration->acCutoffLowRpm = 700;
-	engineConfiguration->acCutoffHighRpm = 5000;
+	engineConfiguration->maxAcRpm = 5000;
+	engineConfiguration->maxAcClt = 100;
+	engineConfiguration->maxAcTps = 75;
 
 	initTemperatureCurve(IAT_FUEL_CORRECTION_CURVE, 1);
 

--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -1151,9 +1151,8 @@ bit unused_1484_bit_31
 
 	int ignMathCalculateAtIndex;+At what trigger index should some ignition-related math be executed? This is a performance trick to reduce load on synchronization trigger callback.;"index", 1, 0, 0, 7000, 0
 
-! todo: start using these parameters!
-	int16_t acCutoffLowRpm;;"RPM", 1, 0, 1, 15000, 0
-	int16_t acCutoffHighRpm;;"RPM", 1, 0, 1, 15000, 0
+	int16_t unused1492;;"", 1, 0, 1, 15000, 0
+	int16_t unused1494;;"", 1, 0, 1, 15000, 0
 	int16_t acIdleRpmBump;+Extra idle target speed when A/C is enabled. Some cars need the extra speed to keep the AC efficient while idling.;"RPM", 1, 0, 0, 1000, 0
 
 	int16_t warningPeriod;set warningPeriod X;"seconds", 1, 0, 0, 60, 0

--- a/firmware/tunerstudio/rusefi.input
+++ b/firmware/tunerstudio/rusefi.input
@@ -2970,26 +2970,24 @@ cmd_set_engine_type_default					= "@@TS_IO_TEST_COMMAND_char@@\x00\x31\x00\x00"
 		field = "RX pin",                               binarySerialRxPin, {useSerialPort == 1}
 
 	dialog = canBus, "CAN Bus"
-		field = "Can Read Enabled",						canReadEnabled
-		field = "Can Write Enabled",					canWriteEnabled
-	    field = "consumeObdSensors",                    consumeObdSensors, { canReadEnabled == 1 && canWriteEnabled == 1}
-		field = "Can Nbc Type",							canNbcType
-		field = "Can Baud Rate",						canBaudRate
+		field = "CAN read enabled",						canReadEnabled
+		field = "CAN write enabled",					canWriteEnabled
+		field = "CAN bitrate",							canBaudRate
+		field = "CAN dash type",						canNbcType
 		field = "Enable rusEFI CAN broadcast",			enableVerboseCanTx
-		field = "use FSIO Table CAN Sniffing Filtering",useFSIOTableForCanSniffingFiltering
 		field = "rusEFI CAN data base address",			verboseCanBaseAddress
-		field = "Can Sleep Period",						canSleepPeriodMs
+		field = "rusEFI CAN data period",				canSleepPeriodMs
 		field = "RX pin",								canRxPin @@if_ts_show_can_pins
 		field = "TX pin",								canTxPin @@if_ts_show_can_pins
 
 	dialog = canBus2, "Secondary CAN Bus"
-		field = "Can Read Enabled",						can2ReadEnabled
-		field = "Can Write Enabled",					can2WriteEnabled
-		field = "Can Nbc Type",							can2NbcType
-		field = "Can Baud Rate",						can2BaudRate
+		field = "CAN read enabled",						can2ReadEnabled
+		field = "CAN write enabled",					can2WriteEnabled
+		field = "CAN bitrate",							can2BaudRate
+		field = "CAN dash type",						can2NbcType
 		field = "Enable rusEFI CAN broadcast",			enableVerboseCan2Tx
 		field = "rusEFI CAN data base address",			verboseCan2BaseAddress
-		field = "Can Sleep Period",						can2SleepPeriodMs
+		field = "rusEFI CAN data period",				can2SleepPeriodMs
 		field = "RX pin",								can2RxPin @@if_ts_show_can_pins
 		field = "TX pin",								can2TxPin @@if_ts_show_can_pins
 
@@ -3578,6 +3576,8 @@ cmd_set_engine_type_default					= "@@TS_IO_TEST_COMMAND_char@@\x00\x31\x00\x00"
 		field = "MAP Averaging Logic @",				mapAveragingSchedulingAtIndex
 		field = "showHumanReadableWarning (affects Burn)",	showHumanReadableWarning
 		field = "Ford redundant TPS mode",				useFordRedundantTps
+		field = "consumeObdSensors",                    consumeObdSensors, { canReadEnabled == 1 && canWriteEnabled == 1}
+		field = "use FSIO Table CAN Sniffing Filtering",useFSIOTableForCanSniffingFiltering
 
 
        help = helpGeneral, "rusEFI General Help"


### PR DESCRIPTION
- Don't set a default CAN dash (pollutes the bus for no good reason)
- Remove unused (and accidentally duplicated) AC RPM fields
- set AC defaults
- CAN UI cleanup/adjustments