### PR TITLE
ignore invalid diag result when checking ign/inj

### DIFF
--- a/firmware/controllers/sensors/sensor_checker.cpp
+++ b/firmware/controllers/sensors/sensor_checker.cpp
@@ -181,7 +181,7 @@ void SensorChecker::onSlowCallback() {
 		}
 
 		auto diag = pin.getDiag();
-		if (diag != PIN_OK) {
+		if (diag != PIN_OK && diag != PIN_INVALID) {
 			auto code = getCodeForInjector(i + 1, diag);
 
 			char description[32];

--- a/firmware/controllers/sensors/sensor_checker.cpp
+++ b/firmware/controllers/sensors/sensor_checker.cpp
@@ -200,7 +200,7 @@ void SensorChecker::onSlowCallback() {
 		}
 
 		auto diag = pin.getDiag();
-		if (diag != PIN_OK) {
+		if (diag != PIN_OK && diag != PIN_INVALID) {
 			auto code = getCodeForIgnition(i + 1, diag);
 
 			char description[32];


### PR DESCRIPTION
Don't try to report any pins that returned `invalid`, since pins those don't have diag information available.

#4418 