### PR TITLE
instant rpm uses full engine cycle

### DIFF
--- a/firmware/controllers/engine_cycle/rpm_calculator.cpp
+++ b/firmware/controllers/engine_cycle/rpm_calculator.cpp
@@ -291,7 +291,7 @@ void rpmShaftPositionCallback(trigger_event_e ckpSignalType,
 #endif /* EFI_SENSOR_CHART */
 
 	// Always update instant RPM even when not spinning up
-	engine->triggerCentral.triggerState.updateInstantRpm(&engine->triggerCentral.triggerFormDetails, nowNt PASS_ENGINE_PARAMETER_SUFFIX);
+	engine->triggerCentral.triggerState.updateInstantRpm(&engine->triggerCentral.triggerFormDetails, index, nowNt PASS_ENGINE_PARAMETER_SUFFIX);
 
 	if (rpmState->isSpinningUp()) {
 		float instantRpm = engine->triggerCentral.triggerState.getInstantRpm();

--- a/firmware/controllers/trigger/trigger_decoder.h
+++ b/firmware/controllers/trigger/trigger_decoder.h
@@ -202,7 +202,7 @@ public:
 	void movePreSynchTimestamps(DECLARE_ENGINE_PARAMETER_SIGNATURE);
 
 #if EFI_ENGINE_CONTROL && EFI_SHAFT_POSITION_INPUT
-	void updateInstantRpm(TriggerFormDetails *triggerFormDetails, efitick_t nowNt DECLARE_ENGINE_PARAMETER_SUFFIX);
+	void updateInstantRpm(TriggerFormDetails *triggerFormDetails, uint32_t index, efitick_t nowNt DECLARE_ENGINE_PARAMETER_SUFFIX);
 #endif
 	/**
 	 * Update timeOfLastEvent[] on every trigger event - even without synchronization
@@ -211,7 +211,7 @@ public:
 	void setLastEventTimeForInstantRpm(efitick_t nowNt DECLARE_ENGINE_PARAMETER_SUFFIX);
 
 private:
-	float calculateInstantRpm(TriggerFormDetails *triggerFormDetails, efitick_t nowNt DECLARE_ENGINE_PARAMETER_SUFFIX);
+	float calculateInstantRpm(TriggerFormDetails *triggerFormDetails, uint32_t index, efitick_t nowNt DECLARE_ENGINE_PARAMETER_SUFFIX);
 
 	float m_instantRpm = 0;
 	float m_instantRpmRatio = 0;

--- a/unit_tests/tests/trigger/test_cam_vvt_input.cpp
+++ b/unit_tests/tests/trigger/test_cam_vvt_input.cpp
@@ -125,6 +125,7 @@ TEST(trigger, testNB2CamInput) {
 
 	// this crank trigger would be easier to test, crank shape is less important for this test
 	eth.setTriggerType(TT_ONE PASS_ENGINE_PARAMETER_SUFFIX);
+	engineConfiguration->isFasterEngineSpinUpEnabled = false;
 
 	engineConfiguration->useOnlyRisingEdgeForTrigger = true;
 


### PR DESCRIPTION
fix #3070 

The problem was that instant RPM was trying to use `currentCycle.current_index`, which doesn't account for trigger patterns that only cover part of the engine cycle (for example, a crank only trigger).

This looks much better now!

![image](https://user-images.githubusercontent.com/568254/127627087-e44a3a27-e773-4d56-95c3-a55251c74fee.png)

As a bonus, this probably helps #3015, since now symmetrical crank instant RPM /actually/ works, instead of only calculating on one tooth per cycle, which effectively broke instant RPM on symmetrical crank triggers.