### PR TITLE
no lua mre debug

### DIFF
--- a/firmware/config/boards/microrusefi/compile_mre_f4_debug.sh
+++ b/firmware/config/boards/microrusefi/compile_mre_f4_debug.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-export EXTRA_PARAMS="-DRAMDISK_INVALID"
+export EXTRA_PARAMS="-DRAMDISK_INVALID -DEFI_LUA=FALSE"
 export DEBUG_LEVEL_OPT="-O0 -ggdb -g"
 
 # export USE_OPENBLT=yes


### PR DESCRIPTION
Turn off lua on the MRE debug build so we stop running out of flash memory.