### PR TITLE
Fix cranking->idling taper phase for useSeparate*ForIdle tables

### DIFF
--- a/firmware/controllers/actuators/idle_thread.cpp
+++ b/firmware/controllers/actuators/idle_thread.cpp
@@ -188,7 +188,7 @@ IIdleController::Phase IdleController::determinePhase(int rpm, int targetRpm, Se
 
 	// If still in the cranking taper, disable closed loop idle
 	if (crankingTaperFraction < 1) {
-		return Phase::CrankToRunTaper;
+		return Phase::CrankToIdleTaper;
 	}
 
 	// No other conditions met, we are idling!

--- a/firmware/controllers/actuators/idle_thread.cpp
+++ b/firmware/controllers/actuators/idle_thread.cpp
@@ -507,8 +507,8 @@ float getIdleTimingAdjustment(int rpm) {
 	return idleControllerInstance.getIdleTimingAdjustment(rpm);
 }
 
-bool isIdling() {
-	return idleControllerInstance.isIdling();
+bool isIdlingOrTaper() {
+	return idleControllerInstance.isIdlingOrTaper();
 }
 
 static void applyPidSettings(DECLARE_ENGINE_PARAMETER_SIGNATURE) {

--- a/firmware/controllers/actuators/idle_thread.h
+++ b/firmware/controllers/actuators/idle_thread.h
@@ -18,7 +18,7 @@ struct IIdleController {
 		Cranking,	// Below cranking threshold
 		Idling,		// Below idle RPM, off throttle
 		Coasting,	// Off throttle but above idle RPM
-		CrankToRunTaper, // Taper between cranking and running
+		CrankToIdleTaper, // Taper between cranking and idling
 		Running,	// On throttle
 	};
 

--- a/firmware/controllers/actuators/idle_thread.h
+++ b/firmware/controllers/actuators/idle_thread.h
@@ -59,8 +59,8 @@ public:
 	float getClosedLoop(IIdleController::Phase phase, float tpsPos, int rpm, int targetRpm) override;
 
 	// Allow querying state from outside
-	bool isIdling() {
-		return m_lastPhase == Phase::Idling;
+	bool isIdlingOrTaper() {
+		return m_lastPhase == Phase::Idling || m_lastPhase == Phase::CrankToIdleTaper;
 	}
 
 private:
@@ -79,7 +79,7 @@ percent_t getIdlePosition();
 
 float getIdleTimingAdjustment(int rpm);
 
-bool isIdling();
+bool isIdlingOrTaper();
 
 void applyIACposition(percent_t position DECLARE_ENGINE_PARAMETER_SUFFIX);
 void setManualIdleValvePosition(int positionPercent);

--- a/firmware/controllers/algo/advance_map.cpp
+++ b/firmware/controllers/algo/advance_map.cpp
@@ -50,7 +50,7 @@ static angle_t getRunningAdvance(int rpm, float engineLoad DECLARE_ENGINE_PARAME
 	float advanceAngle = advanceMap.getValue((float) rpm, engineLoad);
 
 	// get advance from the separate table for Idle
-	if (CONFIG(useSeparateAdvanceForIdle) && isIdling()) {
+	if (CONFIG(useSeparateAdvanceForIdle) && isIdlingOrTaper()) {
 		float idleAdvance = interpolate2d(rpm, config->idleAdvanceBins, config->idleAdvance);
 
 		auto [valid, tps] = Sensor::get(SensorType::DriverThrottleIntent);

--- a/firmware/controllers/algo/airmass/airmass.cpp
+++ b/firmware/controllers/algo/airmass/airmass.cpp
@@ -24,7 +24,7 @@ float AirmassVeModelBase::getVe(int rpm, float load) const {
 
 	auto tps = Sensor::get(SensorType::Tps1);
 	// get VE from the separate table for Idle if idling
-	if (isIdling() && tps && CONFIG(useSeparateVeForIdle)) {
+	if (isIdlingOrTaper() && tps && CONFIG(useSeparateVeForIdle)) {
 		float idleVe = interpolate2d(rpm, config->idleVeBins, config->idleVe);
 		// interpolate between idle table and normal (running) table using TPS threshold
 		ve = interpolateClamped(0.0f, idleVe, CONFIG(idlePidDeactivationTpsThreshold), ve, tps.Value);


### PR DESCRIPTION
Currently useSeparateAdvanceForIdle and useSeparateVeForIdle are broken because of https://github.com/rusefi/rusefi/pull/2900

We fix it by changing the isIdling() method's behavior. This method is used only by useSeparateAdvanceForIdle & useSeparateVeForIdle. And it doesn't know about "CrankToRunTaper" phase. The solution is that CrankToRunTaper should be actually CrankToIdleTaper, because Running phase has higher priority by TPS threshold, and it overrides the taper according to determinePhase(). So there is no transition from cranking to running. There is cranking to idling transition. And therefore isIdling() should return true for CrankToIdleTaper as well.
