### PR TITLE
Add Dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Dependabot will notify about new versions of used GH actions.

Example: https://github.com/hyper-tuner/hyper-tuner-cloud/pulls?q=is%3Apr+label%3Agithub_actions+