### PR TITLE
fix lua CAN RX of 11b frames

### DIFF
--- a/firmware/CHANGELOG.md
+++ b/firmware/CHANGELOG.md
@@ -23,6 +23,11 @@ Release template (copy/paste this for new release):
 
 # Changelog
 
+## Unreleased
+
+### Fixed
+ - Lua CAN reception fixed for 11-bit IDs where the frame would be received, but a corrupt ID was passed to the handler function. #4321
+
 ## July 2022 Release - "Day 130"
 
 ### Added

--- a/firmware/controllers/lua/lua_can_rx.cpp
+++ b/firmware/controllers/lua/lua_can_rx.cpp
@@ -12,7 +12,7 @@ int32_t luaCanRxIds[maxFilterCount] = {0};
 static bool shouldRxCanFrame(const CANRxFrame& frame) {
 	for (size_t i = 0; i < filterCount; i++) {
 		int32_t id = luaCanRxIds[i];
-		if (CAN_SID(frame) == id || CAN_EID(frame) == id) {
+		if (CAN_ID(frame) == id) {
 			return true;
 		}
 	}
@@ -78,7 +78,7 @@ static void handleCanFrame(LuaHandle& ls, CanFrameData* data) {
 
 	// Push bus, ID and DLC
 	lua_pushinteger(ls, data->BusIndex);	// TODO: support multiple busses!
-	lua_pushinteger(ls, CAN_EID(data->Frame));
+	lua_pushinteger(ls, CAN_ID(data->Frame));
 	lua_pushinteger(ls, dlc);
 
 	// Build table for data


### PR DESCRIPTION
Previously the ID could get passed with some garbage in the high bits when processing an 11b frame.