### PR TITLE
Convert TriggerWaveform::wave to a pointer in preparation for code-defined sequences.

### DIFF
--- a/firmware/controllers/trigger/decoders/trigger_structure.cpp
+++ b/firmware/controllers/trigger/decoders/trigger_structure.cpp
@@ -55,10 +55,11 @@ trigger_shape_helper::trigger_shape_helper() {
 	}
 }
 
-TriggerWaveform::TriggerWaveform() :
-		wave(switchTimesBuffer, NULL) {
+TriggerWaveform::TriggerWaveform()
+		: waveStorage(switchTimesBuffer, NULL)
+		, wave(&waveStorage) {
 	initialize(OM_NONE);
-	wave.channels = h.channels;
+	wave->channels = h.channels;
 }
 
 void TriggerWaveform::initialize(operation_mode_e operationMode) {
@@ -85,9 +86,9 @@ void TriggerWaveform::initialize(operation_mode_e operationMode) {
 	memset(initialState, 0, sizeof(initialState));
 	memset(switchTimesBuffer, 0, sizeof(switchTimesBuffer));
 	memset(expectedEventCount, 0, sizeof(expectedEventCount));
-	wave.reset();
-	wave.waveCount = TRIGGER_CHANNEL_COUNT;
-	wave.phaseCount = 0;
+	wave->reset();
+	wave->waveCount = TRIGGER_CHANNEL_COUNT;
+	wave->phaseCount = 0;
 	previousAngle = 0;
 	memset(isRiseEvent, 0, sizeof(isRiseEvent));
 #if EFI_UNIT_TEST
@@ -97,7 +98,7 @@ void TriggerWaveform::initialize(operation_mode_e operationMode) {
 }
 
 size_t TriggerWaveform::getSize() const {
-	return wave.phaseCount;
+	return wave->phaseCount;
 }
 
 int TriggerWaveform::getTriggerWaveformSynchPointIndex() const {
@@ -147,9 +148,9 @@ angle_t TriggerWaveform::getAngle(int index) const {
 	 * See also trigger_central.cpp
 	 * See also getEngineCycleEventCount()
 	 */
-	efiAssert(CUSTOM_ERR_ASSERT, wave.phaseCount != 0, "shapeSize=0", NAN);
-	int crankCycle = index / wave.phaseCount;
-	int remainder = index % wave.phaseCount;
+	efiAssert(CUSTOM_ERR_ASSERT, wave->phaseCount != 0, "shapeSize=0", NAN);
+	int crankCycle = index / wave->phaseCount;
+	int remainder = index % wave->phaseCount;
 
 	auto cycleStartAngle = getCycleDuration() * crankCycle;
 	auto positionWithinCycle = getSwitchAngle(remainder);
@@ -229,9 +230,9 @@ void TriggerWaveform::addEvent(angle_t angle, trigger_wheel_e const channelIndex
 #endif
 
 #if EFI_UNIT_TEST
-	assertIsInBounds(wave.phaseCount, triggerSignalIndeces, "trigger shape overflow");
-	triggerSignalIndeces[wave.phaseCount] = channelIndex;
-	triggerSignalStates[wave.phaseCount] = state;
+	assertIsInBounds(wave->phaseCount, triggerSignalIndeces, "trigger shape overflow");
+	triggerSignalIndeces[wave->phaseCount] = channelIndex;
+	triggerSignalStates[wave->phaseCount] = state;
 #endif // EFI_UNIT_TEST
 
 
@@ -243,46 +244,46 @@ void TriggerWaveform::addEvent(angle_t angle, trigger_wheel_e const channelIndex
 	}
 
 	efiAssertVoid(CUSTOM_ERR_6599, angle > 0 && angle <= 1, "angle should be positive not above 1");
-	if (wave.phaseCount > 0) {
+	if (wave->phaseCount > 0) {
 		if (angle <= previousAngle) {
 			warning(CUSTOM_ERR_TRG_ANGLE_ORDER, "invalid angle order %s %s: new=%.2f/%f and prev=%.2f/%f, size=%d",
 					getTrigger_wheel_e(channelIndex),
 					getTrigger_value_e(state),
 					angle, angle * getCycleDuration(),
 					previousAngle, previousAngle * getCycleDuration(),
-					wave.phaseCount);
+					wave->phaseCount);
 			setShapeDefinitionError(true);
 			return;
 		}
 	}
 	previousAngle = angle;
-	if (wave.phaseCount == 0) {
-		wave.phaseCount = 1;
+	if (wave->phaseCount == 0) {
+		wave->phaseCount = 1;
 		for (int i = 0; i < PWM_PHASE_MAX_WAVE_PER_PWM; i++) {
-			SingleChannelStateSequence *swave = &wave.channels[i];
+			SingleChannelStateSequence *swave = &wave->channels[i];
 
 			if (swave->pinStates == nullptr) {
 				warning(CUSTOM_ERR_STATE_NULL, "wave pinStates is NULL");
 				setShapeDefinitionError(true);
 				return;
 			}
-			wave.setChannelState(i, /* switchIndex */ 0, /* value */ initialState[i]);
+			wave->setChannelState(i, /* switchIndex */ 0, /* value */ initialState[i]);
 		}
 
 		isRiseEvent[0] = TV_RISE == state;
-		wave.setSwitchTime(0, angle);
-		wave.setChannelState(channelIndex, /* channelIndex */ 0, /* value */ state);
+		wave->setSwitchTime(0, angle);
+		wave->setChannelState(channelIndex, /* channelIndex */ 0, /* value */ state);
 		return;
 	}
 
-	int exactMatch = wave.findAngleMatch(angle);
+	int exactMatch = wave->findAngleMatch(angle);
 	if (exactMatch != (int)EFI_ERROR_CODE) {
 		warning(CUSTOM_ERR_SAME_ANGLE, "same angle: not supported");
 		setShapeDefinitionError(true);
 		return;
 	}
 
-	int index = wave.findInsertionAngle(angle);
+	int index = wave->findInsertionAngle(angle);
 
 	/**
 	 * todo: it would be nice to be able to provide trigger angles without sorting them externally
@@ -292,29 +293,29 @@ void TriggerWaveform::addEvent(angle_t angle, trigger_wheel_e const channelIndex
 /*
 	for (int i = size - 1; i >= index; i--) {
 		for (int j = 0; j < PWM_PHASE_MAX_WAVE_PER_PWM; j++) {
-			wave.waves[j].pinStates[i + 1] = wave.getChannelState(j, index);
+			wave->waves[j].pinStates[i + 1] = wave->getChannelState(j, index);
 		}
-		wave.setSwitchTime(i + 1, wave.getSwitchTime(i));
+		wave->setSwitchTime(i + 1, wave->getSwitchTime(i));
 	}
 */
 	isRiseEvent[index] = TV_RISE == state;
 
-	if ((unsigned)index != wave.phaseCount) {
+	if ((unsigned)index != wave->phaseCount) {
 		firmwareError(ERROR_TRIGGER_DRAMA, "are we ever here?");
 	}
 
-	wave.phaseCount++;
+	wave->phaseCount++;
 
 	for (int i = 0; i < PWM_PHASE_MAX_WAVE_PER_PWM; i++) {
-		pin_state_t value = wave.getChannelState(/* channelIndex */i, index - 1);
-		wave.setChannelState(i, index, value);
+		pin_state_t value = wave->getChannelState(/* channelIndex */i, index - 1);
+		wave->setChannelState(i, index, value);
 	}
-	wave.setSwitchTime(index, angle);
-	wave.setChannelState(channelIndex, index, state);
+	wave->setSwitchTime(index, angle);
+	wave->setChannelState(channelIndex, index, state);
 }
 
 angle_t TriggerWaveform::getSwitchAngle(int index) const {
-	return getCycleDuration() * wave.getSwitchTime(index);
+	return getCycleDuration() * wave->getSwitchTime(index);
 }
 
 void setToothedWheelConfiguration(TriggerWaveform *s, int total, int skipped,
@@ -752,7 +753,7 @@ void TriggerWaveform::initializeTriggerWaveform(operation_mode_e ambiguousOperat
 	version++;
 
 	if (!shapeDefinitionError) {
-		wave.checkSwitchTimes(getCycleDuration());
+		wave->checkSwitchTimes(getCycleDuration());
 	}
 
 	if (bothFrontsRequired && useOnlyRisingEdgeForTrigger) {

--- a/firmware/controllers/trigger/decoders/trigger_structure.h
+++ b/firmware/controllers/trigger/decoders/trigger_structure.h
@@ -200,7 +200,8 @@ public:
 	 * but name is supposed to hint at the fact that decoders should not be assigning to it
 	 * Please use "getTriggerSize()" macro or "getSize()" method to read this value
 	 */
-	MultiChannelStateSequence wave;
+	MultiChannelStateSequence waveStorage; // DON'T USE - WILL BE REMOVED LATER
+	MultiChannelStateSequence * const wave;
 
 	// todo: add a runtime validation which would verify that this field was set properly
 	// todo: maybe even automate this flag calculation?
@@ -323,4 +324,4 @@ void setToothedWheelConfiguration(TriggerWaveform *s, int total, int skipped, op
 
 #define TRIGGER_WAVEFORM(x) ENGINE(triggerCentral.triggerShape).x
 
-#define getTriggerSize() TRIGGER_WAVEFORM(wave.phaseCount)
+#define getTriggerSize() TRIGGER_WAVEFORM(wave->phaseCount)

--- a/firmware/controllers/trigger/trigger_emulator_algo.cpp
+++ b/firmware/controllers/trigger/trigger_emulator_algo.cpp
@@ -106,7 +106,7 @@ static void updateTriggerWaveformIfNeeded(PwmConfig *state DECLARE_ENGINE_PARAME
 
 
 		TriggerWaveform *s = &engine->triggerCentral.triggerShape;
-		copyPwmParameters(state, &s->wave);
+		copyPwmParameters(state, s->wave);
 		state->safe.periodNt = -1; // this would cause loop re-initialization
 	}
 }
@@ -146,7 +146,7 @@ static void initTriggerPwm(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 	setTriggerEmulatorRPM(engineConfiguration->triggerSimulatorFrequency PASS_ENGINE_PARAMETER_SUFFIX);
 	triggerSignal.weComplexInit("position sensor",
 			&engine->executor,
-			&s->wave,
+			s->wave,
 			updateTriggerWaveformIfNeeded, (pwm_gen_callback*)emulatorApplyPinState);
 
 	hasInitTriggerEmulator = true;

--- a/firmware/controllers/trigger/trigger_simulator.cpp
+++ b/firmware/controllers/trigger/trigger_simulator.cpp
@@ -33,7 +33,7 @@ int getSimulatedEventTime(const TriggerWaveform& shape, int i) {
 	int stateIndex = i % shape.getSize();
 	int loopIndex = i / shape.getSize();
 
-	return (int) (SIMULATION_CYCLE_PERIOD * (loopIndex + shape.wave.getSwitchTime(stateIndex)));
+	return (int) (SIMULATION_CYCLE_PERIOD * (loopIndex + shape.wave->getSwitchTime(stateIndex)));
 }
 
 void TriggerStimulatorHelper::feedSimulatedEvent(
@@ -48,7 +48,7 @@ void TriggerStimulatorHelper::feedSimulatedEvent(
 
 	int time = getSimulatedEventTime(shape, i);
 
-	const MultiChannelStateSequence& multiChannelStateSequence = shape.wave;
+	const MultiChannelStateSequence& multiChannelStateSequence = *shape.wave;
 
 #if EFI_UNIT_TEST
 	int prevIndex = getPreviousIndex(stateIndex, shape.getSize());

--- a/unit_tests/tests/ignition_injection/test_fuel_map.cpp
+++ b/unit_tests/tests/ignition_injection/test_fuel_map.cpp
@@ -102,31 +102,31 @@ static void confgiureFordAspireTriggerWaveform(TriggerWaveform * s) {
 	s->addEvent720(657.03, T_SECONDARY, TV_FALL);
 	s->addEvent720(720, T_PRIMARY, TV_FALL);
 
-	ASSERT_FLOAT_EQ(53.747 / 720, s->wave.getSwitchTime(0));
-	ASSERT_EQ( 1,  s->wave.getChannelState(1, 0)) << "@0";
-	ASSERT_EQ( 1,  s->wave.getChannelState(1, 0)) << "@0";
+	ASSERT_FLOAT_EQ(53.747 / 720, s->wave->getSwitchTime(0));
+	ASSERT_EQ( 1,  s->wave->getChannelState(1, 0)) << "@0";
+	ASSERT_EQ( 1,  s->wave->getChannelState(1, 0)) << "@0";
 
-	ASSERT_EQ( 0,  s->wave.getChannelState(0, 1)) << "@1";
-	ASSERT_EQ( 0,  s->wave.getChannelState(1, 1)) << "@1";
+	ASSERT_EQ( 0,  s->wave->getChannelState(0, 1)) << "@1";
+	ASSERT_EQ( 0,  s->wave->getChannelState(1, 1)) << "@1";
 
-	ASSERT_EQ( 0,  s->wave.getChannelState(0, 2)) << "@2";
-	ASSERT_EQ( 1,  s->wave.getChannelState(1, 2)) << "@2";
+	ASSERT_EQ( 0,  s->wave->getChannelState(0, 2)) << "@2";
+	ASSERT_EQ( 1,  s->wave->getChannelState(1, 2)) << "@2";
 
-	ASSERT_EQ( 0,  s->wave.getChannelState(0, 3)) << "@3";
-	ASSERT_EQ( 0,  s->wave.getChannelState(1, 3)) << "@3";
+	ASSERT_EQ( 0,  s->wave->getChannelState(0, 3)) << "@3";
+	ASSERT_EQ( 0,  s->wave->getChannelState(1, 3)) << "@3";
 
-	ASSERT_EQ( 1,  s->wave.getChannelState(0, 4)) << "@4";
-	ASSERT_EQ( 1,  s->wave.getChannelState(1, 5)) << "@5";
-	ASSERT_EQ( 0,  s->wave.getChannelState(1, 8)) << "@8";
-	ASSERT_FLOAT_EQ(121.90 / 720, s->wave.getSwitchTime(1));
-	ASSERT_FLOAT_EQ(657.03 / 720, s->wave.getSwitchTime(8));
+	ASSERT_EQ( 1,  s->wave->getChannelState(0, 4)) << "@4";
+	ASSERT_EQ( 1,  s->wave->getChannelState(1, 5)) << "@5";
+	ASSERT_EQ( 0,  s->wave->getChannelState(1, 8)) << "@8";
+	ASSERT_FLOAT_EQ(121.90 / 720, s->wave->getSwitchTime(1));
+	ASSERT_FLOAT_EQ(657.03 / 720, s->wave->getSwitchTime(8));
 
-	ASSERT_EQ( 0,  s->wave.findAngleMatch(53.747 / 720.0)) << "expecting 0";
-	assertEqualsM("expecting not found", -1, s->wave.findAngleMatch(53 / 720.0));
-	ASSERT_EQ(7, s->wave.findAngleMatch(588.045 / 720.0));
+	ASSERT_EQ( 0,  s->wave->findAngleMatch(53.747 / 720.0)) << "expecting 0";
+	assertEqualsM("expecting not found", -1, s->wave->findAngleMatch(53 / 720.0));
+	ASSERT_EQ(7, s->wave->findAngleMatch(588.045 / 720.0));
 
-	ASSERT_EQ( 0,  s->wave.findInsertionAngle(23.747 / 720.0)) << "expecting 0";
-	ASSERT_EQ( 1,  s->wave.findInsertionAngle(63.747 / 720.0)) << "expecting 1";
+	ASSERT_EQ( 0,  s->wave->findInsertionAngle(23.747 / 720.0)) << "expecting 0";
+	ASSERT_EQ( 1,  s->wave->findInsertionAngle(63.747 / 720.0)) << "expecting 1";
 }
 
 TEST(misc, testAngleResolver) {
@@ -141,9 +141,9 @@ TEST(misc, testAngleResolver) {
 	engine->initializeTriggerWaveform(PASS_ENGINE_PARAMETER_SIGNATURE);
 
 	assertEqualsM("index 2", 52.76, triggerFormDetails->eventAngles[3]); // this angle is relation to synch point
-	assertEqualsM("time 2", 0.3233, ts->wave.getSwitchTime(2));
+	assertEqualsM("time 2", 0.3233, ts->wave->getSwitchTime(2));
 	assertEqualsM("index 5", 412.76, triggerFormDetails->eventAngles[6]);
-	assertEqualsM("time 5", 0.5733, ts->wave.getSwitchTime(5));
+	assertEqualsM("time 5", 0.5733, ts->wave->getSwitchTime(5));
 
 	ASSERT_EQ(4, ts->getTriggerWaveformSynchPointIndex());
 

--- a/unit_tests/tests/trigger/test_miata_na_tdc.cpp
+++ b/unit_tests/tests/trigger/test_miata_na_tdc.cpp
@@ -21,7 +21,7 @@ TEST(miata, miata_na_tdc) {
 		eth.setTimeAndInvokeEventsUs(time);
 
 		emulatorHelper.handleEmulatorCallback(
-				shape.wave,
+				*shape.wave,
 				i  % shape.getSize() PASS_ENGINE_PARAMETER_SUFFIX);
 	}
 

--- a/unit_tests/tests/trigger/test_nissan_vq_vvt.cpp
+++ b/unit_tests/tests/trigger/test_nissan_vq_vvt.cpp
@@ -24,7 +24,7 @@ static void func(TriggerCallback *callback) {
 	Engine *engine = callback->engine;
 	EXPAND_Engine;
 
-	int value = callback->form->wave.getChannelState(0, formIndex);
+	int value = callback->form->wave->getChannelState(0, formIndex);
 	efitick_t nowNt = getTimeNowNt();
 	if (callback->isVvt) {
 		trigger_value_e v = value ? TV_RISE : TV_FALL;

--- a/unit_tests/tests/trigger/test_trigger_decoder.cpp
+++ b/unit_tests/tests/trigger/test_trigger_decoder.cpp
@@ -467,10 +467,10 @@ TEST(misc, testTriggerDecoder) {
 
 	initializeSkippedToothTriggerWaveformExt(s, 2, 0, FOUR_STROKE_CAM_SENSOR);
 	assertEqualsM("shape size", s->getSize(), 4);
-	ASSERT_EQ(s->wave.getSwitchTime(0), 0.25);
-	ASSERT_EQ(s->wave.getSwitchTime(1), 0.5);
-	ASSERT_EQ(s->wave.getSwitchTime(2), 0.75);
-	ASSERT_EQ(s->wave.getSwitchTime(3), 1);
+	ASSERT_EQ(s->wave->getSwitchTime(0), 0.25);
+	ASSERT_EQ(s->wave->getSwitchTime(1), 0.5);
+	ASSERT_EQ(s->wave->getSwitchTime(2), 0.75);
+	ASSERT_EQ(s->wave->getSwitchTime(3), 1);
 
 	}
 


### PR DESCRIPTION
It will eventually be class to support dynamic universal patterns in addition to ROM-based
tables.