### PR TITLE
rusEFI console does not stay alive #3912

### DIFF
--- a/firmware/config/boards/hellen/cypress/config/controllers/algo/rusefi_generated.h
+++ b/firmware/config/boards/hellen/cypress/config/controllers/algo/rusefi_generated.h
@@ -191,7 +191,7 @@
 #define benchTestOnTime_offset 1746
 #define binarySerialRxPin_offset 1575
 #define binarySerialTxPin_offset 1574
-#define BLOCKING_FACTOR 256
+#define BLOCKING_FACTOR 1024
 #define boardUseCrankPullUp_offset 1260
 #define boardUseTachPullUp_offset 1260
 #define boardUseTempPullUp_offset 1260

--- a/firmware/config/boards/kinetis/config/controllers/algo/rusefi_generated.h
+++ b/firmware/config/boards/kinetis/config/controllers/algo/rusefi_generated.h
@@ -182,7 +182,7 @@
 #define benchTestOnTime_offset 1746
 #define binarySerialRxPin_offset 1575
 #define binarySerialTxPin_offset 1574
-#define BLOCKING_FACTOR 256
+#define BLOCKING_FACTOR 1024
 #define boardUseCrankPullUp_offset 1260
 #define boardUseTachPullUp_offset 1260
 #define boardUseTempPullUp_offset 1260

--- a/firmware/config/boards/subaru_eg33/config/controllers/algo/rusefi_generated.h
+++ b/firmware/config/boards/subaru_eg33/config/controllers/algo/rusefi_generated.h
@@ -199,7 +199,7 @@
 #define benchTestOnTime_offset 1746
 #define binarySerialRxPin_offset 1575
 #define binarySerialTxPin_offset 1574
-#define BLOCKING_FACTOR 256
+#define BLOCKING_FACTOR 1024
 #define boardUseCrankPullUp_offset 1260
 #define boardUseTachPullUp_offset 1260
 #define boardUseTempPullUp_offset 1260

--- a/firmware/controllers/generated/rusefi_generated.h
+++ b/firmware/controllers/generated/rusefi_generated.h
@@ -191,7 +191,7 @@
 #define benchTestOnTime_offset 1746
 #define binarySerialRxPin_offset 1575
 #define binarySerialTxPin_offset 1574
-#define BLOCKING_FACTOR 256
+#define BLOCKING_FACTOR 1024
 #define boardUseCrankPullUp_offset 1260
 #define boardUseTachPullUp_offset 1260
 #define boardUseTempPullUp_offset 1260

--- a/firmware/hw_layer/ports/rusefi_halconf.h
+++ b/firmware/hw_layer/ports/rusefi_halconf.h
@@ -74,7 +74,7 @@
 #define PAL_USE_CALLBACKS           TRUE
 
 // USB Serial
-#define SERIAL_USB_BUFFERS_SIZE     320
+#define SERIAL_USB_BUFFERS_SIZE     (1024 + 128)
 #define SERIAL_USB_BUFFERS_NUMBER   2
 
 // USB Mass Storage

--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -84,7 +84,7 @@ struct_no_prefix engine_configuration_s
 #define LE_COMMAND_LENGTH 200
 
 ! see 'blockingFactor' in rusefi.ini
-#define BLOCKING_FACTOR 256
+#define BLOCKING_FACTOR 1024
 
 ! Back in the day we wanted enums to be 32 bit integers.
 ! as of 2020 preference is with ' __attribute__ ((__packed__))' allowing one-byte enums

--- a/java_console/io/src/main/java/com/rusefi/binaryprotocol/IncomingDataBuffer.java
+++ b/java_console/io/src/main/java/com/rusefi/binaryprotocol/IncomingDataBuffer.java
@@ -65,7 +65,7 @@ public class IncomingDataBuffer {
         //     log.debug(loggingPrefix + "Got packet size " + packetSize);
         if (packetSize < 0)
             return null;
-        if (!allowLongResponse && packetSize > Math.max(Fields.BLOCKING_FACTOR, Fields.TS_OUTPUT_SIZE) + 10)
+        if (!allowLongResponse && packetSize > Fields.BLOCKING_FACTOR + 10)
             throw new IllegalArgumentException(packetSize + " packet while not allowLongResponse"); // this is about CRC calculation and mutable buffers on firmware side
 
         isTimeout = waitForBytes(loggingPrefix + msg + " body", start, packetSize + 4);

--- a/java_console/models/src/main/java/com/rusefi/config/generated/Fields.java
+++ b/java_console/models/src/main/java/com/rusefi/config/generated/Fields.java
@@ -186,7 +186,7 @@ public class Fields {
 	public static final int benchTestOnTime_offset = 1746;
 	public static final int binarySerialRxPin_offset = 1575;
 	public static final int binarySerialTxPin_offset = 1574;
-	public static final int BLOCKING_FACTOR = 256;
+	public static final int BLOCKING_FACTOR = 1024;
 	public static final int boardUseCrankPullUp_offset = 1260;
 	public static final int boardUseTachPullUp_offset = 1260;
 	public static final int boardUseTempPullUp_offset = 1260;


### PR DESCRIPTION
While that's not solving all problems for me this must be fixing out channel concurrency for purposes of CRC calculation