### PR TITLE
Make engine* and friends be const pointers in production.

### DIFF
--- a/firmware/controllers/algo/engine.h
+++ b/firmware/controllers/algo/engine.h
@@ -399,5 +399,7 @@ void doScheduleStopEngine();
 // These externs aren't needed for unit tests - everything is injected instead
 #if !EFI_UNIT_TEST
 extern Engine ___engine;
-#endif // EFI_UNIT_TEST
+static Engine * const engine = &___engine;
+#else // EFI_UNIT_TEST
 extern Engine *engine;
+#endif // EFI_UNIT_TEST

--- a/firmware/controllers/algo/engine_configuration.cpp
+++ b/firmware/controllers/algo/engine_configuration.cpp
@@ -129,8 +129,6 @@ static engine_configuration_s activeConfigurationLocalStorage;
 engine_configuration_s & activeConfiguration = activeConfigurationLocalStorage;
 #endif /* EFI_ACTIVE_CONFIGURATION_IN_FLASH */
 
-extern engine_configuration_s *engineConfiguration;
-
 void rememberCurrentConfiguration() {
 #if ! EFI_ACTIVE_CONFIGURATION_IN_FLASH
 	memcpy(&activeConfiguration, engineConfiguration, sizeof(engine_configuration_s));

--- a/firmware/controllers/algo/engine_configuration.h
+++ b/firmware/controllers/algo/engine_configuration.h
@@ -65,9 +65,13 @@ void setBoardConfigOverrides(void);
 
 #if !EFI_UNIT_TEST
 extern persistent_config_container_s persistentState;
-#endif // EFI_UNIT_TEST
+static engine_configuration_s * const engineConfiguration =
+	&persistentState.persistentConfiguration.engineConfiguration;
+static persistent_config_s * const config = &persistentState.persistentConfiguration;
+#else // EFI_UNIT_TEST
 extern engine_configuration_s *engineConfiguration;
 extern persistent_config_s *config;
+#endif // EFI_UNIT_TEST
 
 /**
  * & is reference in C++ (not C)

--- a/firmware/controllers/engine_controller.cpp
+++ b/firmware/controllers/engine_controller.cpp
@@ -98,7 +98,6 @@
  * Would love to pass reference to configuration object into constructor but C++ does allow attributes after parenthesized initializer
  */
 Engine ___engine CCM_OPTIONAL;
-Engine * engine = &___engine;
 
 #else // EFI_UNIT_TEST
 

--- a/firmware/controllers/flash_main.cpp
+++ b/firmware/controllers/flash_main.cpp
@@ -29,10 +29,6 @@
 
 static bool needToWriteConfiguration = false;
 
-extern persistent_config_container_s persistentState;
-
-extern engine_configuration_s *engineConfiguration;
-
 /* if we store settings externally */
 #if EFI_STORAGE_EXT_SNOR == TRUE
 

--- a/firmware/controllers/persistent_store.cpp
+++ b/firmware/controllers/persistent_store.cpp
@@ -29,15 +29,6 @@
 
 persistent_config_container_s persistentState CCM_OPTIONAL;
 
-persistent_config_s *config = &persistentState.persistentConfiguration;
-
-/**
- * todo: it really looks like these fields should become 'static', i.e. private
- * the whole 'extern ...' pattern is less then perfect, I guess the 'God object' Engine
- * would be a smaller evil. Whatever is needed should be passed into methods/modules/files as an explicit parameter.
- */
-engine_configuration_s *engineConfiguration = &persistentState.persistentConfiguration.engineConfiguration;
-
 #else // EFI_UNIT_TEST
 
 persistent_config_s * config;

--- a/firmware/controllers/settings.cpp
+++ b/firmware/controllers/settings.cpp
@@ -50,8 +50,6 @@ void printSpiState(const engine_configuration_s *engineConfiguration) {
 		boolToString(engineConfiguration->is_enabled_spi_4));
 }
 
-extern engine_configuration_s *engineConfiguration;
-
 static void printOutputs(const engine_configuration_s *engineConfiguration) {
 	efiPrintf("injectionPins: mode %s", getPin_output_mode_e(engineConfiguration->injectionPinMode));
 	for (size_t i = 0; i < engineConfiguration->specs.cylindersCount; i++) {
@@ -1220,7 +1218,7 @@ void initSettings(void) {
 
 	// todo: start saving values into flash right away?
 
-	addConsoleActionP("showconfig", (VoidPtr) doPrintConfiguration, &engine);
+	addConsoleAction("showconfig", doPrintConfiguration);
 	addConsoleAction("tempinfo", printTemperatureInfo);
 	addConsoleAction("tpsinfo", printTPSInfo);
 	addConsoleAction("calibrate_tps_1_closed", grabTPSIsClosed);


### PR DESCRIPTION
This allows the compiler to see through the pointer and make accesses faster.
It saves 1336 bytes of text.