### PR TITLE
hotfix 2944: broken icon paths in rusefi_autoupdate

### DIFF
--- a/java_console/.idea/ant.xml
+++ b/java_console/.idea/ant.xml
@@ -2,8 +2,6 @@
 <project version="4">
   <component name="AntConfiguration">
     <buildFile url="file://$PROJECT_DIR$/build.xml">
-      <maximumHeapSize value="1024" />
-      <maximumStackSize value="256" />
       <executeOn event="beforeCompilation" target="before_IDEA_Build" />
     </buildFile>
   </component>

--- a/java_console/.idea/ant.xml
+++ b/java_console/.idea/ant.xml
@@ -2,6 +2,8 @@
 <project version="4">
   <component name="AntConfiguration">
     <buildFile url="file://$PROJECT_DIR$/build.xml">
+      <maximumHeapSize value="1024" />
+      <maximumStackSize value="256" />
       <executeOn event="beforeCompilation" target="before_IDEA_Build" />
     </buildFile>
   </component>


### PR DESCRIPTION
The problem was that none classloader of rusefi_autoupdate contains the path to `rusefi_console.jar` and URLClassLoader which is used to load `rusefi_console.jar` didn't embed in the classloaders hierarchy. Nevertheless, to load icons you use `getResource()` from `Class` this method just resolves resource name according to class package and consequently use its ClassLoader `getResource()` method. Eventually, the path to the `rusefi_console.jar` keeps nowhere after invoking the `Launcher.main` method. Thus, to solve this problem we should someway insert the path for `rusefi_console.jar`.

Solutions:
1. Insert jar's URL to system classloader using Reflection API
2. Embed classloader with jar's URL to the classloaders hierarchy. __Maybe impossible__
3. Use only our custom classloader with jar's URL to load icons. __Used in branch__

'Cause the `AutoupdateUtil.class.getResource()` was removing the leading slashes and I had no idea where these paths with slashes come from, I had to emulate this logic in my classloader.
