### PR TITLE
Rusefi input cosmetics

### DIFF
--- a/firmware/tunerstudio/rusefi.input
+++ b/firmware/tunerstudio/rusefi.input
@@ -1019,8 +1019,8 @@ gaugeCategory = Debug
 
 gaugeCategory = Sensors - Basic
    RPMGauge          = RPMValue,           "RPM - engine speed",       "RPM",       0,   {rpmHardLimit + 2000},     200,    {cranking_rpm},    {rpmHardLimit - 500},  {rpmHardLimit},   0,   0
-   CLTGauge          = coolant,       "Coolant temp",        "deg C",      -40,    140,     -15,      1,      95,   110,   1,   1
-   IATGauge          = intake,     "Intake air temp",        "deg C",      -40,    140,     -15,      1,      95,   110,   1,   1
+   CLTGauge          = coolant,       "Coolant temp",        "C",      -40,    140,     -15,      1,      95,   110,   1,   1
+   IATGauge          = intake,     "Intake air temp",        "C",      -40,    140,     -15,      1,      95,   110,   1,   1
    afr1Gauge         = AFRValue, @@GAUGE_NAME_AFR@@,          "",       10,   19.4,      12,     13,      15,    16,   2,   2
    afr2Gauge         = AFRValue2, @@GAUGE_NAME_AFR2@@,        "",       10,   19.4,      12,     13,      15,    16,   2,   2
    lambda1Gauge      = lambdaValue, @@GAUGE_NAME_LAMBDA@@,    "",       0.65,   1.2,      0.7,     0.75,      1.1,    1.15,   3,   2
@@ -1043,8 +1043,8 @@ gaugeCategory = Sensors - Extra 1
    internalMcuTemperatureGauge = internalMcuTemperature, @@GAUGE_NAME_ECU_TEMPERATURE@@, "C",     0,   100,     0,    0,    75,  100,   0,   0
    OilPressGauge   	 = oilPressure,   @@GAUGE_NAME_OIL_PRESSURE@@,       @@GAUGE_NAME_OIL_PRESSURE_UNITS@@,        0,    750,      35,     75,     550,   700,   0,   0	
    idleAirValvePositionGauge = idleAirValvePosition, "Idle position", "%",     0,   100,     0,    0,    100,  100,   1,   1
-   AuxT1Gauge        = auxt1,     @@GAUGE_NAME_AUX_TEMP1@@,        "deg C",      -40,    140,     -15,      1,      95,   110,   1,   1
-   AuxT2Gauge        = auxt2,     @@GAUGE_NAME_AUX_TEMP2@@,        "deg C",      -40,    140,     -15,      1,      95,   110,   1,   1
+   AuxT1Gauge        = auxt1,     @@GAUGE_NAME_AUX_TEMP1@@,        "C",      -40,    140,     -15,      1,      95,   110,   1,   1
+   AuxT2Gauge        = auxt2,     @@GAUGE_NAME_AUX_TEMP2@@,        "C",      -40,    140,     -15,      1,      95,   110,   1,   1
    lowFuelPressureGauge = lowFuelPressure, @@GAUGE_NAME_FUEL_PRESSURE_LOW@@, @@GAUGE_NAME_FUEL_PRESSURE_LOW_UNITS@@, 0, 700, 0, 0, 700, 700, 1, 0
    highFuelPressureGauge = highFuelPressure, @@GAUGE_NAME_FUEL_PRESSURE_HIGH@@, @@GAUGE_NAME_FUEL_PRESSURE_HIGH_UNITS@@, 0, 200, 0, 0, 200, 200, 1, 0
    flexPercentGauge = flexPercent, @@GAUGE_NAME_FLEX@@, "%", 0, 100, 0, 0, 100, 100, 0, 0
@@ -1065,7 +1065,7 @@ gaugeCategory = Acceleration Enrichment
 
 gaugeCategory = Fueling
    ;Name               Var            Title                 Units        Lo      Hi      LoD    LoW       HiW   HiD    vd  ld
-   tChargeGauge          = tCharge,     @@GAUGE_NAME_FUEL_CHARGE_TEMP@@,        "deg C",      -40,    140,     -15,      1,      95,   110,   1,   1
+   tChargeGauge          = tCharge,     @@GAUGE_NAME_FUEL_CHARGE_TEMP@@,        "C",      -40,    140,     -15,      1,      95,   110,   1,   1
    baroCorrectionGauge  = baroCorrection,@@GAUGE_NAME_FUEL_BARO_CORR@@,           "ratio",        0.5,    1.5,      0.6,     0.7,     1.3,   1.4,   1,   1
    crankingFuelGauge = crankingFuelMs,   @@GAUGE_NAME_FUEL_CRANKING@@,      "mg",        0,   100,     0, 0,      100,    100,   3, 1
    iatCorrectionGauge = iatCorrection, @@GAUGE_NAME_FUEL_IAT_CORR@@, "mult",     0,   3,     0,    0,    3,  3,   2,   2

--- a/firmware/tunerstudio/rusefi.input
+++ b/firmware/tunerstudio/rusefi.input
@@ -1018,7 +1018,7 @@ gaugeCategory = Debug
 
 
 gaugeCategory = Sensors - Basic
-   RPMGauge        = RPMValue,           "RPM - engine speed",       "RPM",       0,   15000,     200,    500,    6000,  6000,   0,   0
+   RPMGauge          = RPMValue,           "RPM - engine speed",       "RPM",       0,   {rpmHardLimit + 2000},     200,    {cranking_rpm},    {rpmHardLimit - 500},  {rpmHardLimit},   0,   0
    CLTGauge          = coolant,       "Coolant temp",        "deg C",      -40,    140,     -15,      1,      95,   110,   1,   1
    IATGauge          = intake,     "Intake air temp",        "deg C",      -40,    140,     -15,      1,      95,   110,   1,   1
    afr1Gauge         = AFRValue, @@GAUGE_NAME_AFR@@,          "",       10,   19.4,      12,     13,      15,    16,   2,   2


### PR DESCRIPTION
rusefi.input: adjust RPM gauge limits
- Low red zone - up to 200
- Low yellow zone - up to Cranking RPM limit
- High yellow zone - from (RPM Hard Limit - 500)
- High red zone - from RPM Hard limit and up to (RPM Hard limit + 2000)

rusefi.input: "deg C" -> "C" on all gauges 