### PR TITLE
more granular trigger error messages

### DIFF
--- a/firmware/controllers/algo/engine.cpp
+++ b/firmware/controllers/algo/engine.cpp
@@ -383,26 +383,6 @@ void Engine::preCalculate() {
 }
 
 #if EFI_SHAFT_POSITION_INPUT
-void Engine::OnTriggerStateDecodingError() {
-	warning(CUSTOM_SYNC_COUNT_MISMATCH, "trigger not happy current %d/%d expected %d/%d",
-			triggerCentral.triggerState.currentCycle.eventCount[0],
-			triggerCentral.triggerState.currentCycle.eventCount[1],
-			TRIGGER_WAVEFORM(getExpectedEventCount(0)),
-			TRIGGER_WAVEFORM(getExpectedEventCount(1)));
-
-	if (engineConfiguration->verboseTriggerSynchDetails || (triggerCentral.triggerState.someSortOfTriggerError() && !engineConfiguration->silentTriggerError)) {
-#if EFI_PROD_CODE
-		efiPrintf("error: synchronizationPoint @ index %d expected %d/%d got %d/%d",
-				triggerCentral.triggerState.currentCycle.current_index,
-				TRIGGER_WAVEFORM(getExpectedEventCount(0)),
-				TRIGGER_WAVEFORM(getExpectedEventCount(1)),
-				triggerCentral.triggerState.currentCycle.eventCount[0],
-				triggerCentral.triggerState.currentCycle.eventCount[1]);
-#endif /* EFI_PROD_CODE */
-	}
-
-}
-
 void Engine::OnTriggerStateProperState(efitick_t nowNt) {
 	rpmCalculator.setSpinningUp(nowNt);
 }
@@ -431,18 +411,19 @@ void Engine::OnTriggerSyncronization(bool wasSynchronized, bool isDecodingError)
 		// 'triggerStateListener is not null' means we are running a real engine and now just preparing trigger shape
 		// that's a bit of a hack, a sweet OOP solution would be a real callback or at least 'needDecodingErrorLogic' method?
 		if (isDecodingError) {
-			OnTriggerStateDecodingError();
+#if EFI_PROD_CODE
+			if (engineConfiguration->verboseTriggerSynchDetails || (triggerCentral.triggerState.someSortOfTriggerError() && !engineConfiguration->silentTriggerError)) {
+				efiPrintf("error: synchronizationPoint @ index %d expected %d/%d got %d/%d",
+						triggerCentral.triggerState.currentCycle.current_index,
+						TRIGGER_WAVEFORM(getExpectedEventCount(0)),
+						TRIGGER_WAVEFORM(getExpectedEventCount(1)),
+						triggerCentral.triggerState.currentCycle.eventCount[0],
+						triggerCentral.triggerState.currentCycle.eventCount[1]);
+			}
+#endif /* EFI_PROD_CODE */
 		}
 
 		engine->triggerErrorDetection.add(isDecodingError);
-
-		if (triggerCentral.isTriggerDecoderError()) {
-			warning(CUSTOM_OBD_TRG_DECODING, "trigger decoding issue. expected %d/%d got %d/%d",
-					TRIGGER_WAVEFORM(getExpectedEventCount(0)),
-					TRIGGER_WAVEFORM(getExpectedEventCount(1)),
-					triggerCentral.triggerState.currentCycle.eventCount[0],
-					triggerCentral.triggerState.currentCycle.eventCount[1]);
-		}
 	}
 
 }

--- a/firmware/controllers/algo/engine.h
+++ b/firmware/controllers/algo/engine.h
@@ -239,7 +239,6 @@ public:
 	efitick_t startStopStateLastPushTime = 0;
 
 #if EFI_SHAFT_POSITION_INPUT
-	void OnTriggerStateDecodingError();
 	void OnTriggerStateProperState(efitick_t nowNt) override;
 	void OnTriggerSyncronization(bool wasSynchronized, bool isDecodingError) override;
 	void OnTriggerSynchronizationLost() override;

