### PR TITLE
Revert "forced 4 byte thing is actually no longer needed so much"

### DIFF
--- a/firmware/controllers/algo/auto_generated_enginetypes.cpp
+++ b/firmware/controllers/algo/auto_generated_enginetypes.cpp
@@ -144,6 +144,8 @@ case DBG_VVT_3_PID:
   return "DBG_VVT_3_PID";
 case DBG_VVT_4_PID:
   return "DBG_VVT_4_PID";
+case Force_4_bytes_size_debug_mode_e:
+  return "Force_4_bytes_size_debug_mode_e";
 case UNUSED23:
   return "UNUSED23";
   }
@@ -195,6 +197,8 @@ case FRANKENSO_MIATA_NA6_VAF:
   return "FRANKENSO_MIATA_NA6_VAF";
 case FRANKENSO_QA_ENGINE:
   return "FRANKENSO_QA_ENGINE";
+case Force_4_bytes_size_engine_type:
+  return "Force_4_bytes_size_engine_type";
 case GY6_139QMB:
   return "GY6_139QMB";
 case HELLEN72_ETB:
@@ -378,6 +382,8 @@ case VW_B6:
 }
 const char *getTrigger_type_e(trigger_type_e value){
 switch(value) {
+case Force_4_bytes_size_trigger_type:
+  return "Force_4_bytes_size_trigger_type";
 case TT_1_16:
   return "TT_1_16";
 case TT_2JZ_1_12:

--- a/firmware/controllers/algo/engine_types.h
+++ b/firmware/controllers/algo/engine_types.h
@@ -243,6 +243,7 @@ typedef enum {
 	TEST_109 = 109,
 	TEST_110 = 110,
 
+	Force_4_bytes_size_engine_type = ENUM_32_BITS,
 } engine_type_e;
 
 /**
@@ -316,6 +317,7 @@ typedef enum {
 	DBG_VVT_3_PID = 50,
 	DBG_VVT_4_PID = 51,
 
+	Force_4_bytes_size_debug_mode_e = ENUM_32_BITS,
 } debug_mode_e;
 
 /**
@@ -526,6 +528,8 @@ typedef enum {
 	//
 	TT_UNUSED = 70, // this is used if we want to iterate over all trigger types
 
+	// todo: convert to ENUM_16_BITS? I can see 257 triggers but not 65K triggers
+	Force_4_bytes_size_trigger_type = ENUM_32_BITS,
 } trigger_type_e; // TriggerProcessor.java has this "trigger_type_e" name hard-coded!
 
 

--- a/firmware/gen_enum_to_string.sh
+++ b/firmware/gen_enum_to_string.sh
@@ -10,7 +10,7 @@ java -DSystemOut.name=logs/gen_java_enum -cp ../java_tools/enum2string.jar com.r
 java -DSystemOut.name=logs/gen_java_enum -cp ../java_tools/enum2string.jar com.rusefi.ToJavaEnum -enumInputFile controllers/sensors/sensor_type.h -outputPath ../java_console/io/src/main/java/com/rusefi/enums
 [ $? -eq 0 ] || { echo "ERROR generating sensors"; exit 1; }
 
-java -DSystemOut.name=logs/gen_java_enum -cp ../java_tools/enum2string.jar com.rusefi.ToJavaEnum -enumInputFile controllers/algo/engine_types.h   -outputPath ../java_console/io/src/main/java/com/rusefi/enums
+java -DSystemOut.name=logs/gen_java_enum -cp ../java_tools/enum2string.jar com.rusefi.ToJavaEnum -enumInputFile controllers/algo/engine_types.h   -outputPath ../java_console/io/src/main/java/com/rusefi/enums -definition integration/rusefi_config.txt
 [ $? -eq 0 ] || { echo "ERROR generating types"; exit 1; }
 
 

--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -70,7 +70,7 @@
 ! Any time an incompatible change is made to the configuration format stored in flash,
 ! update this string to the current date! It is required to also update TS_SIGNATURE above
 ! when this happens.
-#define FLASH_DATA_VERSION 10006
+#define FLASH_DATA_VERSION 10007
 
 #define LOG_DELIMITER "`"
 

--- a/java_console/io/src/main/java/com/rusefi/enums/debug_mode_e.java
+++ b/java_console/io/src/main/java/com/rusefi/enums/debug_mode_e.java
@@ -56,4 +56,5 @@ public enum debug_mode_e {
 	DBG_VVT_2_PID,
 	DBG_VVT_3_PID,
 	DBG_VVT_4_PID,
+	Force_4_bytes_size_debug_mode_e,
 }

--- a/java_console/io/src/main/java/com/rusefi/enums/engine_type_e.java
+++ b/java_console/io/src/main/java/com/rusefi/enums/engine_type_e.java
@@ -115,4 +115,5 @@ public enum engine_type_e {
 	TEST_108,
 	TEST_109,
 	TEST_110,
+	Force_4_bytes_size_engine_type,
 }

--- a/java_console/io/src/main/java/com/rusefi/enums/trigger_type_e.java
+++ b/java_console/io/src/main/java/com/rusefi/enums/trigger_type_e.java
@@ -75,4 +75,5 @@ public enum trigger_type_e {
 	TT_NISSAN_MR18_CRANK,
 	TT_TOOTHED_WHEEL_32_2,
 	TT_UNUSED,
+	Force_4_bytes_size_trigger_type,
 }


### PR DESCRIPTION
This reverts commit 364783f65851c3b1fa3d0f36eb1a0eac306202cc.

Let's do this the Right Way later instead of breaking things.

Fix #3784 