### PR TITLE
auto detect HSE clock speed

### DIFF
--- a/firmware/config/boards/STM32F407VET6_Mini.bat
+++ b/firmware/config/boards/STM32F407VET6_Mini.bat
@@ -5,7 +5,7 @@ rem TODO: somehow this -DDUMMY is helping us to not mess up the parameters, why?
 rem https://github.com/rusefi/rusefi/issues/684
 rem this board has only 512K flash so using custom FLASH_ADDR
 rem You probably want "flash0  : org = 0x08000000, len = 450K" in the .ld file
-set EXTRA_PARAMS=-DDUMMY -DEFI_COMMUNICATION_PIN=GPIOB_9 -DSTM32_HSECLK=25000000U -DSTM32_PLLM_VALUE=25 -DSTM32_RTCPRE_VALUE=25 -DDEFAULT_ENGINE_TYPE=MINIMAL_PINS^
+set EXTRA_PARAMS=-DDUMMY -DEFI_COMMUNICATION_PIN=GPIOB_9 -DSTM32_PLLM_VALUE=25 -DSTM32_RTCPRE_VALUE=25 -DDEFAULT_ENGINE_TYPE=MINIMAL_PINS^
  -DEFI_INTERNAL_FLASH=FALSE ^
  -DHAL_USE_RTC=FALSE ^
  -DBOARD_OTG_NOVBUSSENS ^

--- a/firmware/config/boards/STM32F407VET6_Mini.bat
+++ b/firmware/config/boards/STM32F407VET6_Mini.bat
@@ -5,7 +5,7 @@ rem TODO: somehow this -DDUMMY is helping us to not mess up the parameters, why?
 rem https://github.com/rusefi/rusefi/issues/684
 rem this board has only 512K flash so using custom FLASH_ADDR
 rem You probably want "flash0  : org = 0x08000000, len = 450K" in the .ld file
-set EXTRA_PARAMS=-DDUMMY -DEFI_COMMUNICATION_PIN=GPIOB_9 -DSTM32_PLLM_VALUE=25 -DSTM32_RTCPRE_VALUE=25 -DDEFAULT_ENGINE_TYPE=MINIMAL_PINS^
+set EXTRA_PARAMS=-DDUMMY -DEFI_COMMUNICATION_PIN=GPIOB_9 -DSTM32_RTCPRE_VALUE=25 -DDEFAULT_ENGINE_TYPE=MINIMAL_PINS^
  -DEFI_INTERNAL_FLASH=FALSE ^
  -DHAL_USE_RTC=FALSE ^
  -DBOARD_OTG_NOVBUSSENS ^

--- a/firmware/config/boards/hellen/hellen121nissan/board.h
+++ b/firmware/config/boards/hellen/hellen121nissan/board.h
@@ -57,10 +57,6 @@
 #define STM32_LSECLK                32768U
 #endif
 
