### PR TITLE
shrink multi cylinder map average buffer

### DIFF
--- a/firmware/controllers/engine_cycle/map_averaging.cpp
+++ b/firmware/controllers/engine_cycle/map_averaging.cpp
@@ -64,8 +64,8 @@ static volatile int mapMeasurementsCounter = 0;
  */
 static float v_averagedMapValue;
 
-// allow a bit more smoothing
-#define MAX_MAP_BUFFER_LENGTH (MAX_CYLINDER_COUNT * 2)
+// allow smoothing up to number of cylinders
+#define MAX_MAP_BUFFER_LENGTH (MAX_CYLINDER_COUNT)
 // in MAP units, not voltage!
 static float averagedMapRunningBuffer[MAX_MAP_BUFFER_LENGTH];
 int mapMinBufferLength = 0;

--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -948,7 +948,7 @@ custom uart_device_e 1 bits, U08, @OFFSET@, [0:1], "Off", "UART1", "UART2", "UAR
 	output_pin_e secondSolenoidPin;Some Subaru and some Mazda use double-solenoid idle air valve
 	switch_input_pin_e startStopButtonPin;See also starterControlPin
 	
-	int mapMinBufferLength;;"count", 1, 0, 0, 24, 0
+	int mapMinBufferLength;+This many MAP samples are used to estimate the current MAP. This many samples are considered, and the minimum taken. Recommended value is 1 for single-throttle engines, and your number of cylinders for individual throttle bodies.;"count", 1, 0, 1, 24, 0
 	int16_t idlePidDeactivationTpsThreshold;+Below this throttle position, the engine is considered idling.;"%", 1, 0, 0, 50, 0
 	int16_t stepperParkingExtraSteps;;"%", 1, 0, 0, 3000, 0
 	uint16_t tps1SecondaryMin;;"ADC", 1, 0, 0, 1000, 0

--- a/firmware/tunerstudio/rusefi.input
+++ b/firmware/tunerstudio/rusefi.input
@@ -2563,7 +2563,7 @@ cmd_set_engine_type_default					= "@@TS_IO_TEST_COMMAND_char@@\x00\x31\x00\x00"
 		field = "High value threshold",					mapErrorDetectionTooHigh
 		field = ""
 		field = "Measure Map Only In One Cylinder",		measureMapOnlyInOneCylinder
-		field = "Minimum MAP samples",					mapMinBufferLength
+		field = "Cylinder count to sample MAP",					mapMinBufferLength
 
 	dialog = mapSettings, "", yAxis
 		panel = mapCommon


### PR DESCRIPTION
discussion in #3309, saves 48 bytes of precious memory