### PR TITLE
update wideband firmware

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -22,7 +22,6 @@
 [submodule "firmware/controllers/can/wideband_firmware"]
 	path = firmware/controllers/can/wideband_firmware
 	url = https://github.com/mck1117/wideband
-	branch = 20210110-hotfix
 [submodule "firmware/ext/uzlib"]
 	path = firmware/ext/uzlib
 	url = https://github.com/pfalcon/uzlib

--- a/firmware/controllers/sensors/AemXSeriesLambda.cpp
+++ b/firmware/controllers/sensors/AemXSeriesLambda.cpp
@@ -99,37 +99,14 @@ void AemXSeriesWideband::decodeAemXSeries(const CANRxFrame& frame, efitick_t now
 	setValidValue(lambdaFloat, nowNt);
 }
 
-// TODO: include rusEFI wideband file directly
-namespace wbo
-{
-struct StandardData
-{
-    uint8_t Version;
-    uint8_t Valid;
-
-    uint16_t Lambda;
-    uint16_t TemperatureC;
-
-    uint16_t pad;
-};
-
-struct DiagData
-{
-    uint16_t Esr;
-    uint16_t NernstDc;
-    uint8_t PumpDuty;
-    uint8_t Status;
-
-    uint8_t HeaterDuty;
-    uint8_t pad;
-};
-} // namespace wbo
+#include "wideband_firmware/for_rusefi/wideband_can.h"
 
 void AemXSeriesWideband::decodeRusefiStandard(const CANRxFrame& frame, efitick_t nowNt) {
 	auto data = reinterpret_cast<const wbo::StandardData*>(&frame.data8[0]);
 
-	// TODO: enforce version check
-	//bool versionValid = data->Version != RUSEFI_WIDEBAND_VERSION;
+	if (data->Version != RUSEFI_WIDEBAND_VERSION) {
+		// TODO: firmwareError here
+	}
 
 	float lambda = 0.0001f * data->Lambda;
 	engine->outputChannels.wbTemperature[m_sensorIndex] = data->TemperatureC;


### PR DESCRIPTION
Update wideband firmware to a version that uses the new, custom format! That means we're up to date with `master` on the wideband controller, which gets us the new goodness like temperature decoding, versioned messages, and better resolution for things like ESR, temperature, and other debugging parameters.