### PR TITLE
Make the module API more concise.

### DIFF
--- a/firmware/controllers/actuators/idle_thread.cpp
+++ b/firmware/controllers/actuators/idle_thread.cpp
@@ -553,7 +553,7 @@ void startIdleBench(void) {
 #endif /* EFI_UNIT_TEST */
 
 void startIdleThread() {
-	engine->engineModules.unmock<IdleController>().init(&engineConfiguration->idleTimingPid);
+	engine->module<IdleController>().unmock().init(&engineConfiguration->idleTimingPid);
 
 	getIdlePid()->initPidClass(&engineConfiguration->idleRpmPid);
 

--- a/firmware/controllers/algo/advance_map.cpp
+++ b/firmware/controllers/algo/advance_map.cpp
@@ -51,7 +51,7 @@ static angle_t getRunningAdvance(int rpm, float engineLoad) {
 
 	// get advance from the separate table for Idle
 	if (engineConfiguration->useSeparateAdvanceForIdle &&
-	    engine->engineModules.unmock<IdleController>().isIdlingOrTaper()) {
+	    engine->module<IdleController>().unmock().isIdlingOrTaper()) {
 		float idleAdvance = interpolate2d(rpm, config->idleAdvanceBins, config->idleAdvance);
 
 		auto [valid, tps] = Sensor::get(SensorType::DriverThrottleIntent);
@@ -89,7 +89,7 @@ angle_t getAdvanceCorrections(int rpm) {
 		iatCorrection = iatAdvanceCorrectionMap.getValue(rpm, iat);
 	}
 
-	float pidTimingCorrection = engine->engineModules.unmock<IdleController>().getIdleTimingAdjustment(rpm);
+	float pidTimingCorrection = engine->module<IdleController>().unmock().getIdleTimingAdjustment(rpm);
 
 	if (engineConfiguration->debugMode == DBG_IGNITION_TIMING) {
 #if EFI_TUNER_STUDIO

--- a/firmware/controllers/algo/airmass/airmass.cpp
+++ b/firmware/controllers/algo/airmass/airmass.cpp
@@ -24,7 +24,7 @@ float AirmassVeModelBase::getVe(int rpm, float load) const {
 
 	auto tps = Sensor::get(SensorType::Tps1);
 	// get VE from the separate table for Idle if idling
-	if (engine->engineModules.unmock<IdleController>().isIdlingOrTaper() &&
+	if (engine->module<IdleController>().unmock().isIdlingOrTaper() &&
 	    tps && engineConfiguration->useSeparateVeForIdle) {
 		float idleVe = interpolate2d(rpm, config->idleVeBins, config->idleVe);
 		// interpolate between idle table and normal (running) table using TPS threshold

--- a/firmware/controllers/algo/engine.h
+++ b/firmware/controllers/algo/engine.h
@@ -131,6 +131,14 @@ public:
 		EngineModule // dummy placeholder so the previous entries can all have commas
 		> engineModules;
 
+	/**
+	 * Slightly shorter helper function to keep the code looking clean.
+	 */
+	template<typename get_t>
+	auto & module() {
+		return engineModules.get<get_t>();
+	}
+
 	cyclic_buffer<int> triggerErrorDetection;
 
 	GearControllerBase *gearController;

--- a/firmware/controllers/algo/engine2.cpp
+++ b/firmware/controllers/algo/engine2.cpp
@@ -155,7 +155,7 @@ void EngineState::periodicFastCallback() {
 	}
 
 	// Store the pre-wall wetting injection duration for scheduling purposes only, not the actual injection duration
-	engine->injectionDuration = engine->engineModules.get<InjectorModel>().getInjectionDuration(injectionMass);
+	engine->injectionDuration = engine->module<InjectorModel>()->getInjectionDuration(injectionMass);
 
 	float fuelLoad = getFuelingLoad();
 	injectionOffset = getInjectionOffset(rpm, fuelLoad);

--- a/firmware/controllers/algo/fuel_math.cpp
+++ b/firmware/controllers/algo/fuel_math.cpp
@@ -279,7 +279,7 @@ float getInjectionMass(int rpm) {
 	float injectionFuelMass = cycleFuelMass * durationMultiplier;
 
 	// Prepare injector flow rate & deadtime
-	engine->engineModules.get<InjectorModel>().prepare();
+	engine->module<InjectorModel>()->prepare();
 
 	floatms_t tpsAccelEnrich = engine->tpsAccelEnrichment.getTpsEnrichment();
 	efiAssert(CUSTOM_ERR_ASSERT, !cisnan(tpsAccelEnrich), "NaN tpsAccelEnrich", 0);
@@ -288,7 +288,7 @@ float getInjectionMass(int rpm) {
 	// For legacy reasons, the TPS accel table is in units of milliseconds, so we have to convert BACK to mass
 	float tpsAccelPerInjection = durationMultiplier * tpsAccelEnrich;
 
-	float tpsFuelMass = engine->engineModules.get<InjectorModel>().getFuelMassForDuration(tpsAccelPerInjection);
+	float tpsFuelMass = engine->module<InjectorModel>()->getFuelMassForDuration(tpsAccelPerInjection);
 
 	return injectionFuelMass + tpsFuelMass;
 #else

--- a/firmware/controllers/engine_cycle/main_trigger_callback.cpp
+++ b/firmware/controllers/engine_cycle/main_trigger_callback.cpp
@@ -172,7 +172,7 @@ void InjectionEvent::onTriggerTooth(size_t trgEventIndex, int rpm, efitick_t now
 	// Perform wall wetting adjustment on fuel mass, not duration, so that
 	// it's correct during fuel pressure (injector flow) or battery voltage (deadtime) transients
 	injectionMassGrams = wallFuel.adjust(injectionMassGrams);
-	const floatms_t injectionDuration = engine->engineModules.get<InjectorModel>().getInjectionDuration(injectionMassGrams);
+	const floatms_t injectionDuration = engine->module<InjectorModel>()->getInjectionDuration(injectionMassGrams);
 
 #if EFI_PRINTF_FUEL_DETAILS
 	if (printFuelDebug) {

--- a/unit_tests/tests/trigger/test_injection_scheduling.cpp
+++ b/unit_tests/tests/trigger/test_injection_scheduling.cpp
@@ -22,7 +22,7 @@ TEST(injectionScheduling, NormalDutyCycle) {
 	// Injection duration of 20ms
 	MockInjectorModel2 im;
 	EXPECT_CALL(im, getInjectionDuration(_)).WillOnce(Return(20.0f));
-	engine->engineModules.set<InjectorModel>(&im);
+	engine->module<InjectorModel>().set(&im);
 
 	{
 		InSequence is;

--- a/unit_tests/tests/trigger/test_trigger_decoder.cpp
+++ b/unit_tests/tests/trigger/test_trigger_decoder.cpp
@@ -697,7 +697,7 @@ void doTestFuelSchedulerBug299smallAndMedium(int startUpDelayMs) {
 	// Injection duration of 12.5ms
 	MockInjectorModel2 im;
 	EXPECT_CALL(im, getInjectionDuration(_)).WillRepeatedly(Return(12.5f));
-	engine->engineModules.set<InjectorModel>(&im);
+	engine->module<InjectorModel>().set(&im);
 
 	assertEqualsM("duty for maf=3", 62.5, getInjectorDutyCycle(GET_RPM()));
 
@@ -857,7 +857,7 @@ void doTestFuelSchedulerBug299smallAndMedium(int startUpDelayMs) {
 	// Injection duration of 17.5ms
 	MockInjectorModel2 im2;
 	EXPECT_CALL(im2, getInjectionDuration(_)).WillRepeatedly(Return(17.5f));
-	engine->engineModules.set<InjectorModel>(&im2);
+	engine->module<InjectorModel>().set(&im2);
 
 	// duty cycle above 75% is a special use-case because 'special' fuel event overlappes the next normal event in batch mode
 	assertEqualsM("duty for maf=3", 87.5, getInjectorDutyCycle(GET_RPM()));
@@ -994,7 +994,7 @@ TEST(big, testFuelSchedulerBug299smallAndLarge) {
 	// Injection duration of 17.5ms
 	MockInjectorModel2 im;
 	EXPECT_CALL(im, getInjectionDuration(_)).WillRepeatedly(Return(17.5f));
-	engine->engineModules.set<InjectorModel>(&im);
+	engine->module<InjectorModel>().set(&im);
 
 	assertEqualsM("Lduty for maf=3", 87.5, getInjectorDutyCycle(GET_RPM()));
 
@@ -1061,7 +1061,7 @@ TEST(big, testFuelSchedulerBug299smallAndLarge) {
 	engine->injectionDuration = 2.0f;
 	MockInjectorModel2 im2;
 	EXPECT_CALL(im2, getInjectionDuration(_)).WillRepeatedly(Return(2.0f));
-	engine->engineModules.set<InjectorModel>(&im2);
+	engine->module<InjectorModel>().set(&im2);
 
 	ASSERT_EQ( 10,  getInjectorDutyCycle(GET_RPM())) << "Lduty for maf=3";
 


### PR DESCRIPTION
engineModules.get<FOO>(). becomes modules<FOO>()->

I believe the new API is more conducive to supporting arrays, by doing std::array<T, N> or
std::array<Mockable<T>, N>, with the support of a helper class.