### PR TITLE
Rusefi input fixes: make some tables more frienly looking

### DIFF
--- a/firmware/tunerstudio/rusefi.input
+++ b/firmware/tunerstudio/rusefi.input
@@ -753,14 +753,14 @@ enable2ndByteCanID = false
 	curve = cltIdleRPMCurve, "Idle Target RPM"
       columnLabel = "Coolant", "RPM"
       xAxis       = -40, 120, 9
-      yAxis       =  0, 8000, 9
+      yAxis       = 0, 2400, 13
       xBins       = cltIdleRpmBins, coolant
       yBins       = cltIdleRpm, RPMValue
       gauge       = CLTGauge
 
 	curve = idleAdvanceCurve, "Idle Advance Angle"
       columnLabel = "RPM", "degrees"
-      xAxis       = 0, 8000, 9
+      xAxis       = 0, 2400, 13
       yAxis       = -100, 100, 11
       xBins       = idleAdvanceBins, RPMValue
       yBins       = idleAdvance
@@ -768,7 +768,7 @@ enable2ndByteCanID = false
 
 	curve = idleVeCurve, "Idle VE"
       columnLabel = "RPM", "%"
-      xAxis       = 0, 8000, 9
+      xAxis       = 0, 2400, 13
       yAxis       = 0, 250, 11
       xBins       = idleVeBins, RPMValue
       yBins       = idleVe
@@ -780,7 +780,7 @@ enable2ndByteCanID = false
     
 	curve = crankingAdvanceCurve, "Cranking Advance Angle"
       columnLabel = "RPM", "degrees"
-      xAxis       = 0, 8000, 9
+      xAxis       = 0, 2400, 13
       yAxis       = -100, 100, 11
       xBins       = crankingAdvanceBins, RPMValue
       yBins       = crankingAdvance

--- a/firmware/tunerstudio/rusefi.input
+++ b/firmware/tunerstudio/rusefi.input
@@ -753,23 +753,23 @@ enable2ndByteCanID = false
 	curve = cltIdleRPMCurve, "Idle Target RPM"
       columnLabel = "Coolant", "RPM"
       xAxis       = -40, 120, 9
-      yAxis       =  0, 8000, 10
+      yAxis       =  0, 8000, 9
       xBins       = cltIdleRpmBins, coolant
       yBins       = cltIdleRpm, RPMValue
       gauge       = CLTGauge
 
 	curve = idleAdvanceCurve, "Idle Advance Angle"
       columnLabel = "RPM", "degrees"
-      xAxis       = 0, 8000, 10
-      yAxis       = -100, 100, 10
+      xAxis       = 0, 8000, 9
+      yAxis       = -100, 100, 11
       xBins       = idleAdvanceBins, RPMValue
       yBins       = idleAdvance
       gauge       = RPMGauge
 
 	curve = idleVeCurve, "Idle VE"
       columnLabel = "RPM", "%"
-      xAxis       = 0, 8000, 10
-      yAxis       = 0, 250, 10
+      xAxis       = 0, 8000, 9
+      yAxis       = 0, 250, 11
       xBins       = idleVeBins, RPMValue
       yBins       = idleVe
 #if LAMBDA
@@ -780,8 +780,8 @@ enable2ndByteCanID = false
     
 	curve = crankingAdvanceCurve, "Cranking Advance Angle"
       columnLabel = "RPM", "degrees"
-      xAxis       = 0, 8000, 10
-      yAxis       = -100, 100, 10
+      xAxis       = 0, 8000, 9
+      yAxis       = -100, 100, 11
       xBins       = crankingAdvanceBins, RPMValue
       yBins       = crankingAdvance
       gauge       = RPMGauge


### PR DESCRIPTION
From this:
![Screenshot from 2021-09-01 20-47-31](https://user-images.githubusercontent.com/28624689/131726679-9e322a9a-c3f9-4eaa-a0a1-12e9be3eaff1.png)
To this:
![Screenshot from 2021-09-01 21-45-21](https://user-images.githubusercontent.com/28624689/131726786-55cacb78-0267-4d92-a38b-53d56ef4afbf.png)
Same for few other Idle and Crank related tables.