### PR TITLE
minor trigger decoder refactoring

### DIFF
--- a/firmware/controllers/trigger/trigger_central.cpp
+++ b/firmware/controllers/trigger/trigger_central.cpp
@@ -113,11 +113,7 @@ static bool vvtWithRealDecoder(vvt_mode_e vvtMode) {
 static angle_t syncAndReport(TriggerCentral *tc, int divider, int remainder) {
 	angle_t engineCycle = getEngineCycle(engine->getOperationMode());
 
-	angle_t offset = tc->triggerState.syncEnginePhase(divider, remainder, engineCycle);
-	if (offset > 0) {
-		tc->triggerState.vvtSyncCounter++;
-	}
-	return offset;
+	return tc->triggerState.syncEnginePhase(divider, remainder, engineCycle);
 }
 
 static void turnOffAllDebugFields(void *arg) {

--- a/firmware/controllers/trigger/trigger_decoder.cpp
+++ b/firmware/controllers/trigger/trigger_decoder.cpp
@@ -80,8 +80,6 @@ void TriggerState::resetTriggerState() {
 
 	totalEventCountBase = 0;
 	isFirstEvent = true;
-
-	synchronizedPhase.init();
 }
 
 void TriggerState::setTriggerErrorState() {
@@ -227,6 +225,8 @@ void TriggerStateWithRunningStatistics::resetTriggerState() {
 	spinningEventIndex = 0;
 	prevInstantRpmValue = 0;
 	m_instantRpm = 0;
+
+	synchronizedPhase.init();
 }
 
 void TriggerStateWithRunningStatistics::movePreSynchTimestamps() {
@@ -394,7 +394,7 @@ void TriggerCentral::validateCamVvtCounters() {
 	}
 }
 
-angle_t TriggerState::syncEnginePhase(int divider, int remainder, angle_t engineCycle) {
+angle_t TriggerStateWithRunningStatistics::syncEnginePhase(int divider, int remainder, angle_t engineCycle) {
 	efiAssert(OBD_PCM_Processor_Fault, remainder < divider, "syncEnginePhase", false);
 	angle_t totalShift = 0;
 	while (getTotalRevolutionCounter() % divider != remainder) {
@@ -409,6 +409,10 @@ angle_t TriggerState::syncEnginePhase(int divider, int remainder, angle_t engine
 
 	// Allow injection/ignition to happen, we've now fully sync'd the crank based on new cam information
 	synchronizedPhase.reset();
+
+	if (totalShift > 0) {
+		vvtSyncCounter++;
+	}
 
 	return totalShift;
 }

--- a/firmware/controllers/trigger/trigger_decoder.h
+++ b/firmware/controllers/trigger/trigger_decoder.h
@@ -86,7 +86,6 @@ public:
 	 * this is important for crank-based virtual trigger and VVT magic
 	 */
 	void incrementTotalEventCounter();
-	angle_t syncEnginePhase(int divider, int remainder, angle_t engineCycle);
 
 	efitime_t getTotalEventCounter() const;
 
@@ -156,13 +155,6 @@ public:
 			const trigger_config_s& triggerConfig
 			);
 
-	// Returns true if syncEnginePhase has been called,
-	// i.e. if we have enough VVT information to have full sync on
-	// an indeterminite crank pattern
-	bool hasSynchronizedPhase() const {
-		return !synchronizedPhase.hasElapsedSec(3);
-	}
-
 private:
 	void resetCurrentCycleState();
 	bool isSyncPoint(const TriggerWaveform& triggerShape, trigger_type_e triggerType) const;
@@ -172,8 +164,6 @@ private:
 	int64_t totalEventCountBase;
 
 	bool isFirstEvent;
-
-	Timer synchronizedPhase;
 };
 
 // we only need 90 degrees of events so /4 or maybe even /8 should work?
@@ -187,6 +177,8 @@ class TriggerStateWithRunningStatistics : public TriggerState {
 public:
 	TriggerStateWithRunningStatistics();
 	void resetTriggerState() override;
+
+	angle_t syncEnginePhase(int divider, int remainder, angle_t engineCycle);
 
 	float getInstantRpm() const {
 		return m_instantRpm;
@@ -221,6 +213,13 @@ public:
 	 */
 	void setLastEventTimeForInstantRpm(efitick_t nowNt);
 
+	// Returns true if syncEnginePhase has been called,
+	// i.e. if we have enough VVT information to have full sync on
+	// an indeterminite crank pattern
+	bool hasSynchronizedPhase() const {
+		return !synchronizedPhase.hasElapsedSec(3);
+	}
+
 private:
 	float calculateInstantRpm(
 		TriggerWaveform const & triggerShape, TriggerFormDetails *triggerFormDetails,
@@ -229,6 +228,7 @@ private:
 	float m_instantRpm = 0;
 	float m_instantRpmRatio = 0;
 
+	Timer synchronizedPhase;
 };
 
 angle_t getEngineCycle(operation_mode_e operationMode);


### PR DESCRIPTION
- encapsulate `vvtSyncCounter`
- move `syncEnginePhase`/`hasSynchronizedPhase` inside the "primary" trigger decoder class, VVT doesn't need these.