### PR TITLE
trigger decoder returns a result

### DIFF
--- a/firmware/controllers/engine_cycle/main_trigger_callback.cpp
+++ b/firmware/controllers/engine_cycle/main_trigger_callback.cpp
@@ -362,14 +362,6 @@ void mainTriggerCallback(uint32_t trgEventIndex, efitick_t edgeTimestamp) {
 	}
 #endif /* EFI_CDM_INTEGRATION */
 
-	if (trgEventIndex >= engine->engineCycleEventCount) {
-		/**
-		 * this could happen in case of a trigger error, just exit silently since the trigger error is supposed to be handled already
-		 * todo: should this check be somewhere higher so that no trigger listeners are invoked with noise?
-		 */
-		return;
-	}
-
 	int rpm = engine->rpmCalculator.getCachedRpm();
 	if (rpm == 0) {
 		// this happens while we just start cranking

--- a/firmware/controllers/trigger/trigger_central.h
+++ b/firmware/controllers/trigger/trigger_central.h
@@ -122,6 +122,8 @@ public:
 	Timer m_lastEventTimer;
 
 private:
+	void decodeMapCam(efitick_t nowNt, float currentPhase);
+
 	// Keep track of the last time we saw the sync tooth go by (trigger index 0)
 	// not TDC point
 	Timer m_syncPointTimer;

--- a/firmware/controllers/trigger/trigger_decoder.cpp
+++ b/firmware/controllers/trigger/trigger_decoder.cpp
@@ -479,7 +479,7 @@ void TriggerDecoderBase::onShaftSynchronization(
  * @param signal type of event which just happened
  * @param nowNt current time
  */
-void TriggerDecoderBase::decodeTriggerEvent(
+expected<TriggerDecodeResult> TriggerDecoderBase::decodeTriggerEvent(
 		const char *msg,
 		const TriggerWaveform& triggerShape,
 		const TriggerStateCallback triggerCycleCallback,
@@ -502,7 +502,7 @@ void TriggerDecoderBase::decodeTriggerEvent(
 
 	bool useOnlyRisingEdgeForTrigger = triggerConfiguration.UseOnlyRisingEdgeForTrigger;
 
-	efiAssertVoid(CUSTOM_TRIGGER_UNEXPECTED, signal <= SHAFT_3RD_RISING, "unexpected signal");
+	efiAssert(CUSTOM_TRIGGER_UNEXPECTED, signal <= SHAFT_3RD_RISING, "unexpected signal", unexpected);
 
 	trigger_wheel_e triggerWheel = eventIndex[signal];
 	trigger_value_e type = eventType[signal];
@@ -727,7 +727,7 @@ void TriggerDecoderBase::decodeTriggerEvent(
 
 		setShaftSynchronized(false);
 
-		return;
+		return unexpected;
 	}
 
 	// Needed for early instant-RPM detection
@@ -736,6 +736,12 @@ void TriggerDecoderBase::decodeTriggerEvent(
 	}
 
 	triggerStateIndex = currentCycle.current_index;
+
+	if (getShaftSynchronized()) {
+		return TriggerDecodeResult{ currentCycle.current_index };
+	} else {
+		return unexpected;
+	}
 }
 
 bool TriggerDecoderBase::isSyncPoint(const TriggerWaveform& triggerShape, trigger_type_e triggerType) const {

--- a/firmware/controllers/trigger/trigger_decoder.h
+++ b/firmware/controllers/trigger/trigger_decoder.h
@@ -70,6 +70,10 @@ typedef struct {
 #endif // EFI_UNIT_TEST
 } current_cycle_state_s;
 
+struct TriggerDecodeResult {
+	uint32_t CurrentIndex;
+};
+
 /**
  * @see TriggerWaveform for trigger wheel shape definition
  */
@@ -88,7 +92,7 @@ public:
 
 	efitime_t getTotalEventCounter() const;
 
-	void decodeTriggerEvent(
+	expected<TriggerDecodeResult> decodeTriggerEvent(
 			const char *msg,
 			const TriggerWaveform& triggerShape,
 			const TriggerStateCallback triggerCycleCallback,


### PR DESCRIPTION
Return a result with the current trigger tooth, instead of outside components reaching inside the trigger decoder to find out where we are.

Break out a function for MAP cam decode to improve legibility.