### PR TITLE
add hysteresis to limp rpm, boost, injector duty

### DIFF
--- a/firmware/CHANGELOG.md
+++ b/firmware/CHANGELOG.md
@@ -31,6 +31,7 @@ Release template (copy/paste this for new release):
  - Manual electronic throttle synchronization #3680
  - Delay before enabling AC compressor #4502
  - Require full sync for odd cylinder count #4533
+ - Hysteresis on some fuel cuts to avoid engine damage #4541
 
 ### Fixed
  - Inverted vvt control #4464

--- a/firmware/controllers/limp_manager.h
+++ b/firmware/controllers/limp_manager.h
@@ -54,6 +54,23 @@ struct LimpState {
 	}
 };
 
+class Hysteresis {
+public:
+	// returns true if value > rising, false if value < falling, previous if falling < value < rising.
+	bool test(float value, float rising, float falling) {
+		if (value > rising) {
+			m_state = true;
+		} else if (value < falling) {
+			m_state = false;
+		}
+
+		return m_state;
+	}
+
+private:
+	bool m_state = false;
+};
+
 class LimpManager {
 public:
 	// This is called from periodicFastCallback to update internal state
@@ -77,6 +94,10 @@ public:
 
 private:
 	void setFaultRevLimit(int limit);
+
+	Hysteresis m_revLimitHysteresis;
+	Hysteresis m_boostCutHysteresis;
+	Hysteresis m_injectorDutyCutHysteresis;
 
 	// Start with no fault rev limit
 	int32_t m_faultRevLimit = INT32_MAX;

--- a/unit_tests/tests/test_deadband.cpp
+++ b/unit_tests/tests/test_deadband.cpp
@@ -36,3 +36,20 @@ TEST(Deadband, InsideDeadband) {
 	// Now it should flip back
 	EXPECT_TRUE(d.gt(0, -5.01));
 }
+
+TEST(Hysteresis, basic) {
+	Hysteresis h;
+
+	// Below 'rising', should stay false
+	EXPECT_FALSE(h.test(15, 30, 20));
+	EXPECT_FALSE(h.test(25, 30, 20));
+
+	// over 'rising', should go true
+	EXPECT_TRUE(h.test(31, 30, 20));
+
+	// drop back below 'rising', should stay true
+	EXPECT_TRUE(h.test(25, 30, 20));
+
+	// drop below 'falling', should go false
+	EXPECT_FALSE(h.test(15, 30, 20));
+}

--- a/unit_tests/tests/test_limp.cpp
+++ b/unit_tests/tests/test_limp.cpp
@@ -106,13 +106,18 @@ TEST(limp, boostCut) {
 	dut.updateState(1000, 0);
 	EXPECT_TRUE(dut.allowInjection());
 
-	// Above threshold, injection cut
-	Sensor::setMockValue(SensorType::Map, 120);
+	// Above rising threshold, injection cut
+	Sensor::setMockValue(SensorType::Map, 105);
 	dut.updateState(1000, 0);
 	EXPECT_FALSE(dut.allowInjection());
 
-	// Below threshold, should recover
-	Sensor::setMockValue(SensorType::Map, 80);
+	// Below rising threshold, but should have hysteresis, so not cut yet
+	Sensor::setMockValue(SensorType::Map, 95);
+	dut.updateState(1000, 0);
+	EXPECT_FALSE(dut.allowInjection());
+
+	// Below falling threshold, fuel restored
+	Sensor::setMockValue(SensorType::Map, 79);
 	dut.updateState(1000, 0);
 	EXPECT_TRUE(dut.allowInjection());
 


### PR DESCRIPTION
Add hysteresis to force the driver to back off, and maybe save components.

#4529 