### PR TITLE
alternator not industrial pid

### DIFF
--- a/firmware/controllers/actuators/alternator_controller.cpp
+++ b/firmware/controllers/actuators/alternator_controller.cpp
@@ -20,7 +20,7 @@
 #endif /* HAS_OS_ACCESS */
 
 static SimplePwm alternatorControl("alt");
-static PidIndustrial alternatorPid(&persistentState.persistentConfiguration.engineConfiguration.alternatorControl);
+static Pid alternatorPid(&persistentState.persistentConfiguration.engineConfiguration.alternatorControl);
 
 static percent_t currentAltDuty;
 
@@ -43,10 +43,6 @@ class AlternatorController : public PeriodicTimerController {
 			shouldResetPid = false;
 		}
 #endif
-
-		// todo: move this to pid_s one day
-		alternatorPid.antiwindupFreq = engineConfiguration->alternator_antiwindupFreq;
-		alternatorPid.derivativeFilterLoss = engineConfiguration->alternator_derivativeFilterLoss;
 
 		if (engineConfiguration->debugMode == DBG_ALTERNATOR_PID) {
 			// this block could be executed even in on/off alternator control mode

--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -1110,8 +1110,8 @@ custom pin_mode_e 1 bits, U08, @OFFSET@, [0:6], @@pin_mode_e_enum@@
 	pid_s etb;
 	brain_pin_e[TRIGGER_INPUT_PIN_COUNT iterate] triggerInputDebugPins;
 	brain_input_pin_e turboSpeedSensorInputPin;
-	float alternator_derivativeFilterLoss;;"x", 1, 0, -1000000, 1000000, 4
-	float alternator_antiwindupFreq;;"x", 1, 0, -1000000, 1000000, 4
+	float unused1760;;"x", 1, 0, 0, 1, 1
+	float unused1764;;"x", 1, 0, 0, 1, 1
 int16_t tps2Min;Closed throttle#2. todo: extract these two fields into a structure\nSee also tps2_1AdcChannel\nset tps2_min X;"ADC", 1, 0, 0, 1023, 0
 int16_t tps2Max;Full throttle#2. tpsMax value as 10 bit ADC value. Not Voltage!\nSee also tps1_1AdcChannel\nset tps2_max X;"ADC", 1, 0, 0, 1023, 0
 	output_pin_e starterControlPin;See also startStopButtonPin


### PR DESCRIPTION
We don't need industrial PID nonsense for alternator.  It also seems to break alternator debug outputs, which is relevant to https://rusefi.com/forum/viewtopic.php?f=19&t=2226