### PR TITLE
Move LuaThread to CCM, and shuffle a couple items out.

### DIFF
--- a/firmware/controllers/core/fsio_impl.cpp
+++ b/firmware/controllers/core/fsio_impl.cpp
@@ -71,7 +71,7 @@ static LENameOrdinalPair leFuelRate(LE_METHOD_FUEL_FLOW_RATE, "fuel_flow");
 #define SYS_ELEMENT_POOL_SIZE 24
 #define UD_ELEMENT_POOL_SIZE 64
 
-static LEElement sysElements[SYS_ELEMENT_POOL_SIZE] CCM_OPTIONAL;
+static LEElement sysElements[SYS_ELEMENT_POOL_SIZE];
 CCM_OPTIONAL LEElementPool sysPool(sysElements, SYS_ELEMENT_POOL_SIZE);
 
 static LEElement * starterRelayDisableLogic;

--- a/firmware/controllers/engine_controller.cpp
+++ b/firmware/controllers/engine_controller.cpp
@@ -747,10 +747,10 @@ void initEngineContoller() {
  * UNUSED_SIZE constants.
  */
 #ifndef RAM_UNUSED_SIZE
-#define RAM_UNUSED_SIZE 4000
+#define RAM_UNUSED_SIZE 9000
 #endif
 #ifndef CCM_UNUSED_SIZE
-#define CCM_UNUSED_SIZE 2400
+#define CCM_UNUSED_SIZE 32
 #endif
 static char UNUSED_RAM_SIZE[RAM_UNUSED_SIZE];
 static char UNUSED_CCM_SIZE[CCM_UNUSED_SIZE] CCM_OPTIONAL;

--- a/firmware/controllers/lua/lua.cpp
+++ b/firmware/controllers/lua/lua.cpp
@@ -350,7 +350,7 @@ void LuaThread::ThreadTask() {
 }
 
 #if LUA_USER_HEAP > 1
-static LuaThread luaThread;
+static LuaThread luaThread CCM_OPTIONAL;
 #endif
 
 void startLua() {

--- a/firmware/init/sensor/init_thermistors.cpp
+++ b/firmware/init/sensor/init_thermistors.cpp
@@ -19,7 +19,7 @@ struct FuncPair {
 static CCM_OPTIONAL FunctionalSensor clt(SensorType::Clt, MS2NT(10));
 static CCM_OPTIONAL FunctionalSensor iat(SensorType::Iat, MS2NT(10));
 static CCM_OPTIONAL FunctionalSensor aux1(SensorType::AuxTemp1, MS2NT(10));
-static CCM_OPTIONAL FunctionalSensor aux2(SensorType::AuxTemp2, MS2NT(10));
+static FunctionalSensor aux2(SensorType::AuxTemp2, MS2NT(10));
 
 static FuncPair fclt, fiat, faux1, faux2;
 


### PR DESCRIPTION
Lua's stack probably doesn't need DMA.  Allows us to group more of our unused RAM together
in one place.