### PR TITLE
Don't skip firmware jobs if workflow is run manually

### DIFF
--- a/.github/workflows/build-firmware.yaml
+++ b/.github/workflows/build-firmware.yaml
@@ -195,7 +195,7 @@ jobs:
     steps:
     - name: Execution throttle early exit
       # Don't skip any jobs if this workflow was run manually.
-      if: ${{ matrix.skip-rate && github.event_name != "workflow_dispatch" }}
+      if: ${{ matrix.skip-rate && github.event_name != 'workflow_dispatch' }}
       run: if (($(($RANDOM % 100)) < ${{ matrix.skip-rate }})); then echo "skip=not_true" >> $GITHUB_ENV; fi
 
     - uses: actions/checkout@v1

--- a/.github/workflows/build-firmware.yaml
+++ b/.github/workflows/build-firmware.yaml
@@ -196,7 +196,7 @@ jobs:
     - name: Execution throttle early exit
       # Don't skip any jobs if this workflow was run manually.
       if: ${{ matrix.skip-rate && github.event_name != 'workflow_dispatch' }}
-      run: if (($(($RANDOM % 100)) < ${{ matrix.skip-rate }})); then echo "skip=not_true" >> $GITHUB_ENV; fi
+      run: if (($(($RANDOM % 100)) < ${{ matrix.skip-rate }})); then echo "skip=true" >> $GITHUB_ENV; fi
 
     - uses: actions/checkout@v1
       if: ${{ env.skip != 'true' }}

--- a/.github/workflows/build-firmware.yaml
+++ b/.github/workflows/build-firmware.yaml
@@ -1,6 +1,6 @@
 name: FW
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   build-firmware:
@@ -194,8 +194,8 @@ jobs:
 
     steps:
     - name: Execution throttle early exit
-      if: ${{ matrix.skip-rate }}
-      # todo: how do we produce well-defined releases with skip-rate approach? For I can think of hacking the line below before a release
+      # Don't skip any jobs if this workflow was run manually.
+      if: ${{ matrix.skip-rate && github.event_name != "workflow_dispatch" }}
       run: if (($(($RANDOM % 100)) < ${{ matrix.skip-rate }})); then echo "skip=not_true" >> $GITHUB_ENV; fi
 
     - uses: actions/checkout@v1


### PR DESCRIPTION
This is another approach to #3817
This adds the option to run the workflow manually, and if it is run manually, it doesn't skip any jobs.