### PR TITLE
Turbo sensor

### DIFF
--- a/firmware/controllers/sensors/converters/turbocharger_speed_converter.h
+++ b/firmware/controllers/sensors/converters/turbocharger_speed_converter.h
@@ -10,8 +10,10 @@ public:
 	DECLARE_ENGINE_PTR;
 
 	SensorResult convert(float frequency) const override {
-		auto speed = frequency * engineConfiguration->turboSpeedSensorMultiplier;
-		return speed;
+		auto hz = frequency * engineConfiguration->turboSpeedSensorMultiplier;
+
+		auto rpm = hz * 60;
+
+		return rpm;
 	}
 };
-

--- a/firmware/controllers/sensors/frequency_sensor.cpp
+++ b/firmware/controllers/sensors/frequency_sensor.cpp
@@ -14,12 +14,12 @@ static void freqSensorExtiCallback(void* arg) {
 	inst->onEdge(getTimeNowNt());
 }
 
-void FrequencySensor::init(brain_pin_e pin, const char* const msg) {
+void FrequencySensor::init(brain_pin_e pin) {
 	m_pin = pin;
 
 #if EFI_PROD_CODE
 	// todo: refactor https://github.com/rusefi/rusefi/issues/2123
-	efiExtiEnablePin(msg, pin, 
+	efiExtiEnablePin(getSensorName(), pin, 
 		PAL_EVENT_MODE_FALLING_EDGE,
 		freqSensorExtiCallback, reinterpret_cast<void*>(this));
 #endif // EFI_PROD_CODE

--- a/firmware/controllers/sensors/frequency_sensor.h
+++ b/firmware/controllers/sensors/frequency_sensor.h
@@ -6,7 +6,7 @@ public:
 	FrequencySensor(SensorType type, efitick_t timeoutPeriod)
 		: FunctionalSensor(type, timeoutPeriod) { }
 
-	void init(brain_pin_e pin, const char* const msg);
+	void init(brain_pin_e pin);
 	void deInit();
 
 	void onEdge(efitick_t nowNt);

--- a/firmware/controllers/sensors/sensor.cpp
+++ b/firmware/controllers/sensors/sensor.cpp
@@ -51,6 +51,8 @@ static const char* const s_sensorNames[] = {
 	"Aux 4",
 
 	"Vehicle speed",
+
+	"Turbo speed",
 };
 
 // This struct represents one sensor in the registry.

--- a/firmware/controllers/sensors/sensor_type.h
+++ b/firmware/controllers/sensors/sensor_type.h
@@ -75,6 +75,8 @@ enum class SensorType : unsigned char {
 
 	VehicleSpeed = 34,
 
+	TurbochargerSpeed = 35,
+
 	// Leave me at the end!
-	PlaceholderLast = 35,
+	PlaceholderLast = 36,
 };

--- a/firmware/init/sensor/init_flex.cpp
+++ b/firmware/init/sensor/init_flex.cpp
@@ -18,7 +18,7 @@ void initFlexSensor(DECLARE_CONFIG_PARAMETER_SIGNATURE) {
 	}
 
 	flexSensor.setFunction(converter);
-	flexSensor.init(pin, "flex");
+	flexSensor.init(pin);
 	flexSensor.Register();
 }
 

--- a/firmware/init/sensor/init_turbocharger_speed_sensor.cpp
+++ b/firmware/init/sensor/init_turbocharger_speed_sensor.cpp
@@ -4,7 +4,7 @@
 #include "frequency_sensor.h"
 #include "turbocharger_speed_converter.h"
 
-static FrequencySensor turbochargerSpeedSensor(SensorType::VehicleSpeed, MS2NT(500));
+static FrequencySensor turbochargerSpeedSensor(SensorType::TurbochargerSpeed, MS2NT(500));
 static TurbochargerSpeedConverter turbochargerSpeedConverter;
 
 
@@ -19,7 +19,7 @@ void initTurbochargerSpeedSensor(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 	}
 
 	turbochargerSpeedSensor.setFunction(turbochargerSpeedConverter);
-	turbochargerSpeedSensor.init(pin, "tcss");
+	turbochargerSpeedSensor.init(pin);
 	turbochargerSpeedSensor.Register();
 }
 

--- a/firmware/init/sensor/init_vehicle_speed_sensor.cpp
+++ b/firmware/init/sensor/init_vehicle_speed_sensor.cpp
@@ -7,7 +7,6 @@
 static FrequencySensor vehicleSpeedSensor(SensorType::VehicleSpeed, MS2NT(500));
 static VehicleSpeedConverter vehicleSpeedConverter;
 
-
 void initVehicleSpeedSensor(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 	INJECT_ENGINE_REFERENCE(&vehicleSpeedConverter);
 
@@ -19,7 +18,7 @@ void initVehicleSpeedSensor(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 	}
 
 	vehicleSpeedSensor.setFunction(vehicleSpeedConverter);
-	vehicleSpeedSensor.init(pin, "vss");
+	vehicleSpeedSensor.init(pin);
 	vehicleSpeedSensor.Register();
 }
 

--- a/unit_tests/tests/sensor/test_frequency_sensor.cpp
+++ b/unit_tests/tests/sensor/test_frequency_sensor.cpp
@@ -22,7 +22,7 @@ public:
 	void SetUp() override {
 		// If somehow prodcode will be unwrapped for test it MAYBE! will fire with error.
 		// At least we must init FlexSensor somehow
-		dut.init(GPIO_INVALID, "Test");
+		dut.init(GPIO_INVALID);
 		dut.setFunction(identityFunc);
 	}
 

--- a/unit_tests/tests/sensor/test_turbocharger_speed_converter.cpp
+++ b/unit_tests/tests/sensor/test_turbocharger_speed_converter.cpp
@@ -22,7 +22,7 @@ public:
 	}
 
 	float GetFrequencyBySpeedAndCoef(float speed, float coef) {
-		return (speed / coef);
+		return (speed / coef) / 60;
 	}
 
 	void TestForSpeedWithCoef(float expectedSpeed, float coef)


### PR DESCRIPTION
- add sensor type for turbo speed
- output rpm instead of hz
- `FrequencySensor::init` doesn't need msg param, just ask the sensor what it's called

#3243 