### PR TITLE
adjust miata sync conditions

### DIFF
--- a/firmware/controllers/trigger/decoders/trigger_mazda.cpp
+++ b/firmware/controllers/trigger/decoders/trigger_mazda.cpp
@@ -28,8 +28,8 @@ void initializeMazdaMiataNaShape(TriggerWaveform *s) {
 	s->initialize(FOUR_STROKE_CAM_SENSOR);
 
 	// nominal gap is 0.325
-	s->setTriggerSynchronizationGap2(0.1, 0.4);
-	// nominal gap is ~1.6
+	s->setTriggerSynchronizationGap2(0.1, 0.45);
+	// nominal gap is ~1.52
 	s->setSecondTriggerSynchronizationGap2(1.2, 1.8);
 
 	s->useRiseEdge = false;


### PR DESCRIPTION
Zach's car didn't start since he was just outside the sync conditions while cranking.  Tweaks the timing to be a little more generous.

Tested on the car in question using the sync override option.