### PR TITLE
detect bad Lua sensor name when registering

### DIFF
--- a/firmware/controllers/lua/lua_hooks.cpp
+++ b/firmware/controllers/lua/lua_hooks.cpp
@@ -68,9 +68,19 @@ static int lua_getSensorByIndex(lua_State* l) {
 	return getSensor(l, static_cast<SensorType>(zeroBasedSensorIndex));
 }
 
+static SensorType findSensorByName(lua_State* l, const char* name) {
+	SensorType type = findSensorTypeByName(name);
+
+	if (l && type == SensorType::Invalid) {
+		luaL_error(l, "Invalid sensor type: %s", name);
+	}
+
+	return type;
+}
+
 static int lua_getSensorByName(lua_State* l) {
 	auto sensorName = luaL_checklstring(l, 1, nullptr);
-	SensorType type = findSensorTypeByName(sensorName);
+	SensorType type = findSensorByName(l, sensorName);
 
 	return getSensor(l, type);
 }
@@ -361,16 +371,6 @@ namespace LUAAA_NS {
             return new(mem) TCLASS(state, LuaStack<ARGS>::get(state, Ns + 1)...);
         }
     };
-}
-
-static SensorType findSensorByName(lua_State* l, const char* name) {
-	SensorType type = findSensorTypeByName(name);
-
-	if (l && type == SensorType::Invalid) {
-		luaL_error(l, "Invalid sensor type: %s", name);
-	}
-
-	return type;
 }
 
 struct LuaSensor final : public StoredValueSensor {

--- a/firmware/controllers/lua/lua_hooks.cpp
+++ b/firmware/controllers/lua/lua_hooks.cpp
@@ -383,7 +383,13 @@ struct LuaSensor final : public StoredValueSensor {
 	LuaSensor(lua_State* l, const char* name)
 		: StoredValueSensor(findSensorByName(l, name), MS2NT(100))
 	{
-		Register();
+		// do a soft collision check to avoid a fatal error from the hard check in Register()
+		if (Sensor::hasSensor(type())) {
+			luaL_error(l, "Tried to create a Lua sensor of type %s, but one was already registered.", getSensorName());
+		} else {
+			Register();
+			efiPrintf("LUA registered sensor of type %s", getSensorName());
+		}
 	}
 
 	void set(float value) {

--- a/firmware/controllers/lua/lua_hooks.cpp
+++ b/firmware/controllers/lua/lua_hooks.cpp
@@ -384,7 +384,7 @@ struct LuaSensor final : public StoredValueSensor {
 		: StoredValueSensor(findSensorByName(l, name), MS2NT(100))
 	{
 		// do a soft collision check to avoid a fatal error from the hard check in Register()
-		if (Sensor::hasSensor(type())) {
+		if (l && Sensor::hasSensor(type())) {
 			luaL_error(l, "Tried to create a Lua sensor of type %s, but one was already registered.", getSensorName());
 		} else {
 			Register();

--- a/firmware/controllers/lua/lua_hooks.cpp
+++ b/firmware/controllers/lua/lua_hooks.cpp
@@ -340,6 +340,7 @@ static int lua_setAirmass(lua_State* l) {
 
 #endif // EFI_UNIT_TEST
 
+// TODO: PR this back in to https://github.com/gengyong/luaaa
 namespace LUAAA_NS {
     template<typename TCLASS, typename ...ARGS>
     struct PlacementConstructorCaller<TCLASS, lua_State*, ARGS...>

--- a/firmware/controllers/sensors/sensor.cpp
+++ b/firmware/controllers/sensors/sensor.cpp
@@ -245,12 +245,13 @@ void Sensor::unregister() {
  * todo: some sort of hashmap in the future?
  */
 SensorType findSensorTypeByName(const char *name) {
-    for (int i = 0;i<(int)SensorType::PlaceholderLast;i++) {
-    	SensorType type = (SensorType)i;
-    	const char *sensorName = getSensorType(type);
-    	if (strEqualCaseInsensitive(sensorName, name)) {
-    		return type;
-    	}
-    }
-    return SensorType::Invalid;
+	for (int i = 0;i<(int)SensorType::PlaceholderLast;i++) {
+		SensorType type = (SensorType)i;
+		const char *sensorName = getSensorType(type);
+		if (strEqualCaseInsensitive(sensorName, name)) {
+			return type;
+		}
+	}
+
+	return SensorType::Invalid;
 }

--- a/unit_tests/tests/sensor/basic_sensor.cpp
+++ b/unit_tests/tests/sensor/basic_sensor.cpp
@@ -110,4 +110,5 @@ TEST_F(SensorBasic, HasSensorMock) {
 
 TEST_F(SensorBasic, FindByName) {
 	ASSERT_EQ(SensorType::Clt, findSensorTypeByName("Clt"));
+	ASSERT_EQ(SensorType::Clt, findSensorTypeByName("cLT"));
 }


### PR DESCRIPTION
Detect when we fail to decode a sensor name, and trip an error in Lua if/when that happens.

Also do a soft check in case you really do register two of the same sensor so it doesn't tank the whole ECU.

fix #4368