### PR TITLE
embiggen SD log buffer

### DIFF
--- a/firmware/console/status_loop.cpp
+++ b/firmware/console/status_loop.cpp
@@ -126,7 +126,7 @@ static void setWarningEnabled(int value) {
 
 #if EFI_FILE_LOGGING
 // this one needs to be in main ram so that SD card SPI DMA works fine
-static NO_CACHE char sdLogBuffer[150];
+static NO_CACHE char sdLogBuffer[220];
 static uint64_t binaryLogCount = 0;
 
 #endif /* EFI_FILE_LOGGING */


### PR DESCRIPTION
SD log has a buffer overflow that we didn't detect because of #3595 and because of #3594 