### PR TITLE
less macro, more c++

### DIFF
--- a/firmware/controllers/actuators/boost_control.h
+++ b/firmware/controllers/actuators/boost_control.h
@@ -12,10 +12,8 @@
 
 struct IPwm;
 
-class BoostController : public ClosedLoopController<float, percent_t> {
+class BoostController : public ClosedLoopController<float, percent_t>, public EnginePtr  {
 public:
-	DECLARE_ENGINE_PTR;
-
 	void init(IPwm* pmw, const ValueProvider3D* openLoopMap, const ValueProvider3D* closedLoopTargetMap, pid_s* pidParams);
 	void update();
 

--- a/firmware/controllers/actuators/electronic_throttle.cpp
+++ b/firmware/controllers/actuators/electronic_throttle.cpp
@@ -956,7 +956,7 @@ void doInitElectronicThrottle(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 			auto pid = getEtbPidForFunction(func PASS_ENGINE_PARAMETER_SUFFIX);
 
 			anyEtbConfigured |= controller->init(func, motor, pid, &pedal2tpsMap, shouldInitThrottles);
-			INJECT_ENGINE_REFERENCE(engine->etbControllers[i]);
+			engine->etbControllers[i]->inject(PASS_ENGINE_PARAMETER_SIGNATURE);
 		}
 	}
 

--- a/firmware/controllers/actuators/electronic_throttle.h
+++ b/firmware/controllers/actuators/electronic_throttle.h
@@ -43,10 +43,8 @@ struct pid_s;
 class ValueProvider3D;
 struct pid_state_s;
 
-class IEtbController : public ClosedLoopController<percent_t, percent_t> {
+class IEtbController : public ClosedLoopController<percent_t, percent_t> : public EnginePtr  {
 public:
-	DECLARE_ENGINE_PTR;
-
 	// Initialize the throttle.
 	// returns true if the throttle was initialized, false otherwise.
 	virtual bool init(etb_function_e function, DcMotor *motor, pid_s *pidParameters, const ValueProvider3D* pedalMap, bool initializeThrottles = true) = 0;

--- a/firmware/controllers/actuators/electronic_throttle.h
+++ b/firmware/controllers/actuators/electronic_throttle.h
@@ -43,7 +43,7 @@ struct pid_s;
 class ValueProvider3D;
 struct pid_state_s;
 
-class IEtbController : public ClosedLoopController<percent_t, percent_t> : public EnginePtr  {
+class IEtbController : public ClosedLoopController<percent_t, percent_t>, public EnginePtr  {
 public:
 	// Initialize the throttle.
 	// returns true if the throttle was initialized, false otherwise.

--- a/firmware/controllers/actuators/gppwm/gppwm.cpp
+++ b/firmware/controllers/actuators/gppwm/gppwm.cpp
@@ -42,7 +42,7 @@ void initGpPwm(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 		tables[i]->init(cfg.table, cfg.loadBins, cfg.rpmBins);
 
 		// Finally configure the channel
-		INJECT_ENGINE_REFERENCE(&channels[i]);
+		channels[i].inject(PASS_ENGINE_PARAMETER_SIGNATURE);
 		channels[i].init(usePwm, &outputs[i], &pins[i], tables[i], &cfg);
 	}
 }

--- a/firmware/controllers/actuators/gppwm/gppwm_channel.h
+++ b/firmware/controllers/actuators/gppwm/gppwm_channel.h
@@ -9,10 +9,8 @@ class OutputPin;
 struct IPwm;
 class ValueProvider3D;
 
-class GppwmChannel {
+class GppwmChannel : public EnginePtr {
 public:
-	DECLARE_ENGINE_PTR;
-
 	void init(bool usePwm, IPwm* pwm, OutputPin* outputPin, const ValueProvider3D* table, const gppwm_channel* config);
 	float update();
 	percent_t getOutput() const;

--- a/firmware/controllers/actuators/idle_thread.cpp
+++ b/firmware/controllers/actuators/idle_thread.cpp
@@ -563,9 +563,9 @@ void startIdleBench(void) {
 #endif /* EFI_UNIT_TEST */
 
 void startIdleThread(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
-	INJECT_ENGINE_REFERENCE(&idleControllerInstance);
+	idleControllerInstance.inject(PASS_ENGINE_PARAMETER_SIGNATURE);
 	idleControllerInstance.init(&CONFIG(idleTimingPid));
-	INJECT_ENGINE_REFERENCE(&industrialWithOverrideIdlePid);
+	industrialWithOverrideIdlePid.inject(PASS_ENGINE_PARAMETER_SIGNATURE);
 
 	ENGINE(idleController) = &idleControllerInstance;
 

--- a/firmware/controllers/actuators/idle_thread.h
+++ b/firmware/controllers/actuators/idle_thread.h
@@ -31,10 +31,8 @@ struct IIdleController {
 	virtual float getCrankingTaperFraction() const = 0;
 };
 
-class IdleController : public IIdleController {
+class IdleController : public IIdleController, public EnginePtr {
 public:
-	DECLARE_ENGINE_PTR;
-
 	void init(pid_s* idlePidConfig);
 
 	float getIdlePosition();

--- a/firmware/controllers/actuators/vvt.cpp
+++ b/firmware/controllers/actuators/vvt.cpp
@@ -140,7 +140,7 @@ void initAuxPid() {
 			config->vvtTable2RpmBins);
 
 	for (int i = 0;i < CAM_INPUTS_COUNT;i++) {
-		INJECT_ENGINE_REFERENCE(&instances[i]);
+		instances[i].inject(PASS_ENGINE_PARAMETER_SIGNATURE);
 
 		int camIndex = i % CAMS_PER_BANK;
 		int bankIndex = i / CAMS_PER_BANK;

--- a/firmware/controllers/actuators/vvt.h
+++ b/firmware/controllers/actuators/vvt.h
@@ -19,10 +19,8 @@ void initAuxPid();
 void startVvtControlPins();
 void stopVvtControlPins();
 
-class VvtController : public PeriodicTimerController, public ClosedLoopController<angle_t, percent_t> {
+class VvtController : public PeriodicTimerController, public ClosedLoopController<angle_t, percent_t>, public EnginePtr {
 public:
-	DECLARE_ENGINE_PTR;
-
 	void init(int index, int bankIndex, int camIndex, const ValueProvider3D* targetMap);
 
 	// PeriodicTimerController implementation

--- a/firmware/controllers/algo/airmass/airmass.h
+++ b/firmware/controllers/algo/airmass/airmass.h
@@ -11,10 +11,8 @@ struct AirmassModelBase {
 	virtual AirmassResult getAirmass(int rpm) = 0;
 };
 
-class AirmassVeModelBase : public AirmassModelBase {
+class AirmassVeModelBase : public AirmassModelBase, public EnginePtr {
 public:
-	DECLARE_ENGINE_PTR;
-
 	explicit AirmassVeModelBase(const ValueProvider3D& veTable);
 
 protected:

--- a/firmware/controllers/algo/dynoview.cpp
+++ b/firmware/controllers/algo/dynoview.cpp
@@ -146,7 +146,7 @@ int getDynoviewPower(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 void updateDynoView(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 	if (isBrainPinValid(CONFIG(vehicleSpeedSensorInputPin)) &&
 		(!CONFIG(enableCanVss))) {
-		INJECT_ENGINE_REFERENCE(&dynoInstance);
+		dynoInstance.inject(PASS_ENGINE_PARAMETER_SIGNATURE);
 		dynoInstance.update(ICU);
 	}
 }

--- a/firmware/controllers/algo/dynoview.h
+++ b/firmware/controllers/algo/dynoview.h
@@ -19,10 +19,8 @@ typedef enum{
     CAN,
 }vssSrc;
 
-class DynoView {
+class DynoView : public EnginePtr {
 public:
-	DECLARE_ENGINE_PTR;
-
 	// Update the state of the launch control system
 	void update(vssSrc src);
     void updateAcceleration(efitick_t deltaTime, float deltaSpeed);

--- a/firmware/controllers/algo/engine.cpp
+++ b/firmware/controllers/algo/engine.cpp
@@ -130,7 +130,7 @@ static void initVvtShape(int camIndex, TriggerState &initState DECLARE_ENGINE_PA
 
 void Engine::initializeTriggerWaveform(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 	static TriggerState initState;
-	INJECT_ENGINE_REFERENCE(&initState);
+	initState.inject(PASS_ENGINE_PARAMETER_SIGNATURE);
 
 	// Re-read config in case it's changed
 	primaryTriggerConfiguration.update();
@@ -463,13 +463,13 @@ void Engine::OnTriggerSyncronization(bool wasSynchronized) {
 #endif
 
 void Engine::injectEngineReferences() {
-	INJECT_ENGINE_REFERENCE(&triggerCentral);
-	INJECT_ENGINE_REFERENCE(&primaryTriggerConfiguration);
+	triggerCentral.inject(PASS_ENGINE_PARAMETER_SIGNATURE);
+	primaryTriggerConfiguration.inject(PASS_ENGINE_PARAMETER_SIGNATURE);
 	for (int camIndex = 0;camIndex < CAMS_PER_BANK;camIndex++) {
-		INJECT_ENGINE_REFERENCE(&vvtTriggerConfiguration[camIndex]);
+		vvtTriggerConfiguration[camIndex].inject(PASS_ENGINE_PARAMETER_SIGNATURE);
 	}
-	INJECT_ENGINE_REFERENCE(&limpManager);
-	INJECT_ENGINE_REFERENCE(&knockController);
+	limpManager.inject(PASS_ENGINE_PARAMETER_SIGNATURE);
+	knockController.inject(PASS_ENGINE_PARAMETER_SIGNATURE);
 
 	primaryTriggerConfiguration.update();
 	for (int camIndex = 0;camIndex < CAMS_PER_BANK;camIndex++) {
@@ -479,7 +479,7 @@ void Engine::injectEngineReferences() {
 }
 
 void Engine::setConfig(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
-	INJECT_ENGINE_REFERENCE(this);
+	inject(PASS_ENGINE_PARAMETER_SIGNATURE);
 	efi::clear(config);
 
 	injectEngineReferences();

--- a/firmware/controllers/algo/engine.h
+++ b/firmware/controllers/algo/engine.h
@@ -86,10 +86,8 @@ protected:
 
 #define DEFAULT_MOCK_SPEED -1
 
-class Engine final : public TriggerStateListener {
+class Engine final : public TriggerStateListener, public EnginePtr {
 public:
-	DECLARE_ENGINE_PTR;
-
 	Engine();
 	AcState acState;
 	bool enableOverdwellProtection = true;

--- a/firmware/controllers/algo/event_registry.h
+++ b/firmware/controllers/algo/event_registry.h
@@ -19,7 +19,7 @@
 
 class Engine;
 
-class InjectionEvent {
+class InjectionEvent, public EnginePtr {
 public:
 	InjectionEvent();
 
@@ -34,7 +34,6 @@ public:
 	InjectorOutputPin *outputs[MAX_WIRES_COUNT];
 	uint8_t ownIndex = 0;
 	uint8_t cylinderNumber = 0;
-	DECLARE_ENGINE_PTR;
 	event_trigger_position_s injectionStart;
 
 	scheduling_s signalTimerUp;
@@ -93,7 +92,7 @@ public:
 
 #define MAX_OUTPUTS_FOR_IGNITION 2
 
-class IgnitionEvent {
+class IgnitionEvent : public EnginePtr {
 public:
 	IgnitionEvent();
 	IgnitionOutputPin *outputs[MAX_OUTPUTS_FOR_IGNITION];
@@ -128,7 +127,6 @@ public:
 	int cylinderIndex = 0;
 	int8_t cylinderNumber = 0;
 	char *name = nullptr;
-	DECLARE_ENGINE_PTR;
 	IgnitionOutputPin *getOutputForLoggins();
 };
 
@@ -141,7 +139,7 @@ public:
 	bool isReady = false;
 };
 
-class AuxActor {
+class AuxActor : public EnginePtr {
 public:
 	int phaseIndex;
 	int valveIndex;
@@ -149,5 +147,4 @@ public:
 
 	AngleBasedEvent open;
 	AngleBasedEvent close;
-	DECLARE_ENGINE_PTR;
 };

--- a/firmware/controllers/algo/event_registry.h
+++ b/firmware/controllers/algo/event_registry.h
@@ -19,7 +19,7 @@
 
 class Engine;
 
-class InjectionEvent, public EnginePtr {
+class InjectionEvent : public EnginePtr {
 public:
 	InjectionEvent();
 

--- a/firmware/controllers/algo/fuel/fuel_computer.h
+++ b/firmware/controllers/algo/fuel/fuel_computer.h
@@ -9,10 +9,8 @@ struct IFuelComputer {
 };
 
 // This contains the math of the fuel model, but doesn't actually read any configuration
-class FuelComputerBase : public IFuelComputer {
+class FuelComputerBase : public IFuelComputer, public EnginePtr {
 public:
-	DECLARE_ENGINE_PTR;
-
 	mass_t getCycleFuel(mass_t airmass, int rpm, float load) const override;
 
 protected:

--- a/firmware/controllers/algo/fuel/injector_model.h
+++ b/firmware/controllers/algo/fuel/injector_model.h
@@ -27,10 +27,8 @@ private:
 	float m_massFlowRate = 0;
 };
 
-class InjectorModel : public InjectorModelBase {
+class InjectorModel : public InjectorModelBase, public EnginePtr {
 public:
-	DECLARE_ENGINE_PTR;
-
 	void postState(float deadtime) const override;
 	floatms_t getDeadtime() const override;
 	float getInjectorMassFlowRate() const override;

--- a/firmware/controllers/algo/fuel_math.cpp
+++ b/firmware/controllers/algo/fuel_math.cpp
@@ -305,12 +305,12 @@ static InjectorModel injectorModel;
  * is to prepare the fuel map data structure for 3d interpolation
  */
 void initFuelMap(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
-	INJECT_ENGINE_REFERENCE(&sdAirmass);
-	INJECT_ENGINE_REFERENCE(&mafAirmass);
-	INJECT_ENGINE_REFERENCE(&alphaNAirmass);
+	sdAirmass.inject(PASS_ENGINE_PARAMETER_SIGNATURE);
+	mafAirmass.inject(PASS_ENGINE_PARAMETER_SIGNATURE);
+	alphaNAirmass.inject(PASS_ENGINE_PARAMETER_SIGNATURE);
 
-	INJECT_ENGINE_REFERENCE(&fuelComputer);
-	INJECT_ENGINE_REFERENCE(&injectorModel);
+	fuelComputer.inject(PASS_ENGINE_PARAMETER_SIGNATURE);
+	injectorModel.inject(PASS_ENGINE_PARAMETER_SIGNATURE);
 
 	ENGINE(fuelComputer) = &fuelComputer;
 	ENGINE(injectorModel) = &injectorModel;

--- a/firmware/controllers/algo/launch_control.cpp
+++ b/firmware/controllers/algo/launch_control.cpp
@@ -182,7 +182,7 @@ void applyLaunchControlLimiting(bool *limitedSpark, bool *limitedFuel DECLARE_EN
 }
 
 void initLaunchControl(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
-	INJECT_ENGINE_REFERENCE(&launchInstance);
+	launchInstance.inject(PASS_ENGINE_PARAMETER_SIGNATURE);
 
 	isInit = true;
 }

--- a/firmware/controllers/algo/launch_control.h
+++ b/firmware/controllers/algo/launch_control.h
@@ -15,10 +15,8 @@ void setDefaultLaunchParameters(DECLARE_CONFIG_PARAMETER_SIGNATURE);
 void applyLaunchControlLimiting(bool *limitedSpark, bool *limitedFuel DECLARE_ENGINE_PARAMETER_SUFFIX);
 void updateLaunchConditions(DECLARE_ENGINE_PARAMETER_SIGNATURE);
 
-class LaunchControlBase {
+class LaunchControlBase, public EnginePtr {
 public:
-	DECLARE_ENGINE_PTR;
-
 	// Update the state of the launch control system
 	void update();
 

--- a/firmware/controllers/algo/launch_control.h
+++ b/firmware/controllers/algo/launch_control.h
@@ -15,7 +15,7 @@ void setDefaultLaunchParameters(DECLARE_CONFIG_PARAMETER_SIGNATURE);
 void applyLaunchControlLimiting(bool *limitedSpark, bool *limitedFuel DECLARE_ENGINE_PARAMETER_SUFFIX);
 void updateLaunchConditions(DECLARE_ENGINE_PARAMETER_SIGNATURE);
 
-class LaunchControlBase, public EnginePtr {
+class LaunchControlBase : public EnginePtr {
 public:
 	// Update the state of the launch control system
 	void update();

--- a/firmware/controllers/buttonshift.cpp
+++ b/firmware/controllers/buttonshift.cpp
@@ -85,5 +85,5 @@ void ButtonShiftController::update() {
 void initButtonShift(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
     buttonShiftController.init(PASS_ENGINE_PARAMETER_SIGNATURE);
     engine->gearController = &buttonShiftController;
-    INJECT_ENGINE_REFERENCE(&buttonShiftController);
+    buttonShiftController.inject(PASS_ENGINE_PARAMETER_SIGNATURE);
 }

--- a/firmware/controllers/core/engine_ptr.h
+++ b/firmware/controllers/core/engine_ptr.h
@@ -25,15 +25,17 @@ struct persistent_config_s;
 #if EFI_UNIT_TEST
 
 #ifdef __cplusplus
-	#define DECLARE_ENGINE_PTR                                 \
-		Engine *engine = nullptr;                              \
-		engine_configuration_s *engineConfiguration = nullptr; \
-		persistent_config_s *config = nullptr;
+	struct EnginePtr {
+		Engine* engine = nullptr;
+		engine_configuration_s* engineConfiguration = nullptr;
+		persistent_config_s* config = nullptr;
 
-	#define INJECT_ENGINE_REFERENCE(x)                  \
-		(x)->engine = engine;                           \
-		(x)->engineConfiguration = engineConfiguration; \
-		(x)->config = config;
+		void inject(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
+			this->engine = engine;
+			this->engineConfiguration = engineConfiguration;
+			this->config = config;
+		}
+	};
 
 	#define DECLARE_CONFIG_PARAMETER_SIGNATURE engine_configuration_s *engineConfiguration, persistent_config_s *config
 	#define DECLARE_CONFIG_PARAMETER_SUFFIX , DECLARE_CONFIG_PARAMETER_SIGNATURE
@@ -68,9 +70,9 @@ struct persistent_config_s;
 	// These are the non-unit-test (AKA real firmware) noop versions
 
 #ifdef __cplusplus
-	#define DECLARE_ENGINE_PTR
-
-	#define INJECT_ENGINE_REFERENCE(x) {}
+	struct EnginePtr {
+		void inject(DECLARE_ENGINE_PARAMETER_SIGNATURE) { }
+	};
 
 	// these macro are used when we should not have visibility to 'engine'
 	#define DECLARE_CONFIG_PARAMETER_SIGNATURE void

--- a/firmware/controllers/core/engine_ptr.h
+++ b/firmware/controllers/core/engine_ptr.h
@@ -25,18 +25,6 @@ struct persistent_config_s;
 #if EFI_UNIT_TEST
 
 #ifdef __cplusplus
-	struct EnginePtr {
-		Engine* engine = nullptr;
-		engine_configuration_s* engineConfiguration = nullptr;
-		persistent_config_s* config = nullptr;
-
-		void inject(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
-			this->engine = engine;
-			this->engineConfiguration = engineConfiguration;
-			this->config = config;
-		}
-	};
-
 	#define DECLARE_CONFIG_PARAMETER_SIGNATURE engine_configuration_s *engineConfiguration, persistent_config_s *config
 	#define DECLARE_CONFIG_PARAMETER_SUFFIX , DECLARE_CONFIG_PARAMETER_SIGNATURE
 	#define PASS_CONFIG_PARAMETER_SIGNATURE engineConfiguration, config
@@ -51,6 +39,18 @@ struct persistent_config_s;
 	#define PASS_ENGINE_PARAMETER_SUFFIX , PASS_ENGINE_PARAMETER_SIGNATURE
 
 	#define EXTERN_ENGINE extern engine_configuration_s & activeConfiguration
+
+	struct EnginePtr {
+		Engine* engine = nullptr;
+		engine_configuration_s* engineConfiguration = nullptr;
+		persistent_config_s* config = nullptr;
+
+		void inject(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
+			this->engine = engine;
+			this->engineConfiguration = engineConfiguration;
+			this->config = config;
+		}
+	};
 #endif // def __cplusplus
 
 	#define DEFINE_CONFIG_PARAM(x, y) , x y
@@ -70,10 +70,6 @@ struct persistent_config_s;
 	// These are the non-unit-test (AKA real firmware) noop versions
 
 #ifdef __cplusplus
-	struct EnginePtr {
-		void inject(DECLARE_ENGINE_PARAMETER_SIGNATURE) { }
-	};
-
 	// these macro are used when we should not have visibility to 'engine'
 	#define DECLARE_CONFIG_PARAMETER_SIGNATURE void
 	#define DECLARE_CONFIG_PARAMETER_SUFFIX
@@ -90,6 +86,10 @@ struct persistent_config_s;
 	#define PASS_ENGINE_PARAMETER_SUFFIX
 
 	#define ENGINE(x) ___engine.x
+
+	struct EnginePtr {
+		void inject(DECLARE_ENGINE_PARAMETER_SIGNATURE) { }
+	};
 #endif // def __cplusplus
 
 	/**

--- a/firmware/controllers/engine_cycle/aux_valves.cpp
+++ b/firmware/controllers/engine_cycle/aux_valves.cpp
@@ -84,7 +84,7 @@ void initAuxValves(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
 			actor->valveIndex = valveIndex;
 			actor->extra = phaseIndex * 360 + valveIndex * 180;
 
-			INJECT_ENGINE_REFERENCE(actor);
+			actor->inject(PASS_ENGINE_PARAMETER_SIGNATURE);
 			scheduleOpen(actor);
 		}
 	}

--- a/firmware/controllers/engine_cycle/fuel_schedule.cpp
+++ b/firmware/controllers/engine_cycle/fuel_schedule.cpp
@@ -96,7 +96,7 @@ bool FuelSchedule::addFuelEventsForCylinder(int i  DECLARE_ENGINE_PARAMETER_SUFF
 	bool isSimultanious = mode == IM_SIMULTANEOUS;
 
 	InjectionEvent *ev = &elements[i];
-	INJECT_ENGINE_REFERENCE(ev);
+	ev->inject(PASS_ENGINE_PARAMETER_SIGNATURE);
 
 	ev->ownIndex = i;
 	ev->outputs[0] = output;

--- a/firmware/controllers/engine_cycle/knock_logic.h
+++ b/firmware/controllers/engine_cycle/knock_logic.h
@@ -11,10 +11,8 @@
 
 int getCylinderKnockBank(uint8_t cylinderIndex);
 
-class KnockController {
+class KnockController : public EnginePtr {
 public:
-	DECLARE_ENGINE_PTR;
-
 	// onKnockSenseCompleted is the callback from the knock sense driver to report a sensed knock level
 	bool onKnockSenseCompleted(uint8_t cylinderIndex, float dbv, efitick_t lastKnockTime);
 	void periodicFastCallback();

--- a/firmware/controllers/engine_cycle/main_trigger_callback.cpp
+++ b/firmware/controllers/engine_cycle/main_trigger_callback.cpp
@@ -109,7 +109,7 @@ void InjectorOutputPin::open(efitick_t nowNt DECLARE_ENGINE_PARAMETER_SUFFIX) {
 #if EFI_TOOTH_LOGGER
 	LogTriggerInjectorState(nowNt, true PASS_ENGINE_PARAMETER_SUFFIX);
 #endif // EFI_TOOTH_LOGGER
-		INJECT_ENGINE_REFERENCE(this);
+		this->inject(PASS_ENGINE_PARAMETER_SIGNATURE);
 		setHigh();
 	}
 }
@@ -178,11 +178,6 @@ void turnInjectionPinLow(InjectionEvent *event) {
 }
 
 void InjectionEvent::onTriggerTooth(size_t trgEventIndex, int rpm, efitick_t nowNt) {
-	// note that here we take 'engineConfiguration' from DECLARE_ENGINE_PTR.
-	// set engine_type seems to be resetting those references (todo: where exactly? why exactly?) so an event during
-	// engine_type would not end well
-	efiAssertVoid(CUSTOM_ERR_ASSERT, engineConfiguration != nullptr, "assert#1");
-
 	uint32_t eventIndex = injectionStart.triggerEventIndex;
 // right after trigger change we are still using old & invalid fuel schedule. good news is we do not change trigger on the fly in real life
 //		efiAssertVoid(CUSTOM_ERR_ASSERT_VOID, eventIndex < ENGINE(triggerShape.getLength()), "handleFuel/event sch index");
@@ -463,7 +458,7 @@ static bool isPrimeInjectionPulseSkipped(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
  * See testStartOfCrankingPrimingPulse()
  */
 void startPrimeInjectionPulse(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
-	INJECT_ENGINE_REFERENCE(&engine->primeInjEvent);
+	engine->primeInjEvent.inject(PASS_ENGINE_PARAMETER_SIGNATURE);
 
 	// First, we need a protection against 'fake' ignition switch on and off (i.e. no engine started), to avoid repeated prime pulses.
 	// So we check and update the ignition switch counter in non-volatile backup-RAM

--- a/firmware/controllers/engine_cycle/map_averaging.cpp
+++ b/firmware/controllers/engine_cycle/map_averaging.cpp
@@ -280,9 +280,9 @@ void mapAveragingTriggerCallback(
 
 		scheduling_s *starTimer = &startTimers[i][structIndex];
 		scheduling_s *endTimer = &endTimers[i][structIndex];
-		INJECT_ENGINE_REFERENCE(&mapAveragingPin);
-		INJECT_ENGINE_REFERENCE(starTimer);
-		INJECT_ENGINE_REFERENCE(endTimer);
+		mapAveragingPin.inject(PASS_ENGINE_PARAMETER_SIGNATURE);
+		starTimer->inject(PASS_ENGINE_PARAMETER_SIGNATURE);
+		endTimer->inject(PASS_ENGINE_PARAMETER_SIGNATURE);
 
 		// at the moment we schedule based on time prediction based on current RPM and angle
 		// we are loosing precision in case of changing RPM - the further away is the event the worse is precision

--- a/firmware/controllers/engine_cycle/rpm_calculator.cpp
+++ b/firmware/controllers/engine_cycle/rpm_calculator.cpp
@@ -366,7 +366,7 @@ float getCrankshaftAngleNt(efitick_t timeNt DECLARE_ENGINE_PARAMETER_SUFFIX) {
 }
 
 void initRpmCalculator(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
-	INJECT_ENGINE_REFERENCE(&ENGINE(rpmCalculator));
+	ENGINE(rpmCalculator).inject(PASS_ENGINE_PARAMETER_SIGNATURE);
 
 #if ! HW_CHECK_MODE
 	if (hasFirmwareError()) {

--- a/firmware/controllers/engine_cycle/rpm_calculator.h
+++ b/firmware/controllers/engine_cycle/rpm_calculator.h
@@ -42,10 +42,8 @@ typedef enum {
 	RUNNING,
 } spinning_state_e;
 
-class RpmCalculator : public StoredValueSensor {
+class RpmCalculator : public StoredValueSensor, public EnginePtr {
 public:
-	DECLARE_ENGINE_PTR;
-
 #if !EFI_PROD_CODE
 	int mockRpm;
 #endif /* EFI_PROD_CODE */

--- a/firmware/controllers/engine_cycle/spark_logic.cpp
+++ b/firmware/controllers/engine_cycle/spark_logic.cpp
@@ -266,7 +266,7 @@ static void startDwellByTurningSparkPinHigh(IgnitionEvent *event, IgnitionOutput
 		}
 	}
 
-    INJECT_ENGINE_REFERENCE(output);
+	output->inject(PASS_ENGINE_PARAMETER_SIGNATURE);
 	output->setHigh();
 }
 
@@ -292,7 +292,7 @@ void turnSparkPinHigh(IgnitionEvent *event) {
 
 	if (CONFIG(enableTrailingSparks)) {
 		IgnitionOutputPin *output = &enginePins.trailingCoils[event->cylinderNumber];
-		INJECT_ENGINE_REFERENCE(output);
+		output->inject(PASS_ENGINE_PARAMETER_SIGNATURE);
 		// Trailing sparks are enabled - schedule an event for the corresponding trailing coil
 		scheduleByAngle(
 			&event->trailingSparkCharge, nowNt, ENGINE(engineState.trailingSparkAngle),

--- a/firmware/controllers/gear_controller.cpp
+++ b/firmware/controllers/gear_controller.cpp
@@ -3,7 +3,7 @@
 #include "gear_controller.h"
 
 void GearControllerBase::init(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
-    INJECT_ENGINE_REFERENCE(&transmissionController);
+    transmissionController.inject(PASS_ENGINE_PARAMETER_SIGNATURE);
     transmissionController.init();
 }
 

--- a/firmware/controllers/gear_controller.h
+++ b/firmware/controllers/gear_controller.h
@@ -7,10 +7,8 @@
 #include "globalaccess.h"
 #include "simple_tcu.h"
 
-class GearControllerBase {
+class GearControllerBase : public EnginePtr {
 public:
-    DECLARE_ENGINE_PTR;
-
     virtual void update();
     gear_e getDesiredGear() const;
     virtual void init(DECLARE_ENGINE_PARAMETER_SIGNATURE);

--- a/firmware/controllers/limp_manager.h
+++ b/firmware/controllers/limp_manager.h
@@ -23,10 +23,8 @@ private:
 	bool m_value = true;
 };
 
-class LimpManager {
+class LimpManager : public EnginePtr {
 public:
-	DECLARE_ENGINE_PTR;
-
 	// This is called from periodicFastCallback to update internal state
 	void updateState(int rpm, efitick_t nowNt);
 

--- a/firmware/controllers/sensors/converters/turbocharger_speed_converter.h
+++ b/firmware/controllers/sensors/converters/turbocharger_speed_converter.h
@@ -5,10 +5,8 @@
 #include "pch.h"
 #include "sensor_converter_func.h"
 
-class TurbochargerSpeedConverter : public SensorConverter {
+class TurbochargerSpeedConverter : public SensorConverter, public EnginePtr  {
 public:
-	DECLARE_ENGINE_PTR;
-
 	SensorResult convert(float frequency) const override {
 		auto hz = frequency * engineConfiguration->turboSpeedSensorMultiplier;
 

--- a/firmware/controllers/sensors/converters/vehicle_speed_converter.h
+++ b/firmware/controllers/sensors/converters/vehicle_speed_converter.h
@@ -1,10 +1,8 @@
 #include "pch.h"
 #include "sensor_converter_func.h"
 
-class VehicleSpeedConverter : public SensorConverter {
+class VehicleSpeedConverter : public SensorConverter, public EnginePtr {
 public:
-	DECLARE_ENGINE_PTR;
-
 	SensorResult convert(float frequency) const override {
 		auto speed = frequency * engineConfiguration->vehicleSpeedCoef;
 		return speed;

--- a/firmware/controllers/simple_tcu.h
+++ b/firmware/controllers/simple_tcu.h
@@ -2,10 +2,8 @@
 
 #include "tcu.h"
 
-class SimpleTransmissionController: public TransmissionControllerBase {
+class SimpleTransmissionController: public TransmissionControllerBase, public EnginePtr  {
 public:
-    DECLARE_ENGINE_PTR;
-
     void update(gear_e);
     void init();
 };

--- a/firmware/controllers/system/efi_gpio.h
+++ b/firmware/controllers/system/efi_gpio.h
@@ -89,10 +89,8 @@ private:
 /**
  * OutputPin which is reported on Engine Sniffer
  */
-class NamedOutputPin : public virtual OutputPin {
+class NamedOutputPin : public virtual OutputPin, public EnginePtr {
 public:
-	DECLARE_ENGINE_PTR;
-
 	NamedOutputPin();
 	explicit NamedOutputPin(const char *name);
 	void setHigh();
@@ -157,10 +155,8 @@ public:
 		RegisteredNamedOutputPin(const char *name, short pinOffset, short pinModeOffset);
 };
 
-class EnginePins {
+class EnginePins : public EnginePtr {
 public:
-	DECLARE_ENGINE_PTR;
-
 	EnginePins();
 	void startPins();
 	void reset();

--- a/firmware/controllers/system/timer/scheduler.h
+++ b/firmware/controllers/system/timer/scheduler.h
@@ -39,12 +39,10 @@ private:
  * This structure holds information about an event scheduled in the future: when to execute what callback with what parameters
  */
 #pragma pack(push, 4)
-struct scheduling_s {
+struct scheduling_s : public EnginePtr {
 #if EFI_SIGNAL_EXECUTOR_SLEEP
 	virtual_timer_t timer;
 #endif /* EFI_SIGNAL_EXECUTOR_SLEEP */
-
-	DECLARE_ENGINE_PTR;
 
 	/**
 	 * timestamp represented as 64-bit value of ticks since MCU start

--- a/firmware/controllers/trigger/trigger_central.cpp
+++ b/firmware/controllers/trigger/trigger_central.cpp
@@ -52,10 +52,10 @@ TriggerCentral::TriggerCentral() : trigger_central_s(),
 }
 
 void TriggerCentral::init(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
-	INJECT_ENGINE_REFERENCE(&triggerState);
+	triggerState.inject(PASS_ENGINE_PARAMETER_SIGNATURE);
 	for (int bankIndex = 0; bankIndex < BANKS_COUNT; bankIndex++) {
 		for (int camIndex = 0; camIndex < CAMS_PER_BANK; camIndex++) {
-			INJECT_ENGINE_REFERENCE(&vvtState[bankIndex][camIndex]);
+			vvtState[bankIndex][camIndex].inject(PASS_ENGINE_PARAMETER_SIGNATURE);
 		}
 	}
 }

--- a/firmware/controllers/trigger/trigger_central.h
+++ b/firmware/controllers/trigger/trigger_central.h
@@ -36,10 +36,8 @@ public:
  * Probably not: we have an instance of TriggerState which is used for trigger initialization,
  * also composition probably better than inheritance here
  */
-class TriggerCentral final : public trigger_central_s {
+class TriggerCentral final : public trigger_central_s, public EnginePtr {
 public:
-	DECLARE_ENGINE_PTR;
-
 	TriggerCentral();
 	void init(DECLARE_ENGINE_PARAMETER_SIGNATURE);
 	void handleShaftSignal(trigger_event_e signal, efitick_t timestamp DECLARE_ENGINE_PARAMETER_SUFFIX);

--- a/firmware/controllers/trigger/trigger_decoder.h
+++ b/firmware/controllers/trigger/trigger_decoder.h
@@ -24,10 +24,8 @@ struct TriggerStateListener {
 #endif // EFI_SHAFT_POSITION_INPUT
 };
 
-class TriggerConfiguration {
+class TriggerConfiguration : public EnginePtr {
 public:
-	DECLARE_ENGINE_PTR;
-
 	explicit TriggerConfiguration(const char* printPrefix) : PrintPrefix(printPrefix) {}
 	void update();
 
@@ -76,10 +74,8 @@ typedef struct {
 /**
  * @see TriggerWaveform for trigger wheel shape definition
  */
-class TriggerState : public trigger_state_s {
+class TriggerState : public trigger_state_s, public EnginePtr {
 public:
-	DECLARE_ENGINE_PTR;
-
 	TriggerState();
 	/**
 	 * current trigger processing index, between zero and #size

--- a/firmware/development/engine_sniffer.h
+++ b/firmware/development/engine_sniffer.h
@@ -16,10 +16,8 @@
 /**
  * @brief	rusEfi console sniffer data buffer
  */
-class WaveChart {
+class WaveChart : public EnginePtr {
 public:
-	DECLARE_ENGINE_PTR;
-
 	WaveChart();
 	void init();
 	void addEvent3(const char *name, const char *msg);

--- a/firmware/hw_layer/sensors/hip9011_logic.h
+++ b/firmware/hw_layer/sensors/hip9011_logic.h
@@ -80,10 +80,8 @@ public:
 #define DEFINE_PARAM_SUFFIX(x) , x
 #endif
 
-class HIP9011 {
+class HIP9011 : public EnginePtr {
 public:
-	DECLARE_ENGINE_PTR;
-
 	explicit HIP9011(Hip9011HardwareInterface *hardware);
 	int sendCommand(uint8_t cmd);
 	int sendCommandGetReply(uint8_t cmd, uint8_t *reply);

--- a/firmware/init/sensor/init_lambda.cpp
+++ b/firmware/init/sensor/init_lambda.cpp
@@ -4,9 +4,7 @@
 #include "adc_subscription.h"
 #include "function_pointer_sensor.h"
 
-struct GetAfrWrapper {
-	DECLARE_ENGINE_PTR;
-
+struct GetAfrWrapper : public EnginePtr {
 	float getLambda() {
 		return getAfr(PASS_ENGINE_PARAMETER_SIGNATURE) / 14.7f;
 	}
@@ -26,7 +24,7 @@ static AemXSeriesWideband aem2(1, SensorType::Lambda2);
 #endif
 
 void initLambda(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
-	INJECT_ENGINE_REFERENCE(&afrWrapper);
+	afrWrapper.inject(PASS_ENGINE_PARAMETER_SIGNATURE);
 
 #if EFI_CAN_SUPPORT
 	if (CONFIG(enableAemXSeries)) {

--- a/firmware/init/sensor/init_map.cpp
+++ b/firmware/init/sensor/init_map.cpp
@@ -7,9 +7,7 @@
 #include "function_pointer_sensor.h"
 #include "identity_func.h"
 
-struct GetBaroWrapper {
-	DECLARE_ENGINE_PTR;
-
+struct GetBaroWrapper : public EnginePtr {
 	float getBaro() {
 		return ::getBaroPressure(PASS_ENGINE_PARAMETER_SIGNATURE);
 	}
@@ -113,7 +111,7 @@ void configureMapFunction(DECLARE_CONFIG_PARAMETER_SIGNATURE) {
 }
 
 void initMap(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
-	INJECT_ENGINE_REFERENCE(&baroWrapper);
+	baroWrapper.inject(PASS_ENGINE_PARAMETER_SIGNATURE);
 
 	auto mapChannel = engineConfiguration->map.sensor.hwChannel;
 

--- a/firmware/init/sensor/init_turbocharger_speed_sensor.cpp
+++ b/firmware/init/sensor/init_turbocharger_speed_sensor.cpp
@@ -9,7 +9,7 @@ static TurbochargerSpeedConverter turbochargerSpeedConverter;
 
 
 void initTurbochargerSpeedSensor(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
-	INJECT_ENGINE_REFERENCE(&turbochargerSpeedConverter);
+	turbochargerSpeedConverter.inject(PASS_ENGINE_PARAMETER_SIGNATURE);
 
 	auto pin = CONFIG(turboSpeedSensorInputPin);
 

--- a/firmware/init/sensor/init_vehicle_speed_sensor.cpp
+++ b/firmware/init/sensor/init_vehicle_speed_sensor.cpp
@@ -8,7 +8,7 @@ static FrequencySensor vehicleSpeedSensor(SensorType::VehicleSpeed, MS2NT(500));
 static VehicleSpeedConverter vehicleSpeedConverter;
 
 void initVehicleSpeedSensor(DECLARE_ENGINE_PARAMETER_SIGNATURE) {
-	INJECT_ENGINE_REFERENCE(&vehicleSpeedConverter);
+	vehicleSpeedConverter.inject(PASS_ENGINE_PARAMETER_SIGNATURE);
 
 	auto pin = CONFIG(vehicleSpeedSensorInputPin);
 

--- a/firmware/util/math/pid.h
+++ b/firmware/util/math/pid.h
@@ -27,11 +27,8 @@ struct pid_s;
 /**
  * default basic implementation also known as PidParallelController
  */
-class Pid : public pid_state_s {
-
+class Pid : public pid_state_s, public EnginePtr {
 public:
-	DECLARE_ENGINE_PTR;
-
 	Pid();
 	explicit Pid(pid_s *parameters);
 	void initPidClass(pid_s *parameters);

--- a/unit_tests/engine_test_helper.cpp
+++ b/unit_tests/engine_test_helper.cpp
@@ -72,11 +72,11 @@ EngineTestHelper::EngineTestHelper(engine_type_e engineType, configuration_callb
 
 	memset(&activeConfiguration, 0, sizeof(activeConfiguration));
 
-	INJECT_ENGINE_REFERENCE(&enginePins);
+	enginePins.inject(PASS_ENGINE_PARAMETER_SIGNATURE);
 	enginePins.reset();
 	enginePins.unregisterPins();
 
-	INJECT_ENGINE_REFERENCE(&waveChart);
+	waveChart.inject(PASS_ENGINE_PARAMETER_SIGNATURE);
 	waveChart.init();
 
 	setCurveValue(config->cltFuelCorrBins, config->cltFuelCorr, CLT_CURVE_SIZE, -40, 1.5);

--- a/unit_tests/tests/ignition_injection/test_fuel_computer.cpp
+++ b/unit_tests/tests/ignition_injection/test_fuel_computer.cpp
@@ -17,7 +17,7 @@ TEST(FuelComputer, getCycleFuel) {
 	WITH_ENGINE_TEST_HELPER(TEST_ENGINE);
 
 	MockFuelComputer dut;
-	INJECT_ENGINE_REFERENCE(&dut);
+	dut.inject(PASS_ENGINE_PARAMETER_SIGNATURE);
 
 	EXPECT_CALL(dut, getTargetLambdaLoadAxis(FloatEq(0.8f)))
 		.WillOnce(Return(0.8f));
@@ -45,7 +45,7 @@ TEST(FuelComputer, FlexFuel) {
 
 	MockVp3d lambdaTable;
 	FuelComputer dut(lambdaTable);
-	INJECT_ENGINE_REFERENCE(&dut);
+	dut.inject(PASS_ENGINE_PARAMETER_SIGNATURE);
 
 	// easier values for testing
 	engineConfiguration->stoichRatioPrimary = 15;

--- a/unit_tests/tests/ignition_injection/test_fuel_math.cpp
+++ b/unit_tests/tests/ignition_injection/test_fuel_math.cpp
@@ -47,7 +47,7 @@ TEST(AirmassModes, AlphaNNormal) {
 		.WillOnce(Return(35.0f));
 
 	AlphaNAirmass dut(veTable);
-	INJECT_ENGINE_REFERENCE(&dut);
+	dut.inject(PASS_ENGINE_PARAMETER_SIGNATURE);
 
 	Sensor::setMockValue(SensorType::Tps1, 0.71f);
 
@@ -66,7 +66,7 @@ TEST(AirmassModes, AlphaNFailedTps) {
 	StrictMock<MockVp3d> veTable;
 
 	AlphaNAirmass dut(veTable);
-	INJECT_ENGINE_REFERENCE(&dut);
+	dut.inject(PASS_ENGINE_PARAMETER_SIGNATURE);
 
 	// explicitly reset the sensor
 	Sensor::resetMockValue(SensorType::Tps1);
@@ -88,7 +88,7 @@ TEST(AirmassModes, MafNormal) {
 		.WillOnce(Return(75.0f));
 
 	MafAirmass dut(veTable);
-	INJECT_ENGINE_REFERENCE(&dut);
+	dut.inject(PASS_ENGINE_PARAMETER_SIGNATURE);
 
 	auto airmass = dut.getAirmassImpl(200, 6000);
 
@@ -122,7 +122,7 @@ TEST(AirmassModes, VeOverride) {
 
 	WITH_ENGINE_TEST_HELPER(TEST_ENGINE);
 	DummyAirmassModel dut(veTable);
-	INJECT_ENGINE_REFERENCE(&dut);
+	dut.inject(PASS_ENGINE_PARAMETER_SIGNATURE);
 
 	// Use default mode - will call with 10
 	dut.getAirmass(0);

--- a/unit_tests/tests/ignition_injection/test_injector_model.cpp
+++ b/unit_tests/tests/ignition_injection/test_injector_model.cpp
@@ -61,7 +61,7 @@ TEST(InjectorModel, getInjectionDurationNonlinear) {
 TEST(InjectorModel, nonlinearPolynomial) {
 	WITH_ENGINE_TEST_HELPER(TEST_ENGINE);
 	InjectorModel dut;
-	INJECT_ENGINE_REFERENCE(&dut);
+	dut.inject(PASS_ENGINE_PARAMETER_SIGNATURE);
 
 	CONFIG(applyNonlinearBelowPulse) = MS2US(10);
 
@@ -89,7 +89,7 @@ TEST(InjectorModel, Deadtime) {
 	}
 
 	InjectorModel dut;
-	INJECT_ENGINE_REFERENCE(&dut);
+	dut.inject(PASS_ENGINE_PARAMETER_SIGNATURE);
 
 	Sensor::setMockValue(SensorType::BatteryVoltage, 3);
 	EXPECT_EQ(dut.getDeadtime(), 6);
@@ -122,7 +122,7 @@ TEST_P(FlowRateFixture, FlowRateRatio) {
 	EXPECT_CALL(dut, getInjectorFlowRatio()).WillOnce(Return(flowRatio));
 
 	WITH_ENGINE_TEST_HELPER(TEST_ENGINE);
-	INJECT_ENGINE_REFERENCE(&dut);
+	dut.inject(PASS_ENGINE_PARAMETER_SIGNATURE);
 	engineConfiguration->injector.flow = 500;
 
 	// 500 cc/min = 6g/s
@@ -142,7 +142,7 @@ TEST_P(FlowRateFixture, PressureRatio) {
 	EXPECT_CALL(dut, getAbsoluteRailPressure()).WillOnce(Return(400 * pressureRatio + fakeMap));
 
 	WITH_ENGINE_TEST_HELPER(TEST_ENGINE);
-	INJECT_ENGINE_REFERENCE(&dut);
+	dut.inject(PASS_ENGINE_PARAMETER_SIGNATURE);
 
 	// Use injector compensation
 	engineConfiguration->injectorCompensationMode = ICM_SensedRailPressure;
@@ -161,7 +161,7 @@ TEST(InjectorModel, NegativePressureDelta) {
 	StrictMock<TesterGetRailPressure> dut;
 
 	WITH_ENGINE_TEST_HELPER(TEST_ENGINE);
-	INJECT_ENGINE_REFERENCE(&dut);
+	dut.inject(PASS_ENGINE_PARAMETER_SIGNATURE);
 
 	// Use injector compensation
 	engineConfiguration->injectorCompensationMode = ICM_SensedRailPressure;
@@ -181,7 +181,7 @@ TEST(InjectorModel, VariableInjectorFlowModeNone) {
 	StrictMock<TesterGetRailPressure> dut;
 
 	WITH_ENGINE_TEST_HELPER(TEST_ENGINE);
-	INJECT_ENGINE_REFERENCE(&dut);
+	dut.inject(PASS_ENGINE_PARAMETER_SIGNATURE);
 
 	engineConfiguration->injectorCompensationMode = ICM_None;
 
@@ -193,7 +193,7 @@ TEST(InjectorModel, RailPressureFixed) {
 	InjectorModel dut;
 
 	WITH_ENGINE_TEST_HELPER(TEST_ENGINE);
-	INJECT_ENGINE_REFERENCE(&dut);
+	dut.inject(PASS_ENGINE_PARAMETER_SIGNATURE);
 
 	// Reference pressure is 350kpa
 	engineConfiguration->fuelReferencePressure = 350;
@@ -207,7 +207,7 @@ TEST(InjectorModel, RailPressureSensed) {
 	InjectorModel dut;
 
 	WITH_ENGINE_TEST_HELPER(TEST_ENGINE);
-	INJECT_ENGINE_REFERENCE(&dut);
+	dut.inject(PASS_ENGINE_PARAMETER_SIGNATURE);
 
 	// Reference pressure is 350kpa
 	engineConfiguration->injectorCompensationMode = ICM_SensedRailPressure;
@@ -225,7 +225,7 @@ TEST(InjectorModel, FailedPressureSensor) {
 	InjectorModel dut;
 
 	WITH_ENGINE_TEST_HELPER(TEST_ENGINE);
-	INJECT_ENGINE_REFERENCE(&dut);
+	dut.inject(PASS_ENGINE_PARAMETER_SIGNATURE);
 
 	// Reference pressure is 350kpa
 	engineConfiguration->injectorCompensationMode = ICM_SensedRailPressure;
@@ -244,7 +244,7 @@ TEST(InjectorModel, MissingPressureSensor) {
 	InjectorModel dut;
 
 	WITH_ENGINE_TEST_HELPER(TEST_ENGINE);
-	INJECT_ENGINE_REFERENCE(&dut);
+	dut.inject(PASS_ENGINE_PARAMETER_SIGNATURE);
 
 	// Reference pressure is 350kpa
 	engineConfiguration->injectorCompensationMode = ICM_SensedRailPressure;

--- a/unit_tests/tests/sensor/test_turbocharger_speed_converter.cpp
+++ b/unit_tests/tests/sensor/test_turbocharger_speed_converter.cpp
@@ -14,7 +14,7 @@ public:
 
 	void SetUp() override {
 		WITH_ENGINE_TEST_HELPER(ENGINE_TEST_HELPER);
-		INJECT_ENGINE_REFERENCE(&dut);
+		dut.inject(PASS_ENGINE_PARAMETER_SIGNATURE);
 	}
 
 	void SetCoef(float new_coef) {

--- a/unit_tests/tests/sensor/test_vehicle_speed_converter.cpp
+++ b/unit_tests/tests/sensor/test_vehicle_speed_converter.cpp
@@ -14,7 +14,7 @@ public:
 
 	void SetUp() override {
 		WITH_ENGINE_TEST_HELPER(ENGINE_TEST_HELPER);
-		INJECT_ENGINE_REFERENCE(&dut);
+		dut.inject(PASS_ENGINE_PARAMETER_SIGNATURE);
 	}
 
 	void SetCoef(float new_coef) {

--- a/unit_tests/tests/test_boost.cpp
+++ b/unit_tests/tests/test_boost.cpp
@@ -16,7 +16,7 @@ TEST(BoostControl, Setpoint) {
 	engineConfiguration->boostType = CLOSED_LOOP;
 
 	BoostController bc;
-	INJECT_ENGINE_REFERENCE(&bc);
+	bc.inject(PASS_ENGINE_PARAMETER_SIGNATURE);
 
 	// Should return unexpected without a pedal map cfg'd
 	EXPECT_EQ(bc.getSetpoint(), unexpected);
@@ -36,7 +36,7 @@ TEST(BoostControl, ObservePlant) {
 	WITH_ENGINE_TEST_HELPER(TEST_ENGINE);
 
 	BoostController bc;
-	INJECT_ENGINE_REFERENCE(&bc);
+	bc.inject(PASS_ENGINE_PARAMETER_SIGNATURE);
 
 	Sensor::resetMockValue(SensorType::Map);
 	// Check that invalid MAP returns unexpected
@@ -58,7 +58,7 @@ TEST(BoostControl, OpenLoop) {
 	WITH_ENGINE_TEST_HELPER(TEST_ENGINE);
 
 	BoostController bc;
-	INJECT_ENGINE_REFERENCE(&bc);
+	bc.inject(PASS_ENGINE_PARAMETER_SIGNATURE);
 
 	// Without table set, should return unexpected
 	EXPECT_EQ(bc.getOpenLoop(0), unexpected);
@@ -74,7 +74,7 @@ TEST(BoostControl, ClosedLoop) {
 	WITH_ENGINE_TEST_HELPER(TEST_ENGINE);
 
 	BoostController bc;
-	INJECT_ENGINE_REFERENCE(&bc);
+	bc.inject(PASS_ENGINE_PARAMETER_SIGNATURE);
 
 	pid_s pidCfg = {
 		1, 0, 0,	 // P controller, easier to test
@@ -116,7 +116,7 @@ TEST(BoostControl, SetOutput) {
 	StrictMock<MockPwm> pwm;
 	StrictMock<MockEtb> etb;
 	BoostController bc;
-	INJECT_ENGINE_REFERENCE(&bc);
+	bc.inject(PASS_ENGINE_PARAMETER_SIGNATURE);
 
 	// ETB wastegate position & PWM should both be set
 	EXPECT_CALL(etb, setWastegatePosition(25.0f));

--- a/unit_tests/tests/test_dynoview.cpp
+++ b/unit_tests/tests/test_dynoview.cpp
@@ -20,7 +20,7 @@ TEST(DynoView, VSS_T1) {
     WITH_ENGINE_TEST_HELPER(TEST_ENGINE);
 
     DynoView dut;
-    INJECT_ENGINE_REFERENCE(&dut);
+    dut.inject(PASS_ENGINE_PARAMETER_SIGNATURE);
 
     // Test Speed trashold
     engineConfiguration->vehicleWeight = 900; 
@@ -40,7 +40,7 @@ TEST(DynoView, algo) {
     WITH_ENGINE_TEST_HELPER(TEST_ENGINE);
 
     DynoView dut;
-    INJECT_ENGINE_REFERENCE(&dut);
+    dut.inject(PASS_ENGINE_PARAMETER_SIGNATURE);
 
     // Test Speed trashold
     engineConfiguration->vehicleWeight = 900; 
@@ -65,7 +65,7 @@ TEST(DynoView, VSS_fast) {
     WITH_ENGINE_TEST_HELPER(TEST_ENGINE);
 
     DynoView dut;
-    INJECT_ENGINE_REFERENCE(&dut);
+    dut.inject(PASS_ENGINE_PARAMETER_SIGNATURE);
 
     // Test Speed trashold
     engineConfiguration->vehicleWeight = 900; //kg
@@ -89,7 +89,7 @@ TEST(DynoView, VSS_Torque) {
     WITH_ENGINE_TEST_HELPER(TEST_ENGINE);
 
     DynoView dut;
-    INJECT_ENGINE_REFERENCE(&dut);
+    dut.inject(PASS_ENGINE_PARAMETER_SIGNATURE);
 
     // Test Speed trashold
     engineConfiguration->vehicleWeight = 900; //kg

--- a/unit_tests/tests/test_etb.cpp
+++ b/unit_tests/tests/test_etb.cpp
@@ -261,7 +261,7 @@ TEST(etb, testSetpointOnlyPedal) {
 	engineConfiguration->useETBforIdleControl = false;
 
 	EtbController etb;
-	INJECT_ENGINE_REFERENCE(&etb);
+	etb.inject(PASS_ENGINE_PARAMETER_SIGNATURE);
 
 	// Mock pedal map that's just passthru pedal -> target
 	StrictMock<MockVp3d> pedalMap;
@@ -337,7 +337,7 @@ TEST(etb, setpointIdle) {
 	Sensor::setMockValue(SensorType::AcceleratorPedal, 0.0f, true);
 
 	EtbController etb;
-	INJECT_ENGINE_REFERENCE(&etb);
+	etb.inject(PASS_ENGINE_PARAMETER_SIGNATURE);
 
 	// Mock pedal map that's just passthru pedal -> target
 	StrictMock<MockVp3d> pedalMap;
@@ -395,7 +395,7 @@ TEST(etb, setpointRevLimit) {
 	Sensor::setMockValue(SensorType::AcceleratorPedal, 0.0f, true);
 
 	EtbController etb;
-	INJECT_ENGINE_REFERENCE(&etb);
+	etb.inject(PASS_ENGINE_PARAMETER_SIGNATURE);
 
 	// Mock pedal map to just return 80%
 	StrictMock<MockVp3d> pedalMap;
@@ -527,7 +527,7 @@ TEST(etb, setOutputInvalid) {
 	StrictMock<MockMotor> motor;
 
 	EtbController etb;
-	INJECT_ENGINE_REFERENCE(&etb);
+	etb.inject(PASS_ENGINE_PARAMETER_SIGNATURE);
 	etb.init(ETB_Throttle1, &motor, nullptr, nullptr, true);
 
 	// Should be disabled in case of unexpected
@@ -546,7 +546,7 @@ TEST(etb, setOutputValid) {
 	Sensor::setMockValue(SensorType::AcceleratorPedal, 0.0f, true);
 
 	EtbController etb;
-	INJECT_ENGINE_REFERENCE(&etb);
+	etb.inject(PASS_ENGINE_PARAMETER_SIGNATURE);
 	etb.init(ETB_Throttle1, &motor, nullptr, nullptr, true);
 
 	// Should be enabled and value set
@@ -567,7 +567,7 @@ TEST(etb, setOutputValid2) {
 	Sensor::setMockValue(SensorType::AcceleratorPedal, 0.0f, true);
 
 	EtbController etb;
-	INJECT_ENGINE_REFERENCE(&etb);
+	etb.inject(PASS_ENGINE_PARAMETER_SIGNATURE);
 	etb.init(ETB_Throttle1, &motor, nullptr, nullptr, true);
 
 	// Should be enabled and value set
@@ -588,7 +588,7 @@ TEST(etb, setOutputOutOfRangeHigh) {
 	Sensor::setMockValue(SensorType::AcceleratorPedal, 0.0f, true);
 
 	EtbController etb;
-	INJECT_ENGINE_REFERENCE(&etb);
+	etb.inject(PASS_ENGINE_PARAMETER_SIGNATURE);
 	etb.init(ETB_Throttle1, &motor, nullptr, nullptr, true);
 
 	// Should be enabled and value set
@@ -609,7 +609,7 @@ TEST(etb, setOutputOutOfRangeLow) {
 	Sensor::setMockValue(SensorType::AcceleratorPedal, 0.0f, true);
 
 	EtbController etb;
-	INJECT_ENGINE_REFERENCE(&etb);
+	etb.inject(PASS_ENGINE_PARAMETER_SIGNATURE);
 	etb.init(ETB_Throttle1, &motor, nullptr, nullptr, true);
 
 	// Should be enabled and value set
@@ -630,7 +630,7 @@ TEST(etb, setOutputPauseControl) {
 	Sensor::setMockValue(SensorType::AcceleratorPedal, 0.0f, true);
 
 	EtbController etb;
-	INJECT_ENGINE_REFERENCE(&etb);
+	etb.inject(PASS_ENGINE_PARAMETER_SIGNATURE);
 	etb.init(ETB_Throttle1, &motor, nullptr, nullptr, true);
 
 	// Pause control - should get no output
@@ -652,7 +652,7 @@ TEST(etb, setOutputLimpHome) {
 	Sensor::setMockValue(SensorType::AcceleratorPedal, 0.0f, true);
 
 	EtbController etb;
-	INJECT_ENGINE_REFERENCE(&etb);
+	etb.inject(PASS_ENGINE_PARAMETER_SIGNATURE);
 	etb.init(ETB_Throttle1, &motor, nullptr, nullptr, true);
 
 	// Should be disabled when in ETB limp mode
@@ -702,7 +702,7 @@ TEST(etb, openLoopThrottle) {
 	Sensor::setMockValue(SensorType::AcceleratorPedal, 0, true);
 
 	EtbController etb;
-	INJECT_ENGINE_REFERENCE(&etb);
+	etb.inject(PASS_ENGINE_PARAMETER_SIGNATURE);
 	etb.init(ETB_Throttle1, nullptr, nullptr, nullptr, true);
 
 	// Map [0, 100] -> [-50, 50]
@@ -725,7 +725,7 @@ TEST(etb, openLoopNonThrottle) {
 	Sensor::setMockValue(SensorType::AcceleratorPedal, 0, true);
 
 	EtbController etb;
-	INJECT_ENGINE_REFERENCE(&etb);
+	etb.inject(PASS_ENGINE_PARAMETER_SIGNATURE);
 	etb.init(ETB_Wastegate, nullptr, nullptr, nullptr, false);
 
 	// Map [0, 100] -> [-50, 50]

--- a/unit_tests/tests/test_gppwm.cpp
+++ b/unit_tests/tests/test_gppwm.cpp
@@ -76,7 +76,7 @@ TEST(GpPwm, OutputOnOff) {
 TEST(GpPwm, GetOutput) {
 	WITH_ENGINE_TEST_HELPER(TEST_ENGINE);
 	GppwmChannel ch;
-	INJECT_ENGINE_REFERENCE(&ch);
+	ch.inject(PASS_ENGINE_PARAMETER_SIGNATURE);
 
 	gppwm_channel cfg;
 	cfg.loadAxis = GPPWM_Tps;

--- a/unit_tests/tests/test_idle_controller.cpp
+++ b/unit_tests/tests/test_idle_controller.cpp
@@ -21,7 +21,7 @@ using ICP = IIdleController::Phase;
 TEST(idle_v2, timingPid) {
 	WITH_ENGINE_TEST_HELPER(TEST_ENGINE);
 	IdleController dut;
-	INJECT_ENGINE_REFERENCE(&dut);
+	dut.inject(PASS_ENGINE_PARAMETER_SIGNATURE);
 
 	engineConfiguration->useIdleTimingPidControl = true;
 
@@ -57,7 +57,7 @@ TEST(idle_v2, timingPid) {
 TEST(idle_v2, testTargetRpm) {
 	WITH_ENGINE_TEST_HELPER(TEST_ENGINE);
 	IdleController dut;
-	INJECT_ENGINE_REFERENCE(&dut);
+	dut.inject(PASS_ENGINE_PARAMETER_SIGNATURE);
 
 	for (size_t i = 0; i < efi::size(engineConfiguration->cltIdleRpmBins); i++) {
 		CONFIG(cltIdleRpmBins)[i] = i * 10;
@@ -71,7 +71,7 @@ TEST(idle_v2, testTargetRpm) {
 TEST(idle_v2, testDeterminePhase) {
 	WITH_ENGINE_TEST_HELPER(TEST_ENGINE);
 	IdleController dut;
-	INJECT_ENGINE_REFERENCE(&dut);
+	dut.inject(PASS_ENGINE_PARAMETER_SIGNATURE);
 
 	// TPS threshold 5% for easy test
 	CONFIG(idlePidDeactivationTpsThreshold) = 5;
@@ -117,7 +117,7 @@ TEST(idle_v2, testDeterminePhase) {
 TEST(idle_v2, crankingOpenLoop) {
 	WITH_ENGINE_TEST_HELPER(TEST_ENGINE);
 	IdleController dut;
-	INJECT_ENGINE_REFERENCE(&dut);
+	dut.inject(PASS_ENGINE_PARAMETER_SIGNATURE);
 
 	engineConfiguration->crankingIACposition = 50;
 
@@ -143,7 +143,7 @@ TEST(idle_v2, crankingOpenLoop) {
 TEST(idle_v2, runningOpenLoopBasic) {
 	WITH_ENGINE_TEST_HELPER(TEST_ENGINE);
 	IdleController dut;
-	INJECT_ENGINE_REFERENCE(&dut);
+	dut.inject(PASS_ENGINE_PARAMETER_SIGNATURE);
 
 	engineConfiguration->manIdlePosition = 50;
 
@@ -159,7 +159,7 @@ TEST(idle_v2, runningOpenLoopBasic) {
 TEST(idle_v2, runningFanAcBump) {
 	WITH_ENGINE_TEST_HELPER(TEST_ENGINE);
 	IdleController dut;
-	INJECT_ENGINE_REFERENCE(&dut);
+	dut.inject(PASS_ENGINE_PARAMETER_SIGNATURE);
 
 	engineConfiguration->manIdlePosition = 50;
 	engineConfiguration->acIdleExtraOffset = 9;
@@ -198,7 +198,7 @@ TEST(idle_v2, runningFanAcBump) {
 TEST(idle_v2, runningOpenLoopTpsTaper) {
 	WITH_ENGINE_TEST_HELPER(TEST_ENGINE);
 	IdleController dut;
-	INJECT_ENGINE_REFERENCE(&dut);
+	dut.inject(PASS_ENGINE_PARAMETER_SIGNATURE);
 
 	// Zero out base tempco table
 	setArrayValues(config->cltIdleCorr, 0.0f);
@@ -226,7 +226,7 @@ struct MockOpenLoopIdler : public IdleController {
 TEST(idle_v2, testOpenLoopCranking) {
 	WITH_ENGINE_TEST_HELPER(TEST_ENGINE);
 	StrictMock<MockOpenLoopIdler> dut;
-	INJECT_ENGINE_REFERENCE(&dut);
+	dut.inject(PASS_ENGINE_PARAMETER_SIGNATURE);
 
 	CONFIG(overrideCrankingIacSetting) = true;
 
@@ -239,7 +239,7 @@ TEST(idle_v2, testOpenLoopCranking) {
 TEST(idle_v2, openLoopRunningTaper) {
 	WITH_ENGINE_TEST_HELPER(TEST_ENGINE);
 	StrictMock<MockOpenLoopIdler> dut;
-	INJECT_ENGINE_REFERENCE(&dut);
+	dut.inject(PASS_ENGINE_PARAMETER_SIGNATURE);
 
 	EXPECT_CALL(dut, getRunningOpenLoop(30, SensorResult(0))).WillRepeatedly(Return(25));
 	EXPECT_CALL(dut, getCrankingOpenLoop(30)).WillRepeatedly(Return(75));
@@ -264,7 +264,7 @@ TEST(idle_v2, openLoopRunningTaper) {
 TEST(idle_v2, getCrankingTaperFraction) {
 	WITH_ENGINE_TEST_HELPER(TEST_ENGINE);
 	StrictMock<MockOpenLoopIdler> dut;
-	INJECT_ENGINE_REFERENCE(&dut);
+	dut.inject(PASS_ENGINE_PARAMETER_SIGNATURE);
 
 	CONFIG(afterCrankingIACtaperDuration) = 500;
 
@@ -293,7 +293,7 @@ TEST(idle_v2, getCrankingTaperFraction) {
 TEST(idle_v2, openLoopCoastingTable) {
 	WITH_ENGINE_TEST_HELPER(TEST_ENGINE);
 	IdleController dut;
-	INJECT_ENGINE_REFERENCE(&dut);
+	dut.inject(PASS_ENGINE_PARAMETER_SIGNATURE);
 
 	// enable & configure feature
 	CONFIG(useIacTableForCoasting) = true;
@@ -311,7 +311,7 @@ extern int timeNowUs;
 TEST(idle_v2, closedLoopBasic) {
 	WITH_ENGINE_TEST_HELPER(TEST_ENGINE);
 	IdleController dut;
-	INJECT_ENGINE_REFERENCE(&dut);
+	dut.inject(PASS_ENGINE_PARAMETER_SIGNATURE);
 
 	// Not testing PID here, so we can set very simple PID gains
 	CONFIG(idleRpmPid).pFactor = 0.5;	// 0.5 output per 1 RPM error = 50% per 100 rpm
@@ -339,7 +339,7 @@ TEST(idle_v2, closedLoopBasic) {
 TEST(idle_v2, closedLoopDeadzone) {
 	WITH_ENGINE_TEST_HELPER(TEST_ENGINE);
 	IdleController dut;
-	INJECT_ENGINE_REFERENCE(&dut);
+	dut.inject(PASS_ENGINE_PARAMETER_SIGNATURE);
 
 	// Not testing PID here, so we can set very simple PID gains
 	CONFIG(idleRpmPid).pFactor = 0.5;	// 0.5 output per 1 RPM error = 50% per 100 rpm
@@ -375,7 +375,7 @@ struct IntegrationIdleMock : public IdleController {
 TEST(idle_v2, IntegrationManual) {
 	WITH_ENGINE_TEST_HELPER(TEST_ENGINE);
 	StrictMock<IntegrationIdleMock> dut;
-	INJECT_ENGINE_REFERENCE(&dut);
+	dut.inject(PASS_ENGINE_PARAMETER_SIGNATURE);
 
 	SensorResult expectedTps = 1;
 	float expectedClt = 37;
@@ -408,7 +408,7 @@ TEST(idle_v2, IntegrationManual) {
 TEST(idle_v2, IntegrationAutomatic) {
 	WITH_ENGINE_TEST_HELPER(TEST_ENGINE);
 	StrictMock<IntegrationIdleMock> dut;
-	INJECT_ENGINE_REFERENCE(&dut);
+	dut.inject(PASS_ENGINE_PARAMETER_SIGNATURE);
 
 	CONFIG(idleMode) = IM_AUTO;
 
@@ -446,7 +446,7 @@ TEST(idle_v2, IntegrationAutomatic) {
 TEST(idle_v2, IntegrationClamping) {
 	WITH_ENGINE_TEST_HELPER(TEST_ENGINE);
 	StrictMock<IntegrationIdleMock> dut;
-	INJECT_ENGINE_REFERENCE(&dut);
+	dut.inject(PASS_ENGINE_PARAMETER_SIGNATURE);
 
 	CONFIG(idleMode) = IM_AUTO;
 

--- a/unit_tests/tests/test_knock.cpp
+++ b/unit_tests/tests/test_knock.cpp
@@ -13,7 +13,7 @@ TEST(Knock, Retards) {
 	CONFIG(knockRetardMaximum) = 8;
 
 	KnockController dut;
-	INJECT_ENGINE_REFERENCE(&dut);
+	dut.inject(PASS_ENGINE_PARAMETER_SIGNATURE);
 
 	// No retard unless we knock
 	ASSERT_FLOAT_EQ(dut.getKnockRetard(), 0);
@@ -43,7 +43,7 @@ TEST(Knock, Reapply) {
 	WITH_ENGINE_TEST_HELPER(TEST_ENGINE);
 
 	KnockController dut;
-	INJECT_ENGINE_REFERENCE(&dut);
+	dut.inject(PASS_ENGINE_PARAMETER_SIGNATURE);
 
 	// Knock threshold of 20dBv
 	ENGINE(engineState).knockThreshold = 20;

--- a/unit_tests/tests/test_launch.cpp
+++ b/unit_tests/tests/test_launch.cpp
@@ -6,7 +6,7 @@ TEST(LaunchControl, TpsCondition) {
 	WITH_ENGINE_TEST_HELPER(TEST_ENGINE);
 
 	LaunchControlBase dut;
-	INJECT_ENGINE_REFERENCE(&dut);
+	dut.inject(PASS_ENGINE_PARAMETER_SIGNATURE);
 
 	engineConfiguration->launchTpsTreshold = 10;
 
@@ -28,7 +28,7 @@ TEST(LaunchControl, VSSCondition) {
 	WITH_ENGINE_TEST_HELPER(TEST_ENGINE);
 
 	LaunchControlBase dut;
-	INJECT_ENGINE_REFERENCE(&dut);
+	dut.inject(PASS_ENGINE_PARAMETER_SIGNATURE);
 
 	// Test Speed trashold
 	engineConfiguration->launchActivationMode = ALWAYS_ACTIVE_LAUNCH;
@@ -46,7 +46,7 @@ TEST(LaunchControl, RPMCondition) {
 	WITH_ENGINE_TEST_HELPER(TEST_ENGINE);
 
 	LaunchControlBase dut;
-	INJECT_ENGINE_REFERENCE(&dut);
+	dut.inject(PASS_ENGINE_PARAMETER_SIGNATURE);
 
 	engineConfiguration->launchRpm = 3000;
 
@@ -59,7 +59,7 @@ TEST(LaunchControl, SwitchInputCondition) {
 	WITH_ENGINE_TEST_HELPER(TEST_ENGINE);
 
 	LaunchControlBase dut;
-	INJECT_ENGINE_REFERENCE(&dut);
+	dut.inject(PASS_ENGINE_PARAMETER_SIGNATURE);
 
 	//activation based on VSS
 	engineConfiguration->launchActivationMode = ALWAYS_ACTIVE_LAUNCH;
@@ -102,7 +102,7 @@ TEST(LaunchControl, CombinedCondition) {
 	WITH_ENGINE_TEST_HELPER(TEST_ENGINE);
 
 	LaunchControlBase dut;
-	INJECT_ENGINE_REFERENCE(&dut);
+	dut.inject(PASS_ENGINE_PARAMETER_SIGNATURE);
 
 	//check VSS normal usage
 	engineConfiguration->launchActivationMode=ALWAYS_ACTIVE_LAUNCH;

--- a/unit_tests/tests/test_limp.cpp
+++ b/unit_tests/tests/test_limp.cpp
@@ -26,7 +26,7 @@ TEST(limp, revLimit) {
 	engineConfiguration->rpmHardLimit = 2500;
 
 	LimpManager dut;
-	INJECT_ENGINE_REFERENCE(&dut);
+	dut.inject(PASS_ENGINE_PARAMETER_SIGNATURE);
 
 	// Under rev limit, inj/ign allowed
 	dut.updateState(2000, 0);
@@ -51,7 +51,7 @@ TEST(limp, boostCut) {
 	engineConfiguration->boostCutPressure = 100;
 
 	LimpManager dut;
-	INJECT_ENGINE_REFERENCE(&dut);
+	dut.inject(PASS_ENGINE_PARAMETER_SIGNATURE);
 
 	// Below threshold, injection allowed
 	Sensor::setMockValue(SensorType::Map, 80);
@@ -82,7 +82,7 @@ TEST(limp, oilPressureFailureCase) {
 	engineConfiguration->minOilPressureAfterStart = 200;
 
 	LimpManager dut;
-	INJECT_ENGINE_REFERENCE(&dut);
+	dut.inject(PASS_ENGINE_PARAMETER_SIGNATURE);
 
 	// Low oil pressure!
 	Sensor::setMockValue(SensorType::OilPressure, 50);
@@ -116,7 +116,7 @@ TEST(limp, oilPressureSuccessCase) {
 	engineConfiguration->minOilPressureAfterStart = 200;
 
 	LimpManager dut;
-	INJECT_ENGINE_REFERENCE(&dut);
+	dut.inject(PASS_ENGINE_PARAMETER_SIGNATURE);
 
 	// Low oil pressure!
 	Sensor::setMockValue(SensorType::OilPressure, 50);

--- a/unit_tests/tests/test_vvt.cpp
+++ b/unit_tests/tests/test_vvt.cpp
@@ -18,7 +18,7 @@ TEST(Vvt, setpoint) {
 	engine->rpmCalculator.mockRpm = 4321;
 
 	VvtController dut;
-	INJECT_ENGINE_REFERENCE(&dut);
+	dut.inject(PASS_ENGINE_PARAMETER_SIGNATURE);
 	dut.init(0, 0, 0, &targetMap);
 
 	// Test dut
@@ -31,7 +31,7 @@ TEST(Vvt, observePlant) {
 	engine->triggerCentral.vvtPosition[0][0] = 23;
 
 	VvtController dut;
-	INJECT_ENGINE_REFERENCE(&dut);
+	dut.inject(PASS_ENGINE_PARAMETER_SIGNATURE);
 	dut.init(0, 0, 0, nullptr);
 
 	EXPECT_EQ(23, dut.observePlant().value_or(0));

--- a/unit_tests/tests/trigger/test_injection_scheduling.cpp
+++ b/unit_tests/tests/trigger/test_injection_scheduling.cpp
@@ -15,7 +15,7 @@ TEST(injectionScheduling, NormalDutyCycle) {
 	efitick_t nowNt = 1000000;
 
 	InjectionEvent event;
-	INJECT_ENGINE_REFERENCE(&event);
+	event.inject(PASS_ENGINE_PARAMETER_SIGNATURE);
 	InjectorOutputPin pin;
 	pin.injectorIndex = 0;
 	event.outputs[0] = &pin;


### PR DESCRIPTION
`DECLARE_ENGINE_PTR` is an evil macro hack, we can just use a base class with those members (and an `inject` function) instead.