### PR TITLE
don't "validate instant RPM"

### DIFF
--- a/firmware/controllers/engine_cycle/rpm_calculator.cpp
+++ b/firmware/controllers/engine_cycle/rpm_calculator.cpp
@@ -296,8 +296,6 @@ void rpmShaftPositionCallback(trigger_event_e ckpSignalType,
 	if (rpmState->isSpinningUp()) {
 		float instantRpm = engine->triggerCentral.triggerState.getInstantRpm();
 
-		// validate instant RPM - we shouldn't skip the cranking state
-		instantRpm = minF(instantRpm, CONFIG(cranking.rpm) - 1);
 		rpmState->assignRpmValue(instantRpm);
 #if 0
 		efiPrintf("** RPM: idx=%d sig=%d iRPM=%d", index, ckpSignalType, instantRpm);

--- a/unit_tests/tests/ignition_injection/injection_mode_transition.cpp
+++ b/unit_tests/tests/ignition_injection/injection_mode_transition.cpp
@@ -32,7 +32,7 @@ TEST(fuelControl, transitionIssue1592) {
 	ENGINE(tdcMarkEnabled) = false;
 	setupSimpleTestEngineWithMafAndTT_ONE_trigger(&eth, IM_SEQUENTIAL);
 
-	EXPECT_CALL(eth.mockAirmass, getAirmass(499))
+	EXPECT_CALL(eth.mockAirmass, getAirmass(500))
 		.WillRepeatedly(Return(AirmassResult{0.1008f, 50.0f}));
 
 	// This is easiest to trip on a wheel that requires sync
@@ -50,7 +50,7 @@ TEST(fuelControl, transitionIssue1592) {
 
 	// Yes, this is a ton of fuel but it makes the repro easier
 	engineConfiguration->cranking.baseFuel = 213.6;
-	engineConfiguration->cranking.rpm = 500;
+	engineConfiguration->cranking.rpm = 501;
 
 	// Test the transition from batch cranking to sequential running
 	engineConfiguration->crankingInjectionMode = IM_BATCH;
@@ -58,7 +58,7 @@ TEST(fuelControl, transitionIssue1592) {
 
 
 	// First sync point will schedule cranking pulse since we're in "faster spin up" mode
-	doRevolution(eth, 150);
+	doRevolution(eth, 240);
 
 	{
 		// Injector 2 should be scheduled to open then close

--- a/unit_tests/tests/trigger/test_fasterEngineSpinningUp.cpp
+++ b/unit_tests/tests/trigger/test_fasterEngineSpinningUp.cpp
@@ -108,14 +108,14 @@ static void doTestFasterEngineSpinningUp60_2(int startUpDelayMs, int rpm1, int e
 	// fire 30 tooth rise/fall signals
 	eth.fireTriggerEvents2(30 /* count */, 1 /*ms*/);
 	// now fire missed tooth rise/fall
-	eth.fireRise(4 /*ms*/);
-	EXPECT_EQ(rpm1, GET_RPM()) << "test RPM: After rise " + std::to_string(startUpDelayMs);
-	eth.fireFall(4 /*ms*/);
-	EXPECT_EQ(expectedRpm, GET_RPM()) << "test RPM: with " + std::to_string(startUpDelayMs) + " startUpDelayMs";
+	eth.fireRise(5 /*ms*/);
+	EXPECT_EQ(rpm1, GET_RPM()) << "test RPM: After rise " << std::to_string(startUpDelayMs);
+	eth.fireFall(1 /*ms*/);
+	EXPECT_EQ(expectedRpm, GET_RPM()) << "test RPM: with " << std::to_string(startUpDelayMs) << " startUpDelayMs";
 }
 
 TEST(cranking, testFasterEngineSpinningUp60_2) {
-	doTestFasterEngineSpinningUp60_2(0, 549, 549);
-	doTestFasterEngineSpinningUp60_2(100, 549, 549);
-	doTestFasterEngineSpinningUp60_2(1000, 549, 549);
+	doTestFasterEngineSpinningUp60_2(0, 1000, 1000);
+	doTestFasterEngineSpinningUp60_2(100, 1000, 1000);
+	doTestFasterEngineSpinningUp60_2(1000, 1000, 1000);
 }


### PR DESCRIPTION
Not much reason to do this - we don't make this check at all for non-instant RPM, so there isn't a reason to do it for instant RPM either.  It could actually hinder starting for an engine that starts quickly - it will give a wrong RPM reading if the engine kicks before a full cycle has completed, increasing engine speed past the cranking threshold before a full cycle (and "normal" RPM reading) is complete.  The wrong RPM will cause events to be scheduled late, possibly hindering engine start, as it means ignition timing will be (possibly significantly) retarded from the set value.