### PR TITLE
Fix trigger error indicator

### DIFF
--- a/firmware/controllers/trigger/trigger_decoder.h
+++ b/firmware/controllers/trigger/trigger_decoder.h
@@ -150,7 +150,7 @@ public:
 			);
 
 	bool someSortOfTriggerError() const {
-		return m_timeSinceDecodeError.getElapsedSeconds(1);
+		return !m_timeSinceDecodeError.getElapsedSeconds(1);
 	}
 
 protected:

--- a/unit_tests/run_sharded_tests.sh
+++ b/unit_tests/run_sharded_tests.sh
@@ -5,8 +5,8 @@
 
 set -e
 
-export GTEST_TOTAL_SHARDS=500
-for IDX in {0..499}
+export GTEST_TOTAL_SHARDS=600
+for IDX in {0..599}
 do
 	export GTEST_SHARD_INDEX=$IDX
 	build/rusefi_test

--- a/unit_tests/tests/trigger/test_trigger_decoder_2.cpp
+++ b/unit_tests/tests/trigger/test_trigger_decoder_2.cpp
@@ -85,6 +85,8 @@ TEST(TriggerDecoder, FindsFirstSyncPoint) {
 	doTooth(dut, shape, cfg, t);
 	EXPECT_TRUE(dut.getShaftSynchronized());
 	EXPECT_EQ(2, dut.currentCycle.current_index);
+
+	EXPECT_FALSE(dut.someSortOfTriggerError());
 }
 
 
@@ -130,6 +132,7 @@ TEST(TriggerDecoder, FindsSyncPointMultipleRevolutions) {
 		doTooth(dut, shape, cfg, t);
 		EXPECT_TRUE(dut.getShaftSynchronized());
 		EXPECT_EQ(0, dut.currentCycle.current_index);
+		EXPECT_FALSE(dut.someSortOfTriggerError());
 	}
 }
 
@@ -216,6 +219,7 @@ TEST(TriggerDecoder, NotEnoughTeeth_CausesError) {
 	doTooth(dut, shape, cfg, t);
 	EXPECT_TRUE(dut.getShaftSynchronized());
 	EXPECT_EQ(2, dut.currentCycle.current_index);
+	EXPECT_FALSE(dut.someSortOfTriggerError());
 
 	// Missing tooth, but it comes early - not enough teeth have happened yet!
 	t += MS2NT(2);
@@ -224,4 +228,5 @@ TEST(TriggerDecoder, NotEnoughTeeth_CausesError) {
 	// Sync is lost until we get to another sync point
 	EXPECT_FALSE(dut.getShaftSynchronized());
 	EXPECT_EQ(0, dut.currentCycle.current_index);
+	EXPECT_TRUE(dut.someSortOfTriggerError());
 }


### PR DESCRIPTION
I dropped this: `!`

Adds tests to verify behavior.

Also increases the number of shards used in `run_sharded_tests.sh` since we have more than 500 tests now.