### PR TITLE
core 8 overrides and stepper-as-brain-pin

### DIFF
--- a/firmware/config/boards/atlas/board_configuration.cpp
+++ b/firmware/config/boards/atlas/board_configuration.cpp
@@ -1,7 +1,4 @@
 #include "pch.h"
 
-void setSerialConfigurationOverrides() {
-}
-
 void setSdCardConfigurationOverrides() {
 }

--- a/firmware/config/boards/core8/board_configuration.cpp
+++ b/firmware/config/boards/core8/board_configuration.cpp
@@ -9,7 +9,6 @@
 #include "pch.h"
 
 static void setInjectorPins() {
-	
 	engineConfiguration->injectionPinMode = OM_DEFAULT;
 
 	engineConfiguration->injectionPins[0] = GPIOF_13;
@@ -23,7 +22,6 @@ static void setInjectorPins() {
 }
 
 static void setIgnitionPins() {
-	
 	engineConfiguration->ignitionPinMode = OM_DEFAULT;
 
 	engineConfiguration->ignitionPins[0] = GPIOE_15;
@@ -40,8 +38,7 @@ static void setIgnitionPins() {
 void setSdCardConfigurationOverrides(void) {
 }
 
-void setBoardConfigOverrides(void) {
-	
+static void setEtbConfig() {
 	// TLE9201 driver
 	// This chip has three control pins:
 	// DIR - sets direction of the motor
@@ -72,28 +69,6 @@ void setBoardConfigOverrides(void) {
 	engineConfiguration->etb_use_two_wires = false;
 }
 
-void setPinConfigurationOverrides(void) {
-
-	//CAN 1 bus overwrites
-	engineConfiguration->canTxPin = GPIOD_0;
-	engineConfiguration->canRxPin = GPIOD_1;
-
-	//CAN 2 bus overwrites
-	engineConfiguration->can2RxPin = GPIOB_5;
-	engineConfiguration->can2TxPin = GPIOB_6;
-}
-
-void setSerialConfigurationOverrides(void) {
-}
-
-
-/**
- * @brief   Board-specific configuration defaults.
- *
- * See also setDefaultEngineConfiguration
- *
- * @todo    Add your board-specific code, if any.
- */
 static void setupVbatt() {
 	// 5.6k high side/10k low side = 1.56 ratio divider
 	engineConfiguration->analogInputDividerCoefficient = 1.47f;
@@ -107,14 +82,39 @@ static void setupVbatt() {
 	engineConfiguration->adcVcc = 3.3f;
 }
 
+static void setStepperConfig() {
+	engineConfiguration->idle.stepperDirectionPin = GPIOF_7;
+	engineConfiguration->idle.stepperStepPin = GPIOF_8;
+	engineConfiguration->stepperEnablePin = GPIOF_9;
+}
+
+void setBoardConfigOverrides() {
+	setupVbatt();
+	setEtbConfig();
+	setStepperConfig();
+
+	// PE3 is error LED, configured in board.mk
+	engineConfiguration->communicationLedPin = GPIOG_12;
+	engineConfiguration->runningLedPin = GPIOG_9;
+	engineConfiguration->warningLedPin = GPIOG_10;
+
+	engineConfiguration->clt.config.bias_resistor = 2490;
+	engineConfiguration->iat.config.bias_resistor = 2490;
+
+	//CAN 1 bus overwrites
+	engineConfiguration->canTxPin = GPIOD_0;
+	engineConfiguration->canRxPin = GPIOD_1;
+
+	//CAN 2 bus overwrites
+	engineConfiguration->can2RxPin = GPIOB_5;
+	engineConfiguration->can2TxPin = GPIOB_6;
+}
+
 static void setupDefaultSensorInputs() {
 
 	engineConfiguration->afr.hwChannel = EFI_ADC_11;
 	setEgoSensor(ES_14Point7_Free);
 	
-	engineConfiguration->clt.config.bias_resistor = 2490;
-	engineConfiguration->iat.config.bias_resistor = 2490;
-
 	engineConfiguration->baroSensor.hwChannel = EFI_ADC_NONE;
 
 	engineConfiguration->lps25BaroSensorScl = GPIOB_10;
@@ -122,25 +122,12 @@ static void setupDefaultSensorInputs() {
 
 }
 
-
-static void setLedPins() {
-	// PE3 is error LED, configured in board.mk
-	engineConfiguration->communicationLedPin = GPIOG_12;
-	engineConfiguration->runningLedPin = GPIOG_9;
-	engineConfiguration->warningLedPin = GPIOG_10;
-}
-
 void setBoardDefaultConfiguration(void) {
-	
 	setInjectorPins();
 	setIgnitionPins();
-	setupVbatt();	
-	setLedPins();
 
-	
 	engineConfiguration->sdCardPeriodMs = 50;
 	engineConfiguration->isSdCardEnabled = true;
-
 
 	engineConfiguration->canWriteEnabled = true;
 	engineConfiguration->canReadEnabled = true;
@@ -148,6 +135,4 @@ void setBoardDefaultConfiguration(void) {
 
 	engineConfiguration->canBaudRate = B500KBPS;
 	engineConfiguration->can2BaudRate = B500KBPS;
-	
-
 }

--- a/firmware/config/boards/f407-discovery/board_extra.cpp
+++ b/firmware/config/boards/f407-discovery/board_extra.cpp
@@ -12,13 +12,6 @@ void setPinConfigurationOverrides() {
 }
 
 /**
- * @brief   Board-specific Serial configuration code overrides. Needed by bootloader code.
- * @todo    Add your board-specific code, if any.
- */
-void setSerialConfigurationOverrides() {
-}
-
-/**
  * @brief   Board-specific SD card configuration code overrides. Needed by bootloader code.
  * @todo    Add your board-specific code, if any.
  */

--- a/firmware/config/boards/f429-discovery/board_configuration.cpp
+++ b/firmware/config/boards/f429-discovery/board_configuration.cpp
@@ -1,8 +1,5 @@
 #include "pch.h"
 
-void setSerialConfigurationOverrides() {
-}
-
 void setSdCardConfigurationOverrides() {
 }
 

--- a/firmware/config/boards/nucleo_h743/board_configuration.cpp
+++ b/firmware/config/boards/nucleo_h743/board_configuration.cpp
@@ -1,13 +1,6 @@
 #include "pch.h"
 
 /**
- * @brief   Board-specific Serial configuration code overrides. Needed by bootloader code.
- * @todo    Add your board-specific code, if any.
- */
-void setSerialConfigurationOverrides() {
-}
-
-/**
  * @brief   Board-specific SD card configuration code overrides. Needed by bootloader code.
  * @todo    Add your board-specific code, if any.
  */

--- a/firmware/controllers/algo/engine_configuration.cpp
+++ b/firmware/controllers/algo/engine_configuration.cpp
@@ -1197,3 +1197,4 @@ void setFrankenso0_1_joystick(engine_configuration_s *engineConfiguration) {
 // These symbols are weak so that a board_configuration.cpp file can override them
 __attribute__((weak)) void setBoardDefaultConfiguration() { }
 __attribute__((weak)) void setBoardConfigOverrides() { }
+__attribute__((weak)) void setSerialConfigurationOverrides() { }

--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -628,8 +628,8 @@ struct idle_hardware_s
 	int solenoidFrequency;;"Hz", 1, 0, 0, 3000, 0
 
 	output_pin_e solenoidPin
-	output_pin_e stepperDirectionPin
-	output_pin_e stepperStepPin
+	brain_pin_e stepperDirectionPin
+	brain_pin_e stepperStepPin
 	pin_output_mode_e solenoidPinMode
 end_struct
 
@@ -1314,7 +1314,7 @@ custom stepper_num_micro_steps_e 1 bits, U08,	@OFFSET@,	[0:3], @@stepper_num_mic
 	pin_mode_e spi3MosiMode;
 	pin_mode_e spi3MisoMode;
 	
-	pin_output_mode_e stepperEnablePinMode;
+	brain_pin_e stepperEnablePinMode;
 	brain_pin_e mc33816_rstb;ResetB
 	brain_pin_e mc33816_driven
 

--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -1314,7 +1314,7 @@ custom stepper_num_micro_steps_e 1 bits, U08,	@OFFSET@,	[0:3], @@stepper_num_mic
 	pin_mode_e spi3MosiMode;
 	pin_mode_e spi3MisoMode;
 	
-	brain_pin_e stepperEnablePinMode;
+	pin_output_mode_e stepperEnablePinMode;
 	brain_pin_e mc33816_rstb;ResetB
 	brain_pin_e mc33816_driven
 
@@ -1345,7 +1345,7 @@ custom stepper_num_micro_steps_e 1 bits, U08,	@OFFSET@,	[0:3], @@stepper_num_mic
 	float[SCRIPT_CURVE_8] scriptCurve4Bins;;"x", 1, 0, -999, 1000, 3
 	float[SCRIPT_CURVE_8] scriptCurve4;;"y", 1, 0, -999, 1000, 3
 
-	output_pin_e stepperEnablePin;
+	brain_pin_e stepperEnablePin;
 	brain_pin_e tle8888_cs;
 	pin_output_mode_e tle8888_csPinMode;
 	brain_pin_e mc33816_cs;


### PR DESCRIPTION
Stepper config should be brain pins, as those are internal to ECU, and are only ever STM32 pin names.

Move/add some config to core8 config overrides.