### PR TITLE
Fix potential buffer overrun in cyclic_buffer.

### DIFF
--- a/firmware/controllers/algo/engine2.cpp
+++ b/firmware/controllers/algo/engine2.cpp
@@ -9,6 +9,7 @@
 
 #include "pch.h"
 
+#include "os_access.h"
 #include "speed_density.h"
 #include "fuel_math.h"
 #include "advance_map.h"
@@ -40,6 +41,9 @@ void WarningCodeState::addWarningCode(obd_code_e code) {
 	warningCounter++;
 	lastErrorCode = code;
 	if (!recentWarnings.contains(code)) {
+		chibios_rt::CriticalSectionLocker csl;
+
+		// We don't bother double checking
 		recentWarnings.add((int)code);
 	}
 }


### PR DESCRIPTION
This exposed a buffer overrun, so double the size of the buffer (to account for 720 degree engine
cycle vs 360 degree crank events).

Also use proper numeric limits when computing min/max.
Finally, add a lock around the call to cyclic_buffer that actually caused the contention.