--- a/firmware/controllers/algo/obd_error_codes.h
+++ b/firmware/controllers/algo/obd_error_codes.h
@@ -1751,9 +1751,6 @@ typedef enum {
 	CUSTOM_ZERO_DWELL = 6032,
 	CUSTOM_DWELL_TOO_LONG = 6033,
 	CUSTOM_SKIPPING_STROKE = 6034,
-	CUSTOM_OBD_TRG_DECODING = 6035,
-	// todo: looks like following two errors always happen together, it's just timing affects which one is published?
-	CUSTOM_SYNC_ERROR = 6036,
 	CUSTOM_6037 = 6037,
 	/**
 	 * This error happens if some pinout configuration changes were applied but ECU was not reset afterwards.
@@ -2140,7 +2137,13 @@ typedef enum {
 
 	CUSTOM_ERR_TRIGGER_SYNC = 9000,
 	CUSTOM_OBD_TRIGGER_WAVEFORM = 9001,
-	CUSTOM_SYNC_COUNT_MISMATCH = 9002,
+
+	CUSTOM_PRIMARY_TOO_MANY_TEETH = 9002,
+	CUSTOM_PRIMARY_NOT_ENOUGH_TEETH = 9003,
+
+	CUSTOM_CAM_TOO_MANY_TEETH = 9004,
+	CUSTOM_CAM_NOT_ENOUGH_TEETH = 9005,
+
 	/**
 	 * This is not engine miss detection - this is only internal scheduler state validation
 	 * Should not happen

--- a/firmware/controllers/trigger/trigger_decoder.h
+++ b/firmware/controllers/trigger/trigger_decoder.h
@@ -143,6 +143,9 @@ protected:
 	//  - Saw a sync point but the wrong number of events in the cycle
 	virtual void onTriggerError() { }
 
+	virtual void onNotEnoughTeeth(int actual, int expected) { }
+	virtual void onTooManyTeeth(int actual, int expected) { }
+
 private:
 	void resetCurrentCycleState();
 	bool isSyncPoint(const TriggerWaveform& triggerShape, trigger_type_e triggerType) const;
@@ -224,6 +227,9 @@ public:
 
 	void onTriggerError() override;
 
+	void onNotEnoughTeeth(int actual, int expected) override;
+	void onTooManyTeeth(int actual, int expected) override;
+
 private:
 	float calculateInstantRpm(
 		TriggerWaveform const & triggerShape, TriggerFormDetails *triggerFormDetails,
@@ -238,6 +244,9 @@ private:
 class VvtTriggerDecoder : public TriggerDecoderBase {
 public:
 	VvtTriggerDecoder(const char* name) : TriggerDecoderBase(name) { }
+
+	void onNotEnoughTeeth(int actual, int expected) override;
+	void onTooManyTeeth(int actual, int expected) override;
 };
 
 angle_t getEngineCycle(operation_mode_e operationMode);

--- a/unit_tests/tests/trigger/test_cam_vvt_input.cpp
+++ b/unit_tests/tests/trigger/test_cam_vvt_input.cpp
@@ -54,7 +54,7 @@ TEST(trigger, testNoStartUpWarnings) {
 		eth.fireFall(150);
 	}
 	EXPECT_EQ( 1,  unitTestWarningCodeState.recentWarnings.getCount()) << "warningCounter#testNoStartUpWarnings CUSTOM_SYNC_COUNT_MISMATCH expected";
-	EXPECT_EQ(CUSTOM_SYNC_ERROR, unitTestWarningCodeState.recentWarnings.get(0).Code);
+	EXPECT_EQ(CUSTOM_PRIMARY_TOO_MANY_TEETH, unitTestWarningCodeState.recentWarnings.get(0).Code);
 }
 
 TEST(trigger, testNoisyInput) {
@@ -74,7 +74,7 @@ TEST(trigger, testNoisyInput) {
 	ASSERT_EQ(NOISY_RPM,  Sensor::getOrZero(SensorType::Rpm)) << "testNoisyInput RPM should be noisy";
 
 	ASSERT_EQ( 2,  unitTestWarningCodeState.recentWarnings.getCount()) << "warningCounter#testNoisyInput";
-	ASSERT_EQ(CUSTOM_SYNC_COUNT_MISMATCH, unitTestWarningCodeState.recentWarnings.get(0).Code) << "@0";
+	ASSERT_EQ(CUSTOM_PRIMARY_NOT_ENOUGH_TEETH, unitTestWarningCodeState.recentWarnings.get(0).Code) << "@0";
 	ASSERT_EQ(OBD_Crankshaft_Position_Sensor_A_Circuit_Malfunction, unitTestWarningCodeState.recentWarnings.get(1).Code) << "@0";
 }
 

--- a/unit_tests/tests/trigger/test_real_cranking_nissan_vq40.cpp
+++ b/unit_tests/tests/trigger/test_real_cranking_nissan_vq40.cpp
@@ -36,5 +36,5 @@ TEST(realCrankingVQ40, normalCranking) {
 	// TODO: why warnings?
 	ASSERT_EQ(2, eth.recentWarnings()->getCount());
 	ASSERT_EQ(CUSTOM_OUT_OF_ORDER_COIL, eth.recentWarnings()->get(0).Code);	// this is from a coil being protected by overdwell protection
-	ASSERT_EQ(CUSTOM_SYNC_ERROR, eth.recentWarnings()->get(1).Code);
+	ASSERT_EQ(CUSTOM_PRIMARY_TOO_MANY_TEETH, eth.recentWarnings()->get(1).Code);
 }

--- a/unit_tests/tests/trigger/test_real_nb2_cranking.cpp
+++ b/unit_tests/tests/trigger/test_real_nb2_cranking.cpp
@@ -31,7 +31,7 @@ TEST(realCrankingNB2, normalCranking) {
 
 	EXPECT_EQ(3, eth.recentWarnings()->getCount());
 	EXPECT_EQ(CUSTOM_OUT_OF_ORDER_COIL, eth.recentWarnings()->get(0).Code);
-	EXPECT_EQ(CUSTOM_PRIMARY_TOO_MANY_TEETH, eth.recentWarnings()->get(1).Code);
+	EXPECT_EQ(CUSTOM_CAM_TOO_MANY_TEETH, eth.recentWarnings()->get(1).Code);
 	EXPECT_EQ(CUSTOM_PRIMARY_NOT_ENOUGH_TEETH, eth.recentWarnings()->get(2).Code);
 }
 
@@ -52,8 +52,9 @@ TEST(realCrankingNB2, crankingMissingInjector) {
 
 	ASSERT_EQ(316, round(Sensor::getOrZero(SensorType::Rpm)));
 
-	EXPECT_EQ(3, eth.recentWarnings()->getCount());
+	EXPECT_EQ(4, eth.recentWarnings()->getCount());
 	EXPECT_EQ(CUSTOM_OUT_OF_ORDER_COIL, eth.recentWarnings()->get(0).Code);
-	EXPECT_EQ(CUSTOM_PRIMARY_TOO_MANY_TEETH, eth.recentWarnings()->get(1).Code);
+	EXPECT_EQ(CUSTOM_CAM_TOO_MANY_TEETH, eth.recentWarnings()->get(1).Code);
 	EXPECT_EQ(CUSTOM_PRIMARY_NOT_ENOUGH_TEETH, eth.recentWarnings()->get(2).Code);
+	EXPECT_EQ(CUSTOM_PRIMARY_TOO_MANY_TEETH, eth.recentWarnings()->get(3).Code);
 }

--- a/unit_tests/tests/trigger/test_real_nb2_cranking.cpp
+++ b/unit_tests/tests/trigger/test_real_nb2_cranking.cpp
@@ -29,10 +29,10 @@ TEST(realCrankingNB2, normalCranking) {
 
 	ASSERT_EQ(876, round(Sensor::getOrZero(SensorType::Rpm)));
 
-	ASSERT_EQ(3, eth.recentWarnings()->getCount());
-	ASSERT_EQ(CUSTOM_OUT_OF_ORDER_COIL, eth.recentWarnings()->get(0).Code);
-	ASSERT_EQ(CUSTOM_SYNC_ERROR, eth.recentWarnings()->get(1).Code);
-	ASSERT_EQ(CUSTOM_SYNC_COUNT_MISMATCH, eth.recentWarnings()->get(2).Code);
+	EXPECT_EQ(3, eth.recentWarnings()->getCount());
+	EXPECT_EQ(CUSTOM_OUT_OF_ORDER_COIL, eth.recentWarnings()->get(0).Code);
+	EXPECT_EQ(CUSTOM_PRIMARY_TOO_MANY_TEETH, eth.recentWarnings()->get(1).Code);
+	EXPECT_EQ(CUSTOM_PRIMARY_NOT_ENOUGH_TEETH, eth.recentWarnings()->get(2).Code);
 }
 
 TEST(realCrankingNB2, crankingMissingInjector) {
@@ -52,8 +52,8 @@ TEST(realCrankingNB2, crankingMissingInjector) {
 
 	ASSERT_EQ(316, round(Sensor::getOrZero(SensorType::Rpm)));
 
-	ASSERT_EQ(3, eth.recentWarnings()->getCount());
-	ASSERT_EQ(CUSTOM_OUT_OF_ORDER_COIL, eth.recentWarnings()->get(0).Code);
-	ASSERT_EQ(CUSTOM_SYNC_ERROR, eth.recentWarnings()->get(1).Code);
-	ASSERT_EQ(CUSTOM_SYNC_COUNT_MISMATCH, eth.recentWarnings()->get(2).Code);
+	EXPECT_EQ(3, eth.recentWarnings()->getCount());
+	EXPECT_EQ(CUSTOM_OUT_OF_ORDER_COIL, eth.recentWarnings()->get(0).Code);
+	EXPECT_EQ(CUSTOM_PRIMARY_TOO_MANY_TEETH, eth.recentWarnings()->get(1).Code);
+	EXPECT_EQ(CUSTOM_PRIMARY_NOT_ENOUGH_TEETH, eth.recentWarnings()->get(2).Code);
 }


### PR DESCRIPTION
Instead of some catch-all trigger warnings, have exactly one warning per type of trigger error: primary or cam, too many or too few teeth.