### PR TITLE
make macos happy

### DIFF
--- a/firmware/controllers/core/state_sequence.h
+++ b/firmware/controllers/core/state_sequence.h
@@ -77,7 +77,6 @@ public:
 	}
 
 	void setSwitchTime(const int phaseIndex, const float value) {
-		efiAssertVoid(CUSTOM_ERR_PWM_SWITCH_ASSERT, switchTimes != nullptr, "switchTimes");
 		switchTimes[phaseIndex] = value;
 	}
 

--- a/unit_tests/tests/test_can_serial.cpp
+++ b/unit_tests/tests/test_can_serial.cpp
@@ -12,6 +12,7 @@
 #include "engine_test_helper.h"
 #include "serial_can.h"
 
+#include <array>
 #include <list>
 #include <string>
 

--- a/unit_tests/tests/test_can_serial.cpp
+++ b/unit_tests/tests/test_can_serial.cpp
@@ -8,13 +8,12 @@
  * @author Andrey Belomutskiy, (c) 2012-2020
  */
 
-#include <list>
-#include <string>
-
 #include "pch.h"
 #include "engine_test_helper.h"
 #include "serial_can.h"
 
+#include <list>
+#include <string>
 
 using namespace std::string_literals;
 


### PR DESCRIPTION
You can't include anything before pch.

You also have to include `<array>` if you intend to use `std::array`.