-#if !defined(STM32_HSECLK)
-#define STM32_HSECLK                8000000U
-#endif
-
 /*
  * Board voltages.
  * Required for performance limits calculation.

--- a/firmware/config/boards/hellen/hellen121vag/board.h
+++ b/firmware/config/boards/hellen/hellen121vag/board.h
@@ -57,10 +57,6 @@
 #define STM32_LSECLK                32768U
 #endif
 
-#if !defined(STM32_HSECLK)
-#define STM32_HSECLK                8000000U
-#endif
-
 /*
  * Board voltages.
  * Required for performance limits calculation.

--- a/firmware/config/boards/hellen/hellen128/board.h
+++ b/firmware/config/boards/hellen/hellen128/board.h
@@ -57,10 +57,6 @@
 #define STM32_LSECLK                32768U
 #endif
 
-#if !defined(STM32_HSECLK)
-#define STM32_HSECLK                8000000U
-#endif
-
 /*
  * Board voltages.
  * Required for performance limits calculation.

--- a/firmware/config/boards/hellen/hellen64_miataNA6_94/board.h
+++ b/firmware/config/boards/hellen/hellen64_miataNA6_94/board.h
@@ -57,10 +57,6 @@
 #define STM32_LSECLK                32768U
 #endif
 
-#if !defined(STM32_HSECLK)
-#define STM32_HSECLK                8000000U
-#endif
-
 /*
  * Board voltages.
  * Required for performance limits calculation.

--- a/firmware/config/boards/hellen/hellen72/board.h
+++ b/firmware/config/boards/hellen/hellen72/board.h
@@ -57,10 +57,6 @@
 #define STM32_LSECLK                32768U
 #endif
 
-#if !defined(STM32_HSECLK)
-#define STM32_HSECLK                8000000U
-#endif
-
 /*
  * Board voltages.
  * Required for performance limits calculation.

--- a/firmware/config/boards/prometheus/board.h
+++ b/firmware/config/boards/prometheus/board.h
@@ -41,10 +41,6 @@
 #define STM32_LSECLK                32768U
 #endif
 
-#if !defined(STM32_HSECLK)
-#define STM32_HSECLK                8000000U
-#endif
-
 /*
  * Board voltages.
  * Required for performance limits calculation.

--- a/firmware/config/boards/subaru_eg33/board.h
+++ b/firmware/config/boards/subaru_eg33/board.h
@@ -28,10 +28,6 @@
 
 #define STM32_LSEDRV                (3U << 3U)
 
-#if !defined(STM32_HSECLK)
-#define STM32_HSECLK                25000000U
-#endif
-
 /*
  * Board voltages.
  * Required for performance limits calculation.

--- a/firmware/config/boards/subaru_eg33/mcuconf.h
+++ b/firmware/config/boards/subaru_eg33/mcuconf.h
@@ -11,10 +11,6 @@
 
 #include "../../../hw_layer/ports/stm32/stm32f7/cfg/mcuconf.h"
 
-/* clocks adjust for 25 MHz ocs */
-#undef STM32_PLLM_VALUE
-#define STM32_PLLM_VALUE				25
-
 //#undef STM32_LSE_ENABLED
 //#define STM32_LSE_ENABLED FALSE
 

--- a/firmware/hw_layer/ports/stm32/mcuconf_common_f4_f7.h
+++ b/firmware/hw_layer/ports/stm32/mcuconf_common_f4_f7.h
@@ -323,3 +323,12 @@
  * WDG driver system settings.
  */
 #define STM32_WDG_USE_IWDG                  FALSE
+
+
+extern unsigned char detected_hse_mhz;
+
+#define STM32_PLLM_VALUE 8
+
+#ifndef STM32_PLLM_VALUE
+#define STM32_PLLM_VALUE                    (detected_hse_mhz)
+#endif

--- a/firmware/hw_layer/ports/stm32/mcuconf_common_f4_f7.h
+++ b/firmware/hw_layer/ports/stm32/mcuconf_common_f4_f7.h
@@ -324,11 +324,14 @@
  */
 #define STM32_WDG_USE_IWDG                  FALSE
 
+// We auto detect the value of HSE, so set the default PLLM value to the maximum,
+// so we don't accidentially overclock to processor before we know how fast HSE is
+#define STM32_PLLM_VALUE 25
 
-extern unsigned char detected_hse_mhz;
+// This also means we have to pretend (for now) we have a 25MHz HSE fitted
+#define STM32_HSECLK 25000000
 
-#define STM32_PLLM_VALUE 8
+// After boot, we will detect the real frequency, and adjust the PLL M value to suit
 
-#ifndef STM32_PLLM_VALUE
-#define STM32_PLLM_VALUE                    (detected_hse_mhz)
-#endif
+#define ENABLE_AUTO_DETECT_HSE
+

