### PR TITLE
dead mock iat/clt

### DIFF
--- a/firmware/controllers/engine_controller.cpp
+++ b/firmware/controllers/engine_controller.cpp
@@ -111,18 +111,6 @@ void initDataStructures(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 #endif // EFI_ENGINE_CONTROL
 }
 
-#if EFI_ENABLE_MOCK_ADC
-
-static void initMockVoltage(void) {
-#if EFI_SIMULATOR
-	setMockCltVoltage(2);
-	setMockIatVoltage(2);
-#endif /* EFI_SIMULATOR */
-}
-
-#endif /* EFI_ENABLE_MOCK_ADC */
-
-
 #if !EFI_UNIT_TEST
 
 static void doPeriodicSlowCallback(DECLARE_ENGINE_PARAMETER_SIGNATURE);
@@ -518,11 +506,6 @@ void commonInitEngineController(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 	 */
 	prepareShapes(PASS_ENGINE_PARAMETER_SIGNATURE);
 #endif /* EFI_PROD_CODE && EFI_ENGINE_CONTROL */
-
-
-#if EFI_ENABLE_MOCK_ADC
-	initMockVoltage();
-#endif /* EFI_ENABLE_MOCK_ADC */
 
 #if EFI_SENSOR_CHART
 	initSensorChart();

--- a/firmware/controllers/engine_controller.h
+++ b/firmware/controllers/engine_controller.h
@@ -26,7 +26,5 @@ void setMockVoltage(int hwChannel, float voltage DECLARE_ENGINE_PARAMETER_SUFFIX
 void setMockMapVoltage(float voltage DECLARE_ENGINE_PARAMETER_SUFFIX);
 void setMockAfrVoltage(float voltage DECLARE_ENGINE_PARAMETER_SUFFIX);
 void setMockMafVoltage(float voltage DECLARE_ENGINE_PARAMETER_SUFFIX);
-void setMockIatVoltage(float voltage DECLARE_ENGINE_PARAMETER_SUFFIX);
-void setMockCltVoltage(float voltage DECLARE_ENGINE_PARAMETER_SUFFIX);
 
 void printCurrentState(Logging *logging, int seconds, const char *engineTypeName, const char *firmwareBuildId);

--- a/firmware/controllers/engine_controller_misc.cpp
+++ b/firmware/controllers/engine_controller_misc.cpp
@@ -41,14 +41,6 @@ void setMockVoltage(int hwChannel, float voltage DECLARE_ENGINE_PARAMETER_SUFFIX
 	engine->engineState.mockAdcState.setMockVoltage(hwChannel, voltage PASS_ENGINE_PARAMETER_SUFFIX);
 }
 
-void setMockCltVoltage(float voltage DECLARE_ENGINE_PARAMETER_SUFFIX) {
-	setMockVoltage(engineConfiguration->clt.adcChannel, voltage PASS_ENGINE_PARAMETER_SUFFIX);
-}
-
-void setMockIatVoltage(float voltage DECLARE_ENGINE_PARAMETER_SUFFIX) {
-	setMockVoltage(engineConfiguration->iat.adcChannel, voltage PASS_ENGINE_PARAMETER_SUFFIX);
-}
-
 void setMockMafVoltage(float voltage DECLARE_ENGINE_PARAMETER_SUFFIX) {
 	setMockVoltage(engineConfiguration->mafAdcChannel, voltage PASS_ENGINE_PARAMETER_SUFFIX);
 }

--- a/firmware/controllers/settings.cpp
+++ b/firmware/controllers/settings.cpp
@@ -1025,11 +1025,9 @@ struct command_f_s {
 const command_f_s commandsF[] = {
 #if EFI_ENGINE_CONTROL
 #if EFI_ENABLE_MOCK_ADC
-		{MOCK_IAT_COMMAND, setMockIatVoltage},
 		{MOCK_MAF_COMMAND, setMockMafVoltage},
 		{MOCK_AFR_COMMAND, setMockAfrVoltage},
 		{MOCK_MAP_COMMAND, setMockMapVoltage},
-		{MOCK_CLT_COMMAND, setMockCltVoltage},
 #endif // EFI_ENABLE_MOCK_ADC
 		{"injection_offset", setInjectionOffset},
 		{"global_trigger_offset_angle", setGlobalTriggerAngleOffset},

--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -1729,8 +1729,6 @@ float[FSIO_TABLE_8] fsioTable4RpmBins;RPM is float and not integer in order to u
 
 end_struct
 
-#define MOCK_IAT_COMMAND "mock_iat_voltage"
-#define MOCK_CLT_COMMAND "mock_clt_voltage"
 #define MOCK_MAP_COMMAND "mock_map_voltage"
 #define MOCK_AFR_COMMAND "mock_afr_voltage"
 #define MOCK_MAF_COMMAND "mock_maf_voltage"


### PR DESCRIPTION
Dead mock setters for iat/clt. Superceded long ago by just setting the mock sensor value itself.