### PR TITLE
fix nb1 vs na8 config

### DIFF
--- a/firmware/config/boards/hellen/hellen-nb1/board_configuration.cpp
+++ b/firmware/config/boards/hellen/hellen-nb1/board_configuration.cpp
@@ -62,6 +62,11 @@ static void setupVbatt() {
 }
 
 static void setupDefaultSensorInputs() {
+	// trigger inputs, hall
+	engineConfiguration->triggerInputPins[0] = H144_IN_CRANK;
+	engineConfiguration->triggerInputPins[1] = GPIO_UNASSIGNED;
+	engineConfiguration->triggerInputPins[2] = GPIO_UNASSIGNED;
+	engineConfiguration->camInputs[0] = H144_IN_CAM;
 
 	engineConfiguration->tps1_1AdcChannel = EFI_ADC_4;
 	engineConfiguration->tps2_1AdcChannel = EFI_ADC_NONE;
@@ -89,14 +94,14 @@ void setBoardConfigOverrides() {
 
 	engineConfiguration->canTxPin = GPIOD_1;
 	engineConfiguration->canRxPin = GPIOD_0;
+
+	if (engineConfiguration->trigger.type == TT_MAZDA_MIATA_NB1) {
+	    engineConfiguration->trigger.type = TT_MIATA_VVT;
+	}
 }
 
 void setSerialConfigurationOverrides() {
 	engineConfiguration->useSerialPort = false;
-
-
-
-
 }
 
 
@@ -154,14 +159,4 @@ void setSdCardConfigurationOverrides() {
 	engineConfiguration->spi2sckPin = H_SPI2_SCK;
 	engineConfiguration->sdCardCsPin = H_SPI2_CS;
 	engineConfiguration->is_enabled_spi_2 = true;
-
-	if (engineConfiguration->trigger.type == TT_MAZDA_MIATA_NB1) {
-	    engineConfiguration->trigger.type = TT_MIATA_VVT;
-	}
-
-	// trigger inputs, hall
-	engineConfiguration->triggerInputPins[0] = H144_IN_CRANK;
-	engineConfiguration->triggerInputPins[1] = GPIO_UNASSIGNED;
-	engineConfiguration->triggerInputPins[2] = GPIO_UNASSIGNED;
-	engineConfiguration->camInputs[0] = H144_IN_CAM;
 }

--- a/firmware/config/boards/hellen/hellenNA8_96/board.mk
+++ b/firmware/config/boards/hellen/hellenNA8_96/board.mk
@@ -1,18 +1,15 @@
 # Combine the related files for a specific platform and MCU.
 
 # Target ECU board design
-BOARDCPPSRC = $(BOARDS_DIR)/hellen/hellen-nb1/board_configuration.cpp
-BOARDINC = $(BOARDS_DIR)/hellen/hellen-nb1
+BOARDCPPSRC = $(BOARDS_DIR)/hellen/hellenNA8_96/board_configuration.cpp
+BOARDINC = $(BOARDS_DIR)/hellen/hellenNA8_96
 
 # Set this if you want a default engine type other than normal hellen-nb1
 ifeq ($(DEFAULT_ENGINE_TYPE),)
   DEFAULT_ENGINE_TYPE = -DDEFAULT_ENGINE_TYPE=HELLEN_NA8_96
 endif
 
-
 DDEFS += -DEFI_MAIN_RELAY_CONTROL=TRUE
-
-
 
 # Add them all together
 DDEFS += -DFIRMWARE_ID=\"hellenNB1\" $(DEFAULT_ENGINE_TYPE)

--- a/firmware/config/boards/hellen/hellenNA8_96/board_configuration.cpp
+++ b/firmware/config/boards/hellen/hellenNA8_96/board_configuration.cpp
@@ -63,8 +63,8 @@ static void setupVbatt() {
 
 static void setupDefaultSensorInputs() {
 	// trigger inputs, hall
-	engineConfiguration->triggerInputPins[0] = GPIOA_6;
-	engineConfiguration->triggerInputPins[1] = GPIOB_1;
+	engineConfiguration->triggerInputPins[0] = H144_IN_CAM;
+	engineConfiguration->triggerInputPins[1] = H144_IN_CRANK;
 	engineConfiguration->triggerInputPins[2] = GPIO_UNASSIGNED;
 	engineConfiguration->camInputs[0] = GPIO_UNASSIGNED;
 


### PR DESCRIPTION
NA8 was using NB1 board config file, and was overriding trigger input pins so you couldn't change pinout.