### PR TITLE
lock and delay gpio init

### DIFF
--- a/firmware/controllers/system/efi_gpio.cpp
+++ b/firmware/controllers/system/efi_gpio.cpp
@@ -554,8 +554,15 @@ void OutputPin::initPin(const char *msg, brain_pin_e brainPin, const pin_output_
 	setDefaultPinState(outputMode);
 
 #if EFI_GPIO_HARDWARE && EFI_PROD_CODE
+	// Prevent another thread trying to set this pin while we initialize it
+	chibios_rt::CriticalSectionLocker csl;
+
 	efiSetPadMode(msg, brainPin, mode);
+
 	if (brain_pin_is_onchip(brainPin)) {
+		// let the pin state change happen
+		chThdSleepMilliseconds(1);
+
 		int actualValue = palReadPad(port, pin);
 		// we had enough drama with pin configuration in board.h and else that we shall self-check
 

--- a/firmware/controllers/system/efi_gpio.cpp
+++ b/firmware/controllers/system/efi_gpio.cpp
@@ -554,9 +554,6 @@ void OutputPin::initPin(const char *msg, brain_pin_e brainPin, const pin_output_
 	setDefaultPinState(outputMode);
 
 #if EFI_GPIO_HARDWARE && EFI_PROD_CODE
-	// Prevent another thread trying to set this pin while we initialize it
-	chibios_rt::CriticalSectionLocker csl;
-
 	efiSetPadMode(msg, brainPin, mode);
 
 	if (brain_pin_is_onchip(brainPin)) {


### PR DESCRIPTION
~prevent other threads from editing our pin while we aren't looking~ (we're already under lock there), and also wait 1ms after pin init to check startup state in case things take a second to happen