### PR TITLE
Enable ENABLE_AUTO_DETECT_HSE only if STM32_HSECLK is not defined

### DIFF
--- a/firmware/hw_layer/ports/stm32/mcuconf_common_f4_f7.h
+++ b/firmware/hw_layer/ports/stm32/mcuconf_common_f4_f7.h
@@ -335,12 +335,15 @@
  */
 #define STM32_WDG_USE_IWDG                  FALSE
 
-// Pretend we have a 25MHz external crystal.  This value isn't actually used since we
-// configure the PLL to start on the HSI oscillator, then compute HSE's speed at runtime
-// and reconfigure the PLL appropriately.
-#define STM32_HSECLK 25000000
+/* Some boards need to know clock early on boot.
+ * F429-Discovery board configures clock and then SDRAM early on boot */
+#ifndef STM32_HSECLK
+    // Pretend we have a 25MHz external crystal.  This value isn't actually used since we
+    // configure the PLL to start on the HSI oscillator, then compute HSE's speed at runtime
+    // and reconfigure the PLL appropriately.
+    #define STM32_HSECLK 25000000
 
-// After boot, we will detect the real frequency, and adjust the PLL M value to suit
+    // After boot, we will detect the real frequency, and adjust the PLL M value to suit
 
-#define ENABLE_AUTO_DETECT_HSE
-
+    #define ENABLE_AUTO_DETECT_HSE
+#endif


### PR DESCRIPTION
Some board (like stm32f429-disco) with SDRAM need clock to be
enabled in __early_init (before .bss and .data initialization).
So if STM32_HSECLK defined - skip clock detection.