### PR TITLE
allow removal from event queue

### DIFF
--- a/firmware/controllers/system/timer/event_queue.h
+++ b/firmware/controllers/system/timer/event_queue.h
@@ -50,6 +50,7 @@ public:
 	 * O(size) - linear search in sorted linked list
 	 */
 	bool insertTask(scheduling_s *scheduling, efitime_t timeX, action_s action);
+	void remove(scheduling_s* scheduling);
 
 	int executeAll(efitime_t now);
 	bool executeOne(efitime_t now);


### PR DESCRIPTION
#3071 and #3196 

With the ability to remove, we can pre-schedule the coil firing, then remove it later once we know precise timing, preventing hung coils in case of trigger loss.