### PR TITLE
SD card UI cleanup

### DIFF
--- a/firmware/config/boards/hellen/hellen-nb1/prepend.txt
+++ b/firmware/config/boards/hellen/hellen-nb1/prepend.txt
@@ -19,6 +19,7 @@
 #define ts_show_can2 false
 #define ts_show_software_knock true
 #define ts_show_hardware_simulator false
+#define ts_show_sd_pins false
 
 #define show_test_presets false
 #define show_Frankenso_presets false

--- a/firmware/config/boards/hellen/hellen121nissan/prepend.txt
+++ b/firmware/config/boards/hellen/hellen121nissan/prepend.txt
@@ -19,6 +19,7 @@
 #define ts_show_can2 false
 #define ts_show_software_knock true
 #define ts_show_hardware_simulator false
+#define ts_show_sd_pins false
 
 #define show_test_presets false
 #define show_Frankenso_presets false

--- a/firmware/config/boards/hellen/hellen121vag/prepend.txt
+++ b/firmware/config/boards/hellen/hellen121vag/prepend.txt
@@ -19,6 +19,7 @@
 #define ts_show_can2 false
 #define ts_show_software_knock true
 #define ts_show_hardware_simulator false
+#define ts_show_sd_pins false
 
 #define show_test_presets false
 #define show_Frankenso_presets false

--- a/firmware/config/boards/hellen/hellen128/prepend.txt
+++ b/firmware/config/boards/hellen/hellen128/prepend.txt
@@ -19,6 +19,7 @@
 #define ts_show_can2 false
 #define ts_show_software_knock true
 #define ts_show_hardware_simulator false
+#define ts_show_sd_pins false
 
 #define show_test_presets false
 #define show_Frankenso_presets false

--- a/firmware/config/boards/hellen/hellen154hyundai/prepend.txt
+++ b/firmware/config/boards/hellen/hellen154hyundai/prepend.txt
@@ -19,6 +19,7 @@
 #define ts_show_can2 false
 #define ts_show_software_knock true
 #define ts_show_hardware_simulator false
+#define ts_show_sd_pins false
 
 #define show_test_presets false
 #define show_Frankenso_presets false

--- a/firmware/config/boards/hellen/hellen64_miataNA6_94/prepend.txt
+++ b/firmware/config/boards/hellen/hellen64_miataNA6_94/prepend.txt
@@ -19,6 +19,7 @@
 #define ts_show_can2 false
 #define ts_show_software_knock true
 #define ts_show_hardware_simulator false
+#define ts_show_sd_pins false
 
 #define show_test_presets false
 #define show_Frankenso_presets false

--- a/firmware/config/boards/hellen/hellen72/prepend.txt
+++ b/firmware/config/boards/hellen/hellen72/prepend.txt
@@ -19,6 +19,7 @@
 #define ts_show_can2 false
 #define ts_show_software_knock true
 #define ts_show_hardware_simulator false
+#define ts_show_sd_pins false
 
 #define show_test_presets false
 #define show_Frankenso_presets false

--- a/firmware/config/boards/hellen/hellen81/prepend.txt
+++ b/firmware/config/boards/hellen/hellen81/prepend.txt
@@ -19,6 +19,7 @@
 #define ts_show_can2 false
 #define ts_show_software_knock false
 #define ts_show_hardware_simulator false
+#define ts_show_sd_pins false
 
 #define show_test_presets false
 #define show_Frankenso_presets false

--- a/firmware/config/boards/hellen/hellen88bmw/prepend.txt
+++ b/firmware/config/boards/hellen/hellen88bmw/prepend.txt
@@ -19,6 +19,7 @@
 #define ts_show_can2 false
 #define ts_show_software_knock true
 #define ts_show_hardware_simulator false
+#define ts_show_sd_pins false
 
 #define show_test_presets false
 #define show_Frankenso_presets false

--- a/firmware/config/boards/hellen/hellenNA8_96/prepend.txt
+++ b/firmware/config/boards/hellen/hellenNA8_96/prepend.txt
@@ -19,6 +19,7 @@
 #define ts_show_can2 false
 #define ts_show_software_knock true
 #define ts_show_hardware_simulator false
+#define ts_show_sd_pins false
 
 #define show_test_presets false
 #define show_Frankenso_presets false

--- a/firmware/config/boards/microrusefi/prepend.txt
+++ b/firmware/config/boards/microrusefi/prepend.txt
@@ -24,6 +24,7 @@
 #define ts_show_can2 false
 #define ts_show_software_knock true
 #define ts_show_hardware_simulator false
