### PR TITLE
use name of pwm

### DIFF
--- a/firmware/controllers/system/timer/pwm_generator_logic.cpp
+++ b/firmware/controllers/system/timer/pwm_generator_logic.cpp
@@ -264,7 +264,7 @@ static void timerCallback(PwmConfig *state) {
 		return;
 	}
 
-	state->executor->scheduleByTimestampNt("pwm", &state->scheduling, switchTimeNt, { timerCallback, state });
+	state->executor->scheduleByTimestampNt(state->name, &state->scheduling, switchTimeNt, { timerCallback, state });
 	state->dbgNestingLevel--;
 }
 


### PR DESCRIPTION
Print the name of which PWM controller is responsible, so we can figure out what happened here:

![image_from_ios](https://user-images.githubusercontent.com/568254/138509832-6ca35855-4292-47d0-bc37-914c7a287e45.jpg)

