### PR TITLE
Unit tests for vehicle speed.cpp #3081

### DIFF
--- a/unit_tests/efifeatures.h
+++ b/unit_tests/efifeatures.h
@@ -76,5 +76,3 @@
 #define EFI_FUEL_PUMP TRUE
 
 #define EFI_LUA TRUE
-
-#define EFI_VEHICLE_SPEED TRUE

--- a/unit_tests/efifeatures.h
+++ b/unit_tests/efifeatures.h
@@ -76,3 +76,5 @@
 #define EFI_FUEL_PUMP TRUE
 
 #define EFI_LUA TRUE
+
+#define EFI_VEHICLE_SPEED TRUE

--- a/unit_tests/tests/test_vehicle_speed.cpp
+++ b/unit_tests/tests/test_vehicle_speed.cpp
@@ -42,7 +42,6 @@ TEST(VehicleSpeedSensor, testValidSpeedDetection) {
 
 	// Init global variables
 	CONFIG(vehicleSpeedSensorInputPin) = anyPin;
-	brain_pin_markUsed(anyPin, vehicleSpeedSensorMessage PASS_ENGINE_PARAMETER_SUFFIX);
 	engineConfiguration->vehicleSpeedCoef = 0.5f;
 
 	// Valid speed 15kmh should be returned
@@ -58,12 +57,13 @@ TEST(VehicleSpeedSensor, testInvalidSpeed) {
 
 	// Init global variables
 	CONFIG(vehicleSpeedSensorInputPin) = anyPin;
-	brain_pin_markUsed(anyPin, vehicleSpeedSensorMessage PASS_ENGINE_PARAMETER_SUFFIX);
 	engineConfiguration->vehicleSpeedCoef = 0.5f;
 
 	// Invalid (slow) interval, should return 0 speed
 	simulatePeriodicSignalForCallback(eth, 0.5f, vsCallback PASS_ENGINE_PARAMETER_SUFFIX);
 	float measuredSpeed = getVehicleSpeed(PASS_ENGINE_PARAMETER_SIGNATURE);
+
+	// Direct comparasion as invalid speed shoud return true zero
 	EXPECT_EQ(0.0f, measuredSpeed);
 }
 

--- a/unit_tests/tests/test_vehicle_speed.cpp
+++ b/unit_tests/tests/test_vehicle_speed.cpp
@@ -38,9 +38,9 @@ static void simulatePeriodicSignalForCallback(
 }
 
 TEST(VehicleSpeedSensor, testValidSpeedDetection) {
+	// Setup
+	setMockVehicleSpeed(-1);
 	WITH_ENGINE_TEST_HELPER(TEST_ENGINE);
-
-	// Init global variables
 	CONFIG(vehicleSpeedSensorInputPin) = anyPin;
 	engineConfiguration->vehicleSpeedCoef = 0.5f;
 
@@ -50,12 +50,14 @@ TEST(VehicleSpeedSensor, testValidSpeedDetection) {
 	float measuredSpeed = getVehicleSpeed(PASS_ENGINE_PARAMETER_SIGNATURE);
 	EXPECT_NEAR(15.0f, measuredSpeed, 0.01);
 
+	// Tear down
+	setMockVehicleSpeed(-1);
 }
 
 TEST(VehicleSpeedSensor, testInvalidSpeed) {
+	// Setup
+	setMockVehicleSpeed(-1);
 	WITH_ENGINE_TEST_HELPER(TEST_ENGINE);
-
-	// Init global variables
 	CONFIG(vehicleSpeedSensorInputPin) = anyPin;
 	engineConfiguration->vehicleSpeedCoef = 0.5f;
 
@@ -65,5 +67,8 @@ TEST(VehicleSpeedSensor, testInvalidSpeed) {
 
 	// Direct comparasion as invalid speed shoud return true zero
 	EXPECT_EQ(0.0f, measuredSpeed);
+
+	// Tear down
+	setMockVehicleSpeed(-1);
 }
 

--- a/unit_tests/tests/test_vehicle_speed.cpp
+++ b/unit_tests/tests/test_vehicle_speed.cpp
@@ -1,0 +1,73 @@
+#include "pch.h"
+
+#include "vehicle_speed.h"
+
+extern void vsCallback(DECLARE_ENGINE_PARAMETER_SIGNATURE);
+typedef void(*vss_callback_fp)(DECLARE_ENGINE_PARAMETER_SIGNATURE) ;
+
+/*
+ * 	Used to convert expected speed into simulation frequency
+ */
+static float speedToSimulationFrequency(float speedCoef, float speed)
+{
+	return speed/speedCoef;
+}
+
+/*
+ * 	Use engine test helper as time source,
+ * 	to simulate periodic signal on input pin with passed callback.
+ */
+static void simulatePeriodicSignalForCallback(
+	EngineTestHelper& eth,
+	float freqHz,
+	vss_callback_fp cb
+	DECLARE_ENGINE_PARAMETER_SUFFIX)
+{
+	constexpr auto periods = 50;
+	auto period = (1 / freqHz);
+
+	for (auto i = 0; i < periods; i++) {
+		cb(PASS_ENGINE_PARAMETER_SIGNATURE);
+		// Time rewind after the callback, due internal vehicle_speed.cpp logic
+		// (last signal time check for stop tracking)
+		eth.moveTimeForwardSec(period);
+	}
+
+}
+
+
+TEST(VehicleSpeedSensor, testValidSpeedDetection) {
+	WITH_ENGINE_TEST_HELPER(TEST_ENGINE);
+
+	constexpr float expectedSpeed = 15.0f;
+	constexpr float speedCoef = 0.5f;
+
+	// Init global variables
+	CONFIG(vehicleSpeedSensorInputPin) = GPIOA_0;
+	brain_pin_markUsed(GPIOA_0, "VSS" PASS_ENGINE_PARAMETER_SUFFIX);
+	engineConfiguration->vehicleSpeedCoef = speedCoef;
+
+	float freq = speedToSimulationFrequency(engineConfiguration->vehicleSpeedCoef, expectedSpeed);
+	simulatePeriodicSignalForCallback(eth, freq, vsCallback PASS_ENGINE_PARAMETER_SUFFIX);
+	float measuredSpeed = getVehicleSpeed(PASS_ENGINE_PARAMETER_SIGNATURE);
+	EXPECT_NEAR(expectedSpeed, measuredSpeed, 0.01);
+
+}
+
+TEST(VehicleSpeedSensor, testInvalidSpeed) {
+	WITH_ENGINE_TEST_HELPER(TEST_ENGINE);
+
+	constexpr float freq = 0.5f; // Invalid period > 1sec
+	constexpr float returnedOnInvalidFreq = 0.0f;
+	constexpr float speedCoef = 0.5f;
+
+	// Init global variables
+	CONFIG(vehicleSpeedSensorInputPin) = GPIOA_0;
+	brain_pin_markUsed(GPIOA_0, "VSS" PASS_ENGINE_PARAMETER_SUFFIX);
+	engineConfiguration->vehicleSpeedCoef = speedCoef;
+
+	simulatePeriodicSignalForCallback(eth, freq, vsCallback PASS_ENGINE_PARAMETER_SUFFIX);
+	float measuredSpeed = getVehicleSpeed(PASS_ENGINE_PARAMETER_SIGNATURE);
+	EXPECT_EQ(returnedOnInvalidFreq, measuredSpeed);
+}
+

--- a/unit_tests/tests/test_vehicle_speed.cpp
+++ b/unit_tests/tests/test_vehicle_speed.cpp
@@ -5,11 +5,13 @@
 extern void vsCallback(DECLARE_ENGINE_PARAMETER_SIGNATURE);
 typedef void(*vss_callback_fp)(DECLARE_ENGINE_PARAMETER_SIGNATURE) ;
 
+static constexpr brain_pin_e anyPin = GPIOA_0;
+static constexpr const char* const vehicleSpeedSensorMessage = "VSS";
+
 /*
  * 	Used to convert expected speed into simulation frequency
  */
-static float speedToSimulationFrequency(float speedCoef, float speed)
-{
+static float speedToSimulationFrequency(float speedCoef, float speed) {
 	return speed/speedCoef;
 }
 
@@ -35,7 +37,6 @@ static void simulatePeriodicSignalForCallback(
 
 }
 
-
 TEST(VehicleSpeedSensor, testValidSpeedDetection) {
 	WITH_ENGINE_TEST_HELPER(TEST_ENGINE);
 
@@ -43,8 +44,8 @@ TEST(VehicleSpeedSensor, testValidSpeedDetection) {
 	constexpr float speedCoef = 0.5f;
 
 	// Init global variables
-	CONFIG(vehicleSpeedSensorInputPin) = GPIOA_0;
-	brain_pin_markUsed(GPIOA_0, "VSS" PASS_ENGINE_PARAMETER_SUFFIX);
+	CONFIG(vehicleSpeedSensorInputPin) = anyPin;
+	brain_pin_markUsed(anyPin, vehicleSpeedSensorMessage PASS_ENGINE_PARAMETER_SUFFIX);
 	engineConfiguration->vehicleSpeedCoef = speedCoef;
 
 	float freq = speedToSimulationFrequency(engineConfiguration->vehicleSpeedCoef, expectedSpeed);
@@ -62,8 +63,8 @@ TEST(VehicleSpeedSensor, testInvalidSpeed) {
 	constexpr float speedCoef = 0.5f;
 
 	// Init global variables
-	CONFIG(vehicleSpeedSensorInputPin) = GPIOA_0;
-	brain_pin_markUsed(GPIOA_0, "VSS" PASS_ENGINE_PARAMETER_SUFFIX);
+	CONFIG(vehicleSpeedSensorInputPin) = anyPin;
+	brain_pin_markUsed(anyPin, vehicleSpeedSensorMessage PASS_ENGINE_PARAMETER_SUFFIX);
 	engineConfiguration->vehicleSpeedCoef = speedCoef;
 
 	simulatePeriodicSignalForCallback(eth, freq, vsCallback PASS_ENGINE_PARAMETER_SUFFIX);

--- a/unit_tests/tests/test_vehicle_speed.cpp
+++ b/unit_tests/tests/test_vehicle_speed.cpp
@@ -40,35 +40,30 @@ static void simulatePeriodicSignalForCallback(
 TEST(VehicleSpeedSensor, testValidSpeedDetection) {
 	WITH_ENGINE_TEST_HELPER(TEST_ENGINE);
 
-	constexpr float expectedSpeed = 15.0f;
-	constexpr float speedCoef = 0.5f;
-
 	// Init global variables
 	CONFIG(vehicleSpeedSensorInputPin) = anyPin;
 	brain_pin_markUsed(anyPin, vehicleSpeedSensorMessage PASS_ENGINE_PARAMETER_SUFFIX);
-	engineConfiguration->vehicleSpeedCoef = speedCoef;
+	engineConfiguration->vehicleSpeedCoef = 0.5f;
 
-	float freq = speedToSimulationFrequency(engineConfiguration->vehicleSpeedCoef, expectedSpeed);
+	// Valid speed 15kmh should be returned
+	float freq = speedToSimulationFrequency(engineConfiguration->vehicleSpeedCoef, 15.0f);
 	simulatePeriodicSignalForCallback(eth, freq, vsCallback PASS_ENGINE_PARAMETER_SUFFIX);
 	float measuredSpeed = getVehicleSpeed(PASS_ENGINE_PARAMETER_SIGNATURE);
-	EXPECT_NEAR(expectedSpeed, measuredSpeed, 0.01);
+	EXPECT_NEAR(15.0f, measuredSpeed, 0.01);
 
 }
 
 TEST(VehicleSpeedSensor, testInvalidSpeed) {
 	WITH_ENGINE_TEST_HELPER(TEST_ENGINE);
 
-	constexpr float freq = 0.5f; // Invalid period > 1sec
-	constexpr float returnedOnInvalidFreq = 0.0f;
-	constexpr float speedCoef = 0.5f;
-
 	// Init global variables
 	CONFIG(vehicleSpeedSensorInputPin) = anyPin;
 	brain_pin_markUsed(anyPin, vehicleSpeedSensorMessage PASS_ENGINE_PARAMETER_SUFFIX);
-	engineConfiguration->vehicleSpeedCoef = speedCoef;
+	engineConfiguration->vehicleSpeedCoef = 0.5f;
 
-	simulatePeriodicSignalForCallback(eth, freq, vsCallback PASS_ENGINE_PARAMETER_SUFFIX);
+	// Invalid (slow) interval, should return 0 speed
+	simulatePeriodicSignalForCallback(eth, 0.5f, vsCallback PASS_ENGINE_PARAMETER_SUFFIX);
 	float measuredSpeed = getVehicleSpeed(PASS_ENGINE_PARAMETER_SIGNATURE);
-	EXPECT_EQ(returnedOnInvalidFreq, measuredSpeed);
+	EXPECT_EQ(0.0f, measuredSpeed);
 }
 

--- a/unit_tests/tests/tests.mk
+++ b/unit_tests/tests/tests.mk
@@ -86,4 +86,5 @@ TESTS_SRC_CPP = \
 	tests/trigger/test_all_triggers.cpp \
 	tests/test_stepper.cpp \
 	tests/sensor/test_frequency_sensor.cpp \
+	tests/sensor/test_vehicle_speed.cpp \
 


### PR DESCRIPTION
I has found, what wrapping 
`
	CONFIG(vehicleSpeedSensorInputPin) = GPIOA_0;
	brain_pin_markUsed(GPIOA_0, "VSS" PASS_ENGINE_PARAMETER_SUFFIX);
	engineConfiguration->vehicleSpeedCoef = speedCoef;
`
into function causes big mess and tons of parameters, so i just copy-paste it.

Idk why `brain_pin_markUsed()` dont works, and vehicleSpeed still has `NOT_ASSIGNED`, so i used direct 'CONFIG(vehicleSpeedSensorInputPin) = GPIOA_0;' too.