### PR TITLE
tunerstudio: indicators: no blank indicators in off state

### DIFF
--- a/firmware/tunerstudio/rusefi.input
+++ b/firmware/tunerstudio/rusefi.input
@@ -1318,60 +1318,57 @@ gaugeCategory = GPPWM Outputs
    gauge6 = VBattGauge
    gauge7 = dwellGauge
    gauge8 = ignadvGauge
-   
 
+   ;         =                     expression,             off-label,            on-label, off-bg, off-fg,  on-bg,  on-fg
+   ; Line 1
+   ; important status
+   ; todo: do we want to drop this line since we have "config error" feature thing below?
+   indicator =            { hasCriticalError },          "No errors",    "CRITICAL ERROR",  white,  black,    red,  black
+   indicator =                    { needBurn },     "Settings saved",   "Unsaved changes",  white,  black, yellow,  black
+   indicator =                   { isWarnNow },        "No warnings",           "Warning",  white,  black, yellow,  black
+   indicator =                 { checkEngine },    "No Check Engine",      "Check Engine",  white,  black,    red,  black
+   indicator =               { isTriggerError},         "Trigger OK",       "Trigger ERR",  white,  black,    red,  black
+   indicator =  { isIgnitionEnabledIndicator },       "Ignition OFF",       "Ignition ON", yellow,  black,  white,  black
+   indicator = { isInjectionEnabledIndicator },      "Injection OFF",      "Injection ON", yellow,  black,  white,  black
 
-;         =   expression,            off-label,            on-label,            off-bg, off-fg, on-bg, on-fg
-	; important status
-	; todo: do we want to drop this line since we have "config error" feature thing below?
-    indicator = { hasCriticalError }, "",   "CRITICAL ERROR",   white, black, red,   black
+   ; this is required so that the "config error" feature works in TS
+   ; don't change this line - TS is looking for an indicator with particular text/styling
+   ; you don't even have to show it by default
+   indicator = { hasCriticalError }, "No config error", "Config error", white, black, red, black
 
-    indicator = { needBurn }, "",  "unsaved changes",   white, black, yellow,   black
-    indicator = { isWarnNow }, "",   "WARNING",   white, black, yellow,   black
-    indicator = { checkEngine }, "",      "Check Engine",       white,  black,  red, black
-    indicator = { isTriggerError}, "Trigger OK",      "Trigger ERR",       white,  black,  red, black
-    indicator = { isIgnitionEnabledIndicator}, "no ignition",   "ignition",   yellow, black, white,   black
-    indicator = { isInjectionEnabledIndicator}, "no injection",   "injection",   yellow, black, white,   black
+   ; minor info
+   indicator =                    { isFanOn },             "Fan OFF",            "Fan ON",  white,  black,  green,  black
+   indicator =                   { isFan2On },           "Fan 2 OFF",          "Fan 2 ON",  white,  black,  green,  black
+   indicator =              { isMainRelayOn },      "Main Relay Off",     "Main Relay ON",  white,  black,  green,  black
+   indicator =        { fuelCutReason == 11 },          "No cleanup",       "Cyl cleanup",  white,  black, yellow,  black
+   ; Line 2
+   ;         =                     expression,             off-label,            on-label, off-bg, off-fg,  on-bg,  on-fg
+   indicator =               { isFuelPumpOn },       "Fuel Pump Off",      "Fuel Pump On",  white,  black,  green,  black
+   indicator =              { clutchUpState },        "No clutch Up",         "Clutch Up",  white,  black,    red,  black
+   indicator =            { clutchDownState },      "No clutch Down",       "Clutch Down",  white,  black, yellow,  black
+   indicator =            { brakePedalState },          "No braking",        "Brake down",  white,  black,    red,  black
+   indicator =              { acButtonState },       "AC Switch off",      "AC Switch on",  white,  black,   blue,  white
+   indicator =                { m_acEnabled },        "AC Relay off",       "AC Relay on",  white,  black,   blue,  white
+   indicator =           { isIdleClosedLoop },          "Not idling",            "Idling",  white,  black,  green,  black
+   indicator =             { isIdleCoasting },        "Not coasting",          "Coasting",  white,  black,  green,  black
+   indicator =                 { dfcoActive },       "Not decel cut",         "Decel cut",  white,  black, yellow,  black
+   indicator =             { tpsAccelActive },        "No TPS accel",  "TPS accel active",  white,  black, yellow,  black
+   ; error codes
+   indicator =                 { isTpsError },              "TPS Ok",         "TPS error",   white, black,    red,  black
 
