### PR TITLE
fix engine sniffer repaint

### DIFF
--- a/java_console/ui/src/main/java/com/rusefi/ui/engine/EngineSnifferPanel.java
+++ b/java_console/ui/src/main/java/com/rusefi/ui/engine/EngineSnifferPanel.java
@@ -221,10 +221,8 @@ public class EngineSnifferPanel {
             image.setWaveReport(wr, revolutions);
         }
 
-        /**
-         * this is to fix the UI glitch when images tab shows a tiny square
-         */
-        UiUtils.trueLayout(chartPanel.getParent());
+        // Repaint now that we've updated state
+        SwingUtilities.invokeLater(() -> UiUtils.trueRepaint(imagePanel));
     }
 
     public JPanel getPanel() {

--- a/java_console/ui/src/main/java/com/rusefi/ui/engine/UpDownImage.java
+++ b/java_console/ui/src/main/java/com/rusefi/ui/engine/UpDownImage.java
@@ -129,7 +129,6 @@ public class UpDownImage extends JPanel {
         this.engineReport = wr;
         propagateDwellIntoSensor(wr);
         this.revolutions = revolutions;
-        UiUtils.trueRepaint(this);
     }
 
     private void propagateDwellIntoSensor(EngineReport wr) {


### PR DESCRIPTION
fix broken engine sniffer due to silent failure of `assertAwtThread`

This also greatly reduces the number of repaints we queue - it's now just one per update, instead of one _per row_ per update.