### PR TITLE
wall fuel tweaks

### DIFF
--- a/firmware/console/binary/tunerstudio_outputs.h
+++ b/firmware/console/binary/tunerstudio_outputs.h
@@ -70,8 +70,8 @@ struct TunerStudioOutputChannels : ts_outputs_s {
 	uint16_t currentEnginePhase; // 70
 
 	// Wall model AE
-	scaled_ms wallFuelAmount; // 72
-	scaled_channel<int16_t, 1000> wallFuelCorrection; // 74
+	scaled_fuel_mass_mg wallFuelAmount; // 72
+	scaled_fuel_mass_mg wallFuelCorrection; // 74
 	
 	// TPS/load AE
 	scaled_percent unused76; // 76

--- a/firmware/console/status_loop.cpp
+++ b/firmware/console/status_loop.cpp
@@ -611,8 +611,8 @@ static void updateFuelInfo() {
 	updateFuelResults();
 
 	const auto& wallFuel = engine->injectionEvents.elements[0].wallFuel;
-	tsOutputChannels.wallFuelAmount = wallFuel.getWallFuel();
-	tsOutputChannels.wallFuelCorrection = wallFuel.wallFuelCorrection;
+	tsOutputChannels.wallFuelAmount = wallFuel.getWallFuel() * 1000;			// Convert grams to mg
+	tsOutputChannels.wallFuelCorrection = wallFuel.wallFuelCorrection * 1000;	// Convert grams to mg
 
 	tsOutputChannels.injectionOffset = engine->engineState.injectionOffset;
 

--- a/firmware/controllers/algo/wall_fuel.cpp
+++ b/firmware/controllers/algo/wall_fuel.cpp
@@ -11,14 +11,15 @@ void WallFuel::resetWF() {
 	wallFuel = 0;
 }
 
-floatms_t WallFuel::adjust(floatms_t desiredFuel) {
+float WallFuel::adjust(float desiredMassGrams) {
 	invocationCounter++;
-	if (cisnan(desiredFuel)) {
-		return desiredFuel;
+	if (cisnan(desiredMassGrams)) {
+		return desiredMassGrams;
 	}
+
 	// disable this correction for cranking
 	if (engine->rpmCalculator.isCranking()) {
-		return desiredFuel;
+		return desiredMassGrams;
 	}
 
 	ScopePerf perf(PE::WallFuelAdjust);
@@ -29,7 +30,7 @@ floatms_t WallFuel::adjust(floatms_t desiredFuel) {
 				SAE 1999-01-0553 by Peter J Maloney
 
 		M_cmd = commanded fuel mass (output of this function)
-		desiredFuel = desired fuel mass (input to this function)
+		desiredMassGrams = desired fuel mass (input to this function)
 		fuelFilmMass = fuel film mass (how much is currently on the wall)
 
 		First we compute how much fuel to command, by accounting for
@@ -57,21 +58,22 @@ floatms_t WallFuel::adjust(floatms_t desiredFuel) {
 		     decreases with decreasing manifold pressure.
 	*/
 
-	// if tau is really small, we get div/0.
+	// if tau or beta is really small, we get div/0.
 	// you probably meant to disable wwae.
 	float tau = engineConfiguration->wwaeTau;
-	if (tau < 0.01f) {
-		return desiredFuel;
+	float beta = engineConfiguration->wwaeBeta;
+
+	if (tau < 0.01f || beta < 0.01f) {
+		return desiredMassGrams;
 	}
 
 	// Ignore really slow RPM
 	int rpm = GET_RPM();
 	if (rpm < 100) {
-		return desiredFuel;
+		return desiredMassGrams;
 	}
 
 	float alpha = expf_taylor(-120 / (rpm * tau));
-	float beta = engineConfiguration->wwaeBeta;
 
 #if EFI_TUNER_STUDIO
 	if (engineConfiguration->debugMode == DBG_KNOCK) {
@@ -89,7 +91,7 @@ floatms_t WallFuel::adjust(floatms_t desiredFuel) {
 	}
 
 	float fuelFilmMass = wallFuel;
-	float M_cmd = (desiredFuel - (1 - alpha) * fuelFilmMass) / (1 - beta);
+	float M_cmd = (desiredMassGrams - (1 - alpha) * fuelFilmMass) / (1 - beta);
 
 #if EFI_TUNER_STUDIO
 	if (engineConfiguration->debugMode == DBG_KNOCK) {
@@ -115,13 +117,10 @@ floatms_t WallFuel::adjust(floatms_t desiredFuel) {
 #endif // EFI_TUNER_STUDIO
 
 	wallFuel = fuelFilmMassNext;
-	wallFuelCorrection = M_cmd - desiredFuel;
+	wallFuelCorrection = M_cmd - desiredMassGrams;
 	return M_cmd;
 }
 
-floatms_t WallFuel::getWallFuel() const {
+float WallFuel::getWallFuel() const {
 	return wallFuel;
 }
-
-
-

--- a/firmware/controllers/algo/wall_fuel.h
+++ b/firmware/controllers/algo/wall_fuel.h
@@ -12,11 +12,11 @@
 class WallFuel : public wall_fuel_state {
 public:
 	/**
-	 * @param target desired squirt duration
-	 * @return total adjusted fuel squirt duration once wall wetting is taken into effect
+	 * @param desiredMassGrams desired fuel quantity, in grams
+	 * @return total adjusted fuel squirt mass in grams once wall wetting is taken into effect
 	 */
-	floatms_t adjust(floatms_t target);
-	floatms_t getWallFuel() const;
+	float adjust(float desiredMassGrams);
+	float getWallFuel() const;
 	void resetWF();
 	int invocationCounter = 0;
 };

--- a/firmware/tunerstudio/rusefi.input
+++ b/firmware/tunerstudio/rusefi.input
@@ -272,8 +272,8 @@ enable2ndByteCanID = false
 	  fuelPidCorrection2=scalar, S16,    298,       "%",{1/@@PACK_MULT_PERCENT@@},         0
 
 ; Wall model AE
-      wallFuelAmount  = scalar,  U16,     72,     "ms",{1/@@PACK_MULT_MS@@},         0
-      wallFuelCorrection=scalar, S16,     74,       "ms",0.001,         0
+      wallFuelAmount  = scalar,  U16,     72,     "mg",{1/@@PACK_MULT_FUEL_MASS@@},       0
+      wallFuelCorrection=scalar, S16,     74,     "mg",{1/@@PACK_MULT_FUEL_MASS@@},       0
 
 ; TPS/load AE
       unusedLoadDelta = scalar,  S16,     76,    "value",{1/@@PACK_MULT_PERCENT@@},         0


### PR DESCRIPTION
- Log something actually useful instead of claiming it's milliseconds (it's not)
- Clarify units on wall wetting
- disable WW if either beta or tau is zero