### PR TITLE
simulator gets a heap

### DIFF
--- a/simulator/simulator/efifeatures.h
+++ b/simulator/simulator/efifeatures.h
@@ -149,3 +149,4 @@
 #define EFI_JOYSTICK FALSE
 
 #define EFI_LUA TRUE
+#define LUA_USER_HEAP 100000


### PR DESCRIPTION
If you give the Lua interpreter no memory, it does not work.

fix #3561