### PR TITLE
use tooth angle instead of timed angle

### DIFF
--- a/firmware/console/status_loop.cpp
+++ b/firmware/console/status_loop.cpp
@@ -872,16 +872,6 @@ void updateTunerStudioState(TunerStudioOutputChannels *tsOutputChannels) {
 	}
 }
 
-void updateCurrentEnginePhase() {
-	if (auto phase = engine->triggerCentral.getCurrentEnginePhase(getTimeNowNt())) {
-		angle_t angle = phase.Value - tdcPosition();
-		wrapAngle(angle, "updateCurrentEnginePhase", CUSTOM_ERR_6555);
-		tsOutputChannels.currentEnginePhase = angle;
-	} else {
-		tsOutputChannels.currentEnginePhase = 0;
-	}
-}
-
 void prepareTunerStudioOutputs(void) {
 	// sensor state for EFI Analytics Tuner Studio
 	updateTunerStudioState(&tsOutputChannels);

--- a/firmware/console/status_loop.h
+++ b/firmware/console/status_loop.h
@@ -11,7 +11,6 @@
 
 void updateDevConsoleState(void);
 void prepareTunerStudioOutputs(void);
-void updateCurrentEnginePhase();
 void startStatusThreads(void);
 void initStatusLoop(void);
 

--- a/firmware/controllers/trigger/trigger_central.cpp
+++ b/firmware/controllers/trigger/trigger_central.cpp
@@ -656,7 +656,9 @@ void TriggerCentral::handleShaftSignal(trigger_event_e signal, efitick_t timesta
 		mainTriggerCallback(triggerIndexForListeners, timestamp);
 
 #if EFI_TUNER_STUDIO
-		updateCurrentEnginePhase();
+		auto toothAngle = engine->triggerCentral.triggerFormDetails.eventAngles[triggerIndexForListeners] - tdcPosition();
+		wrapAngle(toothAngle, "currentEnginePhase", CUSTOM_ERR_6555);
+		tsOutputChannels.currentEnginePhase = toothAngle;
 #endif
 	}
 }


### PR DESCRIPTION
improve engine phase logging by using actual tooth angle, instead of inferring angle from last sync point

this improves accuracy when cranking due to engine speed variation (think: harley cranking with 900cc cylinders)

relevant to #3645 