### PR TITLE
GCC-10 and C++ 2a: supress depricated volatile use errors

### DIFF
--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -62,7 +62,9 @@ endif
 
 # C++ specific options here (added to USE_OPT).
 ifeq ($(USE_CPPOPT),)
-  USE_CPPOPT = -std=c++2a -Wno-register -fno-rtti -fno-threadsafe-statics -fno-exceptions -fno-use-cxa-atexit
+  USE_CPPOPT  = -std=c++2a -Wno-register -fno-rtti -fno-threadsafe-statics -fno-exceptions -fno-use-cxa-atexit
+  # gcc-10 c++ 2a depricated uses of volatile errors
+  USE_CPPOPT += -Wno-deprecated
 endif
 
 # Hellen is one of the boards which cares

--- a/firmware/check.c
+++ b/firmware/check.c
@@ -14,11 +14,4 @@
 	#error "GCC compiler >= 9.3.1 required"
 #endif
 
-#if (GCC_VERSION > 1000)
-	#pragma message("GCC is " STR(__GNUC__)"."STR(__GNUC_MINOR__)"."STR(__GNUC_PATCHLEVEL__))
-	#error "GCC10 not supported see https://github.com/rusefi/rusefi/labels/Gcc10"
-#endif
-
-
-
 #endif


### PR DESCRIPTION
Related to https://github.com/rusefi/rusefi/issues/3644