### PR TITLE
OpenBLT: add as submodule under firmware/ext

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -33,3 +33,6 @@
 	path = firmware/controllers/lua/luaaa
 	url = https://github.com/rusefi/luaaa
 	branch = rusefi_prod_2019
+[submodule "firmware/ext/openblt"]
+	path = firmware/ext/openblt
+	url = git@github.com:rusefi/openblt.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -35,4 +35,4 @@
 	branch = rusefi_prod_2019
 [submodule "firmware/ext/openblt"]
 	path = firmware/ext/openblt
-	url = git@github.com:rusefi/openblt.git
+	url = https://github.com/rusefi/openblt

--- a/.gitmodules
+++ b/.gitmodules
@@ -36,3 +36,4 @@
 [submodule "firmware/ext/openblt"]
 	path = firmware/ext/openblt
 	url = https://github.com/rusefi/openblt
+	branch = rusefi_prod


### PR DESCRIPTION
OpenBLT is forked for RusEFI, rusefi_prod brunch is used.