### PR TITLE
shard unit tests

### DIFF
--- a/.github/workflows/build-unit-tests.yaml
+++ b/.github/workflows/build-unit-tests.yaml
@@ -93,4 +93,4 @@ jobs:
 
     - name: Run Tests (sharded)
       working-directory: ./unit_tests/
-      run: ./run_sharded_tests.sh
+      run: bash ./run_sharded_tests.sh

--- a/.github/workflows/build-unit-tests.yaml
+++ b/.github/workflows/build-unit-tests.yaml
@@ -90,3 +90,7 @@ jobs:
       with:
         github_token: ${{ github.token }}
         branch: master
+
+    - name: Run Tests (sharded)
+      working-directory: ./unit_tests/
+      run: ./run_sharded_tests.sh

--- a/unit_tests/run_sharded_tests.sh
+++ b/unit_tests/run_sharded_tests.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# This script runs every test in its own process (own invocation of rusefi_test executable)
+# This allows us to test for accidental cross-test leakage that fixes/breaks something
+
+set -e
+
+export GTEST_TOTAL_SHARDS=500
+for IDX in {0..500}
+do
+	export GTEST_SHARD_INDEX=$IDX
+	build/rusefi_test
+done
+
+unset GTEST_TOTAL_SHARDS
+unset GTEST_SHARD_INDEX

--- a/unit_tests/run_sharded_tests.sh
+++ b/unit_tests/run_sharded_tests.sh
@@ -6,7 +6,7 @@
 set -e
 
 export GTEST_TOTAL_SHARDS=500
-for IDX in {0..500}
+for IDX in {0..499}
 do
 	export GTEST_SHARD_INDEX=$IDX
 	build/rusefi_test

--- a/unit_tests/tests/test_etb.cpp
+++ b/unit_tests/tests/test_etb.cpp
@@ -447,6 +447,9 @@ TEST(etb, etbTpsSensor) {
 	Sensor::setMockValue(SensorType::WastegatePosition, 33.0f);
 	Sensor::setMockValue(SensorType::IdlePosition, 66.0f);
 
+	// Redundant accelerator pedal required for init
+	Sensor::setMockValue(SensorType::AcceleratorPedal, 0, true);
+
 	// Test first throttle
 	{
 		EtbController etb;
@@ -478,6 +481,10 @@ TEST(etb, etbTpsSensor) {
 
 TEST(etb, setOutputInvalid) {
 	WITH_ENGINE_TEST_HELPER(TEST_ENGINE);
+
+	// Redundant TPS & accelerator pedal required for init
+	Sensor::setMockValue(SensorType::Tps1, 0, true);
+	Sensor::setMockValue(SensorType::AcceleratorPedal, 0, true);
 
 	StrictMock<MockMotor> motor;
 
@@ -644,6 +651,10 @@ TEST(etb, closedLoopPid) {
 TEST(etb, openLoopThrottle) {
 	WITH_ENGINE_TEST_HELPER(TEST_ENGINE);
 
+	// Redundant TPS & accelerator pedal required for init
+	Sensor::setMockValue(SensorType::Tps1, 0, true);
+	Sensor::setMockValue(SensorType::AcceleratorPedal, 0, true);
+
 	EtbController etb;
 	INJECT_ENGINE_REFERENCE(&etb);
 	etb.init(ETB_Throttle1, nullptr, nullptr, nullptr, true);
@@ -661,6 +672,10 @@ TEST(etb, openLoopThrottle) {
 
 TEST(etb, openLoopNonThrottle) {
 	WITH_ENGINE_TEST_HELPER(TEST_ENGINE);
+
+	// Redundant TPS & accelerator pedal required for init
+	Sensor::setMockValue(SensorType::Tps1, 0, true);
+	Sensor::setMockValue(SensorType::AcceleratorPedal, 0, true);
 
 	EtbController etb;
 	INJECT_ENGINE_REFERENCE(&etb);


### PR DESCRIPTION
Run every unit test individually to test for cross-test-spillage