### PR TITLE
add option to always use instant RPM

### DIFF
--- a/firmware/controllers/engine_cycle/rpm_calculator.cpp
+++ b/firmware/controllers/engine_cycle/rpm_calculator.cpp
@@ -245,7 +245,7 @@ void RpmCalculator::setSpinningUp(efitick_t nowNt) {
 void rpmShaftPositionCallback(trigger_event_e ckpSignalType,
 		uint32_t index, efitick_t nowNt) {
 
-	bool alwaysInstantRpm = config->alwaysInstantRpm;
+	bool alwaysInstantRpm = engineConfiguration->alwaysInstantRpm;
 
 	RpmCalculator *rpmState = &engine->rpmCalculator;
 

--- a/firmware/controllers/engine_cycle/rpm_calculator.cpp
+++ b/firmware/controllers/engine_cycle/rpm_calculator.cpp
@@ -245,6 +245,8 @@ void RpmCalculator::setSpinningUp(efitick_t nowNt) {
 void rpmShaftPositionCallback(trigger_event_e ckpSignalType,
 		uint32_t index, efitick_t nowNt) {
 
+	bool alwaysInstantRpm = config->alwaysInstantRpm;
+
 	RpmCalculator *rpmState = &engine->rpmCalculator;
 
 	if (index == 0) {
@@ -260,17 +262,19 @@ void rpmShaftPositionCallback(trigger_event_e ckpSignalType,
 		 * and each revolution of crankshaft consists of two engine cycles revolutions
 		 *
 		 */
-			if (periodSeconds == 0) {
-				rpmState->setRpmValue(NOISY_RPM);
-				rpmState->rpmRate = 0;
-			} else {
-				int mult = (int)getEngineCycle(engine->getOperationMode()) / 360;
-				float rpm = 60 * mult / periodSeconds;
+			if (!alwaysInstantRpm) {
+				if (periodSeconds == 0) {
+					rpmState->setRpmValue(NOISY_RPM);
+					rpmState->rpmRate = 0;
+				} else {
+					int mult = (int)getEngineCycle(engine->getOperationMode()) / 360;
+					float rpm = 60 * mult / periodSeconds;
 
-				auto rpmDelta = rpm - rpmState->previousRpmValue;
-				rpmState->rpmRate = rpmDelta / (mult * periodSeconds);
+					auto rpmDelta = rpm - rpmState->previousRpmValue;
+					rpmState->rpmRate = rpmDelta / (mult * periodSeconds);
 
-				rpmState->setRpmValue(rpm > UNREALISTIC_RPM ? NOISY_RPM : rpm);
+					rpmState->setRpmValue(rpm > UNREALISTIC_RPM ? NOISY_RPM : rpm);
+				}
 			}
 		} else {
 			// we are here only once trigger is synchronized for the first time
@@ -296,7 +300,7 @@ void rpmShaftPositionCallback(trigger_event_e ckpSignalType,
 		engine->triggerCentral.triggerShape, &engine->triggerCentral.triggerFormDetails,
 		index, nowNt);
 
-	if (rpmState->isSpinningUp()) {
+	if (alwaysInstantRpm || rpmState->isSpinningUp()) {
 		float instantRpm = engine->triggerCentral.triggerState.getInstantRpm();
 
 		rpmState->assignRpmValue(instantRpm);

--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -1050,7 +1050,7 @@ custom idle_mode_e 4 bits, U32, @OFFSET@, [0:0], "Open Loop + Closed Loop", "Ope
 	bit isIgnitionEnabled;+Enable ignition - This is default off for new projects as a safety feature, set to "true" to enable ignition and further ignition settings.
 	bit isCylinderCleanupEnabled;+When enabled if TPS is held above 95% no fuel is injected while cranking to clear excess fuel from the cylinders.
 	bit unused1476b3
-	bit unusedBit4_1476
+	bit alwaysInstantRpm
 	bit isMapAveragingEnabled
 	bit overrideCrankingIacSetting;+If enabled, use separate temperature multiplier table for cranking idle position.\nIf disabled, use normal running multiplier table applied to the cranking base position.
 	bit useSeparateAdvanceForIdle;+This activates a separate ignition timing table for idle conditions, this can help idle stability by using ignition retard and advance either side of the desired idle speed. Extra retard at low idle speeds will prevent stalling and extra advance at high idle speeds can help reduce engine power and slow the idle speed.

--- a/firmware/tunerstudio/rusefi.input
+++ b/firmware/tunerstudio/rusefi.input
@@ -3653,6 +3653,7 @@ cmd_set_engine_type_default					= "@@TS_IO_TEST_COMMAND_char@@\x00\x31\x00\x00"
 		field = "Ford redundant TPS mode",				useFordRedundantTps
 		field = "consumeObdSensors",                    consumeObdSensors, { canReadEnabled == 1 && canWriteEnabled == 1}
 		field = "Artificial Misfire",                   artificialTestMisfire
+		field = "Always use instant RPM",				alwaysInstantRpm
 		panel = mapCamDialog
 		panel = allTriggerDebug
 		panel = torqueCurve


### PR DESCRIPTION
Pretty self explanatory.  Never uses "slow" RPM, always uses instant RPM.

On my v8, this fixes a post-start stumble presumably caused by inaccurate ignition timing (maybe fuel timing too) that happens during the engine's rapid acceleration from cranking to idle (the engine goes from 150 -> 1100 rpm in 0.21 second!).