### PR TITLE
Hellen128 board variant

### DIFF
--- a/firmware/config/boards/hellen/hellen128/board_configuration.cpp
+++ b/firmware/config/boards/hellen/hellen128/board_configuration.cpp
@@ -91,81 +91,18 @@ static void setupDefaultSensorInputs() {
 	engineConfiguration->auxTempSensor2.adcChannel = EFI_ADC_NONE;
 }
 
-void setBoardConfigOverrides() {
-	setHellen176LedPins();
-	setupVbatt();
-	setSdCardConfigurationOverrides();
-
-    // this specific Hellen has less common pull-up value R49
-	engineConfiguration->clt.config.bias_resistor = 2700;
-	engineConfiguration->iat.config.bias_resistor = 2700;
-
-	engineConfiguration->canTxPin = H176_CAN_TX;
-	engineConfiguration->canRxPin = H176_CAN_RX;
-}
-
-void setSerialConfigurationOverrides() {
-	engineConfiguration->useSerialPort = false;
-
-
-
-
-}
-
-
-/**
- * @brief   Board-specific configuration defaults.
- *
- * See also setDefaultEngineConfiguration
- *
- * @todo    Add your board-specific code, if any.
- */
-void setBoardDefaultConfiguration() {
-
+void setHellen128ETBConfig() {
 	BitbangI2c m_i2c;
-	uint8_t variant[2];
+	uint8_t variant[2]={0xff,0xff};
 
 	//same pins as for LPS25
 	m_i2c.init(GPIOB_10, GPIOB_11);
 	m_i2c.read(0x20, variant, sizeof(variant));
 
-
-	setInjectorPins();
-	setIgnitionPins();
-
-	engineConfiguration->isSdCardEnabled = true;
-
-	engineConfiguration->enableSoftwareKnock = true;
-
-	engineConfiguration->fuelPumpPin = GPIOD_15;
-	engineConfiguration->idle.solenoidPin = GPIO_UNASSIGNED;
-	engineConfiguration->fanPin = GPIOD_12;	// OUT_PWM8
-	engineConfiguration->mainRelayPin = GPIO_UNASSIGNED;
-
-	engineConfiguration->starterControlPin = H176_OUT_IO10;
-	engineConfiguration->startStopButtonPin = H176_IN_A16;
-	engineConfiguration->startStopButtonMode = PI_PULLDOWN;
-
-	// "required" hardware is done - set some reasonable defaults
-	setupDefaultSensorInputs();
-
-	// Some sensible defaults for other options
-	setOperationMode(engineConfiguration, FOUR_STROKE_CRANK_SENSOR);
-	engineConfiguration->trigger.type = TT_TOOTHED_WHEEL_60_2;
-	engineConfiguration->useOnlyRisingEdgeForTrigger = true;
-	setAlgorithm(LM_SPEED_DENSITY);
-
-	engineConfiguration->specs.cylindersCount = 4;
-	engineConfiguration->specs.firingOrder = FO_1_3_4_2;
-	engineConfiguration->specs.displacement = 2.295f;
-
-	engineConfiguration->ignitionMode = IM_INDIVIDUAL_COILS; // IM_WASTED_SPARK
-	engineConfiguration->crankingInjectionMode = IM_SEQUENTIAL;
-	engineConfiguration->injectionMode = IM_SEQUENTIAL;//IM_BATCH;// IM_SEQUENTIAL;
-
+	efiPrintf ("BoardID [%02x%02x] ", variant[0],variant[1] );
 
 	//Rev C is different then Rev A/B
-	if ((variant[0] == 0x63) && (variant[1] = 0x00)) {
+	if ((variant[0] == 0x63) && (variant[1] == 0x00)) {
 		// TLE9201 driver
 		// This chip has three control pins:
 		// DIR - sets direction of the motor
@@ -201,7 +138,72 @@ void setBoardDefaultConfiguration() {
 		engineConfiguration->etbIo[0].directionPin2 = H176_OUT_PWM3;
 		engineConfiguration->etbIo[0].controlPin = H176_OUT_PWM1; // ETB_EN
 		engineConfiguration->etb_use_two_wires = true;
-	}
+	}	
+}
+
+void setBoardConfigOverrides() {
+	setHellen176LedPins();
+	setupVbatt();
+	setSdCardConfigurationOverrides();
+	setHellen128ETBConfig();
+
+    // this specific Hellen has less common pull-up value R49
+	engineConfiguration->clt.config.bias_resistor = 2700;
+	engineConfiguration->iat.config.bias_resistor = 2700;
+
+	engineConfiguration->canTxPin = H176_CAN_TX;
+	engineConfiguration->canRxPin = H176_CAN_RX;
+}
+
+void setSerialConfigurationOverrides() {
+	engineConfiguration->useSerialPort = false;
+
+
+
+
+}
+
+
+/**
+ * @brief   Board-specific configuration defaults.
+ *
+ * See also setDefaultEngineConfiguration
+ *
+ * @todo    Add your board-specific code, if any.
+ */
+void setBoardDefaultConfiguration() {
+	setInjectorPins();
+	setIgnitionPins();
+
+	engineConfiguration->isSdCardEnabled = true;
+
+	engineConfiguration->enableSoftwareKnock = true;
+
+	engineConfiguration->fuelPumpPin = GPIOD_15;
+	engineConfiguration->idle.solenoidPin = GPIO_UNASSIGNED;
+	engineConfiguration->fanPin = GPIOD_12;	// OUT_PWM8
+	engineConfiguration->mainRelayPin = GPIO_UNASSIGNED;
+
+	engineConfiguration->starterControlPin = H176_OUT_IO10;
+	engineConfiguration->startStopButtonPin = H176_IN_A16;
+	engineConfiguration->startStopButtonMode = PI_PULLDOWN;
+
+	// "required" hardware is done - set some reasonable defaults
+	setupDefaultSensorInputs();
+
+	// Some sensible defaults for other options
+	setOperationMode(engineConfiguration, FOUR_STROKE_CRANK_SENSOR);
+	engineConfiguration->trigger.type = TT_TOOTHED_WHEEL_60_2;
+	engineConfiguration->useOnlyRisingEdgeForTrigger = true;
+	setAlgorithm(LM_SPEED_DENSITY);
+
+	engineConfiguration->specs.cylindersCount = 4;
+	engineConfiguration->specs.firingOrder = FO_1_3_4_2;
+	engineConfiguration->specs.displacement = 2.295f;
+
+	engineConfiguration->ignitionMode = IM_INDIVIDUAL_COILS; // IM_WASTED_SPARK
+	engineConfiguration->crankingInjectionMode = IM_SEQUENTIAL;
+	engineConfiguration->injectionMode = IM_SEQUENTIAL;//IM_BATCH;// IM_SEQUENTIAL;
 
 	strcpy(engineConfiguration->engineMake, ENGINE_MAKE_MERCEDES);
 	strcpy(engineConfiguration->engineCode, "");

--- a/firmware/config/boards/hellen/hellen128/board_configuration.cpp
+++ b/firmware/config/boards/hellen/hellen128/board_configuration.cpp
@@ -123,11 +123,11 @@ void setSerialConfigurationOverrides() {
 void setBoardDefaultConfiguration() {
 
 	BitbangI2c m_i2c;
-	uint16_t variant;
+	uint8_t variant[2];
 
 	//same pins as for LPS25
 	m_i2c.init(GPIOB_10, GPIOB_11);
-	m_i2c.read(0x20, &variant, sizeof(variant));
+	m_i2c.read(0x20, variant, sizeof(variant));
 
 
 	setInjectorPins();
@@ -165,7 +165,7 @@ void setBoardDefaultConfiguration() {
 
 
 	//Rev C is different then Rev A/B
-	if (variant == 0x0063) {
+	if ((variant[0] == 0x63) && (variant[1] = 0x00)) {
 		// TLE9201 driver
 		// This chip has three control pins:
 		// DIR - sets direction of the motor
@@ -176,7 +176,7 @@ void setBoardDefaultConfiguration() {
 		// PWM pin
 		engineConfiguration->etbIo[0].controlPin = H176_OUT_PWM3;
 		// DIR pin
-		engineConfiguration->etbIo[0].directionPin1 = H176_OUT_PWM2
+		engineConfiguration->etbIo[0].directionPin1 = H176_OUT_PWM2;
 		// Disable pin
 		engineConfiguration->etbIo[0].disablePin = H176_OUT_PWM1;
 		// Unused
@@ -186,7 +186,7 @@ void setBoardDefaultConfiguration() {
 		// PWM pin
 		engineConfiguration->etbIo[1].controlPin = GPIOI_2;
 		// DIR pin
-		engineConfiguration->etbIo[1].directionPin1 = GPIOH_13
+		engineConfiguration->etbIo[1].directionPin1 = GPIOH_13;
 		// Disable pin
 		engineConfiguration->etbIo[1].disablePin = GPIOB_7;
 		// Unused


### PR DESCRIPTION
Tested on Hellen128 revC -> Board id is read correctly.
2022-03-21_23_38_27_832: EngineState: i2c on PB10
2022-03-21_23_38_27_833: EngineState: i2c on PB11
2022-03-21_23_38_27_837: EngineState: BoardID [6300]
[...]
2022-03-21_23_38_28_080: EngineState: ETB Disable on PD13
2022-03-21_23_38_28_084: EngineState: ETB Dir 1 on PC6
2022-03-21_23_38_28_085: EngineState: ETB Enable on PC7