### PR TITLE
Compile each project's PCH to a separate file to reduce developer friction

### DIFF
--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -18,6 +18,7 @@ PROJECT_DIR = .
 # Configure precompiled header
 PCH_DIR = $(PROJECT_DIR)/pch
 PCHSRC = $(PCH_DIR)/pch.h
+PCHSUB = firmware
 
 # Imported source files and paths
 CHIBIOS_CONTRIB = ChibiOS-Contrib
@@ -61,7 +62,7 @@ endif
 
 # C++ specific options here (added to USE_OPT).
 ifeq ($(USE_CPPOPT),)
-  USE_CPPOPT = -std=c++17 -Wno-register -fno-rtti -fno-threadsafe-statics -fno-exceptions -fno-use-cxa-atexit -Winvalid-pch
+  USE_CPPOPT = -std=c++17 -Wno-register -fno-rtti -fno-threadsafe-statics -fno-exceptions -fno-use-cxa-atexit
 endif
 
 # Hellen is one of the boards which cares

--- a/firmware/bootloader/src/Makefile
+++ b/firmware/bootloader/src/Makefile
@@ -120,6 +120,7 @@ PROJECT_DIR = ..
 # Configure precompiled header
 PCH_DIR = $(PROJECT_DIR)/pch
 PCHSRC = $(PCH_DIR)/pch.h
+PCHSUB = bootloader
 
 # Imported source files and paths
 CHIBIOS = $(PROJECT_DIR)/ChibiOS

--- a/firmware/rusefi_pch.mk
+++ b/firmware/rusefi_pch.mk
@@ -3,10 +3,11 @@
 # Add the PCH dir to source path
 SRCPATHS += $(PCH_DIR)
 
-PCHOBJ = $(addprefix $(PCH_DIR)/, $(notdir $(PCHSRC:.h=.h.gch)))
+PCHOBJ = $(addprefix $(PCH_DIR)/, $(notdir $(PCHSRC:.h=.h.gch)))/$(PCHSUB)
 
 # Compile precompiled header file(s) as a cpp file, but output to .h.gch file
-$(PCHOBJ) : $(PCH_DIR)/%.h.gch : %.h Makefile
+$(PCHOBJ) : $(PCH_DIR)/%.h.gch/$(PCHSUB) : %.h Makefile
+	@mkdir -p $<.gch
 ifeq ($(USE_VERBOSE_COMPILE),yes)
 	@echo
 	$(CPPC) -c $(CPPFLAGS) $(AOPT) -I. $(IINCDIR) $< -o $@

--- a/simulator/Makefile
+++ b/simulator/Makefile
@@ -26,6 +26,7 @@ RULESFILE = ../firmware/rusefi_rules.mk
 # Configure precompiled header
 PCH_DIR = $(PROJECT_DIR)/pch
 PCHSRC = $(PCH_DIR)/pch.h
+PCHSUB = simulator
 
 # used by USE_SMART_BUILD
 CONFDIR = .
@@ -64,7 +65,7 @@ endif
 
 # C++ specific options here (added to USE_OPT).
 ifeq ($(USE_CPPOPT),)
-  USE_CPPOPT = -std=c++17 -Wno-register -fno-rtti -Winvalid-pch
+  USE_CPPOPT = -std=c++17 -Wno-register -fno-rtti
 endif
 
 # Enable this if you want the linker to remove unused code and data.

--- a/unit_tests/tests/test_util.cpp
+++ b/unit_tests/tests/test_util.cpp
@@ -510,9 +510,9 @@ TEST(util, WrapAround62) {
 		// Test random progression, positive and negative.
 		uint32_t seed = time(NULL);
 		printf("Testing with seed 0x%08x\n", seed);
-		srandom(seed);
+		srand(seed);
 		for (unsigned i = 0; i < 10000; i++) {
-			int32_t delta = random();
+			int32_t delta = rand();
 			if (delta < 0) {
 				delta = ~delta;
 			}

--- a/unit_tests/unit_test_rules.mk
+++ b/unit_tests/unit_test_rules.mk
@@ -10,6 +10,7 @@ INCDIR += 	$(UNIT_TESTS_DIR)/googletest/googlemock/include \
 
 PCH_DIR = ../firmware/pch
 PCHSRC = $(PCH_DIR)/pch.h
+PCHSUB = unit_tests
 
 include $(PROJECT_DIR)/rusefi_rules.mk
 
@@ -55,7 +56,7 @@ endif
 
 # C++ specific options here (added to USE_OPT).
 ifeq ($(USE_CPPOPT),)
-  USE_CPPOPT = -std=gnu++17 -fno-rtti -fpermissive -fno-use-cxa-atexit -Winvalid-pch
+  USE_CPPOPT = -std=gnu++17 -fno-rtti -fpermissive -fno-use-cxa-atexit
 endif
 
 # Enable this if you want the linker to remove unused code and data


### PR DESCRIPTION
Having to remove the precompiled header when switching from firmware to simulator to unit_tests and
back again is annoying.  Use a directory to store the precompiled header output.  Turn off
precompiled header warnings as GCC still complains even if it finds a valid one eventually.