--- a/firmware/hw_layer/ports/stm32/osc_detector.cpp
+++ b/firmware/hw_layer/ports/stm32/osc_detector.cpp
@@ -1,0 +1,90 @@
+
+#include "hal.h"
+
+unsigned char detected_hse_mhz;
+
+static void startClocksUseHsi() {
+	/* PWR clock enable.*/
+	RCC->APB1ENR = RCC_APB1ENR_PWREN;
+
+  /* PWR initialization.*/
+#if defined(STM32F4XX) || defined(__DOXYGEN__)
+	PWR->CR = STM32_VOS;
+#else
+	PWR->CR = 0;
+#endif
+
+	/* HSI setup, it enforces the reset situation in order to handle possible
+		problems with JTAG probes and re-initializations.*/
+	RCC->CR |= RCC_CR_HSION;                  /* Make sure HSI is ON.         */
+	while (!(RCC->CR & RCC_CR_HSIRDY))
+	;                                       /* Wait until HSI is stable.    */
+
+	/* HSI is selected as new source without touching the other fields in
+		CFGR. Clearing the register has to be postponed after HSI is the
+		new source.*/
+	RCC->CFGR &= ~RCC_CFGR_SW;                /* Reset SW, selecting HSI.     */
+	while ((RCC->CFGR & RCC_CFGR_SWS) != RCC_CFGR_SWS_HSI)
+	;                                       /* Wait until HSI is selected.  */
+
+	/* Registers finally cleared to reset values.*/
+	RCC->CR &= RCC_CR_HSITRIM | RCC_CR_HSION; /* CR Reset value.              */
+	RCC->CFGR = 0;                            /* CFGR reset value.            */
+
+	// Start LSI
+	RCC->CSR |= RCC_CSR_LSION;
+	while ((RCC->CSR & RCC_CSR_LSIRDY) == 0)
+		;                           /* Waits until LSI is stable.               */
+
+	// Start HSE
+	RCC->CR |= RCC_CR_HSEON;
+	while ((RCC->CR & RCC_CR_HSERDY) == 0)
+		;                           /* Waits until HSE is stable.               */
+}
+
+uint32_t getOneCapture() {
+	// wait for input capture
+	while ((TIM5->SR & TIM_SR_CC1IF) == 0);
+
+	// Return captured count
+	return TIM5->CCR1;
+}
+
+uint32_t getAverageLsiCounts() {
+	// Burn one count
+	getOneCapture();
+
+	uint32_t sum = 0;
+
+	for (size_t i = 0; i < 16; i++)
+	{
+		sum += getOneCapture();
+	}
+
+	return sum / 16;
+}
+
+extern "C" void __core_init() {
+	// Start clocks running, switch to use HSI
+	startClocksUseHsi();
+
+	// Turn on timer 5
+	RCC->APB1ENR |= RCC_APB1ENR_TIM5EN;
+
+	// Remap to connect LSI to input capture channel 4
+	TIM5->OR = TIM_OR_TI4_RMP;
+
+	// Start TIM5
+	TIM5->CR |= TIM_CR1_CEN;
+
+	auto hsiCounts = getAverageLsiCounts();
+
+	useHse();
+
+	auto hseCounts = getAverageLsiCounts();
+
+	// The external clocks's frequency is the ratio of the measured LSI speed, times HSI's speed (16MHz)
+	uint32_t internalClockMhz = 16 * hseCounts / hsiCounts;
+
+	
+}

--- a/firmware/hw_layer/ports/stm32/osc_detector.cpp
+++ b/firmware/hw_layer/ports/stm32/osc_detector.cpp
@@ -95,9 +95,9 @@ extern "C" void __late_init() {
 	auto hseCounts = getAverageLsiCounts();
 
 	// The external clocks's frequency is the ratio of the measured LSI speed, times HSI's speed (16MHz)
-	float internalClockMhz = 16.0f * hseCounts / hsiCounts;
+	float hseFrequencyMhz = 16.0f * hseCounts / hsiCounts;
 
-	uint8_t pllMValue = efiRound(internalClockMhz, 1);
+	uint8_t pllMValue = efiRound(hseFrequencyMhz, 1);
 
 	reprogramPll(pllMValue);
 }

