### PR TITLE
Print BSS and RAM4 totals at the end of make.

### DIFF
--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -409,3 +409,7 @@ openblt_clean:
 
 # Enable precompiled header
 include rusefi_pch.mk
+
+POST_MAKE_ALL_RULE_HOOK: $(BUILDDIR)/$(PROJECT).elf
+	@java -jar ../java_tools/gcc_map_reader.jar $(BUILDDIR)/$(PROJECT).map | grep Total || echo Unable to run gcc_map_reader
+	@$(TRGT)objdump -h $(BUILDDIR)/$(PROJECT).elf | grep -w ram4


### PR DESCRIPTION
The compiler was outsmarting us: UNUSED_CCM disappeared entirely (probably because of the *0),
while UNUSED_RAM was helpfully moved to read-only flash.  It's possible making these not static
would have helped, but link time optimization might have gotten rid of them too.

Instead, print BSS and RAM4 totals at the end using the java script.  If java is unable to run,
don't error out the Makefile, just complain a little and move on.  Until the gcc_map_reader
actually works with RAM4, we print it manually.