### PR TITLE
init the timer before we try to use it

### DIFF
--- a/firmware/controllers/system/periodic_task.h
+++ b/firmware/controllers/system/periodic_task.h
@@ -36,7 +36,10 @@ public:
 	 * This invokes PeriodicTask() immediately and starts the cycle of invocations and sleeps
 	 */
 	virtual void Start() {
+#if !EFI_UNIT_TEST
 		chVTObjectInit(&timer);
+#endif // EFI_UNIT_TEST
+
 		runAndScheduleNext(this);
 	}
 };


### PR DESCRIPTION
fixes the crash-on-start introduced by #3195 