### PR TITLE
call handleShaftSignal

### DIFF
--- a/unit_tests/engine_test_helper.cpp
+++ b/unit_tests/engine_test_helper.cpp
@@ -174,7 +174,7 @@ void EngineTestHelper::firePrimaryTriggerRise() {
 	Engine *engine = &this->engine;
 	EXPAND_Engine;
 	LogTriggerTooth(SHAFT_PRIMARY_RISING, nowNt PASS_ENGINE_PARAMETER_SUFFIX);
-	engine->triggerCentral.handleShaftSignal(SHAFT_PRIMARY_RISING, nowNt PASS_ENGINE_PARAMETER_SUFFIX);
+	handleShaftSignal(0, true, nowNt PASS_ENGINE_PARAMETER_SUFFIX);
 }
 
 void EngineTestHelper::firePrimaryTriggerFall() {
@@ -182,7 +182,7 @@ void EngineTestHelper::firePrimaryTriggerFall() {
 	Engine *engine = &this->engine;
 	EXPAND_Engine;
 	LogTriggerTooth(SHAFT_PRIMARY_FALLING, nowNt PASS_ENGINE_PARAMETER_SUFFIX);
-	engine->triggerCentral.handleShaftSignal(SHAFT_PRIMARY_FALLING, nowNt PASS_ENGINE_PARAMETER_SUFFIX);
+	handleShaftSignal(0, false, nowNt PASS_ENGINE_PARAMETER_SUFFIX);
 }
 
 void EngineTestHelper::fireTriggerEventsWithDuration(float durationMs) {

--- a/unit_tests/tests/trigger/test_real_cranking_miata_na6.cpp
+++ b/unit_tests/tests/trigger/test_real_cranking_miata_na6.cpp
@@ -30,7 +30,7 @@ static void fireTriggerEvent(EngineTestHelper*eth, double timestampS, trigger_wh
 	EXPAND_Engine;
 	timeNowUs = 1'000'000 * timestampS;
 	printf("MIATANA: posting time=%d event=%d\n", timeNowUs, event);
-	engine->triggerCentral.handleShaftSignal(event, getTimeNowNt() PASS_ENGINE_PARAMETER_SUFFIX);
+	hwHandleShaftSignal((int)channel, !isFall, getTimeNowNt() PASS_ENGINE_PARAMETER_SUFFIX);
 }
 
 TEST(cranking, hardcodedRealCranking) {


### PR DESCRIPTION
call `handleShaftSignal` instead of `engine->triggerCentral.handleShaftSignal` in unit tests

fixes #3096