### PR TITLE
Remove the EFI_NO_CONFIG_WORKING_COPY option - it is now the default.

### DIFF
--- a/firmware/config/boards/hellen/cypress/efifeatures.h
+++ b/firmware/config/boards/hellen/cypress/efifeatures.h
@@ -61,8 +61,6 @@
  */
 #define EFI_TUNER_STUDIO TRUE
 
-#undef EFI_NO_CONFIG_WORKING_COPY
-
 /**
  * Bluetooth UART setup support.
  */

--- a/firmware/config/boards/kinetis/efifeatures.h
+++ b/firmware/config/boards/kinetis/efifeatures.h
@@ -60,8 +60,6 @@
  */
 #define EFI_TUNER_STUDIO TRUE
 
-#define EFI_NO_CONFIG_WORKING_COPY TRUE
-
 /**
  * Bluetooth UART setup support.
  */

--- a/firmware/console/binary/tunerstudio.h
+++ b/firmware/console/binary/tunerstudio.h
@@ -42,8 +42,6 @@ bool handlePlainCommand(TsChannelBase* tsChannel, uint8_t command);
  */
 void handleQueryCommand(TsChannelBase* tsChannel, ts_response_format_e mode);
 
-char *getWorkingPageAddr();
-
 void tunerStudioDebug(TsChannelBase* tsChannel, const char *msg);
 void tunerStudioError(TsChannelBase* tsChannel, const char *msg);
 

--- a/firmware/controllers/core/error_handling.cpp
+++ b/firmware/controllers/core/error_handling.cpp
@@ -22,10 +22,6 @@ bool hasFirmwareErrorFlag = false;
 const char *dbg_panic_file;
 int dbg_panic_line;
 
-#if EFI_TUNER_STUDIO && !defined(EFI_NO_CONFIG_WORKING_COPY)
-extern persistent_config_s configWorkingCopy;
-#endif
-
 const char* getFirmwareError(void) {
 	return criticalErrorMessageBuffer;
 }
@@ -120,11 +116,7 @@ bool warning(obd_code_e code, const char *fmt, ...) {
 
 	if (CONFIG(showHumanReadableWarning)) {
 #if EFI_TUNER_STUDIO
- #if defined(EFI_NO_CONFIG_WORKING_COPY)
-  memcpy(persistentState.persistentConfiguration.warning_message, warningBuffer, sizeof(warningBuffer));
- #else /* defined(EFI_NO_CONFIG_WORKING_COPY) */
-  memcpy(configWorkingCopy.warning_message, warningBuffer, sizeof(warningBuffer));
- #endif /* defined(EFI_NO_CONFIG_WORKING_COPY) */
+		memcpy(persistentState.persistentConfiguration.warning_message, warningBuffer, sizeof(warningBuffer));
 #endif /* EFI_TUNER_STUDIO */
 	}
 


### PR DESCRIPTION
EDIT:  New goal:
    Any change entered via TunerStudio will now be applied immediately (modulo activeConfiguration
    stuff - TBD).  This makes for a more consistent user experience.  It also save 20,000 bytes of BSS.
