### PR TITLE
TinerStudio: no need to have 3s timeout, 300mS is ok.

### DIFF
--- a/firmware/tunerstudio/rusefi.input
+++ b/firmware/tunerstudio/rusefi.input
@@ -73,7 +73,7 @@ enable2ndByteCanID = false
 ;e.g. put writeblocks off and add an interwrite delay
    writeBlocks = on
    interWriteDelay = 10
-   blockReadTimeout    = 3000; Milliseconds general timeout
+   blockReadTimeout    = 300; Milliseconds general timeout
    
  ; delayAfterPortOpen = 500  
    


### PR DESCRIPTION
This allows faster detection of device disconnect and faster recovery