### PR TITLE
Stepper direct push pull driver

### DIFF
--- a/firmware/controllers/actuators/dc_motors.cpp
+++ b/firmware/controllers/actuators/dc_motors.cpp
@@ -131,6 +131,23 @@ DcMotor* initDcMotor(const dc_io& io, size_t index, bool useTwoWires) {
 	return &hw.dcMotor;
 }
 
+DcMotor* initDcMotor(brain_pin_e coil_p, brain_pin_e coil_m, size_t index) {
+	auto& hw = dcHardware[index];
+
+	hw.start(
+		true, /* useTwoWires */
+		GPIO_UNASSIGNED, /* pinEnable */
+		coil_p,
+		coil_m,
+		GPIO_UNASSIGNED, /* pinDisable */
+		engineConfiguration->stepperDcInvertedPins,
+		&engine->executor,
+		engineConfiguration->etbFreq /* same in case of stepper? */
+	);
+
+	return &hw.dcMotor;
+}
+
 void setDcMotorFrequency(size_t index, int hz) {
 	dcHardware[index].setFrequency(hz);
 }

--- a/firmware/controllers/actuators/dc_motors.h
+++ b/firmware/controllers/actuators/dc_motors.h
@@ -12,6 +12,7 @@
 class DcMotor;
 
 DcMotor* initDcMotor(const dc_io& io, size_t index, bool useTwoWires);
+DcMotor* initDcMotor(brain_pin_e coil_p, brain_pin_e coil_m, size_t index);
 
 // Manual control of motors for use by console commands
 void setDcMotorFrequency(size_t index, int hz);

--- a/firmware/controllers/actuators/idle_hardware.cpp
+++ b/firmware/controllers/actuators/idle_hardware.cpp
@@ -74,7 +74,12 @@ bool isIdleHardwareRestartNeeded() {
 			isConfigurationChanged(useStepperIdle) ||
 			isConfigurationChanged(useETBforIdleControl) ||
 			isConfigurationChanged(idle.solenoidPin) ||
-			isConfigurationChanged(secondSolenoidPin);
+			isConfigurationChanged(secondSolenoidPin) ||
+			isConfigurationChanged(useRawOutputToDriveIdleStepper) ||
+			isConfigurationChanged(stepper_raw_output[0])  ||
+			isConfigurationChanged(stepper_raw_output[1])  ||
+			isConfigurationChanged(stepper_raw_output[2])  ||
+			isConfigurationChanged(stepper_raw_output[3]);
 }
 
 bool isIdleMotorBusy() {
@@ -89,9 +94,26 @@ void initIdleHardware() {
 	if (engineConfiguration->useStepperIdle) {
 		StepperHw* hw;
 
-		if (engineConfiguration->useHbridgesToDriveIdleStepper) {
-			auto motorA = initDcMotor(engineConfiguration->stepperDcIo[0], 2, /*useTwoWires*/ true);
-			auto motorB = initDcMotor(engineConfiguration->stepperDcIo[1], 3, /*useTwoWires*/ true);
+		if (engineConfiguration->useRawOutputToDriveIdleStepper) {
+			auto motorA = initDcMotor(engineConfiguration->stepper_raw_output[0],
+				engineConfiguration->stepper_raw_output[1], ETB_COUNT + 0);
+			auto motorB = initDcMotor(engineConfiguration->stepper_raw_output[2],
+				engineConfiguration->stepper_raw_output[3], ETB_COUNT + 1);
+
+			if (motorA && motorB) {
+				iacHbridgeHw.initialize(
+					motorA,
+					motorB,
+					engineConfiguration->idleStepperReactionTime
+				);
+			}
+
+			hw = &iacHbridgeHw;
+		} else if (engineConfiguration->useHbridgesToDriveIdleStepper) {
+			auto motorA = initDcMotor(engineConfiguration->stepperDcIo[0],
+				ETB_COUNT + 0, /*useTwoWires*/ true);
+			auto motorB = initDcMotor(engineConfiguration->stepperDcIo[1],
+				ETB_COUNT + 1, /*useTwoWires*/ true);
 
 			if (motorA && motorB) {
 				iacHbridgeHw.initialize(

--- a/firmware/controllers/actuators/idle_thread.cpp
+++ b/firmware/controllers/actuators/idle_thread.cpp
@@ -66,13 +66,20 @@ void idleDebug(const char *msg, percent_t value) {
 
 static void showIdleInfo() {
 	const char * idleModeStr = getIdle_mode_e(engineConfiguration->idleMode);
-	efiPrintf("useStepperIdle=%s useHbridges=%s",
-			boolToString(engineConfiguration->useStepperIdle), boolToString(engineConfiguration->useHbridgesToDriveIdleStepper));
+	efiPrintf("useStepperIdle=%s useHbridges=%s useRawOutput=%s",
+			boolToString(engineConfiguration->useStepperIdle),
+			boolToString(engineConfiguration->useHbridgesToDriveIdleStepper),
+			boolToString(engineConfiguration->useRawOutputToDriveIdleStepper));
 	efiPrintf("idleMode=%s position=%.2f",
 			idleModeStr, getIdlePosition());
 
 	if (engineConfiguration->useStepperIdle) {
-		if (engineConfiguration->useHbridgesToDriveIdleStepper) {
+		if (engineConfiguration->useRawOutputToDriveIdleStepper) {
+			efiPrintf(" A+=%s", hwPortname(engineConfiguration->stepper_raw_output[0]));
+			efiPrintf(" A-=%s", hwPortname(engineConfiguration->stepper_raw_output[1]));
+			efiPrintf(" B+=%s", hwPortname(engineConfiguration->stepper_raw_output[2]));
+			efiPrintf(" B-=%s", hwPortname(engineConfiguration->stepper_raw_output[3]));
+		} else if (engineConfiguration->useHbridgesToDriveIdleStepper) {
 			efiPrintf("Coil A:");
 			efiPrintf(" pin1=%s", hwPortname(engineConfiguration->stepperDcIo[0].directionPin1));
 			efiPrintf(" pin2=%s", hwPortname(engineConfiguration->stepperDcIo[0].directionPin2));


### PR DESCRIPTION
GP1-GP4 on MRE is now can be used to directly drive 4-wire stepper idle valve.
Do not forget to enable "useTLE8888 stepper" option. This will enable Push-Pull mode for corresponding outputs.

Depends on https://github.com/rusefi/rusefi/pull/3749