### PR TITLE
Openblt scripts

### DIFF
--- a/firmware/flash_can.sh
+++ b/firmware/flash_can.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# This script will try to flash/update RusEFI part of firmware over can0 interface.
+#
+# You may want to bring can0 interface up first:
+# sudo ip link set can0 type can bitrate 500000 ; sudo ifconfig can0 up
+# Sometimes (after communication errors) you may like to restart interface with:
+# sudo ifconfig can0 down; sudo ip link set can0 type can bitrate 500000 ; sudo ifconfig can0 up
+
+echo This script assumes that you are using can0 interface and it is ready, otherwise read comments inside
+echo This script assumes that you have BootCommander somewhere in your PATH, otherwise read comments inside
+BootCommander -t=xcp_can -d=can0 deliver/rusefi_update.srec
+
+# OR
+# You can build it from sources with:
+# (cd ext/openblt/Host/Source/LibOpenBLT/ ; mkdir build ; cd build ; cmake .. ; make -j )
+# and
+# (cd ext/openblt/Host/Source/BootCommander/ ; mkdir build ; cd build ; cmake .. ; make -j )
+# And run:
+# ext/openblt/Host/BootCommander -t=xcp_can -d=can0 deliver/rusefi_update.srec

--- a/firmware/flash_dfu_openblt_only.sh
+++ b/firmware/flash_dfu_openblt_only.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# This script will flash OpenBLT bootloader only.
+# User should prefer to flash composite image,
+# see flash_dfu.sh/flash_dfu.bat
+
+dfu-util --alt 0 --download deliver/openblt.dfu --reset


### PR DESCRIPTION
This adds script to flash OpenBLT bootloader only over DFU.
This adds script to update RusEFI part of FW over can.

You may want to run `dfu_erase.sh` first to test how to flash over can. Then `flash_dfu_openblt_only.sh` to flash bootloader only.
Then connect you CAN adapter, bring can0 interface up and run `flash_can.sh` to test FW update over CAN.