+#define ts_show_sd_pins false
 
 #define show_test_presets false
 #define show_Frankenso_presets false

--- a/firmware/config/boards/proteus/prepend.txt
+++ b/firmware/config/boards/proteus/prepend.txt
@@ -15,6 +15,7 @@
 #define ts_show_can2 false
 #define ts_show_software_knock true
 #define ts_show_hardware_simulator false
+#define ts_show_sd_pins false
 
 ! in case of direct Lua control we need UI to undo defaults
 #define ts_show_etb_pins true

--- a/firmware/config/boards/subaru_eg33/prepend.txt
+++ b/firmware/config/boards/subaru_eg33/prepend.txt
@@ -12,6 +12,7 @@
 #define ts_show_sd_card true
 #define ts_show_can_pins true
 #define ts_show_tunerstudio_port false
+#define ts_show_sd_pins false
 
 #define show_test_presets false
 #define show_Frankenso_presets false

--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -456,7 +456,7 @@ bit cj125isUaDivided;+Is your UA CJ125 output wired to MCU via resistor divider?
 bit cj125isLsu49
 bit etb_use_two_wires;+TLE7209 uses two-wire mode. TLE9201 and VNH2SP30 do NOT use two wire mode.
 bit isDoubleSolenoidIdle;+Subaru/BMW style where default valve position is somewhere in the middle. First solenoid opens it more while second can close it more than default position.
-bit showSdCardWarning
+bit unused164b14
 bit cj125isUrDivided;+Is your UR CJ125 output wired to MCU via resistor divider?\nLooks like 3v range should be enough, divider generally not needed.
 bit useCicPidForIdle;+Switch between Industrial and Cic PID implementation
 bit useTLE8888_cranking_hack;

--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -2000,6 +2000,7 @@ end_struct
 #define ts_show_can2 true
 #define ts_show_software_knock false
 #define ts_show_hardware_simulator true
+#define ts_show_sd_pins true
 
 ! we need to improve this further - at the moment we need too many boards to prepend 'false'
 #define show_test_presets true

--- a/firmware/tunerstudio/rusefi.input
+++ b/firmware/tunerstudio/rusefi.input
@@ -3150,8 +3150,8 @@ cmd_set_engine_type_default					= "@@TS_IO_TEST_COMMAND_char@@\x00\x31\x00\x00"
 	
 	dialog = sdCard, "SD Card Logger"
 		field = "Enable SD Card",						isSdCardEnabled
-		field = "CS Pin",								sdCardCsPin
-		field = "SPI",									sdCardSpiDevice
+		field = "CS Pin",								sdCardCsPin			@@if_ts_show_sd_pins
+		field = "SPI",									sdCardSpiDevice		@@if_ts_show_sd_pins
 		field = "Write Period",							sdCardPeriodMs
 	
 	dialog = gpsReceiver, "GPS Receiver" 

--- a/firmware/tunerstudio/rusefi.input
+++ b/firmware/tunerstudio/rusefi.input
@@ -3150,7 +3150,6 @@ cmd_set_engine_type_default					= "@@TS_IO_TEST_COMMAND_char@@\x00\x31\x00\x00"
 	
 	dialog = sdCard, "SD Card Logger"
 		field = "Enable SD Card",						isSdCardEnabled
-		field = "showSdCardWarning",					showSdCardWarning
 		field = "CS Pin",								sdCardCsPin
 		field = "SPI",									sdCardSpiDevice
 		field = "Write Period",							sdCardPeriodMs

--- a/firmware/tunerstudio/rusefi.input
+++ b/firmware/tunerstudio/rusefi.input
@@ -3149,6 +3149,8 @@ cmd_set_engine_type_default					= "@@TS_IO_TEST_COMMAND_char@@\x00\x31\x00\x00"
 		field = "Serial Baud Rate",						auxSerialSpeed @@if_ts_show_auxserial_pins
 	
 	dialog = sdCard, "SD Card Logger"
+		field = "#rusEFI logs to SD when powered without USB connected"
+		field = "#rusEFI connects SD to your PC when powered by USB"
 		field = "Enable SD Card",						isSdCardEnabled
 		field = "CS Pin",								sdCardCsPin			@@if_ts_show_sd_pins
 		field = "SPI",									sdCardSpiDevice		@@if_ts_show_sd_pins


### PR DESCRIPTION
- dead `showSdCardWarning`
- hide SD card pinout options on hard wired boards