### PR TITLE
add proteus h7 to list

### DIFF
--- a/firmware/gen_config.sh
+++ b/firmware/gen_config.sh
@@ -34,6 +34,7 @@ for BOARD in \
    "prometheus prometheus_405" \
    "proteus proteus_f7" \
    "proteus proteus_f4" \
+   "proteus proteus_h7" \
    "atlas atlas"\
    ; do
  BOARD_NAME=$(echo "$BOARD" | cut -d " " -f 1)


### PR DESCRIPTION
maybe fix https://github.com/rusefi/web_backend/issues/138

see how proteus_h7 is missing from this list? https://rusefi.com/online/ini/rusefi/2022/01/20/