### PR TITLE
harley pwm fix

### DIFF
--- a/firmware/config/boards/hellen/harley81/board.mk
+++ b/firmware/config/boards/hellen/harley81/board.mk
@@ -13,6 +13,8 @@ DDEFS += -DFIRMWARE_ID=\"hellen81hd\"
 DDEFS += -DEFI_SOFTWARE_KNOCK=TRUE -DSTM32_ADC_USE_ADC3=TRUE
 DDEFS += -DHAL_TRIGGER_USE_PAL=TRUE
 
+DDEFS += -DSTM32_PWM_USE_TIM3=TRUE -DHAL_USE_ICU=FALSE
+
 include $(BOARDS_DIR)/hellen/hellen-common144.mk
 
 # Enable serial pins on expansion header

--- a/firmware/config/boards/hellen/harley81/board_configuration.cpp
+++ b/firmware/config/boards/hellen/harley81/board_configuration.cpp
@@ -187,7 +187,7 @@ void setBoardDefaultConfiguration() {
 	engineConfiguration->clutchDownPinMode = PI_PULLDOWN;
 	engineConfiguration->launchActivationMode = CLUTCH_INPUT_LAUNCH;
 // ?	engineConfiguration->malfunctionIndicatorPin = Gpio::G4; //1E - Check Engine Light
-	engineConfiguration->vrThreshold[0].pin = H144_OUT_PWM6;
+	engineConfiguration->vrThreshold[0].pin = H144_OUT_PWM4;
 }
 
 /**

--- a/firmware/hw_layer/ports/stm32/mcuconf_common_f4_f7.h
+++ b/firmware/hw_layer/ports/stm32/mcuconf_common_f4_f7.h
@@ -209,7 +209,11 @@
 #define STM32_PWM_USE_ADVANCED              FALSE
 #define STM32_PWM_USE_TIM1                  FALSE
 #define STM32_PWM_USE_TIM2                  FALSE
+
+#ifndef STM32_PWM_USE_TIM3
 #define STM32_PWM_USE_TIM3                  FALSE
+#endif
+
 #define STM32_PWM_USE_TIM4                  TRUE
 #define STM32_PWM_USE_TIM5                  TRUE
 #define STM32_PWM_USE_TIM8                  TRUE

--- a/firmware/hw_layer/ports/stm32/stm32_common.cpp
+++ b/firmware/hw_layer/ports/stm32/stm32_common.cpp
@@ -245,6 +245,9 @@ static expected<stm32_pwm_config> getConfigForPin(brain_pin_e pin) {
 #if STM32_PWM_USE_TIM3
 	case Gpio::B4:  return stm32_pwm_config{&PWMD3, 0, 2};
 	case Gpio::B5:  return stm32_pwm_config{&PWMD3, 1, 2};
+
+	case Gpio::C6:  return stm32_pwm_config{&PWMD3, 2, 2};
+	case Gpio::C7:  return stm32_pwm_config{&PWMD3, 3, 2};
 #endif
 #if STM32_PWM_USE_TIM4
 	case Gpio::B6:  return stm32_pwm_config{&PWMD4, 0, 2};
@@ -264,10 +267,21 @@ static expected<stm32_pwm_config> getConfigForPin(brain_pin_e pin) {
 	case Gpio::A3:  return stm32_pwm_config{&PWMD5, 3, 2};
 #endif
 #if STM32_PWM_USE_TIM8
+
+#if !STM32_PWM_USE_TIM3
+	// If TIM3 is not used, put these pins on TIM8 instead..
+	// See https://github.com/rusefi/rusefi/issues/639
+	// See https://github.com/rusefi/rusefi/pull/3032
 	case Gpio::C6:  return stm32_pwm_config{&PWMD8, 0, 3};
 	case Gpio::C7:  return stm32_pwm_config{&PWMD8, 1, 3};
+#endif
+
 	case Gpio::C8:  return stm32_pwm_config{&PWMD8, 2, 3};
 	case Gpio::C9:  return stm32_pwm_config{&PWMD8, 3, 3};
+#endif
+#if STM32_PWM_USE_TIM9
+	case Gpio::E5:  return stm32_pwm_config{&PWMD9, 0, 3};
+	case Gpio::E6:  return stm32_pwm_config{&PWMD9, 1, 3};
 #endif
 	default: return unexpected;
 	}


### PR DESCRIPTION
PWM HW timer conflict between VR and ETB consumers

both are using hardware pwm






but trying to use different frequency on timer

so it's running the ETB at 10khz I think

