### PR TITLE
Use SSH for Doxygen

### DIFF
--- a/.github/workflows/gen-docs.yaml
+++ b/.github/workflows/gen-docs.yaml
@@ -24,8 +24,8 @@ jobs:
       run: |
         if [ "${{github.ref}}" = "refs/heads/master" ]; then
           echo "::set-env name=RUSEFI_SSH_SERVER::${{secrets.RUSEFI_SSH_SERVER}}";
-          echo "::set-env name=RUSEFI_SSH_USER::${{secrets.RUSEFI_SSH_USER}}";
-          echo "::set-env name=RUSEFI_SSH_PASS::${{secrets.RUSEFI_SSH_PASS}}";
+          echo "::set-env name=RUSEFI_DOXYGEN_SSH_USER::${{secrets.RUSEFI_DOXYGEN_SSH_USER}}";
+          echo "::set-env name=RUSEFI_DOXYGEN_SSH_PASS::${{secrets.RUSEFI_DOXYGEN_SSH_PASS}}";
         fi
 
     - name: Generate documentation

--- a/misc/jenkins/generate_doxygen/gen_upload_docs.sh
+++ b/misc/jenkins/generate_doxygen/gen_upload_docs.sh
@@ -9,6 +9,6 @@ doxygen || { echo "doxygen run FAILED"; exit 1; }
 cd ../doxygen
 if [ -n "$RUSEFI_SSH_SERVER" ]; then
   echo "Uploading Doxygen"
-  tar -czf - html | sshpass -p "$RUSEFI_SSH_PASS" ssh -o StrictHostKeyChecking=no "$RUSEFI_SSH_USER"@"$RUSEFI_SSH_SERVER" "tar -xzf -"
+  tar -czf - html | sshpass -p "$RUSEFI_DOXYGEN_SSH_PASS" ssh -o StrictHostKeyChecking=no "$RUSEFI_DOXYGEN_SSH_USER"@"$RUSEFI_SSH_SERVER" "tar -xzf -"
 fi
 [ $? -eq 0 ] || { echo "upload FAILED"; exit 1; }


### PR DESCRIPTION
Required secrets:
RUSEFI_SSH_SERVER
RUSEFI_SSH_USER
RUSEFI_SSH_PASS

Don't remove the FTP secrets yet, as they're still used by other workflows.

FTP runtime: 3h 32m 36s
SSH runtime: 6m 28s