### PR TITLE
simplify cylinder phasing calculation

### DIFF
--- a/firmware/controllers/algo/engine.h
+++ b/firmware/controllers/algo/engine.h
@@ -331,11 +331,6 @@ public:
 	void resetEngineSnifferIfInTestMode();
 
 	/**
-	 * pre-calculated offset for given sequence index within engine cycle
-	 * (not cylinder ID)
-	 */
-	angle_t ignitionPositionWithinEngineCycle[MAX_CYLINDER_COUNT];
-	/**
 	 * pre-calculated reference to which output pin should be used for
 	 * given sequence index within engine cycle
 	 * todo: update documentation

--- a/firmware/controllers/engine_cycle/fuel_schedule.cpp
+++ b/firmware/controllers/engine_cycle/fuel_schedule.cpp
@@ -107,9 +107,7 @@ bool FuelSchedule::addFuelEventsForCylinder(int i ) {
 		warning(CUSTOM_OBD_INJECTION_NO_PIN_ASSIGNED, "no_pin_inj #%s", output->name);
 	}
 
-	angle_t ignitionPositionWithinEngineCycle = engine->ignitionPositionWithinEngineCycle[i];
-
-	float angle = baseAngle + ignitionPositionWithinEngineCycle;
+	float angle = baseAngle + getCylinderAngle(i, ev->cylinderNumber);
 
 	if (TRIGGER_WAVEFORM(getSize()) < 1) {
 		warning(CUSTOM_ERR_NOT_INITIALIZED_TRIGGER, "uninitialized TriggerWaveform");

--- a/firmware/controllers/engine_cycle/spark_logic.cpp
+++ b/firmware/controllers/engine_cycle/spark_logic.cpp
@@ -73,12 +73,14 @@ static void prepareCylinderIgnitionSchedule(angle_t dwellAngleDuration, floatms_
 	// let's save planned duration so that we can later compare it with reality
 	event->sparkDwell = sparkDwell;
 
-	// change of sign here from 'before TDC' to 'after TDC'
-	angle_t ignitionPositionWithinEngineCycle = engine->ignitionPositionWithinEngineCycle[event->cylinderIndex];
-	assertAngleRange(ignitionPositionWithinEngineCycle, "aPWEC", CUSTOM_ERR_6566);
-	// this correction is usually zero (not used)
-	float perCylinderCorrection = engineConfiguration->timing_offset_cylinder[event->cylinderIndex];
-	const angle_t sparkAngle = -engine->engineState.timingAdvance + engine->knockController.getKnockRetard() + ignitionPositionWithinEngineCycle + perCylinderCorrection;
+	const angle_t sparkAngle =
+		// Negate because timing *before* TDC, and we schedule *after* TDC
+		- engine->engineState.timingAdvance
+		// Offset by this cylinder's position in the cycle
+		+ getCylinderAngle(event->cylinderIndex, event->cylinderNumber)
+		// Pull any extra timing for knock retard
+		+ engine->knockController.getKnockRetard();
+
 	efiAssertVoid(CUSTOM_SPARK_ANGLE_9, !cisnan(sparkAngle), "findAngle#9");
 
 	efiAssertVoid(CUSTOM_SPARK_ANGLE_1, !cisnan(sparkAngle), "sparkAngle#1");

--- a/firmware/controllers/math/engine_math.h
+++ b/firmware/controllers/math/engine_math.h
@@ -57,3 +57,11 @@ void setSingleCoilDwell();
 // while for toothed wheels user would have to provide a value
 #define tdcPosition() \
 		(TRIGGER_WAVEFORM(tdcPosition) + engineConfiguration->globalTriggerAngleOffset)
+
+/** Gets phase offset for a particular cylinder's ID and number
+ * For example on 4 cylinder engine with firing order 1-3-4-2, this
+ * returns 0-180-360-540 for index 0-1-2-3
+ * Cylinder number is used for per-cylinder adjustment, if you have
+ * an odd-fire engine (v-twin, V10, some v6, etc)
+ */
+angle_t getCylinderAngle(uint8_t cylinderIndex, uint8_t cylinderNumber);


### PR DESCRIPTION
Fueling and ignition now both use the same math, and incorporate the cylinder offset table. In anticipation of adding a separate small per-cylinder table to set ignition offset, since there's no need to set separate per-cylinder injection offset.

To clarify:
- Existing options become "cylinder offset from even-fire position" which applies to both ignition and injection for that cylinder.  This is for configuring when your crankshaft fires at odd-intervals, like v-twin, some V6, most V10, etc.
- New tables will set per-cylinder ignition-only trim.

probably completes #2501 