### PR TITLE
tunerstudio: GPPWM gauges: unique names, use Note as label

### DIFF
--- a/firmware/tunerstudio/rusefi.input
+++ b/firmware/tunerstudio/rusefi.input
@@ -1264,11 +1264,11 @@ gaugeCategory = Knock
 gaugeCategory = DynoView
 	accelGauge = VssAcceleration, "Vehicle acceleration",    "m/s2",       -10,   10,      -6,     -4,      4,    6,   2,   2
 
-gaugeCategory = Outputs
-	gppwmGauge = gppwmOutput1, "GPPWM Output 1", "%", 0, 100, 0, 0, 100, 100, 1, 1
-	gppwmGauge = gppwmOutput2, "GPPWM Output 2", "%", 0, 100, 0, 0, 100, 100, 1, 1
-	gppwmGauge = gppwmOutput3, "GPPWM Output 3", "%", 0, 100, 0, 0, 100, 100, 1, 1
-	gppwmGauge = gppwmOutput4, "GPPWM Output 4", "%", 0, 100, 0, 0, 100, 100, 1, 1
+gaugeCategory = GPPWM Outputs
+   gppwmGauge1 = gppwmOutput1, { stringValue(gpPwmNote1) }, "%", 0, 100, 0, 0, 100, 100, 1, 1
+   gppwmGauge2 = gppwmOutput2, { stringValue(gpPwmNote2) }, "%", 0, 100, 0, 0, 100, 100, 1, 1
+   gppwmGauge3 = gppwmOutput3, { stringValue(gpPwmNote3) }, "%", 0, 100, 0, 0, 100, 100, 1, 1
+   gppwmGauge4 = gppwmOutput4, { stringValue(gpPwmNote4) }, "%", 0, 100, 0, 0, 100, 100, 1, 1
 
 [WueAnalyze]
     


### PR DESCRIPTION
This fixes issue when only GPPWM 4 output Gauge was available.