### PR TITLE
enable alwaysInstantRpm in some tests

### DIFF
--- a/unit_tests/tests/trigger/test_miata_na_tdc.cpp
+++ b/unit_tests/tests/trigger/test_miata_na_tdc.cpp
@@ -5,6 +5,7 @@
 
 TEST(miata, miata_na_tdc) {
 	EngineTestHelper eth(FRANKENSO_MIATA_NA6_MAP);
+	engineConfiguration->alwaysInstantRpm = true;
 
 #define TEST_REVOLUTIONS 6
 
@@ -26,6 +27,6 @@ TEST(miata, miata_na_tdc) {
 	}
 
 	ASSERT_EQ(167,  round(Sensor::getOrZero(SensorType::Rpm))) << "miata_na_tdc RPM";
-	ASSERT_EQ(294000, engine->tdcScheduler[0].momentX % SIMULATION_CYCLE_PERIOD); // let's assert TDC position and sync point
-	ASSERT_EQ(294000, engine->tdcScheduler[1].momentX % SIMULATION_CYCLE_PERIOD); // let's assert TDC position and sync point
+	ASSERT_EQ(293999, engine->tdcScheduler[0].momentX % SIMULATION_CYCLE_PERIOD); // let's assert TDC position and sync point
+	ASSERT_EQ(293999, engine->tdcScheduler[1].momentX % SIMULATION_CYCLE_PERIOD); // let's assert TDC position and sync point
 }

