### PR TITLE
add getOrZero

### DIFF
--- a/firmware/console/status_loop.cpp
+++ b/firmware/console/status_loop.cpp
@@ -357,7 +357,7 @@ class CommunicationBlinkingTask : public PeriodicTimerController {
 	void PeriodicTask() override {
 		counter++;
 
-		bool lowVBatt = Sensor::get(SensorType::BatteryVoltage).value_or(0) < LOW_VBATT;
+		bool lowVBatt = Sensor::getOrZero(SensorType::BatteryVoltage) < LOW_VBATT;
 
 		if (counter == 1) {
 			// first invocation of BlinkingTask
@@ -493,11 +493,11 @@ static void updateThrottles() {
 }
 
 static void updateLambda() {
-	float lambdaValue = Sensor::get(SensorType::Lambda1).value_or(0);
+	float lambdaValue = Sensor::getOrZero(SensorType::Lambda1);
 	tsOutputChannels.lambda = lambdaValue;
 	tsOutputChannels.airFuelRatio = lambdaValue * ENGINE(engineState.stoichiometricRatio);
 
-	float lambda2Value = Sensor::get(SensorType::Lambda2).value_or(0);
+	float lambda2Value = Sensor::getOrZero(SensorType::Lambda2);
 	tsOutputChannels.lambda2 = lambda2Value;
 	tsOutputChannels.airFuelRatio2 = lambda2Value * ENGINE(engineState.stoichiometricRatio);
 }
@@ -510,7 +510,7 @@ static void updateFuelSensors() {
 
 	tsOutputChannels.flexPercent = Sensor::get(SensorType::FuelEthanolPercent).Value;
 
-	tsOutputChannels.fuelTankLevel = Sensor::get(SensorType::FuelLevel).value_or(0);
+	tsOutputChannels.fuelTankLevel = Sensor::getOrZero(SensorType::FuelLevel);
 }
 
 static void updateVvtSensors() {
@@ -525,7 +525,7 @@ static void updateVvtSensors() {
 
 static void updateVehicleSpeed(int rpm) {
 #if EFI_VEHICLE_SPEED
-	float vehicleSpeed = Sensor::get(SensorType::VehicleSpeed).value_or(0);
+	float vehicleSpeed = Sensor::getOrZero(SensorType::VehicleSpeed);
 	tsOutputChannels.vehicleSpeedKph = vehicleSpeed;
 	tsOutputChannels.speedToRpmRatio = vehicleSpeed / rpm;
 #endif /* EFI_VEHICLE_SPEED */
@@ -557,15 +557,15 @@ static void updateSensors(int rpm) {
 	updateVvtSensors();
 	updateVehicleSpeed(rpm);
 
-	tsOutputChannels.vBatt = Sensor::get(SensorType::BatteryVoltage).value_or(0);
-	tsOutputChannels.baroPressure = Sensor::get(SensorType::BarometricPressure).value_or(0);
-	tsOutputChannels.manifoldAirPressure = Sensor::get(SensorType::Map).value_or(0);
+	tsOutputChannels.vBatt = Sensor::getOrZero(SensorType::BatteryVoltage);
+	tsOutputChannels.baroPressure = Sensor::getOrZero(SensorType::BarometricPressure);
+	tsOutputChannels.manifoldAirPressure = Sensor::getOrZero(SensorType::Map);
 
 	tsOutputChannels.oilPressure = Sensor::get(SensorType::OilPressure).Value;
 
-	tsOutputChannels.idlePositionSensor = Sensor::get(SensorType::IdlePosition).value_or(0);
+	tsOutputChannels.idlePositionSensor = Sensor::getOrZero(SensorType::IdlePosition);
 
-	tsOutputChannels.wastegatePosition = Sensor::get(SensorType::WastegatePosition).value_or(0);
+	tsOutputChannels.wastegatePosition = Sensor::getOrZero(SensorType::WastegatePosition);
 
 #if	HAL_USE_ADC
 	tsOutputChannels.internalMcuTemperature = getMCUInternalTemperature();
@@ -661,16 +661,16 @@ static void updateFlags() {
 // see https://github.com/rusefi/rusefi/issues/3302 and linked tickets
 static void updateTpsDebug() {
 	// TPS 1 pri/sec split
-	tsOutputChannels.debugFloatField1 = Sensor::get(SensorType::Tps1Primary).value_or(0) - Sensor::get(SensorType::Tps1Secondary).value_or(0);
+	tsOutputChannels.debugFloatField1 = Sensor::getOrZero(SensorType::Tps1Primary) - Sensor::getOrZero(SensorType::Tps1Secondary);
 	// TPS 2 pri/sec split
-	tsOutputChannels.debugFloatField2 = Sensor::get(SensorType::Tps2Primary).value_or(0) - Sensor::get(SensorType::Tps2Secondary).value_or(0);
+	tsOutputChannels.debugFloatField2 = Sensor::getOrZero(SensorType::Tps2Primary) - Sensor::getOrZero(SensorType::Tps2Secondary);
 	// TPS1 - TPS2 split
-	tsOutputChannels.debugFloatField3 = Sensor::get(SensorType::Tps1).value_or(0) - Sensor::get(SensorType::Tps2).value_or(0);
+	tsOutputChannels.debugFloatField3 = Sensor::getOrZero(SensorType::Tps1) - Sensor::getOrZero(SensorType::Tps2);
 	// Pedal pri/sec split
-	tsOutputChannels.debugFloatField4 = Sensor::get(SensorType::AcceleratorPedalPrimary).value_or(0) - Sensor::get(SensorType::AcceleratorPedalSecondary).value_or(0);
+	tsOutputChannels.debugFloatField4 = Sensor::getOrZero(SensorType::AcceleratorPedalPrimary) - Sensor::getOrZero(SensorType::AcceleratorPedalSecondary);
 
 	// TPS 1 pri/sec ratio - useful for ford ETB that has partial-range second channel
-	tsOutputChannels.debugFloatField5 = 100 * Sensor::get(SensorType::Tps1Primary).value_or(0) / Sensor::get(SensorType::Tps1Secondary).value_or(0);
+	tsOutputChannels.debugFloatField5 = 100 * Sensor::getOrZero(SensorType::Tps1Primary) / Sensor::getOrZero(SensorType::Tps1Secondary);
 }
 
 void updateTunerStudioState(TunerStudioOutputChannels *tsOutputChannels DECLARE_ENGINE_PARAMETER_SUFFIX) {
@@ -744,7 +744,7 @@ void updateTunerStudioState(TunerStudioOutputChannels *tsOutputChannels DECLARE_
 
 	tsOutputChannels->tpsAccelFuel = engine->engineState.tpsAccelEnrich;
 
-	tsOutputChannels->engineLoadAccelExtra = engine->engineLoadAccelEnrichment.getEngineLoadEnrichment(PASS_ENGINE_PARAMETER_SIGNATURE) * 100 / Sensor::get(SensorType::Map).value_or(0);
+	tsOutputChannels->engineLoadAccelExtra = engine->engineLoadAccelEnrichment.getEngineLoadEnrichment(PASS_ENGINE_PARAMETER_SIGNATURE) * 100 / Sensor::getOrZero(SensorType::Map);
 
 	tsOutputChannels->engineLoadDelta = engine->engineLoadAccelEnrichment.getMaxDelta();
 

--- a/firmware/controllers/actuators/ac_control.cpp
+++ b/firmware/controllers/actuators/ac_control.cpp
@@ -9,7 +9,7 @@ static Deadband<5> maxCltDeadband;
 static Deadband<5> maxTpsDeadband;
 
 static bool getAcState(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
-	auto rpm = Sensor::get(SensorType::Rpm).value_or(0);
+	auto rpm = Sensor::getOrZero(SensorType::Rpm);
 
 	// Engine too slow, disable
 	if (rpm < 500) {
@@ -42,7 +42,7 @@ static bool getAcState(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 	// TPS too high, disable
 	auto maxTps = CONFIG(maxAcTps);
 	if (maxTps != 0) {
-		auto tps = Sensor::get(SensorType::Tps1).value_or(0);
+		auto tps = Sensor::getOrZero(SensorType::Tps1);
 
 		if (maxTpsDeadband.gt(maxTps, tps)) {
 			return false;

--- a/firmware/controllers/actuators/alternator_controller.cpp
+++ b/firmware/controllers/actuators/alternator_controller.cpp
@@ -115,7 +115,7 @@ void showAltInfo(void) {
 			engineConfiguration->alternatorControl.periodMs);
 	efiPrintf("p=%.2f/i=%.2f/d=%.2f offset=%.2f", engineConfiguration->alternatorControl.pFactor,
 			0, 0, engineConfiguration->alternatorControl.offset); // todo: i & d
-	efiPrintf("vbatt=%.2f/duty=%.2f/target=%.2f", Sensor::get(SensorType::BatteryVoltage).value_or(0), currentAltDuty,
+	efiPrintf("vbatt=%.2f/duty=%.2f/target=%.2f", Sensor::getOrZero(SensorType::BatteryVoltage), currentAltDuty,
 			engineConfiguration->targetVBatt);
 }
 

--- a/firmware/controllers/actuators/electronic_throttle.cpp
+++ b/firmware/controllers/actuators/electronic_throttle.cpp
@@ -715,7 +715,7 @@ static void showEthInfo(void) {
 	efiPrintf("etbAutoTune=%d",
 			engine->etbAutoTune);
 
-	efiPrintf("TPS=%.2f", Sensor::get(SensorType::Tps1).value_or(0));
+	efiPrintf("TPS=%.2f", Sensor::getOrZero(SensorType::Tps1));
 
 
 	efiPrintf("etbControlPin=%s duty=%.2f freq=%d",

--- a/firmware/controllers/actuators/idle_thread.cpp
+++ b/firmware/controllers/actuators/idle_thread.cpp
@@ -418,7 +418,7 @@ float IdleController::getClosedLoop(IIdleController::Phase phase, float tpsPos, 
 
 
 		// On failed sensor, use 0 deg C - should give a safe highish idle
-		float clt = Sensor::get(SensorType::Clt).value_or(0);
+		float clt = Sensor::getOrZero(SensorType::Clt);
 		auto tps = Sensor::get(SensorType::DriverThrottleIntent);
 
 		float rpm;
@@ -436,7 +436,7 @@ float IdleController::getClosedLoop(IIdleController::Phase phase, float tpsPos, 
 		float crankingTaper = getCrankingTaperFraction();
 
 		// Determine what operation phase we're in - idling or not
-		float vehicleSpeed = Sensor::get(SensorType::VehicleSpeed).value_or(0);
+		float vehicleSpeed = Sensor::getOrZero(SensorType::VehicleSpeed);
 		auto phase = determinePhase(rpm, targetRpm, tps, vehicleSpeed, crankingTaper);
 		m_lastPhase = phase;
 

--- a/firmware/controllers/algo/airmass/airmass.cpp
+++ b/firmware/controllers/algo/airmass/airmass.cpp
@@ -8,8 +8,8 @@ AirmassVeModelBase::AirmassVeModelBase(const ValueProvider3D& veTable) : m_veTab
 float AirmassVeModelBase::getVeLoadAxis(float passedLoad) const {
 	switch(CONFIG(veOverrideMode)) {
 		case VE_None: return passedLoad;
-		case VE_MAP: return Sensor::get(SensorType::Map).value_or(0);
-		case VE_TPS: return Sensor::get(SensorType::Tps1).value_or(0);
+		case VE_MAP: return Sensor::getOrZero(SensorType::Map);
+		case VE_TPS: return Sensor::getOrZero(SensorType::Tps1);
 		default: return 0;
 	}
 }

--- a/firmware/controllers/algo/airmass/maf_airmass.cpp
+++ b/firmware/controllers/algo/airmass/maf_airmass.cpp
@@ -3,7 +3,7 @@
 #include "maf.h"
 
 AirmassResult MafAirmass::getAirmass(int rpm) {
-	float maf = Sensor::get(SensorType::Maf).value_or(0) + engine->engineLoadAccelEnrichment.getEngineLoadEnrichment(PASS_ENGINE_PARAMETER_SIGNATURE);
+	float maf = Sensor::getOrZero(SensorType::Maf) + engine->engineLoadAccelEnrichment.getEngineLoadEnrichment(PASS_ENGINE_PARAMETER_SIGNATURE);
 	return getAirmassImpl(maf, rpm);
 }
 

--- a/firmware/controllers/algo/airmass/speed_density_airmass.cpp
+++ b/firmware/controllers/algo/airmass/speed_density_airmass.cpp
@@ -42,7 +42,7 @@ float SpeedDensityAirmass::getMap(int rpm) const {
 	float fallbackMap;
 	if (CONFIG(enableMapEstimationTableFallback)) {
 		// if the map estimation table is enabled, estimate map based on the TPS and RPM
-		fallbackMap = m_mapEstimationTable->getValue(rpm, TPS_2_BYTE_PACKING_MULT * Sensor::get(SensorType::Tps1).value_or(0));
+		fallbackMap = m_mapEstimationTable->getValue(rpm, TPS_2_BYTE_PACKING_MULT * Sensor::getOrZero(SensorType::Tps1));
 	} else {
 		fallbackMap = CONFIG(failedMapFallback);
 	}

--- a/firmware/controllers/algo/dynoview.cpp
+++ b/firmware/controllers/algo/dynoview.cpp
@@ -17,7 +17,7 @@ void DynoView::update(vssSrc src) {
     efitimeus_t timeNow, deltaTime = 0.0;
     float speed,deltaSpeed = 0.0;
     timeNow = getTimeNowUs();
-    speed = Sensor::get(SensorType::VehicleSpeed).value_or(0);
+    speed = Sensor::getOrZero(SensorType::VehicleSpeed);
     if (src == ICU) {
         speed = efiRound(speed,1.0);
     } else {

--- a/firmware/controllers/algo/engine.cpp
+++ b/firmware/controllers/algo/engine.cpp
@@ -185,7 +185,7 @@ static void cylinderCleanupControl(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 #if EFI_ENGINE_CONTROL
 	bool newValue;
 	if (engineConfiguration->isCylinderCleanupEnabled) {
-		newValue = !engine->rpmCalculator.isRunning() && Sensor::get(SensorType::DriverThrottleIntent).value_or(0) > CLEANUP_MODE_TPS;
+		newValue = !engine->rpmCalculator.isRunning() && Sensor::getOrZero(SensorType::DriverThrottleIntent) > CLEANUP_MODE_TPS;
 	} else {
 		newValue = false;
 	}

--- a/firmware/controllers/algo/engine2.cpp
+++ b/firmware/controllers/algo/engine2.cpp
@@ -222,7 +222,7 @@ void StartupFuelPumping::setPumpsCounter(int newValue) {
 
 void StartupFuelPumping::update(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 	if (GET_RPM() == 0) {
-		bool isTpsAbove50 = Sensor::get(SensorType::DriverThrottleIntent).value_or(0) >= 50;
+		bool isTpsAbove50 = Sensor::getOrZero(SensorType::DriverThrottleIntent) >= 50;
 
 		if (this->isTpsAbove50 != isTpsAbove50) {
 			setPumpsCounter(pumpsCounter + 1);

--- a/firmware/controllers/algo/launch_control.cpp
+++ b/firmware/controllers/algo/launch_control.cpp
@@ -54,7 +54,7 @@ bool LaunchControlBase::isInsideSwitchCondition() const {
  * then we have to return true, and trust that we would disable by other condition!
  */ 
 bool LaunchControlBase::isInsideSpeedCondition() const {
-	int speed = Sensor::get(SensorType::VehicleSpeed).value_or(0);
+	int speed = Sensor::getOrZero(SensorType::VehicleSpeed);
 	
 	return (CONFIG(launchSpeedTreshold) > speed) || (!(CONFIG(launchActivationMode) ==  ALWAYS_ACTIVE_LAUNCH));
 }

--- a/firmware/controllers/can/can_dash.cpp
+++ b/firmware/controllers/can/can_dash.cpp
@@ -156,7 +156,7 @@ void canDashboardBMW(CanCycle cycle) {
 
 		{
 			CanTxMessage msg(CAN_BMW_E46_DME2);
-			msg.setShortValue((int) ((Sensor::get(SensorType::Clt).value_or(0) + 48.373) / 0.75), 1);
+			msg.setShortValue((int) ((Sensor::getOrZero(SensorType::Clt) + 48.373) / 0.75), 1);
 		}
 	}
 }
@@ -172,7 +172,7 @@ void canMazdaRX8(CanCycle cycle) {
 		{
 			CanTxMessage msg(CAN_MAZDA_RX_RPM_SPEED);
 
-			float kph = Sensor::get(SensorType::VehicleSpeed).value_or(0);
+			float kph = Sensor::getOrZero(SensorType::VehicleSpeed);
 
 			msg.setShortValue(SWAP_UINT16(GET_RPM() * 4), 0);
 			msg.setShortValue(0xFFFF, 2);
@@ -223,7 +223,7 @@ void canDashboardFiat(CanCycle cycle) {
 		{
 			//Fiat Dashboard
 			CanTxMessage msg(CAN_FIAT_MOTOR_INFO);
-			msg.setShortValue((int) (Sensor::get(SensorType::Clt).value_or(0) - 40), 3); //Coolant Temp
+			msg.setShortValue((int) (Sensor::getOrZero(SensorType::Clt) - 40), 3); //Coolant Temp
 			msg.setShortValue(GET_RPM() / 32, 6); //RPM
 		}
 	}
@@ -237,7 +237,7 @@ void canDashboardVAG(CanCycle cycle) {
 			msg.setShortValue(GET_RPM() * 4, 2); //RPM
 		}
 
-		float clt = Sensor::get(SensorType::Clt).value_or(0);
+		float clt = Sensor::getOrZero(SensorType::Clt);
 
 		{
 			CanTxMessage msg(CAN_VAG_CLT);
@@ -275,7 +275,7 @@ void canDashboardW202(CanCycle cycle) {
 	if (cycle.isInterval(CI::_100ms)) {
 		{
 			CanTxMessage msg(W202_STAT_2); //dlc 7
-			msg[0] = (int)(Sensor::get(SensorType::Clt).value_or(0) + 40); // CLT -40 offset
+			msg[0] = (int)(Sensor::getOrZero(SensorType::Clt) + 40); // CLT -40 offset
 			msg[1] = 0x3D; // TBD
 			msg[2] = 0x63; // Const
 			msg[3] = 0x41; // Const
@@ -325,7 +325,7 @@ void canDashboardGenesisCoupe(CanCycle cycle) {
 		}
 		{
 			CanTxMessage msg(GENESIS_COUPLE_COOLANT_329, 8);
-			int clt = Sensor::get(SensorType::Clt).value_or(0) * 2;
+			int clt = Sensor::getOrZero(SensorType::Clt) * 2;
 			msg[1] = clt;
 		}
 	}
@@ -344,7 +344,7 @@ void canDashboardNissanVQ(CanCycle cycle) {
 		{
 			CanTxMessage msg(NISSAN_CLT_551, 8);
 
-			int clt = Sensor::get(SensorType::Clt).value_or(0);
+			int clt = Sensor::getOrZero(SensorType::Clt);
 			msg[0] = clt + 45;
 		}
 
@@ -356,7 +356,7 @@ void canDashboardNissanVQ(CanCycle cycle) {
 			const uint8_t magicByte[4] = {0x03, 0x23, 0x42, 0x63};
 
 			msg[0] = magicByte[rollingId];
-			msg[1] = (int)(Sensor::get(SensorType::AcceleratorPedal).value_or(0) * 255 / 100);
+			msg[1] = (int)(Sensor::getOrZero(SensorType::AcceleratorPedal) * 255 / 100);
 
 			// thank you "102 CAN Communication decoded"
 #define CAN_23D_RPM_MULT 3.15
@@ -424,8 +424,8 @@ void canDashboardBMWE90(CanCycle cycle)
 			if (tmp_cnt >= 0x0F)
 				tmp_cnt = 0x00;
 			CanTxMessage msg(E90_TEMP, 8);
-			msg[0] = (int)(Sensor::get(SensorType::Clt).value_or(0) + e90_temp_offset); //coolant
-			msg[1] = (int)(Sensor::get(SensorType::AuxTemp1).value_or(0) + e90_temp_offset); //oil (AuxTemp1)
+			msg[0] = (int)(Sensor::getOrZero(SensorType::Clt) + e90_temp_offset); //coolant
+			msg[1] = (int)(Sensor::getOrZero(SensorType::AuxTemp1) + e90_temp_offset); //oil (AuxTemp1)
 			msg[2] = tmp_cnt;
 			msg[3] = 0xC8;
 			msg[4] = 0xA7;
@@ -497,7 +497,7 @@ void canDashboardBMWE90(CanCycle cycle)
 		}
 
 		{ //E90_SPEED
-			auto vehicleSpeed = Sensor::get(SensorType::VehicleSpeed).value_or(0); 
+			auto vehicleSpeed = Sensor::getOrZero(SensorType::VehicleSpeed); 
 			float mph = vehicleSpeed * 0.6213712;
 			mph_ctr = ((TIME_I2MS(chVTGetSystemTime()) - mph_timer) / 50);
 			mph_a = (mph_ctr * mph / 2);
@@ -550,11 +550,11 @@ void canDashboardHaltech(CanCycle cycle) {
 			msg[0] = (tmp >> 8);
 			msg[1] = (tmp & 0x00ff);
 			/* MAP */
-			tmp = (((uint16_t)(Sensor::get(SensorType::Map).value_or(0))) * 10); 
+			tmp = (((uint16_t)(Sensor::getOrZero(SensorType::Map))) * 10); 
 			msg[2] = (tmp >> 8);
 			msg[3] = (tmp & 0x00ff);
 			/* TPS  y = x/10 */
-			tmp = (uint16_t)((float)(Sensor::get(SensorType::Tps1).value_or(0)) * 10);
+			tmp = (uint16_t)((float)(Sensor::getOrZero(SensorType::Tps1)) * 10);
 			msg[4] = (tmp >> 8);
 			msg[5] = (tmp & 0x00ff);
 			/* Coolant pressure */
@@ -566,15 +566,15 @@ void canDashboardHaltech(CanCycle cycle) {
 		{ 
 			CanTxMessage msg(0x361, 8);
 			/* Fuel pressure */
-			tmp =  (uint16_t)(Sensor::get(SensorType::FuelPressureLow).value_or(0));
+			tmp =  (uint16_t)(Sensor::getOrZero(SensorType::FuelPressureLow));
 			msg[0] = (tmp >> 8);
 			msg[1] = (tmp&0x00ff);
 			/* Oil pressure */
-			tmp =  (uint16_t)(Sensor::get(SensorType::OilPressure).value_or(0));
+			tmp =  (uint16_t)(Sensor::getOrZero(SensorType::OilPressure));
 			msg[2] = (tmp >> 8);
 			msg[3] = (tmp & 0x00ff);
 			/* Engine Demand */
-			tmp =  (uint16_t)(Sensor::get(SensorType::Map).value_or(0));
+			tmp =  (uint16_t)(Sensor::getOrZero(SensorType::Map));
 			msg[4] = (tmp >> 8);
 			msg[5] = (tmp & 0x00ff);
 			/* Wastegate Pressure */
@@ -686,11 +686,11 @@ void canDashboardHaltech(CanCycle cycle) {
 		{ 
 			CanTxMessage msg(0x368, 8);
 			/* Wideband Sensor 1 */
-			tmp =  (uint16_t)(Sensor::get(SensorType::Lambda1).value_or(0)) * 1000;
+			tmp =  (uint16_t)(Sensor::getOrZero(SensorType::Lambda1)) * 1000;
 			msg[0] = (tmp >> 8);
 			msg[1] = (tmp & 0x00ff);
 			/* Wideband Sensor 2 */
-			tmp =  (uint16_t)(Sensor::get(SensorType::Lambda2).value_or(0) * 1000);
+			tmp =  (uint16_t)(Sensor::getOrZero(SensorType::Lambda2) * 1000);
 			msg[2] = (tmp >> 8);
 			msg[3] = (tmp & 0x00ff);
 			/* Wideband Sensor 3 */
@@ -754,7 +754,7 @@ void canDashboardHaltech(CanCycle cycle) {
 		{ 
 			CanTxMessage msg(0x36C, 8);
 			/* Wheel Speed Front Left */
-			auto vehicleSpeed = Sensor::get(SensorType::VehicleSpeed).value_or(0);
+			auto vehicleSpeed = Sensor::getOrZero(SensorType::VehicleSpeed);
 			tmp = (vehicleSpeed * 10 );
 			msg[0] = (tmp >> 8);
 			msg[1] = (tmp & 0x00ff);
@@ -817,7 +817,7 @@ void canDashboardHaltech(CanCycle cycle) {
 		{ 
 			CanTxMessage msg(0x370, 8);
 			/* Vehicle Speed */
-			auto vehicleSpeed = Sensor::get(SensorType::VehicleSpeed).value_or(0);
+			auto vehicleSpeed = Sensor::getOrZero(SensorType::VehicleSpeed);
 			tmp = (vehicleSpeed * 10 );
 			msg[0] = (tmp >> 8);
 			msg[1] = (tmp & 0x00ff);
@@ -954,7 +954,7 @@ void canDashboardHaltech(CanCycle cycle) {
 		{ 
 			CanTxMessage msg(0x372, 8);
 			/* Battery Voltage */
-			tmp =  (uint16_t)(Sensor::get(SensorType::BatteryVoltage).value_or(0) * 10);
+			tmp =  (uint16_t)(Sensor::getOrZero(SensorType::BatteryVoltage) * 10);
 			msg[0] = (tmp >> 8);
 			msg[1] = (tmp & 0x00ff);
 			/* unused */
@@ -1043,7 +1043,7 @@ void canDashboardHaltech(CanCycle cycle) {
 		{ 
 			CanTxMessage msg(0x3E0, 8);
 			/* Coolant temperature in K y = x/10 */
-			tmp = ((Sensor::get(SensorType::Clt).value_or(0) + 273.15) * 10);
+			tmp = ((Sensor::getOrZero(SensorType::Clt) + 273.15) * 10);
 			msg[0] = (tmp >> 8);
 			msg[1] = (tmp & 0x00ff);
 			/* Air Temperature */

--- a/firmware/controllers/can/can_verbose.cpp
+++ b/firmware/controllers/can/can_verbose.cpp
@@ -62,7 +62,7 @@ static void populateFrame(Speeds& msg) {
 	msg.injDuty = getInjectorDutyCycle(rpm);
 	msg.coilDuty = getCoilDutyCycle(rpm);
 
-	msg.vssKph = Sensor::get(SensorType::VehicleSpeed).value_or(0);
+	msg.vssKph = Sensor::getOrZero(SensorType::VehicleSpeed);
 }
 
 struct PedalAndTps {
@@ -90,16 +90,16 @@ struct Sensors1 {
 };
 
 static void populateFrame(Sensors1& msg) {
-	msg.map = Sensor::get(SensorType::Map).value_or(0);
+	msg.map = Sensor::getOrZero(SensorType::Map);
 
-	msg.clt = Sensor::get(SensorType::Clt).value_or(0) + PACK_ADD_TEMPERATURE;
-	msg.iat = Sensor::get(SensorType::Iat).value_or(0) + PACK_ADD_TEMPERATURE;
+	msg.clt = Sensor::getOrZero(SensorType::Clt) + PACK_ADD_TEMPERATURE;
+	msg.iat = Sensor::getOrZero(SensorType::Iat) + PACK_ADD_TEMPERATURE;
 
-	msg.aux1 = Sensor::get(SensorType::AuxTemp1).value_or(0) + PACK_ADD_TEMPERATURE;
-	msg.aux2 = Sensor::get(SensorType::AuxTemp2).value_or(0) + PACK_ADD_TEMPERATURE;
+	msg.aux1 = Sensor::getOrZero(SensorType::AuxTemp1) + PACK_ADD_TEMPERATURE;
+	msg.aux2 = Sensor::getOrZero(SensorType::AuxTemp2) + PACK_ADD_TEMPERATURE;
 
 	msg.mcuTemp = getMCUInternalTemperature();
-	msg.fuelLevel = Sensor::get(SensorType::FuelLevel).value_or(0);
+	msg.fuelLevel = Sensor::getOrZero(SensorType::FuelLevel);
 }
 
 struct Sensors2 {
@@ -110,10 +110,10 @@ struct Sensors2 {
 };
 
 static void populateFrame(Sensors2& msg) {
-	msg.afr = Sensor::get(SensorType::Lambda1).value_or(0) * STOICH_RATIO;
+	msg.afr = Sensor::getOrZero(SensorType::Lambda1) * STOICH_RATIO;
 	msg.oilPressure = Sensor::get(SensorType::OilPressure).value_or(-1);
 	msg.vvtPos = engine->triggerCentral.getVVTPosition(0, 0);
-	msg.vbatt = Sensor::get(SensorType::BatteryVoltage).value_or(0);
+	msg.vbatt = Sensor::getOrZero(SensorType::BatteryVoltage);
 }
 
 struct Fueling {

--- a/firmware/controllers/can/obd2.cpp
+++ b/firmware/controllers/can/obd2.cpp
@@ -120,7 +120,7 @@ static void handleGetDataRequest(const CANRxFrame& rx) {
 		obdSendValue(_1_MODE, pid, 1, getFuelingLoad(PASS_ENGINE_PARAMETER_SIGNATURE) * ODB_TPS_BYTE_PERCENT);
 		break;
 	case PID_COOLANT_TEMP:
-		obdSendValue(_1_MODE, pid, 1, Sensor::get(SensorType::Clt).value_or(0) + ODB_TEMP_EXTRA);
+		obdSendValue(_1_MODE, pid, 1, Sensor::getOrZero(SensorType::Clt) + ODB_TEMP_EXTRA);
 		break;
 	case PID_STFT_BANK1:
 		obdSendValue(_1_MODE, pid, 1, 128 * ENGINE(stftCorrection)[0]);
@@ -129,13 +129,13 @@ static void handleGetDataRequest(const CANRxFrame& rx) {
 		obdSendValue(_1_MODE, pid, 1, 128 * ENGINE(stftCorrection)[1]);
 		break;
 	case PID_INTAKE_MAP:
-		obdSendValue(_1_MODE, pid, 1, Sensor::get(SensorType::Map).value_or(0));
+		obdSendValue(_1_MODE, pid, 1, Sensor::getOrZero(SensorType::Map));
 		break;
 	case PID_RPM:
 		obdSendValue(_1_MODE, pid, 2, GET_RPM() * ODB_RPM_MULT);	//	rotation/min.	(A*256+B)/4
 		break;
 	case PID_SPEED:
-		obdSendValue(_1_MODE, pid, 1, Sensor::get(SensorType::VehicleSpeed).value_or(0));
+		obdSendValue(_1_MODE, pid, 1, Sensor::getOrZero(SensorType::VehicleSpeed));
 		break;
 	case PID_TIMING_ADVANCE: {
 		float timing = engine->engineState.timingAdvance;
@@ -144,16 +144,16 @@ static void handleGetDataRequest(const CANRxFrame& rx) {
 		break;
 		}
 	case PID_INTAKE_TEMP:
-		obdSendValue(_1_MODE, pid, 1, Sensor::get(SensorType::Iat).value_or(0) + ODB_TEMP_EXTRA);
+		obdSendValue(_1_MODE, pid, 1, Sensor::getOrZero(SensorType::Iat) + ODB_TEMP_EXTRA);
 		break;
 	case PID_INTAKE_MAF:
-		obdSendValue(_1_MODE, pid, 2, Sensor::get(SensorType::Maf).value_or(0) * 100.0f);	// grams/sec	(A*256+B)/100
+		obdSendValue(_1_MODE, pid, 2, Sensor::getOrZero(SensorType::Maf) * 100.0f);	// grams/sec	(A*256+B)/100
 		break;
 	case PID_THROTTLE:
-		obdSendValue(_1_MODE, pid, 1, Sensor::get(SensorType::Tps1).value_or(0) * ODB_TPS_BYTE_PERCENT);	// (A*100/255)
+		obdSendValue(_1_MODE, pid, 1, Sensor::getOrZero(SensorType::Tps1) * ODB_TPS_BYTE_PERCENT);	// (A*100/255)
 		break;
 	case PID_FUEL_AIR_RATIO_1: {
-		float lambda = Sensor::get(SensorType::Lambda1).value_or(0);
+		float lambda = Sensor::getOrZero(SensorType::Lambda1);
 		// phi = 1 / lambda
 		float phi = clampF(0, 1 / lambda, 1.99f);
 

--- a/firmware/controllers/can/rusefi_wideband.cpp
+++ b/firmware/controllers/can/rusefi_wideband.cpp
@@ -123,7 +123,7 @@ void setWidebandOffset(uint8_t index) {
 void sendWidebandInfo() {
 	CanTxMessage m(0xEF5'0000, 2, true);
 
-	float vbatt = Sensor::get(SensorType::BatteryVoltage).value_or(0) * 10;
+	float vbatt = Sensor::getOrZero(SensorType::BatteryVoltage) * 10;
 
 	m[0] = vbatt;
 

--- a/firmware/controllers/core/fsio_impl.cpp
+++ b/firmware/controllers/core/fsio_impl.cpp
@@ -110,17 +110,17 @@ FsioResult getEngineValue(le_action_e action DECLARE_ENGINE_PARAMETER_SUFFIX) {
 	case LE_METHOD_AC_TOGGLE:
 		return getAcToggle(PASS_ENGINE_PARAMETER_SIGNATURE);
 	case LE_METHOD_COOLANT:
-		return Sensor::get(SensorType::Clt).value_or(0);
+		return Sensor::getOrZero(SensorType::Clt);
 	case LE_METHOD_IS_COOLANT_BROKEN:
 		return !Sensor::get(SensorType::Clt).Valid;
 	case LE_METHOD_INTAKE_AIR:
-		return Sensor::get(SensorType::Iat).value_or(0);
+		return Sensor::getOrZero(SensorType::Iat);
 	case LE_METHOD_RPM:
-		return Sensor::get(SensorType::Rpm).value_or(0);
+		return Sensor::getOrZero(SensorType::Rpm);
 	case LE_METHOD_MAF:
-		return Sensor::get(SensorType::Maf).value_or(0);
+		return Sensor::getOrZero(SensorType::Maf);
 	case LE_METHOD_MAP:
-		return Sensor::get(SensorType::Map).value_or(0);
+		return Sensor::getOrZero(SensorType::Map);
 #if EFI_SHAFT_POSITION_INPUT
 	case LE_METHOD_INTAKE_VVT:
 		return engine->triggerCentral.getVVTPosition(0, 0);
@@ -147,13 +147,13 @@ FsioResult getEngineValue(le_action_e action DECLARE_ENGINE_PARAMETER_SUFFIX) {
 	case LE_METHOD_IN_MR_BENCH:
 		return engine->isInMainRelayBench();
 	case LE_METHOD_VBATT:
-		return Sensor::get(SensorType::BatteryVoltage).value_or(0);
+		return Sensor::getOrZero(SensorType::BatteryVoltage);
 	case LE_METHOD_TPS:
-		return Sensor::get(SensorType::DriverThrottleIntent).value_or(0);
+		return Sensor::getOrZero(SensorType::DriverThrottleIntent);
 	case LE_METHOD_FUEL_FLOW_RATE:
 		return engine->engineState.fuelConsumption.getConsumptionGramPerSecond();
 	case LE_METHOD_OIL_PRESSURE:
-		return Sensor::get(SensorType::OilPressure).value_or(0);
+		return Sensor::getOrZero(SensorType::OilPressure);
 	// cfg_xxx references are code generated
 #include "fsio_getters.def"
 	default:
@@ -682,7 +682,7 @@ void runHardcodedFsio(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 
 	// see MAIN_RELAY_LOGIC
 	if (isBrainPinValid(CONFIG(mainRelayPin))) {
-		enginePins.mainRelay.setValue((getTimeNowSeconds() < 2) || (Sensor::get(SensorType::BatteryVoltage).value_or(0) > LOW_VBATT) || engine->isInShutdownMode());
+		enginePins.mainRelay.setValue((getTimeNowSeconds() < 2) || (Sensor::getOrZero(SensorType::BatteryVoltage) > LOW_VBATT) || engine->isInShutdownMode());
 	}
 	// see STARTER_RELAY_LOGIC
 	if (isBrainPinValid(CONFIG(starterRelayDisablePin))) {

--- a/firmware/controllers/engine_cycle/main_trigger_callback.cpp
+++ b/firmware/controllers/engine_cycle/main_trigger_callback.cpp
@@ -311,7 +311,7 @@ static void handleFuel(const bool limitedFuel, uint32_t trgEventIndex, int rpm, 
 	efiAssertVoid(CUSTOM_STACK_6627, getCurrentRemainingStack() > 128, "lowstck#3");
 	efiAssertVoid(CUSTOM_ERR_6628, trgEventIndex < engine->engineCycleEventCount, "handleFuel/event index");
 
-	ENGINE(tpsAccelEnrichment.onNewValue(Sensor::get(SensorType::Tps1).value_or(0) PASS_ENGINE_PARAMETER_SUFFIX));
+	ENGINE(tpsAccelEnrichment.onNewValue(Sensor::getOrZero(SensorType::Tps1) PASS_ENGINE_PARAMETER_SUFFIX));
 	if (trgEventIndex == 0) {
 		ENGINE(tpsAccelEnrichment.onEngineCycleTps(PASS_ENGINE_PARAMETER_SIGNATURE));
 		ENGINE(engineLoadAccelEnrichment.onEngineCycle(PASS_ENGINE_PARAMETER_SIGNATURE));
@@ -456,7 +456,7 @@ void mainTriggerCallback(uint32_t trgEventIndex, efitick_t edgeTimestamp DECLARE
 static bool isPrimeInjectionPulseSkipped(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 	if (!engine->rpmCalculator.isStopped())
 		return true;
-	return CONFIG(isCylinderCleanupEnabled) && (Sensor::get(SensorType::Tps1).value_or(0) > CLEANUP_MODE_TPS);
+	return CONFIG(isCylinderCleanupEnabled) && (Sensor::getOrZero(SensorType::Tps1) > CLEANUP_MODE_TPS);
 }
 
 /**

--- a/firmware/controllers/engine_cycle/map_averaging.cpp
+++ b/firmware/controllers/engine_cycle/map_averaging.cpp
@@ -192,7 +192,7 @@ static void applyMapMinBufferLength(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 void postMapState(TunerStudioOutputChannels *tsOutputChannels) {
 	tsOutputChannels->debugFloatField1 = v_averagedMapValue;
 	tsOutputChannels->debugFloatField2 = engine->engineState.mapAveragingDuration;
-	tsOutputChannels->debugFloatField3 = Sensor::get(SensorType::MapFast).value_or(0);
+	tsOutputChannels->debugFloatField3 = Sensor::getOrZero(SensorType::MapFast);
 	tsOutputChannels->debugIntField1 = mapMeasurementsCounter;
 }
 #endif /* EFI_TUNER_STUDIO */

--- a/firmware/controllers/gauges/lcd_controller.cpp
+++ b/firmware/controllers/gauges/lcd_controller.cpp
@@ -160,10 +160,10 @@ static void showLine(lcd_line_e line, int /*screenY*/) {
 #endif
 		return;
 	case LL_CLT_TEMPERATURE:
-		lcdPrintf("Coolant %.2f", Sensor::get(SensorType::Clt).value_or(0));
+		lcdPrintf("Coolant %.2f", Sensor::getOrZero(SensorType::Clt));
 		return;
 	case LL_IAT_TEMPERATURE:
-		lcdPrintf("Intake Air %.2f", Sensor::get(SensorType::Iat).value_or(0));
+		lcdPrintf("Intake Air %.2f", Sensor::getOrZero(SensorType::Iat));
 		return;
 	case LL_ALGORITHM:
 		lcdPrintf(getEngine_load_mode_e(engineConfiguration->fuelAlgorithm));
@@ -180,7 +180,7 @@ static void showLine(lcd_line_e line, int /*screenY*/) {
 	case LL_TPS:
 		getPinNameByAdcChannel("tps", engineConfiguration->tps1_1AdcChannel, buffer);
 
-		lcdPrintf("Throttle %s %.2f%%", buffer, Sensor::get(SensorType::Tps1).value_or(0));
+		lcdPrintf("Throttle %s %.2f%%", buffer, Sensor::getOrZero(SensorType::Tps1));
 		return;
 	case LL_FUEL_CLT_CORRECTION:
 		lcdPrintf("CLT corr %.2f", getCltFuelCorrection(PASS_ENGINE_PARAMETER_SIGNATURE));
@@ -192,7 +192,7 @@ static void showLine(lcd_line_e line, int /*screenY*/) {
 		lcdPrintf("ING LAG %.2f", engine->engineState.running.injectorLag);
 		return;
 	case LL_VBATT:
-		lcdPrintf("Battery %.2fv", Sensor::get(SensorType::BatteryVoltage).value_or(0));
+		lcdPrintf("Battery %.2fv", Sensor::getOrZero(SensorType::BatteryVoltage));
 		return;
 
 #if	EFI_ANALOG_SENSORS
@@ -206,14 +206,14 @@ static void showLine(lcd_line_e line, int /*screenY*/) {
 #endif
 	case LL_AFR:
 		if (Sensor::hasSensor(SensorType::Lambda1)) {
-			lcdPrintf("AFR: %.2f", Sensor::get(SensorType::Lambda1).value_or(0));
+			lcdPrintf("AFR: %.2f", Sensor::getOrZero(SensorType::Lambda1));
 		} else {
 			lcdPrintf("AFR: none");
 		}
 		return;
 	case LL_MAP:
 		if (Sensor::hasSensor(SensorType::Map)) {
-			lcdPrintf("MAP %.2f", Sensor::get(SensorType::Map).value_or(0));
+			lcdPrintf("MAP %.2f", Sensor::getOrZero(SensorType::Map));
 		} else {
 			lcdPrintf("MAP: none");
 		}
@@ -227,7 +227,7 @@ static void showLine(lcd_line_e line, int /*screenY*/) {
 		return;
 	case LL_MAF_KG_HR:
 		if (Sensor::hasSensor(SensorType::Maf)) {
-			lcdPrintf("MAF: %.2f kg/hr", Sensor::get(SensorType::Maf).value_or(0));
+			lcdPrintf("MAF: %.2f kg/hr", Sensor::getOrZero(SensorType::Maf));
 		} else {
 			lcdPrintf("MAF: none");
 		}

--- a/firmware/controllers/limp_manager.cpp
+++ b/firmware/controllers/limp_manager.cpp
@@ -24,7 +24,7 @@ void LimpManager::updateState(int rpm, efitick_t nowNt) {
 
 	// Limit fuel only on boost pressure (limiting spark bends valves)
 	if (CONFIG(boostCutPressure) != 0) {
-		if (Sensor::get(SensorType::Map).value_or(0) > CONFIG(boostCutPressure)) {
+		if (Sensor::getOrZero(SensorType::Map) > CONFIG(boostCutPressure)) {
 			allowFuel.clear();
 		}
 	}

--- a/firmware/controllers/lua/lua_hooks.cpp
+++ b/firmware/controllers/lua/lua_hooks.cpp
@@ -283,7 +283,7 @@ static int lua_getAirmass(lua_State* l) {
 		return luaL_error(l, "null airmass");
 	}
 
-	auto rpm = Sensor::get(SensorType::Rpm).value_or(0);
+	auto rpm = Sensor::getOrZero(SensorType::Rpm);
 	auto result = airmass->getAirmass(rpm).CylinderAirmass;
 
 	lua_pushnumber(l, result);

--- a/firmware/controllers/math/engine_math.cpp
+++ b/firmware/controllers/math/engine_math.cpp
@@ -84,7 +84,7 @@ floatms_t getSparkDwell(int rpm DECLARE_ENGINE_PARAMETER_SUFFIX) {
 		auto base = interpolate2d(rpm, engineConfiguration->sparkDwellRpmBins, engineConfiguration->sparkDwellValues);
 		auto voltageMult = 0.02f * 
 			interpolate2d(
-				10 * Sensor::get(SensorType::BatteryVoltage).value_or(0),
+				10 * Sensor::getOrZero(SensorType::BatteryVoltage),
 				engineConfiguration->dwellVoltageCorrVoltBins,
 				engineConfiguration->dwellVoltageCorrValues);
 

--- a/firmware/controllers/sensors/map.cpp
+++ b/firmware/controllers/sensors/map.cpp
@@ -171,12 +171,12 @@ extern int mapMinBufferLength;
 
 static void printMAPInfo(void) {
 #if EFI_ANALOG_SENSORS
-	efiPrintf("instant value=%.2fkPa", Sensor::get(SensorType::Map).value_or(0));
+	efiPrintf("instant value=%.2fkPa", Sensor::getOrZero(SensorType::Map));
 
 #if EFI_MAP_AVERAGING
 	efiPrintf("map type=%d/%s MAP=%.2fkPa mapMinBufferLength=%d", engineConfiguration->map.sensor.type,
 			getAir_pressure_sensor_type_e(engineConfiguration->map.sensor.type),
-			Sensor::get(SensorType::Map).value_or(0),
+			Sensor::getOrZero(SensorType::Map),
 			mapMinBufferLength);
 #endif // EFI_MAP_AVERAGING
 

--- a/firmware/controllers/sensors/sensor.h
+++ b/firmware/controllers/sensors/sensor.h
@@ -87,6 +87,13 @@ public:
 	static SensorResult get(SensorType type);
 
 	/*
+	 * Get a reading from the specified sensor, or zero if unavailable.
+	 */
+	static float getOrZero(SensorType type) {
+		return Sensor::get(type).value_or(0);
+	}
+
+	/*
 	 * Get a raw (unconverted) value from the sensor, if available.
 	 */
 	static float getRaw(SensorType type);

--- a/firmware/hw_layer/stepper.cpp
+++ b/firmware/hw_layer/stepper.cpp
@@ -80,7 +80,7 @@ void StepperMotorBase::setInitialPosition(void) {
 	bool isRunning = false;
 #endif /* EFI_SHAFT_POSITION_INPUT */
 	// now check if stepper motor re-initialization is requested - if the throttle pedal is pressed at startup
-	auto tpsPos = Sensor::get(SensorType::DriverThrottleIntent).value_or(0);
+	auto tpsPos = Sensor::getOrZero(SensorType::DriverThrottleIntent);
 	bool forceStepperParking = !isRunning && tpsPos > STEPPER_PARKING_TPS;
 	if (CONFIG(stepperForceParkingEveryRestart))
 		forceStepperParking = true;

--- a/unit_tests/tests/sensor/test_sensor_init.cpp
+++ b/unit_tests/tests/sensor/test_sensor_init.cpp
@@ -230,9 +230,9 @@ TEST(SensorInit, Map) {
 	Sensor::setMockValue(SensorType::MapSlow, 75);
 
 	// Should prefer fast MAP
-	EXPECT_FLOAT_EQ(25, Sensor::get(SensorType::Map).value_or(0));
+	EXPECT_FLOAT_EQ(25, Sensor::getOrZero(SensorType::Map));
 
 	// But when that fails, should return slow MAP
 	Sensor::resetMockValue(SensorType::MapFast);
-	EXPECT_FLOAT_EQ(75, Sensor::get(SensorType::Map).value_or(0));
+	EXPECT_FLOAT_EQ(75, Sensor::getOrZero(SensorType::Map));
 }

--- a/unit_tests/tests/test_logic_expression.cpp
+++ b/unit_tests/tests/test_logic_expression.cpp
@@ -19,7 +19,7 @@ FsioResult getEngineValue(le_action_e action DECLARE_ENGINE_PARAMETER_SUFFIX) {
 	case LE_METHOD_FAN:
 		return engine->fsioState.mockFan;
 	case LE_METHOD_COOLANT:
-		return Sensor::get(SensorType::Clt).value_or(0);
+		return Sensor::getOrZero(SensorType::Clt);
 	case LE_METHOD_RPM:
 		return engine->fsioState.mockRpm;
 	case LE_METHOD_CRANKING_RPM:


### PR DESCRIPTION
Saves some stack since there's no longer a `SensorResult` temporary required for every call to `Sensor::get` if we're just going to discard it anyway.  Also a handy thing to have anyway.

#3302 