### PR TITLE
exti uses a queue

### DIFF
--- a/firmware/hw_layer/digital_input/trigger/trigger_input_exti.cpp
+++ b/firmware/hw_layer/digital_input/trigger/trigger_input_exti.cpp
@@ -27,9 +27,7 @@ static ioline_t camLines[CAM_INPUTS_COUNT];
 static void shaft_callback(void *arg, efitick_t stamp) {
 	// do the time sensitive things as early as possible!
 	TRIGGER_BAIL_IF_DISABLED
-//#if HW_CHECK_MODE
-//	TRIGGER_BAIL_IF_SELF_STIM
-//#endif
+	TRIGGER_BAIL_IF_SELF_STIM
 
 	int index = (int)arg;
 	ioline_t pal_line = shaftLines[index];
@@ -43,9 +41,7 @@ static void shaft_callback(void *arg, efitick_t stamp) {
 
 static void cam_callback(void *arg, efitick_t stamp) {
 	TRIGGER_BAIL_IF_DISABLED
-//#if HW_CHECK_MODE
-//	TRIGGER_BAIL_IF_SELF_STIM
-//#endif
+	TRIGGER_BAIL_IF_SELF_STIM
 
 	int index = (int)arg;
 	ioline_t pal_line = camLines[index];

--- a/firmware/hw_layer/digital_input/trigger/trigger_input_icu.cpp
+++ b/firmware/hw_layer/digital_input/trigger/trigger_input_icu.cpp
@@ -26,9 +26,8 @@ int icuFallingCallbackCounter = 0;
 static void vvtRisingCallback(void *arg) {
 	efitick_t now = getTimeNowNt();
 	TRIGGER_BAIL_IF_DISABLED
-#if HW_CHECK_MODE
 	TRIGGER_BAIL_IF_SELF_STIM
-#endif
+
 	int index = (int)arg;
 
 #if EFI_TOOTH_LOGGER
@@ -43,9 +42,8 @@ static void vvtRisingCallback(void *arg) {
 static void vvtFallingCallback(void * arg) {
 	efitick_t now = getTimeNowNt();
 	TRIGGER_BAIL_IF_DISABLED
-#if HW_CHECK_MODE
 	TRIGGER_BAIL_IF_SELF_STIM
-#endif
+
 	int index = (int)arg;
 #if EFI_TOOTH_LOGGER
 	if (!engineConfiguration->displayLogicLevelsInEngineSniffer) {
@@ -62,9 +60,8 @@ static void shaftRisingCallback(bool isPrimary) {
 	efitick_t stamp = getTimeNowNt();
 
 	TRIGGER_BAIL_IF_DISABLED
-#if HW_CHECK_MODE
 	TRIGGER_BAIL_IF_SELF_STIM
-#endif
+
 	icuRisingCallbackCounter++;
 
 	//	icucnt_t last_width = icuGetWidth(icup); so far we are fine with system time
@@ -76,9 +73,7 @@ static void shaftFallingCallback(bool isPrimary) {
 	efitick_t stamp = getTimeNowNt();
 
 	TRIGGER_BAIL_IF_DISABLED
-#if HW_CHECK_MODE
 	TRIGGER_BAIL_IF_SELF_STIM
-#endif
 
 	icuFallingCallbackCounter++;
 


### PR DESCRIPTION
maybe helps with #4019 

carve off a piece of #3032

Probably actually helps with performance since we don't loop through entries that don't have anything there.