### PR TITLE
Improve NA/NB miata sync parameters

### DIFF
--- a/firmware/controllers/trigger/decoders/trigger_mazda.cpp
+++ b/firmware/controllers/trigger/decoders/trigger_mazda.cpp
@@ -28,9 +28,9 @@ void initializeMazdaMiataNaShape(TriggerWaveform *s) {
 	s->initialize(FOUR_STROKE_CAM_SENSOR);
 
 	// nominal gap is 0.325
-	s->setTriggerSynchronizationGap2(0.15f, 0.45f);
+	s->setTriggerSynchronizationGap2(0.1, 0.45);
 	// nominal gap is ~1.52
-	s->setSecondTriggerSynchronizationGap2(0.65f, 2.3f);
+	s->setSecondTriggerSynchronizationGap2(0.65, 2.3);
 
 	s->useRiseEdge = false;
 
@@ -185,9 +185,9 @@ void initializeMazdaMiataVVtCamShape(TriggerWaveform *s) {
 	s->initialize(FOUR_STROKE_CAM_SENSOR);
 
 	// Nominal gap is 8.92
-	s->setTriggerSynchronizationGap2(7, 13);
+	s->setTriggerSynchronizationGap2(6, 20);
 	// Nominal gap is 0.128
-	s->setSecondTriggerSynchronizationGap2(0.06f, 0.16f);
+	s->setSecondTriggerSynchronizationGap2(0.04f, 0.2f);
 
 	s->addEvent720(325, T_PRIMARY, TV_FALL);
 	s->addEvent720(360, T_PRIMARY, TV_RISE);

--- a/firmware/controllers/trigger/decoders/trigger_mazda.cpp
+++ b/firmware/controllers/trigger/decoders/trigger_mazda.cpp
@@ -28,9 +28,9 @@ void initializeMazdaMiataNaShape(TriggerWaveform *s) {
 	s->initialize(FOUR_STROKE_CAM_SENSOR);
 
 	// nominal gap is 0.325
-	s->setTriggerSynchronizationGap2(0.1, 0.45);
+	s->setTriggerSynchronizationGap2(0.15f, 0.45f);
 	// nominal gap is ~1.52
-	s->setSecondTriggerSynchronizationGap2(1.2, 1.8);
+	s->setSecondTriggerSynchronizationGap2(0.65f, 2.3f);
 
 	s->useRiseEdge = false;
 


### PR DESCRIPTION
Improved sync parameters based on data from logs for NA pattern and NB cam pattern.

#3717 and #3721 