### PR TITLE
reduce updateTunerStudioState stack usage

### DIFF
--- a/firmware/console/status_loop.cpp
+++ b/firmware/console/status_loop.cpp
@@ -648,7 +648,9 @@ static void updateFlags() {
 	tsOutputChannels.clutchDownState = engine->clutchDownState;
 	tsOutputChannels.brakePedalState = engine->brakePedalState;
 
+#if EFI_PROD_CODE
 	tsOutputChannels.isTriggerError = isTriggerErrorNow();
+#endif // EFI_PROD_CODE
 
 #if EFI_INTERNAL_FLASH
 	tsOutputChannels.needBurn = getNeedToWriteConfiguration();


### PR DESCRIPTION
`updateTunerStudioState` uses a ton of stack on unoptimized builds, since it doesn't reuse stack space for multiple different locals/scratch work unless you enable optimization.  It will, however, reuse the same stack space if the work is being done by different functions!

When optimization is enabled, this change has almost no impact - all these new functions get inlined, and the stack space reused so very little is used in that case either way.

helps #3302 