### PR TITLE
SD card logs use timestamp

### DIFF
--- a/firmware/ext/ffconf.h
+++ b/firmware/ext/ffconf.h
@@ -219,10 +219,7 @@
 /  Note that enabling exFAT discards ANSI C (C89) compatibility. */
 
 
-#define FF_FS_NORTC       1
-#define FF_NORTC_MON	5
-#define FF_NORTC_MDAY	1
-#define FF_NORTC_YEAR	2017
+#define FF_FS_NORTC       0
 /* The option FF_FS_NORTC switches timestamp functiton. If the system does not have
 /  any RTC function or valid timestamp is not needed, set FF_FS_NORTC = 1 to disable
 /  the timestamp function. All objects modified by FatFs will have a fixed timestamp


### PR DESCRIPTION
Turns out we just needed to flip a flag for this to work.