### PR TITLE
Change users of MultiChannelStateSequence to use the API

### DIFF
--- a/firmware/controllers/core/state_sequence.cpp
+++ b/firmware/controllers/core/state_sequence.cpp
@@ -74,6 +74,15 @@ pin_state_t MultiChannelStateSequence::getChannelState(const int channelIndex, c
 	return channels[channelIndex].pinStates[phaseIndex];
 }
 
+void MultiChannelStateSequence::setChannelState(const int channelIndex, const int phaseIndex,
+						pin_state_t state) {
+	if (channelIndex >= waveCount) {
+		// todo: would be nice to get this asserting working
+		//firmwareError(OBD_PCM_Processor_Fault, "channel index %d/%d", channelIndex, waveCount);
+	}
+	channels[channelIndex].pinStates[phaseIndex] = state;
+}
+
 /**
  * returns the index at which given value would need to be inserted into sorted array
  */

--- a/firmware/controllers/core/state_sequence.h
+++ b/firmware/controllers/core/state_sequence.h
@@ -75,6 +75,7 @@ public:
 	void setSwitchTime(const int phaseIndex, const float value);
 	void checkSwitchTimes(const float scale) const;
 	pin_state_t getChannelState(const int channelIndex, const int phaseIndex) const;
+	void setChannelState(const int channelIndex, const int phaseIndex, pin_state_t state);
 
 	int findAngleMatch(const float angle) const;
 	int findInsertionAngle(const float angle) const;

--- a/firmware/controllers/trigger/decoders/trigger_structure.cpp
+++ b/firmware/controllers/trigger/decoders/trigger_structure.cpp
@@ -259,19 +259,19 @@ void TriggerWaveform::addEvent(angle_t angle, trigger_wheel_e const channelIndex
 	if (wave.phaseCount == 0) {
 		wave.phaseCount = 1;
 		for (int i = 0; i < PWM_PHASE_MAX_WAVE_PER_PWM; i++) {
-			SingleChannelStateSequence *wave = &this->wave.channels[i];
+			SingleChannelStateSequence *swave = &wave.channels[i];
 
-			if (wave->pinStates == nullptr) {
+			if (swave->pinStates == nullptr) {
 				warning(CUSTOM_ERR_STATE_NULL, "wave pinStates is NULL");
 				setShapeDefinitionError(true);
 				return;
 			}
-			wave->setState(/* switchIndex */ 0, /* value */ initialState[i]);
+			wave.setChannelState(i, /* switchIndex */ 0, /* value */ initialState[i]);
 		}
 
 		isRiseEvent[0] = TV_RISE == state;
 		wave.setSwitchTime(0, angle);
-		wave.channels[channelIndex].setState(/* channelIndex */ 0, /* value */ state);
+		wave.setChannelState(channelIndex, /* channelIndex */ 0, /* value */ state);
 		return;
 	}
 
@@ -307,10 +307,10 @@ void TriggerWaveform::addEvent(angle_t angle, trigger_wheel_e const channelIndex
 
 	for (int i = 0; i < PWM_PHASE_MAX_WAVE_PER_PWM; i++) {
 		pin_state_t value = wave.getChannelState(/* channelIndex */i, index - 1);
-		wave.channels[i].setState(index, value);
+		wave.setChannelState(i, index, value);
 	}
 	wave.setSwitchTime(index, angle);
-	wave.channels[channelIndex].setState(index, state);
+	wave.setChannelState(channelIndex, index, state);
 }
 
 angle_t TriggerWaveform::getSwitchAngle(int index) const {

--- a/unit_tests/tests/trigger/test_nissan_vq_vvt.cpp
+++ b/unit_tests/tests/trigger/test_nissan_vq_vvt.cpp
@@ -24,7 +24,7 @@ static void func(TriggerCallback *callback) {
 	Engine *engine = callback->engine;
 	EXPAND_Engine;
 
-	int value = callback->form->wave.channels[0].getState(formIndex);
+	int value = callback->form->wave.getChannelState(0, formIndex);
 	efitick_t nowNt = getTimeNowNt();
 	if (callback->isVvt) {
 		trigger_value_e v = value ? TV_RISE : TV_FALL;

--- a/unit_tests/tests/trigger/test_trigger_decoder.cpp
+++ b/unit_tests/tests/trigger/test_trigger_decoder.cpp
@@ -467,10 +467,10 @@ TEST(misc, testTriggerDecoder) {
 
 	initializeSkippedToothTriggerWaveformExt(s, 2, 0, FOUR_STROKE_CAM_SENSOR);
 	assertEqualsM("shape size", s->getSize(), 4);
-	ASSERT_EQ(s->wave.switchTimes[0], 0.25);
-	ASSERT_EQ(s->wave.switchTimes[1], 0.5);
-	ASSERT_EQ(s->wave.switchTimes[2], 0.75);
-	ASSERT_EQ(s->wave.switchTimes[3], 1);
+	ASSERT_EQ(s->wave.getSwitchTime(0), 0.25);
+	ASSERT_EQ(s->wave.getSwitchTime(1), 0.5);
+	ASSERT_EQ(s->wave.getSwitchTime(2), 0.75);
+	ASSERT_EQ(s->wave.getSwitchTime(3), 1);
 
 	}
 


### PR DESCRIPTION
Better than reaching into members that should be private.  I didn't feel like actually making them private though, as one user validates pinStates isn't NULL.