### PR TITLE
Configuration for HPFP control algorithm.

### DIFF
--- a/firmware/config/engines/vw_b6.cpp
+++ b/firmware/config/engines/vw_b6.cpp
@@ -126,14 +126,12 @@ void setVwPassatB6(DECLARE_CONFIG_PARAMETER_SIGNATURE) {
 */
 	coolantControl->pin = TLE8888_PIN_5; // "3 - Lowside 2"
 	// "7 - Lowside 1"
-	engineConfiguration->hpfpValvePin = TLE8888_PIN_6;
+	// engineConfiguration->hpfpValvePin = TLE8888_PIN_6; // Disable for now
 
 	setBoschVAGETB(PASS_CONFIG_PARAMETER_SIGNATURE);
 
 
 	engineConfiguration->injector.flow = 300;
-	engineConfiguration->tempHpfpStart = 120;
-	engineConfiguration->tempHpfpDuration = 30;
 
 	engineConfiguration->idle.solenoidPin = GPIO_UNASSIGNED;
 	engineConfiguration->fanPin = GPIO_UNASSIGNED;

--- a/firmware/controllers/algo/rusefi_enums.h
+++ b/firmware/controllers/algo/rusefi_enums.h
@@ -642,3 +642,11 @@ typedef enum __attribute__ ((__packed__)) {
 	INJ_None = 0,
 	INJ_PolynomialAdder = 1,
 } InjectorNonlinearMode;
+
+typedef enum __attribute__ ((__packed__)) {
+    HPFP_CAM_NONE = 0,
+    HPFP_CAM_IN1 = 1,
+    HPFP_CAM_EX1 = 2,
+    HPFP_CAM_IN2 = 3,
+    HPFP_CAM_EX2 = 4,
+} hpfp_cam_e;

--- a/firmware/controllers/engine_cycle/high_pressure_fuel_pump.cpp
+++ b/firmware/controllers/engine_cycle/high_pressure_fuel_pump.cpp
@@ -15,68 +15,9 @@
 
 #if EFI_HPFP
 
-#define LOBE_COUNT 3
-
-class HpfpActor {
-public:
-	angle_t extra;
-	int phaseIndex;
-
-	AngleBasedEvent open;
-	AngleBasedEvent close;
-	DECLARE_ENGINE_PTR;
-};
-
-static HpfpActor actors[LOBE_COUNT];
-
-static void plainPinTurnOff(RegisteredNamedOutputPin *output) {
-	output->setLow();
-}
-
-void hpfpPlainPinTurnOn(HpfpActor *current);
-
-static void scheduleNextCycle(HpfpActor *actor) {
-#if EFI_UNIT_TEST
-	Engine *engine = actor->engine;
-	EXPAND_Engine;
-#endif /* EFI_UNIT_TEST */
-
-	scheduleOrQueue(&actor->open,
-	TRIGGER_EVENT_UNDEFINED, getTimeNowNt(), actor->extra + CONFIG(tempHpfpStart),
-		{hpfpPlainPinTurnOn, actor }
-	PASS_ENGINE_PARAMETER_SUFFIX
-	);
-
-	scheduleOrQueue(&actor->close,
-	TRIGGER_EVENT_UNDEFINED, getTimeNowNt(),
-			actor->extra + CONFIG(tempHpfpStart) + CONFIG(tempHpfpDuration),
-			{ plainPinTurnOff, &enginePins.hpfpValve }
-	PASS_ENGINE_PARAMETER_SUFFIX
-			);
-}
-
-void hpfpPlainPinTurnOn(HpfpActor *current) {
-	RegisteredNamedOutputPin *output = &enginePins.hpfpValve;
-	int highPressureKpa = Sensor::get(SensorType::FuelPressureHigh).Value;
-	// very basic control strategy
-	if (highPressureKpa < BAR2KPA(50)) {
-		output->setHigh();
-	}
-	scheduleNextCycle(current);
-}
 
 void initHPFP(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
-	if (!isBrainPinValid(engineConfiguration->hpfpValvePin)) {
-		return;
-	}
-
-	for (int i = 0; i < LOBE_COUNT; i++) {
-		HpfpActor *actor = &actors[i];
-		INJECT_ENGINE_REFERENCE(actor);
-
-		actor->extra = 720 / LOBE_COUNT * i;
-		scheduleNextCycle(actor);
-	}
+	// Deleted to make new code diff easier
 }
 
 #endif // EFI_HPFP

--- a/firmware/controllers/settings.cpp
+++ b/firmware/controllers/settings.cpp
@@ -1196,10 +1196,6 @@ static void setValue(const char *paramStr, const char *valueStr) {
 		engineConfiguration->wwaeTau = valueF;
 	} else if (strEqualCaseInsensitive(paramStr, "wwaeBeta")) {
 		engineConfiguration->wwaeBeta = valueF;
-	} else if (strEqualCaseInsensitive(paramStr, "tempHpfpStart")) {
-		engineConfiguration->tempHpfpStart = valueF;
-	} else if (strEqualCaseInsensitive(paramStr, "tempHpfpDuration")) {
-		engineConfiguration->tempHpfpDuration = valueF;
 	} else if (strEqualCaseInsensitive(paramStr, "cranking_dwell")) {
 		engineConfiguration->ignitionDwellForCrankingMs = valueF;
 #if EFI_PROD_CODE

--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -714,8 +714,7 @@ pin_input_mode_e throttlePedalUpPinMode;
 	uint16_t idlePositionMax;+Voltage when the idle valve is open.\nYou probably don't have one of these!\n1 volt = 1000 units;"mv", 1, 0, 0, 5000, 0
 
 
-	uint16_t tempHpfpStart;;"units", 1, 0, -20, 100, 0
-	uint16_t tempHpfpDuration;;"units", 1, 0, -20, 100, 0
+        uint16_t[2] unusedExHpfp;;"", 1, 0, -20, 100, 0
 
 	uint32_t tunerStudioSerialSpeed;+Secondary TTL channel baud rate;"BPs", 1, 0, 0, 1000000, 0
 
@@ -1474,7 +1473,38 @@ tChargeMode_e tChargeMode;
 int8_t[MAX_CYLINDER_COUNT iterate] fuelTrim;;"Percent", @@PERCENT_TRIM_BYTE_PACKING_DIV@@, 0, -25, 25, 2
 
 	float[GAP_TRACKING_LENGTH iterate] triggerGapOverrideTo;;"to", 1, 0, 0, 20, 2
-	int[326] mainUnusedEnd;;"units", 1, 0, -20, 100, 0
+
+! Someday there will be a 6th option for BMW S55 that uses a separate shaft just for HPFP
+#define hpfp_cam_e_enum "NONE", "Intake 1", "Exhaust 1", "Intake 2", "Exhaust 2"
+#define HPFP_LOBE_PROFILE_SIZE 16
+#define HPFP_DEADTIME_SIZE 8
+#define HPFP_TARGET_SIZE 10
+#define HPFP_COMPENSATION_SIZE 10
+
+        custom hpfp_cam_e 1 bits, U08, @OFFSET@, [0:2], @@hpfp_cam_e_enum@@
+
+        uint8_t hpfpCamLobes;;"lobes/cam", 1, 0, 1, 255, 0
+        hpfp_cam_e hpfpCam;
+        uint8_t hpfpPeakPos;+Crank angle ATDC of first lobe peak;"deg", 1, 0, 0, 255, 0
+        uint8_t hpfpMinAngle;+If the requested activation time is below this angle, don't bother running the pump;"deg", 1, 0, 0, 255, 0
+        uint16_t autoscale hpfpPumpVolume;+Size of the pump chamber in cc.  Typical Bosch HDP5 has a 9.0mm diameter, typical BMW N* stroke is 4.4mm.;"cc", 0.001, 0, 0, 65, 3
+        uint8_t hpfpActivationAngle;+How long to keep the valve activated (in order to allow the pump to build pressure and keep the valve open on its own);"deg", 1, 0, 0, 255, 0
+        uint8_t unusedFiller_4703;;"", 1, 0, 0, 255, 0
+        uint16_t autoscale hpfpPidP;;"%/kPa", 0.001, 0, 0, 65, 3
+        uint16_t autoscale hpfpPidI;;"%/kPa/lobe", 0.00001, 0, 0, 0.65, 5
+        uint16_t hpfpTargetDecay;+The fastest rate the target pressure can be reduced by.  This is because HPFP have no way to bleed off pressure other than injecting fuel.;"kPa/s", 1, 0, 0, 65000, 0
+        uint8_t[HPFP_LOBE_PROFILE_SIZE] autoscale hpfpLobeProfileQuantityBins;;"%", 0.5, 0, 0, 100, 1
+        uint8_t[HPFP_LOBE_PROFILE_SIZE] autoscale hpfpLobeProfileAngle;;"deg", 0.5, 0, 0, 125, 1
+        uint8_t[HPFP_DEADTIME_SIZE] hpfpDeadtimeVoltsBins;;"volts", 1, 0, 0, 255, 0
+        uint16_t[HPFP_DEADTIME_SIZE] autoscale hpfpDeadtimeMS;;"ms", 0.001, 0, 0, 65, 0
+        uint16_t[HPFP_TARGET_SIZE x HPFP_TARGET_SIZE] hpfpTarget;;"kPa", 1, 0, 0, 65000, 0
+        uint16_t[HPFP_TARGET_SIZE] autoscale hpfpTargetLoadBins;;"load", 0.1, 0, 0, 6500, 1
+        uint8_t[HPFP_TARGET_SIZE] autoscale hpfpTargetRpmBins;;"RPM", 50, 0, 0, 12500, 0
+	int8_t[HPFP_COMPENSATION_SIZE x HPFP_COMPENSATION_SIZE] hpfpCompensation;;"%", 1, 0, -100, 100, 0
+        uint16_t[HPFP_COMPENSATION_SIZE] autoscale hpfpCompensationLoadBins;;"cc/lobe", 0.001, 0, 0, 65, 3
+        uint8_t[HPFP_COMPENSATION_SIZE] autoscale hpfpCompensationRpmBins;;"RPM", 50, 0, 0, 12500, 0
+
+	int[218] mainUnusedEnd;;"units", 1, 0, -20, 100, 0
 
 ! end of engine_configuration_s
 end_struct

--- a/firmware/tunerstudio/rusefi.input
+++ b/firmware/tunerstudio/rusefi.input
@@ -851,6 +851,20 @@ enable2ndByteCanID = false
       lineLabel   = "Warmup Correction"
       lineLabel   = "Recommended WUE"
 
+    curve = hpfpLobeProfileCurve, "HPFP Lobe Profile"
+        columnLabel = "% pump volume", "angle"
+        xAxis       = 0, 100, 11
+        yAxis       = 0, 240, 13
+        xBins       = hpfpLobeProfileQuantityBins
+        yBins       = hpfpLobeProfileAngle
+
+    curve = hpfpDeadtimeCurve, "HPFP Valve Deadtime"
+        columnLabel = "volts", "ms"
+        xAxis       = 5, 15, 11
+        yAxis       = 0, 5, 6
+        xBins       = hpfpDeadtimeVoltsBins
+        yBins       = hpfpDeadtimeMS
+
 [TableEditor]
    ;       table_id,    map3d_id,    "title",      page
 
@@ -1014,6 +1028,17 @@ enable2ndByteCanID = false
 		yBins		= gearCountArray, tcuCurrentGear
 		zBins		= tcuSolenoidTable
 		xyLabels	= "Solenoid", "Gear"
+
+    table = hpfpTargetTable, hpfpTargetTableId, "HPFP Target Fuel Pressure", 1
+        xBins     = hpfpTargetRpmBins, RPMValue
+        yBins     = hpfpTargetLoadBins, veTableYAxis
+        zBins     = hpfpTarget
+
+    table = hpfpCompensationTable, hpfpCompensationTableId, "HPFP Pump Compensation Factor", 1
+        xBins     = hpfpCompensationRpmBins, RPMValue
+        yBins     = hpfpCompensationLoadBins, fuelRunning
+        zBins     = hpfpCompensation
+
 
 [GaugeConfigurations]
 
@@ -1671,9 +1696,14 @@ menuDialog = main
 
 
 		# EXPERIMENTAL FEATURES
+                submenu = mc33Dialog,                           "GDI Dreams"
+		subMenu = hpfpCamDialog,			"HPFP Cam Configuration"
+		subMenu = hpfpPumpDialog,			"HPFP Pump Configuration", {hpfpCamLobes != 0}
+                subMenu = hpfpTargetTable,                      "HPFP Target Pressure", {hpfpCamLobes != 0}
+                subMenu = hpfpCompensationTable,                "HPFP Pump Compensation", {hpfpCamLobes != 0}
+                subMenu = std_separator
 		subMenu = parkingLot,				"Experimental/Broken"
 		subMenu = rotaryDialog, 			"Rotary"
-		subMenu = mc33Dialog,			"GDI Dreams"
 		subMenu = vrThreshold,				"VR Sensor Threshold"
 		subMenu = std_separator
 		
@@ -2326,10 +2356,6 @@ cmd_set_engine_type_default					= "@@TS_IO_TEST_COMMAND_char@@\x00\x31\x00\x00"
 		field = "MC33816 rstb",							mc33816_rstb
 		field = "MC33816 flag0",						mc33816_flag0
 		field = "MC33816 SPI Device",					mc33972spiDevice
-		field = "HPFP Valve Pin",						hpfpValvePin
-		field = "HPFP Valve Pin Mode",					hpfpValvePinMode
-		field = tempHpfpStart, tempHpfpStart 
-		field = tempHpfpDuration, tempHpfpDuration 
 
 		field = "Boost voltage",						mc33_hvolt
 
@@ -3896,6 +3922,23 @@ cmd_set_engine_type_default					= "@@TS_IO_TEST_COMMAND_char@@\x00\x31\x00\x00"
 		panel = gppwm4left
 		panel = gppwm4Tbl, {gppwm4_pin != 0}
 
+    dialog = hpfpCamDialog, "HPFP Cam Configuration"
+        field = "Number of lobes", hpfpCamLobes
+        field = "If using VVT, which cam the pump is driven from", hpfpCam, {hpfpCamLobes != 0}
+        field = "Angle of first lobe", hpfpPeakPos, {hpfpCamLobes != 0}
+        panel = hpfpLobeProfileCurve, {hpfpCamLobes != 0}
+
+    dialog = hpfpPumpDialog, "HPFP Pump Configuration"
+        field = "Valve Pin", hpfpValvePin, {hpfpCamLobes != 0}
+        field = "Valve Pin Mode", hpfpValvePinMode, {hpfpCamLobes != 0}
+        field = "Pump volume", hpfpPumpVolume, {hpfpCamLobes != 0}
+        field = "Minimum angle", hpfpMinAngle, {hpfpCamLobes != 0}
+        field = "Activation angle", hpfpActivationAngle, {hpfpCamLobes != 0}
+        field = "Target decay rate", hpfpTargetDecay, {hpfpCamLobes != 0}
+        field = "Proportional gain", hpfpPidP, {hpfpCamLobes != 0}
+        field = "Integral gain", hpfpPidI, {hpfpCamLobes != 0}
+        panel = hpfpDeadtimeCurve, {hpfpCamLobes != 0}
+
 [Tools]
  ;addTool = toolName, PanelName
  addTool = veTableGenerator, "VE Table Generator", veTableTbl
@@ -3903,5 +3946,3 @@ cmd_set_engine_type_default					= "@@TS_IO_TEST_COMMAND_char@@\x00\x31\x00\x00"
 #else
  addTool = afrTableGenerator, "AFR Table Generator", afrTableTbl
 #endif
-
-


### PR DESCRIPTION
Remove the old algorithm so the diff that includes the new algorithm doesn't intermix unrelated code.

The algorithm is the same one as before, but the configuration is separated out as requested.