### PR TITLE
switch back to flag

### DIFF
--- a/firmware/controllers/trigger/trigger_decoder.cpp
+++ b/firmware/controllers/trigger/trigger_decoder.cpp
@@ -226,7 +226,7 @@ void TriggerStateWithRunningStatistics::resetTriggerState() {
 	prevInstantRpmValue = 0;
 	m_instantRpm = 0;
 
-	synchronizedPhase.init();
+	m_hasSynchronizedPhase = false;
 }
 
 void TriggerStateWithRunningStatistics::movePreSynchTimestamps() {
@@ -408,7 +408,7 @@ angle_t TriggerStateWithRunningStatistics::syncEnginePhase(int divider, int rema
 	}
 
 	// Allow injection/ignition to happen, we've now fully sync'd the crank based on new cam information
-	synchronizedPhase.reset();
+	m_hasSynchronizedPhase = true;
 
 	if (totalShift > 0) {
 		vvtSyncCounter++;

--- a/firmware/controllers/trigger/trigger_decoder.h
+++ b/firmware/controllers/trigger/trigger_decoder.h
@@ -217,7 +217,7 @@ public:
 	// i.e. if we have enough VVT information to have full sync on
 	// an indeterminite crank pattern
 	bool hasSynchronizedPhase() const {
-		return !synchronizedPhase.hasElapsedSec(3);
+		return m_hasSynchronizedPhase;
 	}
 
 private:
@@ -228,7 +228,7 @@ private:
 	float m_instantRpm = 0;
 	float m_instantRpmRatio = 0;
 
-	Timer synchronizedPhase;
+	bool m_hasSynchronizedPhase = false;
 };
 
 angle_t getEngineCycle(operation_mode_e operationMode);


### PR DESCRIPTION
Switch vvt sync back to flag. We can just reset the flag when we lose sync, since there may be conditions where we want to spend long periods of time without trying to resync based on cam.