-
-	; this is required so that the "config error" feature works in TS
-	; don't change this line - TS is looking for an indicator with particular text/styling
-	; you don't even have to show it by default
-	indicator = { hasCriticalError }, "Config Error", "Config Error", white, black, red,   black
-
-	; minor info	
-    indicator = { isFanOn },   "fan off",     "fan on",     white, black, green,   black
-	indicator = { isFan2On }, "fan 2 off",   "fan 2 on",   white, black, green,   black
-	indicator = { isMainRelayOn }, "main relay off",   "main relay on",   white, black, green,   black
-    indicator = { fuelCutReason == 11 }, "no cyl cleanup",   "cyl cleanup",   white, black, yellow,   black
-    indicator = { isFuelPumpOn}, "pump off",   "pump on",   white, black, green,   black
-    indicator = { clutchUpState }, "Clutch Up",   "clutch Up",   white, black, red,   black
-    indicator = { clutchDownState }, "Clutch Down",   "Clutch Down",   white, black, yellow,   black
-    indicator = { brakePedalState }, "brake",   "brake down",   white, black, red,   black
-    indicator = { acButtonState }, "AC switch off", "AC switch on", white, black, blue, white
-	indicator = { m_acEnabled }, "AC off", "AC on", white, black, blue, white
-	indicator = { isIdleClosedLoop }, "not idling", "idling", white, black, green, black
-	indicator = { isIdleCoasting }, "not coasting", "coasting", white, black, green, black
-	indicator = { dfcoActive }, "no decel cut", "decel cut", white, black, yellow, black
-	indicator = { tpsAccelActive }, "no TPS accel", "TPS accel active", white, black, yellow, black
-
-    ; error codes
-    indicator = { isTpsError}, "tps",   "tps error",   white, black, red,   black
-	indicator = { isTps2Error}, "tps 2",   "tps 2 error",   white, black, red,   black
-	indicator = { isPedalError}, "pedal",   "pedal error",   white, black, red,   black
-    indicator = { isCltError}, "clt",   "clt error",   white, black, red,   black
-    indicator = { isIatError}, "iat",   "iat error",   white, black, red,   black
-
-;  not implemented
-;    indicator = { ind_map_error}, "map",   "map error",   white, black, red,   black
-
-	indicator = { sd_present }, "no SD card", "SD card OK",   white, black, green, black
-	indicator = { sd_logging_internal }, "SD logging", "SD logging", white, black, green, black
-	indicator = { sd_msd }, "SD USB", "SD USB", white, black, green, black
-	indicator = { etbRevLimitActive }, "", "ETB RPM Limit", white, black, yellow, black
-
+   ; Line 3
+   ;         =                     expression,             off-label,            on-label, off-bg, off-fg,  on-bg,  on-fg
+   indicator =                { isTps2Error },            "TPS 2 Ok",       "TPS 2 error",  white,  black,    red,  black
+   indicator =               { isPedalError },            "Pedal Ok",       "Pedal error",  white,  black,    red,  black
+   indicator =                 { isCltError },              "CLT Ok",         "CLT error",  white,  black,    red,  black
+   indicator =                 { isIatError },              "IAT Ok",         "IAT error",  white,  black,    red,  black
+   ; not implemented
+   ; indicator = { ind_map_error}, "map",   "map error",   white, black, red,   black
+   indicator =                 { sd_present },          "No SD card",   "SD card present",  white,  black,  green,  black
+   indicator =        { sd_logging_internal },       "No SD logging",        "SD logging",  white,  black,  green,  black
+   indicator =                     { sd_msd },           "No SD USB",            "SD USB",  white,  black,  green,  black
+   indicator =          { etbRevLimitActive },    "No ETB RPM Limit",     "ETB RPM Limit",  white,  black, yellow,  black
 ; looks like TS would append four system indicators below: Data Logging, ???, Not Connected, Protocol Error
-
 
 [KeyActions]
 	showPanel = spi,  spiFunction


### PR DESCRIPTION
I'd like to see something on indicator even it is off.
From this:
![Screenshot from 2022-08-27 20-55-11](https://user-images.githubusercontent.com/28624689/187042281-176a0965-3e7e-4cac-b625-2351f4816e75.png)
to this:
![Screenshot from 2022-08-27 19-47-14](https://user-images.githubusercontent.com/28624689/187042285-cd25d2c6-1c57-4e14-9ec3-0ee9617735e6.png)

