### PR TITLE
Fix Pinouts again

### DIFF
--- a/misc/jenkins/generate_pinouts/gen_upload_pinouts.sh
+++ b/misc/jenkins/generate_pinouts/gen_upload_pinouts.sh
@@ -34,7 +34,7 @@ for c in $CONNECTORS; do
     exit 1;
   fi
   echo "IMG "$IMG
-  if [ $IMG ]; then
+  if [ "$IMG" != "null" ]; then
     cp $(dirname $c)/$IMG $DIR
   fi
   ls $DIR

--- a/misc/pinout-gen/append.sh
+++ b/misc/pinout-gen/append.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 DIR=$(cd -P -- "$(dirname -- "$0")" && pwd -P)"/"
-TEXT=$(sed -e "/\/\/\/DATA\/\/\//{a \ \`$1\ \`,\n///DATA///" -e "d}" $2)
+TEXT=$(sed -e "/\/\/\/DATA\/\/\//{a \ \`$(echo ${1//\//\\/} | tr -d '\n')\ \`,\n///DATA///" -e "d}" $2)
 if [ $? -ne 0 ]; then
   echo "Error in append.sh"
   exit 1;


### PR DESCRIPTION
quick fix

I'm not sure what actually changed. It appears that yq now outputs "null" for a key that's not found, which was one problem, but I'm not sure what changed to cause the main problem.