### PR TITLE
dead code in map avg

### DIFF
--- a/firmware/controllers/engine_cycle/map_averaging.cpp
+++ b/firmware/controllers/engine_cycle/map_averaging.cpp
@@ -149,8 +149,7 @@ void mapAveragingAdcCallback(adcsample_t adcValue) {
 }
 #endif
 
-static void endAveraging(void *arg) {
-	(void) arg;
+static void endAveraging(void*) {
 #if ! EFI_UNIT_TEST
 	chibios_rt::CriticalSectionLocker csl;
 #endif

--- a/firmware/controllers/engine_cycle/map_averaging.cpp
+++ b/firmware/controllers/engine_cycle/map_averaging.cpp
@@ -51,14 +51,6 @@ static volatile int measurementsPerRevolutionCounter = 0;
 static volatile int measurementsPerRevolution = 0;
 
 /**
- * In this lock-free implementation 'readIndex' is always pointing
- * to the consistent copy of accumulator and counter pair
- */
-static int readIndex = 0;
-static float accumulators[2];
-static int counters[2];
-
-/**
  * Running MAP accumulator - sum of all measurements within averaging window
  */
 static volatile float mapAdcAccumulator = 0;
@@ -148,18 +140,6 @@ void mapAveragingAdcCallback(adcsample_t adcValue) {
 	}
 #endif /* EFI_SENSOR_CHART */
 
-	/**
-	 * Local copy is now safe, but it's an overkill: we only
-	 * have one writing thread anyway
-	 */
-	int readIndexLocal = readIndex;
-	int writeIndex = readIndexLocal ^ 1;
-	accumulators[writeIndex] = accumulators[readIndexLocal] + adcValue;
-	counters[writeIndex] = counters[readIndexLocal] + 1;
-	// this would commit the new pair of values
-	readIndex = writeIndex;
-
-	// todo: migrate to the lock-free implementation
 	{
 		// with locking we will have a consistent state
 		chibios_rt::CriticalSectionLocker csl;


### PR DESCRIPTION
Not sure what this was for, but it wasn't doing anything.  Looks like an attempt at a lock-free implementation, but lock free isn't necessary here.  There's so little work to do under lock that the overhead is negligible.