--- a/unit_tests/tests/trigger/test_quad_cam.cpp
+++ b/unit_tests/tests/trigger/test_quad_cam.cpp
@@ -9,6 +9,7 @@ TEST(trigger, testQuadCam) {
 	// setting some weird engine
 	EngineTestHelper eth(FORD_ESCORT_GT);
 	engineConfiguration->isFasterEngineSpinUpEnabled = false;
+	engineConfiguration->alwaysInstantRpm = true;
 
 	setCrankOperationMode();
 
@@ -26,15 +27,16 @@ TEST(trigger, testQuadCam) {
 	engineConfiguration->vvtCamSensorUseRise = true;
 
 	ASSERT_EQ(0, Sensor::getOrZero(SensorType::Rpm));
-	for (int i = 0; i < 2;i++) {
-		eth.fireRise(25);
-		ASSERT_EQ( 0,  Sensor::getOrZero(SensorType::Rpm));
-	}
+
+	eth.fireRise(25);
+	ASSERT_EQ( 0,  Sensor::getOrZero(SensorType::Rpm));
+
 	eth.fireRise(25);
 	// first time we have RPM
 	ASSERT_EQ(2400, Sensor::getOrZero(SensorType::Rpm));
 
 	// need to be out of VVT sync to see VVT sync in action
+	eth.fireRise(25);
 	eth.fireRise(25);
 	eth.fireRise(25);
 

--- a/unit_tests/tests/trigger/test_real_cranking_miata_NA.cpp
+++ b/unit_tests/tests/trigger/test_real_cranking_miata_NA.cpp
@@ -16,6 +16,7 @@ TEST(cranking, realCrankingFromFile) {
 	reader.open("tests/trigger/resources/cranking_na_3.csv", indeces);
 
 	EngineTestHelper eth (FRANKENSO_MIATA_NA6_MAP);
+	engineConfiguration->alwaysInstantRpm = true;
 
 	ssize_t read;
 
@@ -34,18 +35,18 @@ TEST(cranking, realCrankingFromFile) {
 	for (int i = 0; i < 42; i++) {
 		reader.readLine(&eth);
 	}
-	ASSERT_EQ(224, round(Sensor::getOrZero(SensorType::Rpm)))<< reader.lineIndex();
+	EXPECT_EQ(261, round(Sensor::getOrZero(SensorType::Rpm)))<< reader.lineIndex();
 
 
 	for (int i = 0; i < 30; i++) {
 		reader.readLine(&eth);
 	}
-	ASSERT_EQ(456, round(Sensor::getOrZero(SensorType::Rpm)))<< reader.lineIndex() << " @ 2";
+	EXPECT_EQ(738, round(Sensor::getOrZero(SensorType::Rpm)))<< reader.lineIndex() << " @ 2";
 
 	while (reader.haveMore()) {
 		reader.processLine(&eth);
 	}
 
-	ASSERT_EQ(0, eth.recentWarnings()->getCount())<< "warningCounter#realCranking";
-	ASSERT_EQ(407, round(Sensor::getOrZero(SensorType::Rpm)))<< reader.lineIndex();
+	EXPECT_EQ(0, eth.recentWarnings()->getCount())<< "warningCounter#realCranking";
+	EXPECT_EQ(191, round(Sensor::getOrZero(SensorType::Rpm)))<< reader.lineIndex();
 }

--- a/unit_tests/tests/trigger/test_real_cranking_miata_na6.cpp
+++ b/unit_tests/tests/trigger/test_real_cranking_miata_na6.cpp
@@ -36,6 +36,7 @@ static void fireTriggerEvent(EngineTestHelper*eth, double timestampS, trigger_wh
 
 TEST(cranking, hardcodedRealCranking) {
 	EngineTestHelper eth(FRANKENSO_MIATA_NA6_VAF);
+	engineConfiguration->alwaysInstantRpm = true;
 
 #define EVENT(timestamp, channel, value) { fireTriggerEvent(&eth, timestamp, channel, value); }
 
@@ -93,9 +94,9 @@ TEST(cranking, hardcodedRealCranking) {
 	/* 43 */ EVENT(/* timestamp*/1.9822455, T_SECONDARY, /*value*/false);
 	EXPECT_EQ(226, round(Sensor::getOrZero(SensorType::Rpm)));
 
-	// Second sync point, should transition to non-instant RPM
+	// Second sync point
 	/* 44 */ EVENT(/* timestamp*/2.001249, T_PRIMARY, /*value*/false);
-	EXPECT_EQ(239, round(Sensor::getOrZero(SensorType::Rpm)));
+	EXPECT_EQ(277, round(Sensor::getOrZero(SensorType::Rpm)));
 	/* 45 */ EVENT(/* timestamp*/2.0070235, T_SECONDARY, /*value*/true);
 	/* 48 */ EVENT(/* timestamp*/2.04448175, T_SECONDARY, /*value*/false);
 	/* 49 */ EVENT(/* timestamp*/2.06135875, T_SECONDARY, /*value*/true);
@@ -107,12 +108,10 @@ TEST(cranking, hardcodedRealCranking) {
 	/* 59 */ EVENT(/* timestamp*/2.1560195, T_SECONDARY, /*value*/true);
 	/* 60 */ EVENT(/* timestamp*/2.18365925, T_PRIMARY, /*value*/true);
 	/* 61 */ EVENT(/* timestamp*/2.188138, T_SECONDARY, /*value*/false);
-
-	// rpm should now only update at sync point
-	EXPECT_EQ(239, round(Sensor::getOrZero(SensorType::Rpm)));
+	EXPECT_EQ(571, round(Sensor::getOrZero(SensorType::Rpm)));
 	// Third sync point
 	/* 62 */ EVENT(/* timestamp*/2.20460875, T_PRIMARY, /*value*/false);
-	EXPECT_EQ(590, round(Sensor::getOrZero(SensorType::Rpm)));
+	EXPECT_EQ(570, round(Sensor::getOrZero(SensorType::Rpm)));
 
 	/* 63 */ EVENT(/* timestamp*/2.20940075, T_SECONDARY, /*value*/true);
 	/* 64 */ EVENT(/* timestamp*/2.2446445, T_SECONDARY, /*value*/false);
@@ -163,7 +162,7 @@ TEST(cranking, hardcodedRealCranking) {
 
 	EXPECT_EQ( 0,  unitTestWarningCodeState.recentWarnings.getCount()) << "warningCounter#realCranking";
 
-	EXPECT_EQ(755,  round(Sensor::getOrZero(SensorType::Rpm))) << "RPM at the end";
+	EXPECT_EQ(623,  round(Sensor::getOrZero(SensorType::Rpm))) << "RPM at the end";
 }
 
 TEST(cranking, naCrankFromFile) {
@@ -172,11 +171,12 @@ TEST(cranking, naCrankFromFile) {
 	reader.open("tests/trigger/resources/cranking_na_4.csv", indeces);
 
 	EngineTestHelper eth(FRANKENSO_MIATA_NA6_VAF);
+	engineConfiguration->alwaysInstantRpm = true;
 
 	while (reader.haveMore()) {
 		reader.processLine(&eth);
 	}
 
 	EXPECT_EQ(0, eth.recentWarnings()->getCount());
-	EXPECT_EQ(698, round(Sensor::getOrZero(SensorType::Rpm)));
+	EXPECT_EQ(669, round(Sensor::getOrZero(SensorType::Rpm)));
 }

--- a/unit_tests/tests/trigger/test_real_cranking_nissan_vq40.cpp
+++ b/unit_tests/tests/trigger/test_real_cranking_nissan_vq40.cpp
@@ -15,6 +15,7 @@ TEST(realCrankingVQ40, normalCranking) {
 	reader.open("tests/trigger/resources/nissan_vq40_cranking-1.csv", indeces);
 	EngineTestHelper eth (HELLEN_121_NISSAN_6_CYL);
 	engineConfiguration->isFasterEngineSpinUpEnabled = false;
+	engineConfiguration->alwaysInstantRpm = true;
 
 	bool hasSeenFirstVvt = false;
 
@@ -28,9 +29,9 @@ TEST(realCrankingVQ40, normalCranking) {
 		}
 	}
 
-	EXPECT_NEAR(engine->triggerCentral.getVVTPosition(/*bankIndex*/0, /*camIndex*/0), -45.67, 1e-2);
-	EXPECT_NEAR(engine->triggerCentral.getVVTPosition(/*bankIndex*/1, /*camIndex*/0), -45.47, 1e-2);
-	ASSERT_EQ(241, round(Sensor::getOrZero(SensorType::Rpm)))<< reader.lineIndex();
+	EXPECT_NEAR(engine->triggerCentral.getVVTPosition(/*bankIndex*/0, /*camIndex*/0), -45.64, 1e-2);
+	EXPECT_NEAR(engine->triggerCentral.getVVTPosition(/*bankIndex*/1, /*camIndex*/0), -45.45, 1e-2);
+	ASSERT_EQ(101, round(Sensor::getOrZero(SensorType::Rpm)))<< reader.lineIndex();
 
 	// TODO: why warnings?
 	ASSERT_EQ(3, eth.recentWarnings()->getCount());

--- a/unit_tests/tests/trigger/test_real_gm_24x.cpp
+++ b/unit_tests/tests/trigger/test_real_gm_24x.cpp
@@ -9,6 +9,7 @@ TEST(crankingGm24x, gmRealCrankingFromFile) {
 	reader.open("tests/trigger/resources/gm_24x_cranking.csv", indeces);
 	EngineTestHelper eth(TEST_ENGINE);
 	engineConfiguration->isFasterEngineSpinUpEnabled = true;
+	engineConfiguration->alwaysInstantRpm = true;
 
 	eth.setTriggerType(TT_GM_24x);
 
@@ -19,5 +20,5 @@ TEST(crankingGm24x, gmRealCrankingFromFile) {
 	}
 
 	ASSERT_EQ( 0, eth.recentWarnings()->getCount())<< "warningCounter#vwRealCranking";
-	ASSERT_EQ( 128, round(Sensor::getOrZero(SensorType::Rpm)))<< reader.lineIndex();
+	ASSERT_EQ( 139, round(Sensor::getOrZero(SensorType::Rpm)))<< reader.lineIndex();
 }

--- a/unit_tests/tests/trigger/test_real_k24a2.cpp
+++ b/unit_tests/tests/trigger/test_real_k24a2.cpp
@@ -9,6 +9,7 @@ static void doTest(const char* testFile, int expectedRpm) {
 	reader.open(testFile, indeces);
 	EngineTestHelper eth(TEST_ENGINE);
 	engineConfiguration->isFasterEngineSpinUpEnabled = true;
+	engineConfiguration->alwaysInstantRpm = true;
 
 	eth.setTriggerType(TT_HONDA_K_12_1);
 
@@ -23,9 +24,9 @@ static void doTest(const char* testFile, int expectedRpm) {
 }
 
 TEST(realk24, crankingNoPlugs1) {
-	doTest("tests/trigger/resources/cranking_honda_k24a2_no_plugs.csv", 189);
+	doTest("tests/trigger/resources/cranking_honda_k24a2_no_plugs.csv", 188);
 }
 
 TEST(realk24, crankingNoPlugs2) {
-	doTest("tests/trigger/resources/cranking_honda_k24a2_no_plugs_2.csv", 185);
+	doTest("tests/trigger/resources/cranking_honda_k24a2_no_plugs_2.csv", 186);
 }

--- a/unit_tests/tests/trigger/test_real_nb2_cranking.cpp
+++ b/unit_tests/tests/trigger/test_real_nb2_cranking.cpp
@@ -14,19 +14,20 @@ TEST(realCrankingNB2, normalCranking) {
 
 	reader.open("tests/trigger/resources/nb2-cranking-good.csv", indeces);
 	EngineTestHelper eth (HELLEN_NB2);
+	engineConfiguration->alwaysInstantRpm = true;
 
 	while (reader.haveMore()) {
 		reader.processLine(&eth);
 	}
 
 	// VVT position nearly zero!
-	EXPECT_NEAR(engine->triggerCentral.getVVTPosition(0, 0), 3.6569f, 1e-4);
+	EXPECT_NEAR(engine->triggerCentral.getVVTPosition(0, 0), 4.2627f, 1e-4);
 
 	// Check the number of times VVT information was used to adjust crank phase
 	// This should happen exactly once: once we sync, we shouldn't lose it.
 	EXPECT_EQ(engine->triggerCentral.triggerState.camResyncCounter, 2);
 
-	ASSERT_EQ(942, round(Sensor::getOrZero(SensorType::Rpm)));
+	ASSERT_EQ(876, round(Sensor::getOrZero(SensorType::Rpm)));
 
 	ASSERT_EQ(3, eth.recentWarnings()->getCount());
 	ASSERT_EQ(CUSTOM_OUT_OF_ORDER_COIL, eth.recentWarnings()->get(0).Code);
@@ -40,15 +41,16 @@ TEST(realCrankingNB2, crankingMissingInjector) {
 
 	reader.open("tests/trigger/resources/nb2-cranking-good-missing-injector-1.csv", indeces);
 	EngineTestHelper eth (HELLEN_NB2);
+	engineConfiguration->alwaysInstantRpm = true;
 
 	while (reader.haveMore()) {
 		reader.processLine(&eth);
 	}
 
 	// VVT position nearly zero!
-	EXPECT_NEAR(engine->triggerCentral.getVVTPosition(0, 0), -7.1926f, 1e-4);
+	EXPECT_NEAR(engine->triggerCentral.getVVTPosition(0, 0), -2.5231f, 1e-4);
 
-	ASSERT_EQ(668, round(Sensor::getOrZero(SensorType::Rpm)));
+	ASSERT_EQ(316, round(Sensor::getOrZero(SensorType::Rpm)));
 
 	ASSERT_EQ(3, eth.recentWarnings()->getCount());
 	ASSERT_EQ(CUSTOM_OUT_OF_ORDER_COIL, eth.recentWarnings()->get(0).Code);

--- a/unit_tests/tests/trigger/test_real_volkswagen.cpp
+++ b/unit_tests/tests/trigger/test_real_volkswagen.cpp
@@ -15,6 +15,7 @@ TEST(crankingVW, vwRealCrankingFromFile) {
 
 	reader.open("tests/trigger/resources/nick_1.csv", indeces);
 	EngineTestHelper eth (VW_ABA);
+	engineConfiguration->alwaysInstantRpm = true;
 	eth.setTriggerType(TT_60_2_VW);
 
 	while (reader.haveMore()) {
@@ -22,11 +23,12 @@ TEST(crankingVW, vwRealCrankingFromFile) {
 	}
 
 	ASSERT_EQ( 0, eth.recentWarnings()->getCount())<< "warningCounter#vwRealCranking";
-	ASSERT_EQ( 1683, round(Sensor::getOrZero(SensorType::Rpm)))<< reader.lineIndex();
+	ASSERT_EQ( 1695, round(Sensor::getOrZero(SensorType::Rpm)))<< reader.lineIndex();
 }
 
 TEST(crankingVW, crankingTwiceWithGap) {
 	EngineTestHelper eth (VW_ABA);
+	engineConfiguration->alwaysInstantRpm = true;
 	eth.setTriggerType(TT_60_2_VW);
 
 	{
@@ -40,7 +42,7 @@ TEST(crankingVW, crankingTwiceWithGap) {
 		}
 
 		ASSERT_EQ(0, eth.recentWarnings()->getCount())<< "warningCounter#vwRealCranking";
-		ASSERT_EQ(1683, round(Sensor::getOrZero(SensorType::Rpm)))<< reader.lineIndex();
+		ASSERT_EQ(1695, round(Sensor::getOrZero(SensorType::Rpm)))<< reader.lineIndex();
 	}
 
 	auto now = getTimeNowNt();
@@ -57,7 +59,7 @@ TEST(crankingVW, crankingTwiceWithGap) {
 		}
 
 		ASSERT_EQ(0, eth.recentWarnings()->getCount());
-		ASSERT_EQ(1683, round(Sensor::getOrZero(SensorType::Rpm)))<< reader.lineIndex();
+		ASSERT_EQ(1695, round(Sensor::getOrZero(SensorType::Rpm)))<< reader.lineIndex();
 	}
 
 	{
@@ -72,6 +74,6 @@ TEST(crankingVW, crankingTwiceWithGap) {
 		}
 
 		ASSERT_EQ(0, eth.recentWarnings()->getCount());
-		ASSERT_EQ(1683, round(Sensor::getOrZero(SensorType::Rpm)))<< reader.lineIndex();
+		ASSERT_EQ(1695, round(Sensor::getOrZero(SensorType::Rpm)))<< reader.lineIndex();
 	}
 }

--- a/unit_tests/tests/trigger/test_symmetrical_crank.cpp
+++ b/unit_tests/tests/trigger/test_symmetrical_crank.cpp
@@ -48,7 +48,7 @@ TEST(engine, testSymmetricalCrank) {
 
 	// this test is not about isFasterEngineSpinUpEnabled so let's disable it to simplify things
 	engineConfiguration->isFasterEngineSpinUpEnabled = false;
-
+	engineConfiguration->alwaysInstantRpm = true;
 
 	ASSERT_EQ(FOUR_STROKE_SYMMETRICAL_CRANK_SENSOR, engine->getOperationMode());
 
@@ -67,13 +67,6 @@ TEST(engine, testSymmetricalCrank) {
 	ASSERT_TRUE(engine->triggerCentral.triggerState.getShaftSynchronized());
 
 	ASSERT_EQ( 0,  round(Sensor::getOrZero(SensorType::Rpm))) << "RPM#0";
-
-
-
-	for (int i = 0; i < 3; i++) {
-		postFourEvents(&eth, mult);
-		ASSERT_EQ( 0,  round(Sensor::getOrZero(SensorType::Rpm))) << "RPM#0";
-	}
 
 	postFourEvents(&eth, mult);
 	ASSERT_EQ(2084,  round(Sensor::getOrZero(SensorType::Rpm))) << "RPM#11";


### PR DESCRIPTION
Progress to #4460.

This is all tweaks to when we get RPM (always instant gets us rpm earlier), and exact RPM numbers that change a little.