### PR TITLE
new autoscale constraint

### DIFF
--- a/java_tools/configuration_definition/src/main/java/com/rusefi/ConfigField.java
+++ b/java_tools/configuration_definition/src/main/java/com/rusefi/ConfigField.java
@@ -93,8 +93,7 @@ public class ConfigField {
             if (tokens.length > 1) {
                 String scale = tokens[1].trim();
                 if (!hasAutoscale && !scale.trim().equals("1")) {
-                    System.out.println("GRRRRRRRRRRRRRRRR " + "Unexpected scale of " + scale + " without autoscale on " + this);
-//                throw new IllegalStateException("Unexpected scale of " + scale + " without autoscale on " + this);
+                    throw new IllegalStateException("Unexpected scale of " + scale + " without autoscale on " + this);
                 }
             }
         }


### PR DESCRIPTION
```
$ ./gen_config.sh | grep RRRR
mkdir: cannot create directory ‘build’: File exists
RRRRRRRRRRRRRRRR Unexpected scale of 0.1 without autoscale on ConfigField{name='timeConstant', type='uint16_t', arraySizes=[]}
RRRRRRRRRRRRRRRR Unexpected scale of 0.1 without autoscale on ConfigField{name='deadband', type='uint8_t', arraySizes=[]}
RRRRRRRRRRRRRRRR Unexpected scale of 0.1 without autoscale on ConfigField{name='minAfr', type='uint8_t', arraySizes=[]}
RRRRRRRRRRRRRRRR Unexpected scale of 0.1 without autoscale on ConfigField{name='maxAfr', type='uint8_t', arraySizes=[]}
RRRRRRRRRRRRRRRR Unexpected scale of 0.1 without autoscale on ConfigField{name='knockRetardAggression', type='uint8_t', arraySizes=[]}
RRRRRRRRRRRRRRRR Unexpected scale of 0.1 without autoscale on ConfigField{name='knockRetardReapplyRate', type='uint8_t', arraySizes=[]}
RRRRRRRRRRRRRRRR Unexpected scale of 0.1 without autoscale on ConfigField{name='dwellVoltageCorrVoltBins', type='uint8_t', arraySizes=[8]}
RRRRRRRRRRRRRRRR Unexpected scale of 0.02 without autoscale on ConfigField{name='dwellVoltageCorrValues', type='uint8_t', arraySizes=[8]}
RRRRRRRRRRRRRRRR Unexpected scale of {1/1000} without autoscale on ConfigField{name='applyNonlinearBelowPulse', type='uint16_t', arraySizes=[]}
RRRRRRRRRRRRRRRR Unexpected scale of 0.001 without autoscale on ConfigField{name='multisparkSparkDuration', type='uint16_t', arraySizes=[]}
RRRRRRRRRRRRRRRR Unexpected scale of 0.001 without autoscale on ConfigField{name='multisparkDwell', type='uint16_t', arraySizes=[]}
RRRRRRRRRRRRRRRR Unexpected scale of 5 without autoscale on ConfigField{name='tchargeBins', type='uint8_t', arraySizes=[16]}
RRRRRRRRRRRRRRRR Unexpected scale of 0.01 without autoscale on ConfigField{name='tchargeValues', type='uint8_t', arraySizes=[16]}
RRRRRRRRRRRRRRRR Unexpected scale of 0.02 without autoscale on ConfigField{name='triggerCompCenterVolt', type='uint8_t', arraySizes=[]}
RRRRRRRRRRRRRRRR Unexpected scale of 0.02 without autoscale on ConfigField{name='triggerCompHystMin', type='uint8_t', arraySizes=[]}
RRRRRRRRRRRRRRRR Unexpected scale of 0.02 without autoscale on ConfigField{name='triggerCompHystMax', type='uint8_t', arraySizes=[]}
RRRRRRRRRRRRRRRR Unexpected scale of 0.02 without autoscale on ConfigField{name='fuelTrim', type='int8_t', arraySizes=[12]}
RRRRRRRRRRRRRRRR Unexpected scale of 0.02 without autoscale on ConfigField{name='fuelTrim1', type='int8_t', arraySizes=[]}
RRRRRRRRRRRRRRRR Unexpected scale of 0.02 without autoscale on ConfigField{name='fuelTrim2', type='int8_t', arraySizes=[]}
RRRRRRRRRRRRRRRR Unexpected scale of 0.02 without autoscale on ConfigField{name='fuelTrim3', type='int8_t', arraySizes=[]}
RRRRRRRRRRRRRRRR Unexpected scale of 0.02 without autoscale on ConfigField{name='fuelTrim4', type='int8_t', arraySizes=[]}
RRRRRRRRRRRRRRRR Unexpected scale of 0.02 without autoscale on ConfigField{name='fuelTrim5', type='int8_t', arraySizes=[]}
RRRRRRRRRRRRRRRR Unexpected scale of 0.02 without autoscale on ConfigField{name='fuelTrim6', type='int8_t', arraySizes=[]}
RRRRRRRRRRRRRRRR Unexpected scale of 0.02 without autoscale on ConfigField{name='fuelTrim7', type='int8_t', arraySizes=[]}
RRRRRRRRRRRRRRRR Unexpected scale of 0.02 without autoscale on ConfigField{name='fuelTrim8', type='int8_t', arraySizes=[]}
RRRRRRRRRRRRRRRR Unexpected scale of 0.02 without autoscale on ConfigField{name='fuelTrim9', type='int8_t', arraySizes=[]}
RRRRRRRRRRRRRRRR Unexpected scale of 0.02 without autoscale on ConfigField{name='fuelTrim10', type='int8_t', arraySizes=[]}
RRRRRRRRRRRRRRRR Unexpected scale of 0.02 without autoscale on ConfigField{name='fuelTrim11', type='int8_t', arraySizes=[]}
RRRRRRRRRRRRRRRR Unexpected scale of 0.02 without autoscale on ConfigField{name='fuelTrim12', type='int8_t', arraySizes=[]}
RRRRRRRRRRRRRRRR Unexpected scale of {1/100} without autoscale on ConfigField{name='mapEstimateTable', type='uint16_t', arraySizes=[16, 16]}
RRRRRRRRRRRRRRRR Unexpected scale of {1/10} without autoscale on ConfigField{name='lambdaTable', type='uint8_t', arraySizes=[16, 16]}
RRRRRRRRRRRRRRRR Unexpected scale of 0.02 without autoscale on ConfigField{name='tcu_pcAirmassBins', type='uint8_t', arraySizes=[8]}
```