### PR TITLE
efiWatchdog: avoid converting time to float

### DIFF
--- a/firmware/controllers/algo/engine.cpp
+++ b/firmware/controllers/algo/engine.cpp
@@ -454,13 +454,12 @@ void Engine::efiWatchdog() {
 	if (engine->configBurnTimer.hasElapsedSec(5) && engineConfiguration->tempBooleanForVerySpecialLogic) {
 		static efitimems_t mostRecentMs = 0;
 
-		float msNow = currentTimeMillis();
-		if (msNow != 0) {
-			float gapInMs = msNow - mostRecentMs;
+		efitimems_t msNow = currentTimeMillis();
+		if (mostRecentMs != 0) {
+			efitimems_t gapInMs = msNow - mostRecentMs;
 			if (gapInMs > 500) {
-				// float has 24 bits in the mantissa, which should allow up to 8 significant figures
-				// we loose precision here after about 1,000,000 seconds which is 11 days
-				firmwareError(WATCH_DOG_SECONDS, "gap in time: now=%fms gap=%fms", msNow, gapInMs);
+				firmwareError(WATCH_DOG_SECONDS, "gap in time: now=%d mS, was %d mS, gap=%dmS",
+					msNow, mostRecentMs, gapInMs);
 			}
 		}
 		mostRecentMs = msNow;


### PR DESCRIPTION
https://stackoverflow.com/questions/68690961/why-does-converting-int-to-float-lose-precision-in-c-programming-language