### PR TITLE
fix pd2

### DIFF
--- a/firmware/controllers/sensors/software_knock.cpp
+++ b/firmware/controllers/sensors/software_knock.cpp
@@ -22,8 +22,6 @@ static volatile size_t sampleCount = 0;
 chibios_rt::BinarySemaphore knockSem(/* taken =*/ true);
 
 static void completionCallback(ADCDriver* adcp) {
-	palClearPad(GPIOD, 2);
-
 	if (adcp->state == ADC_COMPLETE) {
 		knockNeedsProcess = true;
 


### PR DESCRIPTION
Remove pad clear left in debugging during software knock development.

fix #4244