--- a/firmware/hw_layer/ports/stm32/osc_detector.cpp
+++ b/firmware/hw_layer/ports/stm32/osc_detector.cpp
@@ -56,7 +56,7 @@ static_assert(STM32_HSE_ENABLED);
 
 static void reprogramPll(uint8_t pllM) {
 	// Switch back to HSI to configure PLL
-	useHsi()
+	useHsi();
 
 	// Stop the PLL
 	RCC->CR &= ~RCC_CR_PLLON;

--- a/firmware/hw_layer/ports/stm32/osc_detector.cpp
+++ b/firmware/hw_layer/ports/stm32/osc_detector.cpp
@@ -1,3 +1,18 @@
+/**
+ * @file	osc_detector.cpp
+ * @brief This logic automatically detects the speed of the
+ *        oscillator or crystal connected to HSE.
+ * @date 12 July 2021
+ * 
+ * It works by first using the reasonably-precise HSI oscillator (16MHz) to measure LSI (nominally 32khz, but wide tolerance).
+ * Then, it switches the system clock source to HSE, and repeats the same measurement.  The inaccurate LSI will not drift
+ * significantly in the short period of time between these two measurements, so use it as a transfer standard to compare the speed
+ * of HSI and HSE.  The ratio between the measured speed of LSI when running on HSE vs. HSI will give the ratio of speeds of HSE
+ * and HSI themselves.  Since we know the value of HSI (16mhz), we can compute the speed of HSE.
+ * 
+ * Lastly, the PLL is reconfigured to use the correct input divider such that the input frequency is 1MHz
+ * (PLLM is set to N for an N-MHz HSE crystal).
+ */
 
 #include "hal.h"
 #include "efilib.h"
@@ -75,6 +90,7 @@ static void reprogramPll(uint8_t pllM) {
 	usePll();
 }
 
+// __late_init runs after bss/zero initialziation, but before static constructors and main
 extern "C" void __late_init() {
 	// Turn on timer 5
 	RCC->APB1ENR |= RCC_APB1ENR_TIM5EN;

--- a/firmware/hw_layer/ports/stm32/osc_detector.cpp
+++ b/firmware/hw_layer/ports/stm32/osc_detector.cpp
@@ -14,7 +14,7 @@ static void useHse() {
 	RCC->CFGR |= RCC_CFGR_SW_HSE;
 }
 
-uint32_t getOneCapture() {
+static uint32_t getOneCapture() {
 	// wait for input capture
 	while ((TIM5->SR & TIM_SR_CC4IF) == 0);
 
@@ -22,7 +22,7 @@ uint32_t getOneCapture() {
 	return TIM5->CCR4;
 }
 
-uint32_t getAverageLsiCounts() {
+static uint32_t getAverageLsiCounts() {
 	// Burn one count
 	getOneCapture();
 
@@ -42,7 +42,12 @@ uint32_t getAverageLsiCounts() {
 // This only works if you're using the PLL as the configured clock source!
 static_assert(STM32_SW == RCC_CFGR_SW_PLL);
 
-void reprogramPll(uint8_t pllM) {
+// These clocks must all be enabled for this to work
+static_assert(STM32_HSI_ENABLED);
+static_assert(STM32_LSI_ENABLED);
+static_assert(STM32_HSE_ENABLED);
+
+static void reprogramPll(uint8_t pllM) {
 	// clear SW to use HSI
 	RCC->CFGR &= ~RCC_CFGR_SW;
 

--- a/firmware/hw_layer/ports/stm32/stm32_common.mk
+++ b/firmware/hw_layer/ports/stm32/stm32_common.mk
@@ -7,6 +7,7 @@ HW_LAYER_EMS_CPP += \
 	$(PROJECT_DIR)/hw_layer/ports/stm32/stm32_common.cpp \
 	$(PROJECT_DIR)/hw_layer/ports/stm32/backup_ram.cpp \
 	$(PROJECT_DIR)/hw_layer/ports/stm32/microsecond_timer_stm32.cpp \
+	$(PROJCET_DIR)/hw_layer/ports/stm32/osc_detector.cpp \
 
 RUSEFIASM = $(PROJECT_DIR)/hw_layer/ports/stm32/rusEfiStartup.S
 

--- a/firmware/hw_layer/ports/stm32/stm32_common.mk
+++ b/firmware/hw_layer/ports/stm32/stm32_common.mk
@@ -7,7 +7,7 @@ HW_LAYER_EMS_CPP += \
 	$(PROJECT_DIR)/hw_layer/ports/stm32/stm32_common.cpp \
 	$(PROJECT_DIR)/hw_layer/ports/stm32/backup_ram.cpp \
 	$(PROJECT_DIR)/hw_layer/ports/stm32/microsecond_timer_stm32.cpp \
-	$(PROJCET_DIR)/hw_layer/ports/stm32/osc_detector.cpp \
+	$(PROJECT_DIR)/hw_layer/ports/stm32/osc_detector.cpp \
 
 RUSEFIASM = $(PROJECT_DIR)/hw_layer/ports/stm32/rusEfiStartup.S
 

--- a/firmware/hw_layer/ports/stm32/stm32f4/board.h
+++ b/firmware/hw_layer/ports/stm32/stm32f4/board.h
@@ -56,10 +56,6 @@
 #define STM32_LSECLK                32768U
 #endif
 
-#if !defined(STM32_HSECLK)
-#define STM32_HSECLK                8000000U
-#endif
-
 /*
  * Board voltages.
  * Required for performance limits calculation.

--- a/firmware/hw_layer/ports/stm32/stm32f4/cfg/mcuconf.h
+++ b/firmware/hw_layer/ports/stm32/stm32f4/cfg/mcuconf.h
@@ -53,9 +53,6 @@
 #define STM32_SW                            STM32_SW_PLL
 #define STM32_PLLSRC                        STM32_PLLSRC_HSE
 
-#ifndef STM32_PLLM_VALUE
-#define STM32_PLLM_VALUE                    8
-#endif
 #define STM32_PLLN_VALUE                    336
 #define STM32_PLLP_VALUE                    2
 #define STM32_PLLQ_VALUE                    7

--- a/firmware/hw_layer/ports/stm32/stm32f7/board.h
+++ b/firmware/hw_layer/ports/stm32/stm32f7/board.h
@@ -58,10 +58,6 @@
 
 #define STM32_LSEDRV                (3U << 3U)
 
-#if !defined(STM32_HSECLK)
-#define STM32_HSECLK                8000000U
-#endif
-
 // Nucleo boards use MCO signal from St-Link and NOT oscillator - these need STM32_HSE_BYPASS
 // if you do not have Sl-Link and MCO on your board, you need EFI_USE_OSC
 

--- a/firmware/hw_layer/ports/stm32/stm32f7/cfg/mcuconf.h
+++ b/firmware/hw_layer/ports/stm32/stm32f7/cfg/mcuconf.h
@@ -73,7 +73,6 @@
 #define STM32_CLOCK48_REQUIRED              TRUE
 #define STM32_SW                            STM32_SW_PLL
 #define STM32_PLLSRC                        STM32_PLLSRC_HSE
-#define STM32_PLLM_VALUE                    8
 #define STM32_PLLN_VALUE                    432
 #define STM32_PLLP_VALUE                    2
 #define STM32_PLLQ_VALUE                    9


### PR DESCRIPTION
This allows for universal firmware that can detect any (integer mhz) external crystal frequency.