### PR TITLE
vss based dfco

### DIFF
--- a/firmware/controllers/algo/fuel/dfco.cpp
+++ b/firmware/controllers/algo/fuel/dfco.cpp
@@ -26,7 +26,8 @@ bool DfcoController::getState() const {
 	bool rpmActivate = (rpm > engineConfiguration->coastingFuelCutRpmHigh);
 	bool rpmDeactivate = (rpm < engineConfiguration->coastingFuelCutRpmLow);
 
-	bool vssActivate = (vss > engineConfiguration->coastingFuelCutVssHigh);
+	// greater than or equal so that it works if both config params are set to 0
+	bool vssActivate = (vss >= engineConfiguration->coastingFuelCutVssHigh);
 	bool vssDeactivate = (vss < engineConfiguration->coastingFuelCutVssLow);
 
 	// RPM is high enough, VSS high enough, and DFCO allowed

--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -1172,7 +1172,9 @@ int16_t tps2Max;Full throttle#2. tpsMax value as 10 bit ADC value. Not Voltage!\
 
 
 	uint8_t autoscale tpsAccelLookback;+How long to look back for TPS-based acceleration enrichment. Increasing this time will trigger enrichment for longer when a throttle position change occurs.;"sec", 0.05, 0, 0, 5, 2
-	uint8_t[3] unused1689;;"", 1,0,0,0,0
+	uint8_t coastingFuelCutVssLow;+Below this speed, disable DFCO.;"kph", 1, 0, 0, 255, 0
+	uint8_t coastingFuelCutVssHigh;+Above this speed, allow DFCO.;"kph", 1, 0, 0, 255, 0
+	uint8_t[1] unused1689;;"", 1,0,0,0,0
 	float tpsAccelEnrichmentThreshold;+Maximum change delta of TPS percentage over the 'length'. Actual TPS change has to be above this value in order for TPS/TPS acceleration to kick in.;"roc", 1, 0, 0, 200, 3
 
 	int engineLoadAccelLength;;"cycles", 1, 0, 1, 200, 0

--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -1172,8 +1172,8 @@ int16_t tps2Max;Full throttle#2. tpsMax value as 10 bit ADC value. Not Voltage!\
 
 
 	uint8_t autoscale tpsAccelLookback;+How long to look back for TPS-based acceleration enrichment. Increasing this time will trigger enrichment for longer when a throttle position change occurs.;"sec", 0.05, 0, 0, 5, 2
-	uint8_t coastingFuelCutVssLow;+Below this speed, disable DFCO.;"kph", 1, 0, 0, 255, 0
-	uint8_t coastingFuelCutVssHigh;+Above this speed, allow DFCO.;"kph", 1, 0, 0, 255, 0
+	uint8_t coastingFuelCutVssLow;+Below this speed, disable DFCO. Use this to prevent jerkiness from fuel enable/disable in low gears.;"kph", 1, 0, 0, 255, 0
+	uint8_t coastingFuelCutVssHigh;+Above this speed, allow DFCO. Use this to prevent jerkiness from fuel enable/disable in low gears.;"kph", 1, 0, 0, 255, 0
 	uint8_t[1] unused1689;;"", 1,0,0,0,0
 	float tpsAccelEnrichmentThreshold;+Maximum change delta of TPS percentage over the 'length'. Actual TPS change has to be above this value in order for TPS/TPS acceleration to kick in.;"roc", 1, 0, 0, 200, 1
 

--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -1175,15 +1175,15 @@ int16_t tps2Max;Full throttle#2. tpsMax value as 10 bit ADC value. Not Voltage!\
 	uint8_t coastingFuelCutVssLow;+Below this speed, disable DFCO.;"kph", 1, 0, 0, 255, 0
 	uint8_t coastingFuelCutVssHigh;+Above this speed, allow DFCO.;"kph", 1, 0, 0, 255, 0
 	uint8_t[1] unused1689;;"", 1,0,0,0,0
-	float tpsAccelEnrichmentThreshold;+Maximum change delta of TPS percentage over the 'length'. Actual TPS change has to be above this value in order for TPS/TPS acceleration to kick in.;"roc", 1, 0, 0, 200, 3
+	float tpsAccelEnrichmentThreshold;+Maximum change delta of TPS percentage over the 'length'. Actual TPS change has to be above this value in order for TPS/TPS acceleration to kick in.;"roc", 1, 0, 0, 200, 1
 
 	int engineLoadAccelLength;;"cycles", 1, 0, 1, 200, 0
 
 
 
 	uint32_t uartConsoleSerialSpeed;Band rate for primary TTL;"BPs", 1, 0, 0, 1000000, 0
-	float tpsDecelEnleanmentThreshold;For decel we simply multiply delta of TPS and tFor decel we do not use table?!;"roc", 1, 0, 0, 200, 3
-	float tpsDecelEnleanmentMultiplier;Magic multiplier, we multiply delta of TPS and get fuel squirt duration;"coeff", 1, 0, 0, 200, 3
+	float tpsDecelEnleanmentThreshold;For decel we simply multiply delta of TPS and tFor decel we do not use table?!;"roc", 1, 0, 0, 200, 1
+	float tpsDecelEnleanmentMultiplier;Magic multiplier, we multiply delta of TPS and get fuel squirt duration;"coeff", 1, 0, 0, 200, 2
 	float slowAdcAlpha;+ExpAverage alpha coefficient;"coeff", 1, 0, 0, 200, 3
 	debug_mode_e debugMode;+See http://rusefi.com/s/debugmode\n\nset debug_mode X
 

--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -1361,7 +1361,7 @@ float[CRANKING_ADVANCE_CURVE_SIZE] crankingAdvance    ;+Optional timing advance 
 
 	int16_t coastingFuelCutRpmHigh;+This sets the RPM above which fuel cut is active.;"rpm", 1, 0, 0, 5000, 0
 	int16_t coastingFuelCutRpmLow;+This sets the RPM below which fuel cut is deactivated, this prevents jerking or issues transitioning to idle;"rpm", 1, 0, 0, 5000, 0
-	int16_t coastingFuelCutTps;+Throttle position below which fuel cut is active. With an electronic throttle enabled, this checks against pedal position.;"%", 1, 0, 0, 20, 1
+	int16_t coastingFuelCutTps;+Throttle position below which fuel cut is active. With an electronic throttle enabled, this checks against pedal position.;"%", 1, 0, 0, 20, 0
 	int16_t coastingFuelCutClt;+Fuel cutoff is disabled when the engine is cold.;"C", 1, 0, -100, 100, 0
 	
 	int16_t pidExtraForLowRpm;+Increases PID reaction for RPM<target by adding extra percent to PID-error;"%", 1, 0, 0, 100, 0

--- a/firmware/tunerstudio/rusefi.input
+++ b/firmware/tunerstudio/rusefi.input
@@ -3622,8 +3622,10 @@ cmd_set_engine_type_default					= "@@TS_IO_TEST_COMMAND_char@@\x00\x31\x00\x00"
 	dialog = coastingFuelCutControl, "Coasting Fuel Cutoff Settings"
 		field = "Enable Coasting Fuel Cutoff",			coastingFuelCutEnabled
 		field = "No cut below CLT",				coastingFuelCutClt, {coastingFuelCutEnabled == 1}
-		field = "Cut fuel above",		coastingFuelCutRpmHigh, {coastingFuelCutEnabled == 1}
-		field = "Restore fuel below",	coastingFuelCutRpmLow, {coastingFuelCutEnabled == 1}
+		field = "RPM cut fuel above",		coastingFuelCutRpmHigh, {coastingFuelCutEnabled == 1}
+		field = "RPM restore fuel below",	coastingFuelCutRpmLow, {coastingFuelCutEnabled == 1}
+		field = "Vehicle speed cut above",		coastingFuelCutVssHigh, {coastingFuelCutEnabled == 1}
+		field = "Vehicle speed restore below",	coastingFuelCutVssLow, {coastingFuelCutEnabled == 1}
 		field = "Cut fuel below TPS",			coastingFuelCutTps, {coastingFuelCutEnabled == 1}
 		field = "Cut fuel below MAP",      coastingFuelCutMap, {coastingFuelCutEnabled == 1}
 

--- a/unit_tests/tests/ignition_injection/test_fuelCut.cpp
+++ b/unit_tests/tests/ignition_injection/test_fuelCut.cpp
@@ -51,21 +51,21 @@ TEST(fuelCut, coasting) {
 	eth.engine.periodicFastCallback();
 
 	// this is normal injection mode (the throttle is opened), no fuel cut-off
-	assertEqualsM("inj dur#1 norm", normalInjDuration, engine->injectionDuration);
+	EXPECT_FLOAT_EQ(normalInjDuration, engine->injectionDuration);
 
 	// 'releasing' the throttle
 	Sensor::setMockValue(SensorType::DriverThrottleIntent, 0);
 	eth.engine.periodicFastCallback();
 
 	// Fuel cut-off is enabled now
-	assertEqualsM("inj dur#2 cut", 0.0f, engine->injectionDuration);
+	EXPECT_FLOAT_EQ(0.0f, engine->injectionDuration);
 
 	// Now drop the CLT below threshold
 	Sensor::setMockValue(SensorType::Clt, engineConfiguration->coastingFuelCutClt - 1);
 	eth.engine.periodicFastCallback();
 
 	// Fuel cut-off should be diactivated - the engine is 'cold'
-	assertEqualsM("inj dur#3 clt", normalInjDuration, engine->injectionDuration);
+	EXPECT_FLOAT_EQ(normalInjDuration, engine->injectionDuration);
 
 	// restore CLT
 	Sensor::setMockValue(SensorType::Clt, hotClt);
@@ -74,27 +74,27 @@ TEST(fuelCut, coasting) {
 	eth.engine.periodicFastCallback();
 
 	// Fuel cut-off is enabled - nothing should change
-	assertEqualsM("inj dur#4 mid", normalInjDuration, engine->injectionDuration);
+	EXPECT_FLOAT_EQ(normalInjDuration, engine->injectionDuration);
 
 	// Now drop RPM just below RpmLow threshold
 	Sensor::setMockValue(SensorType::Rpm, engineConfiguration->coastingFuelCutRpmLow - 1);
 	eth.engine.periodicFastCallback();
 
 	// Fuel cut-off is now disabled (the engine is idling)
-	assertEqualsM("inj dur#5 idle", normalInjDuration, engine->injectionDuration);
+	EXPECT_FLOAT_EQ(normalInjDuration, engine->injectionDuration);
 
 	// Now change RPM just below RpmHigh threshold
 	Sensor::setMockValue(SensorType::Rpm, engineConfiguration->coastingFuelCutRpmHigh - 1);
 	eth.engine.periodicFastCallback();
 
 	// Fuel cut-off is still disabled
-	assertEqualsM("inj dur#6 mid", normalInjDuration, engine->injectionDuration);
+	EXPECT_FLOAT_EQ(normalInjDuration, engine->injectionDuration);
 
 	// Now set RPM just above RpmHigh threshold
 	Sensor::setMockValue(SensorType::Rpm, engineConfiguration->coastingFuelCutRpmHigh + 1);
 	eth.engine.periodicFastCallback();
 
 	// Fuel cut-off is active again!
-	assertEqualsM("inj dur#7 cut", 0.0f, engine->injectionDuration);
+	EXPECT_FLOAT_EQ(0.0f, engine->injectionDuration);
 }
 

--- a/unit_tests/tests/ignition_injection/test_fuelCut.cpp
+++ b/unit_tests/tests/ignition_injection/test_fuelCut.cpp
@@ -100,5 +100,34 @@ TEST(fuelCut, coasting) {
 
 	// Fuel cut-off is active again!
 	EXPECT_CUT();
+
+	// Configure vehicle speed thresholds
+	engineConfiguration->coastingFuelCutVssHigh = 50;
+	engineConfiguration->coastingFuelCutVssLow = 40;
+
+	// High speed, should still be cut.
+	Sensor::setMockValue(SensorType::VehicleSpeed, 55);
+	eth.engine.periodicFastCallback();
+	EXPECT_CUT();
+
+	// Between thresholds, still cut.
+	Sensor::setMockValue(SensorType::VehicleSpeed, 45);
+	eth.engine.periodicFastCallback();
+	EXPECT_CUT();
+
+	// Below lower threshold, normal fuel resumes
+	Sensor::setMockValue(SensorType::VehicleSpeed, 35);
+	eth.engine.periodicFastCallback();
+	EXPECT_NORMAL();
+
+	// Between thresholds, still normal.
+	Sensor::setMockValue(SensorType::VehicleSpeed, 45);
+	eth.engine.periodicFastCallback();
+	EXPECT_NORMAL();
+
+	// Back above upper, cut again.
+	Sensor::setMockValue(SensorType::VehicleSpeed, 55);
+	eth.engine.periodicFastCallback();
+	EXPECT_CUT();
 }
 


### PR DESCRIPTION
Add conditions to enable/disable decel fuel cut at low speed. Helps with low-speed jerkiness from decel fuel cut in low gears.