### PR TITLE
Drop SingleChannelStateSequence in favor of MultiChannelStateSequenceWithData

### DIFF
--- a/firmware/controllers/core/state_sequence.cpp
+++ b/firmware/controllers/core/state_sequence.cpp
@@ -9,56 +9,24 @@
 #include "state_sequence.h"
 #include "trigger_structure.h"
 
-MultiChannelStateSequence::MultiChannelStateSequence(unsigned maxWaveCount)
-	: wavePtr(reinterpret_cast<uint8_t *>(&switchTimes[maxWaveCount])) {
-	reset();
-}
-
-void MultiChannelStateSequence::reset(void) {
-	waveCount = 0;
-}
-
-float MultiChannelStateSequence::getSwitchTime(const int index) const {
-	return switchTimes[index];
-}
-
 void MultiChannelStateSequence::checkSwitchTimes(const float scale) const {
-	if (switchTimes[phaseCount - 1] != 1) {
-		firmwareError(CUSTOM_ERR_WAVE_1, "last switch time has to be 1/%f not %.2f/%f", scale,
-				switchTimes[phaseCount - 1], scale * switchTimes[phaseCount - 1]);
+	if (getSwitchTime(phaseCount - 1) != 1) {
+		firmwareError(CUSTOM_ERR_WAVE_1, "last switch time has to be 1/%f not %.2f/%f",
+			      scale, getSwitchTime(phaseCount - 1),
+			      scale * getSwitchTime(phaseCount - 1));
 		return;
 	}
 	for (int i = 0; i < phaseCount - 1; i++) {
-		if (switchTimes[i] >= switchTimes[i + 1]) {
-			firmwareError(CUSTOM_ERR_WAVE_2, "invalid switchTimes @%d: %.2f/%.2f", i, switchTimes[i], switchTimes[i + 1]);
+		if (getSwitchTime(i) >= getSwitchTime(i + 1)) {
+			firmwareError(CUSTOM_ERR_WAVE_2, "invalid switchTimes @%d: %.2f/%.2f",
+				      i, getSwitchTime(i), getSwitchTime(i + 1));
 		}
 	}
 }
 
-pin_state_t MultiChannelStateSequence::getChannelState(const int channelIndex, const int phaseIndex) const {
-	if (channelIndex >= waveCount) {
-		// todo: would be nice to get this asserting working
-		//firmwareError(OBD_PCM_Processor_Fault, "channel index %d/%d", channelIndex, waveCount);
-	}
-	return ((wavePtr[phaseIndex] >> channelIndex) & 1) ? TV_RISE : TV_FALL;
-}
-
-void MultiChannelStateSequence::setChannelState(const int channelIndex, const int phaseIndex,
-						pin_state_t state) {
-	if (channelIndex >= waveCount) {
-		// todo: would be nice to get this asserting working
-		//firmwareError(OBD_PCM_Processor_Fault, "channel index %d/%d", channelIndex, waveCount);
-	}
-	uint8_t & ref = wavePtr[phaseIndex];
-	ref = (ref & ~(1U << channelIndex)) | ((state == TV_RISE ? 1 : 0) << channelIndex);
-}
-
-/**
- * returns the index at which given value would need to be inserted into sorted array
- */
 int MultiChannelStateSequence::findInsertionAngle(const float angle) const {
 	for (int i = phaseCount - 1; i >= 0; i--) {
-		if (angle > switchTimes[i])
+		if (angle > getSwitchTime(i))
 			return i + 1;
 	}
 	return 0;
@@ -66,13 +34,8 @@ int MultiChannelStateSequence::findInsertionAngle(const float angle) const {
 
 int MultiChannelStateSequence::findAngleMatch(const float angle) const {
 	for (int i = 0; i < phaseCount; i++) {
-		if (isSameF(switchTimes[i], angle))
+		if (isSameF(getSwitchTime(i), angle))
 			return i;
 	}
 	return EFI_ERROR_CODE;
-}
-
-void MultiChannelStateSequence::setSwitchTime(const int index, const float value) {
-	efiAssertVoid(CUSTOM_ERR_PWM_SWITCH_ASSERT, switchTimes != NULL, "switchTimes");
-	switchTimes[index] = value;
 }

--- a/firmware/controllers/core/state_sequence.h
+++ b/firmware/controllers/core/state_sequence.h
@@ -9,6 +9,7 @@
 
 #include "rusefi_enums.h"
 #include <new>
+#include <utility>
 #include <stdint.h>
 
 /**
@@ -44,7 +45,7 @@ public:
 	{
 		// Placement new, don't worry - no dynamic memory allocated here
 		// Always pass # elements to child, hopefully it can do something with it
-		new (m_data) base_t(n_elem, std::forward<Args>(args)...);
+		new (&m_base) base_t(n_elem, std::forward<Args>(args)...);
 	}
 
 	base_t * operator->() {
@@ -76,7 +77,10 @@ private:
 		return base_size + n_elem * sizeof(type_t);
 	}
 
-	uint8_t m_data[get_size<tail_t...>(sizeof(base_t))];
+	union {
+		uint8_t m_data[get_size<tail_t...>(sizeof(base_t))];
+		base_t m_base;
+	};
 };
 
 /**
@@ -112,7 +116,7 @@ private:
 	 * values in the (0..1] range which refer to points within the period at at which pin state should be changed
 	 * So, in the simplest case we turn pin off at 0.3 and turn it on at 1 - that would give us a 70% duty cycle PWM
 	 */
-	float switchTimes[];
+	float switchTimes[0];
 	// uint8_t wave[] comes after
 };
 

--- a/firmware/controllers/system/timer/pwm_generator_logic.cpp
+++ b/firmware/controllers/system/timer/pwm_generator_logic.cpp
@@ -19,11 +19,9 @@
 #define ZERO_PWM_THRESHOLD 0.01
 
 SimplePwm::SimplePwm()
-	: sr(pinStates)
-	, seq(_switchTimes, &sr)
 {
-	seq.waveCount = 1;
-	seq.phaseCount = 2;
+	seq->waveCount = 1;
+	seq->phaseCount = 2;
 }
 
 SimplePwm::SimplePwm(const char *name) : SimplePwm()  {
@@ -87,7 +85,7 @@ void SimplePwm::setSimplePwmDutyCycle(float dutyCycle) {
 		mode = PM_FULL;
 	} else {
 		mode = PM_NORMAL;
-		_switchTimes[0] = dutyCycle;
+		seq->setSwitchTime(0, dutyCycle);
 	}
 }
 
@@ -316,16 +314,16 @@ void startSimplePwm(SimplePwm *state, const char *msg, ExecutorInterface *execut
 		return;
 	}
 
-	state->_switchTimes[0] = dutyCycle;
-	state->_switchTimes[1] = 1;
-	state->pinStates[0] = TV_FALL;
-	state->pinStates[1] = TV_RISE;
+	state->seq->setSwitchTime(0, dutyCycle);
+	state->seq->setSwitchTime(1, 1);
+	state->seq->setChannelState(0, 0, TV_FALL);
+	state->seq->setChannelState(0, 1, TV_RISE);
 
 	state->outputPins[0] = output;
 
 	state->setFrequency(frequency);
-	state->setSimplePwmDutyCycle(dutyCycle); // TODO: DUP ABOVE?
-	state->weComplexInit(msg, executor, &state->seq, NULL, (pwm_gen_callback*)applyPinState);
+	state->setSimplePwmDutyCycle(dutyCycle);
+	state->weComplexInit(msg, executor, &*state->seq, NULL, (pwm_gen_callback*)applyPinState);
 }
 
 void startSimplePwmExt(SimplePwm *state, const char *msg,

--- a/firmware/controllers/system/timer/pwm_generator_logic.cpp
+++ b/firmware/controllers/system/timer/pwm_generator_logic.cpp
@@ -20,8 +20,8 @@
 
 SimplePwm::SimplePwm()
 {
-	seq->waveCount = 1;
-	seq->phaseCount = 2;
+	seq.waveCount = 1;
+	seq.phaseCount = 2;
 }
 
 SimplePwm::SimplePwm(const char *name) : SimplePwm()  {
@@ -85,7 +85,7 @@ void SimplePwm::setSimplePwmDutyCycle(float dutyCycle) {
 		mode = PM_FULL;
 	} else {
 		mode = PM_NORMAL;
-		seq->setSwitchTime(0, dutyCycle);
+		seq.setSwitchTime(0, dutyCycle);
 	}
 }
 
@@ -314,16 +314,16 @@ void startSimplePwm(SimplePwm *state, const char *msg, ExecutorInterface *execut
 		return;
 	}
 
-	state->seq->setSwitchTime(0, dutyCycle);
-	state->seq->setSwitchTime(1, 1);
-	state->seq->setChannelState(0, 0, TV_FALL);
-	state->seq->setChannelState(0, 1, TV_RISE);
+	state->seq.setSwitchTime(0, dutyCycle);
+	state->seq.setSwitchTime(1, 1);
+	state->seq.setChannelState(0, 0, TV_FALL);
+	state->seq.setChannelState(0, 1, TV_RISE);
 
 	state->outputPins[0] = output;
 
 	state->setFrequency(frequency);
 	state->setSimplePwmDutyCycle(dutyCycle);
-	state->weComplexInit(msg, executor, &*state->seq, NULL, (pwm_gen_callback*)applyPinState);
+	state->weComplexInit(msg, executor, &state->seq, NULL, (pwm_gen_callback*)applyPinState);
 }
 
 void startSimplePwmExt(SimplePwm *state, const char *msg,

--- a/firmware/controllers/system/timer/pwm_generator_logic.h
+++ b/firmware/controllers/system/timer/pwm_generator_logic.h
@@ -120,10 +120,7 @@ public:
 	SimplePwm();
 	explicit SimplePwm(const char *name);
 	void setSimplePwmDutyCycle(float dutyCycle) override;
-	pin_state_t pinStates[2];
-	SingleChannelStateSequence sr;
-	float _switchTimes[2];
-	MultiChannelStateSequence seq;
+	MultiChannelStateSequenceWithData<2> seq;
 	hardware_pwm* hardPwm = nullptr;
 };
 

--- a/firmware/controllers/trigger/decoders/trigger_structure.cpp
+++ b/firmware/controllers/trigger/decoders/trigger_structure.cpp
@@ -75,11 +75,10 @@ void TriggerWaveform::initialize(operation_mode_e operationMode) {
 	this->operationMode = operationMode;
 	triggerShapeSynchPointIndex = 0;
 	memset(initialState, 0, sizeof(initialState));
-	memset((void *)(&*wave + 1), 0, sizeof(float) * PWM_PHASE_MAX_WAVE_PER_PWM); // Really want to remove this...
 	memset(expectedEventCount, 0, sizeof(expectedEventCount));
-	wave->reset();
-	wave->waveCount = TRIGGER_CHANNEL_COUNT;
-	wave->phaseCount = 0;
+	wave.reset();
+	wave.waveCount = TRIGGER_CHANNEL_COUNT;
+	wave.phaseCount = 0;
 	previousAngle = 0;
 	memset(isRiseEvent, 0, sizeof(isRiseEvent));
 #if EFI_UNIT_TEST
@@ -89,7 +88,7 @@ void TriggerWaveform::initialize(operation_mode_e operationMode) {
 }
 
 size_t TriggerWaveform::getSize() const {
-	return wave->phaseCount;
+	return wave.phaseCount;
 }
 
 int TriggerWaveform::getTriggerWaveformSynchPointIndex() const {
@@ -139,9 +138,9 @@ angle_t TriggerWaveform::getAngle(int index) const {
 	 * See also trigger_central.cpp
 	 * See also getEngineCycleEventCount()
 	 */
-	efiAssert(CUSTOM_ERR_ASSERT, wave->phaseCount != 0, "shapeSize=0", NAN);
-	int crankCycle = index / wave->phaseCount;
-	int remainder = index % wave->phaseCount;
+	efiAssert(CUSTOM_ERR_ASSERT, wave.phaseCount != 0, "shapeSize=0", NAN);
+	int crankCycle = index / wave.phaseCount;
+	int remainder = index % wave.phaseCount;
 
 	auto cycleStartAngle = getCycleDuration() * crankCycle;
 	auto positionWithinCycle = getSwitchAngle(remainder);
@@ -225,9 +224,9 @@ void TriggerWaveform::addEvent(angle_t angle, trigger_wheel_e const channelIndex
 #endif
 
 #if EFI_UNIT_TEST
-	assertIsInBounds(wave->phaseCount, triggerSignalIndeces, "trigger shape overflow");
-	triggerSignalIndeces[wave->phaseCount] = channelIndex;
-	triggerSignalStates[wave->phaseCount] = state;
+	assertIsInBounds(wave.phaseCount, triggerSignalIndeces, "trigger shape overflow");
+	triggerSignalIndeces[wave.phaseCount] = channelIndex;
+	triggerSignalStates[wave.phaseCount] = state;
 #endif // EFI_UNIT_TEST
 
 
@@ -239,39 +238,39 @@ void TriggerWaveform::addEvent(angle_t angle, trigger_wheel_e const channelIndex
 	}
 
 	efiAssertVoid(CUSTOM_ERR_6599, angle > 0 && angle <= 1, "angle should be positive not above 1");
-	if (wave->phaseCount > 0) {
+	if (wave.phaseCount > 0) {
 		if (angle <= previousAngle) {
 			warning(CUSTOM_ERR_TRG_ANGLE_ORDER, "invalid angle order %s %s: new=%.2f/%f and prev=%.2f/%f, size=%d",
 					getTrigger_wheel_e(channelIndex),
 					getTrigger_value_e(state),
 					angle, angle * getCycleDuration(),
 					previousAngle, previousAngle * getCycleDuration(),
-					wave->phaseCount);
+					wave.phaseCount);
 			setShapeDefinitionError(true);
 			return;
 		}
 	}
 	previousAngle = angle;
-	if (wave->phaseCount == 0) {
-		wave->phaseCount = 1;
+	if (wave.phaseCount == 0) {
+		wave.phaseCount = 1;
 		for (int i = 0; i < PWM_PHASE_MAX_WAVE_PER_PWM; i++) {
-			wave->setChannelState(i, /* switchIndex */ 0, /* value */ initialState[i]);
+			wave.setChannelState(i, /* switchIndex */ 0, /* value */ initialState[i]);
 		}
 
 		isRiseEvent[0] = TV_RISE == state;
-		wave->setSwitchTime(0, angle);
-		wave->setChannelState(channelIndex, /* channelIndex */ 0, /* value */ state);
+		wave.setSwitchTime(0, angle);
+		wave.setChannelState(channelIndex, /* channelIndex */ 0, /* value */ state);
 		return;
 	}
 
-	int exactMatch = wave->findAngleMatch(angle);
+	int exactMatch = wave.findAngleMatch(angle);
 	if (exactMatch != (int)EFI_ERROR_CODE) {
 		warning(CUSTOM_ERR_SAME_ANGLE, "same angle: not supported");
 		setShapeDefinitionError(true);
 		return;
 	}
 
-	int index = wave->findInsertionAngle(angle);
+	int index = wave.findInsertionAngle(angle);
 
 	/**
 	 * todo: it would be nice to be able to provide trigger angles without sorting them externally
@@ -281,29 +280,29 @@ void TriggerWaveform::addEvent(angle_t angle, trigger_wheel_e const channelIndex
 /*
 	for (int i = size - 1; i >= index; i--) {
 		for (int j = 0; j < PWM_PHASE_MAX_WAVE_PER_PWM; j++) {
-			wave->waves[j].pinStates[i + 1] = wave->getChannelState(j, index);
+			wave.waves[j].pinStates[i + 1] = wave.getChannelState(j, index);
 		}
-		wave->setSwitchTime(i + 1, wave->getSwitchTime(i));
+		wave.setSwitchTime(i + 1, wave.getSwitchTime(i));
 	}
 */
 	isRiseEvent[index] = TV_RISE == state;
 
-	if ((unsigned)index != wave->phaseCount) {
+	if ((unsigned)index != wave.phaseCount) {
 		firmwareError(ERROR_TRIGGER_DRAMA, "are we ever here?");
 	}
 
-	wave->phaseCount++;
+	wave.phaseCount++;
 
 	for (int i = 0; i < PWM_PHASE_MAX_WAVE_PER_PWM; i++) {
-		pin_state_t value = wave->getChannelState(/* channelIndex */i, index - 1);
-		wave->setChannelState(i, index, value);
+		pin_state_t value = wave.getChannelState(/* channelIndex */i, index - 1);
+		wave.setChannelState(i, index, value);
 	}
-	wave->setSwitchTime(index, angle);
-	wave->setChannelState(channelIndex, index, state);
+	wave.setSwitchTime(index, angle);
+	wave.setChannelState(channelIndex, index, state);
 }
 
 angle_t TriggerWaveform::getSwitchAngle(int index) const {
-	return getCycleDuration() * wave->getSwitchTime(index);
+	return getCycleDuration() * wave.getSwitchTime(index);
 }
 
 void setToothedWheelConfiguration(TriggerWaveform *s, int total, int skipped,
@@ -744,7 +743,7 @@ void TriggerWaveform::initializeTriggerWaveform(operation_mode_e ambiguousOperat
 	version++;
 
 	if (!shapeDefinitionError) {
-		wave->checkSwitchTimes(getCycleDuration());
+		wave.checkSwitchTimes(getCycleDuration());
 	}
 
 	if (bothFrontsRequired && useOnlyRisingEdgeForTrigger) {

--- a/firmware/controllers/trigger/decoders/trigger_structure.h
+++ b/firmware/controllers/trigger/decoders/trigger_structure.h
@@ -60,15 +60,6 @@ public:
 
 #define TRIGGER_CHANNEL_COUNT 3
 
-class trigger_shape_helper {
-public:
-	trigger_shape_helper();
-
-	SingleChannelStateSequence channels[TRIGGER_CHANNEL_COUNT];
-private:
-	pin_state_t pinStates[TRIGGER_CHANNEL_COUNT][PWM_PHASE_MAX_COUNT];
-};
-
 class Engine;
 class TriggerState;
 class TriggerFormDetails;
@@ -199,8 +190,7 @@ public:
 	 * but name is supposed to hint at the fact that decoders should not be assigning to it
 	 * Please use "getTriggerSize()" macro or "getSize()" method to read this value
 	 */
-	MultiChannelStateSequence waveStorage; // DON'T USE - WILL BE REMOVED LATER
-	MultiChannelStateSequence * const wave;
+	MultiChannelStateSequenceWithData<PWM_PHASE_MAX_COUNT> wave;
 
 	// todo: add a runtime validation which would verify that this field was set properly
 	// todo: maybe even automate this flag calculation?
@@ -276,14 +266,6 @@ public:
 	uint16_t findAngleIndex(TriggerFormDetails *details, angle_t angle) const;
 
 private:
-	trigger_shape_helper h;
-
-	/**
-	 * Working buffer for 'wave' instance
-	 * Values are in the 0..1 range
-	 */
-	float switchTimesBuffer[PWM_PHASE_MAX_COUNT];
-
 	/**
 	 * These angles are in trigger DESCRIPTION coordinates - i.e. the way you add events while declaring trigger shape
 	 */

--- a/firmware/controllers/trigger/decoders/trigger_structure.h
+++ b/firmware/controllers/trigger/decoders/trigger_structure.h
@@ -308,4 +308,4 @@ void setToothedWheelConfiguration(TriggerWaveform *s, int total, int skipped, op
 
 #define TRIGGER_WAVEFORM(x) engine->triggerCentral.triggerShape.x
 
-#define getTriggerSize() TRIGGER_WAVEFORM(wave->phaseCount)
+#define getTriggerSize() TRIGGER_WAVEFORM(wave.phaseCount)

--- a/firmware/controllers/trigger/trigger_emulator_algo.cpp
+++ b/firmware/controllers/trigger/trigger_emulator_algo.cpp
@@ -20,7 +20,7 @@ int getPreviousIndex(const int currentIndex, const int size) {
 	return (currentIndex + size - 1) % size;
 }
 
-bool needEvent(const int currentIndex, const MultiChannelStateSequence& mcss, int channelIndex) {
+bool needEvent(const int currentIndex, const MultiChannelStateSequence & mcss, int channelIndex) {
 	int prevIndex = getPreviousIndex(currentIndex, mcss.phaseCount);
 	pin_state_t previousValue = mcss.getChannelState(channelIndex, /*phaseIndex*/prevIndex);
 	pin_state_t currentValue = mcss.getChannelState(channelIndex, /*phaseIndex*/currentIndex);
@@ -106,7 +106,7 @@ static void updateTriggerWaveformIfNeeded(PwmConfig *state) {
 
 
 		TriggerWaveform *s = &engine->triggerCentral.triggerShape;
-		copyPwmParameters(state, s->wave);
+		copyPwmParameters(state, &*s->wave);
 		state->safe.periodNt = -1; // this would cause loop re-initialization
 	}
 }
@@ -146,7 +146,7 @@ static void initTriggerPwm() {
 	setTriggerEmulatorRPM(engineConfiguration->triggerSimulatorFrequency);
 	triggerSignal.weComplexInit("position sensor",
 			&engine->executor,
-			s->wave,
+			&*s->wave,
 			updateTriggerWaveformIfNeeded, (pwm_gen_callback*)emulatorApplyPinState);
 
 	hasInitTriggerEmulator = true;

--- a/firmware/controllers/trigger/trigger_emulator_algo.cpp
+++ b/firmware/controllers/trigger/trigger_emulator_algo.cpp
@@ -106,7 +106,7 @@ static void updateTriggerWaveformIfNeeded(PwmConfig *state) {
 
 
 		TriggerWaveform *s = &engine->triggerCentral.triggerShape;
-		copyPwmParameters(state, &*s->wave);
+		copyPwmParameters(state, &s->wave);
 		state->safe.periodNt = -1; // this would cause loop re-initialization
 	}
 }
@@ -146,7 +146,7 @@ static void initTriggerPwm() {
 	setTriggerEmulatorRPM(engineConfiguration->triggerSimulatorFrequency);
 	triggerSignal.weComplexInit("position sensor",
 			&engine->executor,
-			&*s->wave,
+			&s->wave,
 			updateTriggerWaveformIfNeeded, (pwm_gen_callback*)emulatorApplyPinState);
 
 	hasInitTriggerEmulator = true;

--- a/firmware/controllers/trigger/trigger_simulator.cpp
+++ b/firmware/controllers/trigger/trigger_simulator.cpp
@@ -48,7 +48,7 @@ void TriggerStimulatorHelper::feedSimulatedEvent(
 
 	int time = getSimulatedEventTime(shape, i);
 
-	const MultiChannelStateSequence& multiChannelStateSequence = *shape.wave;
+	const auto & multiChannelStateSequence = *shape.wave;
 
 #if EFI_UNIT_TEST
 	int prevIndex = getPreviousIndex(stateIndex, shape.getSize());

--- a/firmware/controllers/trigger/trigger_simulator.cpp
+++ b/firmware/controllers/trigger/trigger_simulator.cpp
@@ -33,7 +33,7 @@ int getSimulatedEventTime(const TriggerWaveform& shape, int i) {
 	int stateIndex = i % shape.getSize();
 	int loopIndex = i / shape.getSize();
 
-	return (int) (SIMULATION_CYCLE_PERIOD * (loopIndex + shape.wave->getSwitchTime(stateIndex)));
+	return (int) (SIMULATION_CYCLE_PERIOD * (loopIndex + shape.wave.getSwitchTime(stateIndex)));
 }
 
 void TriggerStimulatorHelper::feedSimulatedEvent(
@@ -48,7 +48,7 @@ void TriggerStimulatorHelper::feedSimulatedEvent(
 
 	int time = getSimulatedEventTime(shape, i);
 
-	const auto & multiChannelStateSequence = *shape.wave;
+	const auto & multiChannelStateSequence = shape.wave;
 
 #if EFI_UNIT_TEST
 	int prevIndex = getPreviousIndex(stateIndex, shape.getSize());

--- a/unit_tests/tests/ignition_injection/test_fuel_map.cpp
+++ b/unit_tests/tests/ignition_injection/test_fuel_map.cpp
@@ -103,31 +103,31 @@ static void configureFordAspireTriggerWaveform(TriggerWaveform * s) {
 	s->addEvent720(657.03, T_SECONDARY, TV_FALL);
 	s->addEvent720(720, T_PRIMARY, TV_FALL);
 
-	ASSERT_FLOAT_EQ(53.747 / 720, s->wave->getSwitchTime(0));
-	ASSERT_EQ( 1,  s->wave->getChannelState(1, 0)) << "@0";
-	ASSERT_EQ( 1,  s->wave->getChannelState(1, 0)) << "@0";
+	ASSERT_FLOAT_EQ(53.747 / 720, s->wave.getSwitchTime(0));
+	ASSERT_EQ( 1,  s->wave.getChannelState(1, 0)) << "@0";
+	ASSERT_EQ( 1,  s->wave.getChannelState(1, 0)) << "@0";
 
-	ASSERT_EQ( 0,  s->wave->getChannelState(0, 1)) << "@1";
-	ASSERT_EQ( 0,  s->wave->getChannelState(1, 1)) << "@1";
+	ASSERT_EQ( 0,  s->wave.getChannelState(0, 1)) << "@1";
+	ASSERT_EQ( 0,  s->wave.getChannelState(1, 1)) << "@1";
 
-	ASSERT_EQ( 0,  s->wave->getChannelState(0, 2)) << "@2";
-	ASSERT_EQ( 1,  s->wave->getChannelState(1, 2)) << "@2";
+	ASSERT_EQ( 0,  s->wave.getChannelState(0, 2)) << "@2";
+	ASSERT_EQ( 1,  s->wave.getChannelState(1, 2)) << "@2";
 
-	ASSERT_EQ( 0,  s->wave->getChannelState(0, 3)) << "@3";
-	ASSERT_EQ( 0,  s->wave->getChannelState(1, 3)) << "@3";
+	ASSERT_EQ( 0,  s->wave.getChannelState(0, 3)) << "@3";
+	ASSERT_EQ( 0,  s->wave.getChannelState(1, 3)) << "@3";
 
-	ASSERT_EQ( 1,  s->wave->getChannelState(0, 4)) << "@4";
-	ASSERT_EQ( 1,  s->wave->getChannelState(1, 5)) << "@5";
-	ASSERT_EQ( 0,  s->wave->getChannelState(1, 8)) << "@8";
-	ASSERT_FLOAT_EQ(121.90 / 720, s->wave->getSwitchTime(1));
-	ASSERT_FLOAT_EQ(657.03 / 720, s->wave->getSwitchTime(8));
+	ASSERT_EQ( 1,  s->wave.getChannelState(0, 4)) << "@4";
+	ASSERT_EQ( 1,  s->wave.getChannelState(1, 5)) << "@5";
+	ASSERT_EQ( 0,  s->wave.getChannelState(1, 8)) << "@8";
+	ASSERT_FLOAT_EQ(121.90 / 720, s->wave.getSwitchTime(1));
+	ASSERT_FLOAT_EQ(657.03 / 720, s->wave.getSwitchTime(8));
 
-	ASSERT_EQ( 0,  s->wave->findAngleMatch(53.747 / 720.0)) << "expecting 0";
-	assertEqualsM("expecting not found", -1, s->wave->findAngleMatch(53 / 720.0));
-	ASSERT_EQ(7, s->wave->findAngleMatch(588.045 / 720.0));
+	ASSERT_EQ( 0,  s->wave.findAngleMatch(53.747 / 720.0)) << "expecting 0";
+	assertEqualsM("expecting not found", -1, s->wave.findAngleMatch(53 / 720.0));
+	ASSERT_EQ(7, s->wave.findAngleMatch(588.045 / 720.0));
 
-	ASSERT_EQ( 0,  s->wave->findInsertionAngle(23.747 / 720.0)) << "expecting 0";
-	ASSERT_EQ( 1,  s->wave->findInsertionAngle(63.747 / 720.0)) << "expecting 1";
+	ASSERT_EQ( 0,  s->wave.findInsertionAngle(23.747 / 720.0)) << "expecting 0";
+	ASSERT_EQ( 1,  s->wave.findInsertionAngle(63.747 / 720.0)) << "expecting 1";
 }
 
 TEST(misc, testAngleResolver) {
@@ -142,9 +142,9 @@ TEST(misc, testAngleResolver) {
 	engine->initializeTriggerWaveform();
 
 	assertEqualsM("index 2", 52.76, triggerFormDetails->eventAngles[3]); // this angle is relation to synch point
-	assertEqualsM("time 2", 0.3233, ts->wave->getSwitchTime(2));
+	assertEqualsM("time 2", 0.3233, ts->wave.getSwitchTime(2));
 	assertEqualsM("index 5", 412.76, triggerFormDetails->eventAngles[6]);
-	assertEqualsM("time 5", 0.5733, ts->wave->getSwitchTime(5));
+	assertEqualsM("time 5", 0.5733, ts->wave.getSwitchTime(5));
 
 	ASSERT_EQ(4, ts->getTriggerWaveformSynchPointIndex());
 

--- a/unit_tests/tests/trigger/test_miata_na_tdc.cpp
+++ b/unit_tests/tests/trigger/test_miata_na_tdc.cpp
@@ -21,7 +21,7 @@ TEST(miata, miata_na_tdc) {
 		eth.setTimeAndInvokeEventsUs(time);
 
 		emulatorHelper.handleEmulatorCallback(
-				*shape.wave,
+				shape.wave,
 				i  % shape.getSize());
 	}
 

--- a/unit_tests/tests/trigger/test_nissan_vq_vvt.cpp
+++ b/unit_tests/tests/trigger/test_nissan_vq_vvt.cpp
@@ -22,9 +22,9 @@ public:
 static void func(TriggerCallback *callback) {
 	int formIndex = callback->toothIndex % callback->form->getSize();
 	Engine *engine = callback->engine;
-	
 
-	int value = callback->form->wave->getChannelState(0, formIndex);
+
+	int value = callback->form->wave.getChannelState(0, formIndex);
 	efitick_t nowNt = getTimeNowNt();
 	if (callback->isVvt) {
 		trigger_value_e v = value ? TV_RISE : TV_FALL;

--- a/unit_tests/tests/trigger/test_trigger_decoder.cpp
+++ b/unit_tests/tests/trigger/test_trigger_decoder.cpp
@@ -466,10 +466,10 @@ TEST(misc, testTriggerDecoder) {
 	s->useOnlyRisingEdgeForTriggerTemp = false;
 	initializeSkippedToothTriggerWaveformExt(s, 2, 0, FOUR_STROKE_CAM_SENSOR);
 	assertEqualsM("shape size", s->getSize(), 4);
-	ASSERT_EQ(s->wave->getSwitchTime(0), 0.25);
-	ASSERT_EQ(s->wave->getSwitchTime(1), 0.5);
-	ASSERT_EQ(s->wave->getSwitchTime(2), 0.75);
-	ASSERT_EQ(s->wave->getSwitchTime(3), 1);
+	ASSERT_EQ(s->wave.getSwitchTime(0), 0.25);
+	ASSERT_EQ(s->wave.getSwitchTime(1), 0.5);
+	ASSERT_EQ(s->wave.getSwitchTime(2), 0.75);
+	ASSERT_EQ(s->wave.getSwitchTime(3), 1);
 
 	}
 


### PR DESCRIPTION
Most all the users were Multi* anyways, so just improve that:
1. Allow up to 8 waveforms to share one byte per timestamp.  It could be better but this is simple
   and gets most of the benefit.
2. Use a wrapper structure to handle reserving space for the arrays.  Makes the interface simpler
   and more rigid.  Also saves 4 bytes per Multi*.  Downside is access is now via -> and *,
   not . and (nothing).

Saves 224 bytes of BSS, 1832 bytes of RAM4/CCM, 824 bytes of TEXT (yay? but unexpected...), and
costs 26 bytes of RODATA (more yay?)