### PR TITLE
make tunerstudio_io_serial_ports happy with pch

### DIFF
--- a/firmware/config/boards/proteus/board.mk
+++ b/firmware/config/boards/proteus/board.mk
@@ -29,9 +29,7 @@ ifneq ($(PROJECT_CPU),ARCH_STM32H7)
 endif
 
 # disable hardware serial ports on H7
-ifeq ($(PROJECT_CPU),ARCH_STM32H7)
-	DDEFS += -DTS_NO_PRIMARY -DTS_NO_SECONDARY
-else
+ifeq ($(PROJECT_CPU),ARCH_STM32F4)
 	# Hardware serial port on UART 2 -> PD5/PD6
 	DDEFS += -DSTM32_UART_USE_USART2=TRUE
 	DDEFS += -DTS_PRIMARY_UART=UARTD2

--- a/firmware/config/stm32f7ems/efifeatures.h
+++ b/firmware/config/stm32f7ems/efifeatures.h
@@ -36,10 +36,9 @@
 #undef EFI_USE_UART_DMA
 #define EFI_USE_UART_DMA FALSE
 
-#undef TS_PRIMARY_UART
-#undef TS_SECONDARY_UART
-#undef TS_PRIMARY_SERIAL
-#undef TS_SECONDARY_SERIAL
+// UART driver not implemented on F7
+#define TS_NO_PRIMARY
+#define TS_NO_SECONDARY
 
 #define AUX_SERIAL_DEVICE (&SD6)
 

--- a/firmware/console/binary/tunerstudio_io.h
+++ b/firmware/console/binary/tunerstudio_io.h
@@ -9,6 +9,18 @@
 #pragma once
 #include "global.h"
 
+#if (!defined(TS_NO_PRIMARY) && (defined(TS_PRIMARY_UART) || defined(TS_PRIMARY_SERIAL)))
+	#define HAS_PRIMARY true
+#else
+	#define HAS_PRIMARY false
+#endif
+
+#if (!defined(TS_NO_SECONDARY) && (defined(TS_SECONDARY_UART) || defined(TS_SECONDARY_SERIAL)))
+	#define HAS_SECONDARY true
+#else
+	#define HAS_SECONDARY false
+#endif
+
 #if EFI_USB_SERIAL
 #include "usbconsole.h"
 #endif // EFI_USB_SERIAL

--- a/firmware/console/binary/tunerstudio_io_serial.cpp
+++ b/firmware/console/binary/tunerstudio_io_serial.cpp
@@ -4,6 +4,7 @@
 
 #include "tunerstudio_io.h"
 
+#if HAS_PRIMARY || HAS_PRIMARY
 #if HAL_USE_SERIAL
 void SerialTsChannel::start(uint32_t baud) {
 	SerialConfig cfg = {
@@ -64,3 +65,4 @@ size_t UartTsChannel::readTimeout(uint8_t* buffer, size_t size, int timeout) {
 	return size;
 }
 #endif // HAL_USE_UART
+#endif // HAS_PRIMARY || HAS_PRIMARY

--- a/firmware/console/binary/tunerstudio_io_serial_ports.cpp
+++ b/firmware/console/binary/tunerstudio_io_serial_ports.cpp
@@ -4,24 +4,12 @@
  * @date Mar 26, 2021
  */
 
-#include "engine.h"
+#include "pch.h"
 
 #if EFI_PROD_CODE || EFI_SIMULATOR
 #include "tunerstudio.h"
 #include "tunerstudio_io.h"
 #include "connector_uart_dma.h"
-
-#if (!defined(TS_NO_PRIMARY) && (defined(TS_PRIMARY_UART) || defined(TS_PRIMARY_SERIAL)))
-	#define HAS_PRIMARY true
-#else
-	#define HAS_PRIMARY false
-#endif
-
-#if (!defined(TS_NO_SECONDARY) && (defined(TS_SECONDARY_UART) || defined(TS_SECONDARY_SERIAL)))
-	#define HAS_SECONDARY true
-#else
-	#define HAS_SECONDARY false
-#endif
 
 #if HAS_PRIMARY
 	#ifdef TS_PRIMARY_UART


### PR DESCRIPTION
Needed some minor header adjustments to compile properly with pch.  This was compiling by luck before, and the failure now would still fail even if we just included one header instead of it being a proper pch.