### PR TITLE
unit test build times

### DIFF
--- a/.github/workflows/build-unit-tests.yaml
+++ b/.github/workflows/build-unit-tests.yaml
@@ -52,7 +52,7 @@ jobs:
 
     - name: Build Tests
       working-directory: ./unit_tests/
-      run: make -j4
+      run: make -j4 COVERAGE=yes
       
     - name: Run Tests
       working-directory: ./unit_tests/

--- a/unit_tests/rules.mk
+++ b/unit_tests/rules.mk
@@ -65,8 +65,8 @@ endif
 
 ifeq ($(IS_MAC),yes)
 	ODFLAGS	  = -x --syms
-	ASFLAGS   = $(MCFLAGS) -Wa,-amhls=$(LSTDIR)/$(notdir $(<:.s=.lst)) $(ADEFS)
-	ASXFLAGS  = $(MCFLAGS) -Wa,-amhls=$(LSTDIR)/$(notdir $(<:.S=.lst)) $(ADEFS)
+	ASFLAGS   = $(MCFLAGS) -Wa $(ADEFS)
+	ASXFLAGS  = $(MCFLAGS) -Wa $(ADEFS)
 	CFLAGS    = $(MCFLAGS) $(OPT) $(COPT)   $(CWARN)   $(DEFS)
 	CPPFLAGS  = $(MCFLAGS) $(OPT) $(CPPOPT) $(CPPWARN) $(DEFS)
 	LDFLAGS = $(MCFLAGS) $(LLIBDIR)

--- a/unit_tests/rules.mk
+++ b/unit_tests/rules.mk
@@ -73,10 +73,10 @@ ifeq ($(IS_MAC),yes)
 else
 	# not mac
 	ODFLAGS	  = -x --syms
-	ASFLAGS   = $(MCFLAGS) -Wa,-amhls=$(LSTDIR)/$(notdir $(<:.s=.lst)) $(ADEFS)
-	ASXFLAGS  = $(MCFLAGS) -Wa,-amhls=$(LSTDIR)/$(notdir $(<:.S=.lst)) $(ADEFS)
-	CFLAGS    = $(MCFLAGS) $(OPT) $(COPT) $(CWARN) -Wa,-alms=$(LSTDIR)/$(notdir $(<:.c=.lst)) $(DEFS)
-	CPPFLAGS  = $(MCFLAGS) $(OPT) $(CPPOPT) $(CPPWARN) -Wa,-alms=$(LSTDIR)/$(notdir $(<:.cpp=.lst)) $(DEFS)
+	ASFLAGS   = $(MCFLAGS) $(ADEFS)
+	ASXFLAGS  = $(MCFLAGS) $(ADEFS)
+	CFLAGS    = $(MCFLAGS) $(OPT) $(COPT) $(CWARN) $(DEFS)
+	CPPFLAGS  = $(MCFLAGS) $(OPT) $(CPPOPT) $(CPPWARN) $(DEFS)
 	ifeq ($(USE_LINK_GC),yes)
 	  LDFLAGS = $(MCFLAGS) -Wl,-Map=$(BUILDDIR)/$(PROJECT).map,--cref,--no-warn-mismatch,--gc-sections $(LLIBDIR)
 	else

--- a/unit_tests/unit_test_rules.mk
+++ b/unit_tests/unit_test_rules.mk
@@ -18,8 +18,11 @@ ifeq ($(USE_OPT),)
 # -O2 is needed for mingw, without it there is a linking issue to isnanf?!?!
   #USE_OPT = $(RFLAGS) -O2 -fgnu89-inline -ggdb -fomit-frame-pointer -falign-functions=16 -std=gnu99 -Werror-implicit-function-declaration -Werror -Wno-error=pointer-sign -Wno-error=unused-function -Wno-error=unused-variable -Wno-error=sign-compare -Wno-error=unused-parameter -Wno-error=missing-field-initializers
   USE_OPT = -c -Wall -O0 -ggdb -g
-  USE_OPT += -fprofile-arcs -ftest-coverage
   USE_OPT += -Werror=missing-field-initializers
+endif
+
+ifeq ($(COVERAGE),yes)
+	USE_OPT += -fprofile-arcs -ftest-coverage
 endif
 
 

--- a/unit_tests/unit_test_rules.mk
+++ b/unit_tests/unit_test_rules.mk
@@ -183,7 +183,10 @@ ULIBDIR =
 
 # List all user libraries here
 ULIBS = -lm
-ULIBS += --coverage
+
+ifeq ($(COVERAGE),yes)
+	ULIBS += --coverage
+endif
 
 ifneq ($(OS),Windows_NT)
 	ULIBS += -fsanitize=address


### PR DESCRIPTION
- don't emit assembly listings for unit tests (nobody looks at these?), worth about 20%
- disable code coverage unless specified, and specify it in CI runs, worth another 15%

Total improvement: 32% reduction in compile time.

Address sanitizer stays on, since it was only worth about 4% on my machine.

fix #3485 