### PR TITLE
Extend LogField to support scaled_channel divisors.

### DIFF
--- a/firmware/console/binary_log/log_field.cpp
+++ b/firmware/console/binary_log/log_field.cpp
@@ -34,7 +34,7 @@ void LogField::writeHeader(Writer& outBuffer) const {
 	buffer[45] = 0;
 
 	// Offset 46, length 4 = Scale
-	copyFloat(buffer + 46, 1.0f / m_multiplier);
+	copyFloat(buffer + 46, m_multiplier);
 
 	// Offset 50, length 4 = shift before scaling (always 0)
 	copyFloat(buffer + 50, 0);

--- a/firmware/console/binary_log/log_field.h
+++ b/firmware/console/binary_log/log_field.h
@@ -7,11 +7,12 @@
 struct Writer;
 class LogField {
 public:
-	template <typename TValue, int TMult = 1>
-	constexpr LogField(const scaled_channel<TValue, TMult>& toRead, const char* name, const char* units, int8_t digits)
-		: m_type(resolveType<TValue>())
-		, m_multiplier(TMult)
+	template <typename TValue, int TMult, int TDiv>
+	constexpr LogField(const scaled_channel<TValue, TMult, TDiv>& toRead,
+			   const char* name, const char* units, int8_t digits)
+		: m_multiplier(float(TDiv) / TMult)
 		, m_addr(toRead.getFirstByteAddr())
+		, m_type(resolveType<TValue>())
 		, m_digits(digits)
 		, m_size(sizeForType(resolveType<TValue>()))
 		, m_name(name)
@@ -59,11 +60,11 @@ private:
 		}
 	}
 
-	const Type m_type;
 	const float m_multiplier;
 	const char* const m_addr;
+	const Type m_type;
 	const int8_t m_digits;
-	const size_t m_size;
+	const uint8_t m_size;
 
 	const char* const m_name;
 	const char* const m_units;


### PR DESCRIPTION
Also move the type field for better packing.  Saves about 500 bytes of flash.
This fixes #3574.