### PR TITLE
stm32: microsecond timer: set correct period value

### DIFF
--- a/firmware/hw_layer/ports/stm32/microsecond_timer_stm32.cpp
+++ b/firmware/hw_layer/ports/stm32/microsecond_timer_stm32.cpp
@@ -33,17 +33,24 @@ static void hwTimerCallback(PWMDriver*) {
 }
 
 static constexpr PWMConfig timerConfig = {
-	SCHEDULER_TIMER_FREQ,
-	UINT32_MAX,		// timer period = 2^32 counts
-	nullptr,		// No update callback
-	{
+	.frequency = SCHEDULER_TIMER_FREQ,
+	/* wanted timer period = 2^32 counts,
+	 * but driver set (period - 1) value to register
+	 * also period is uint32_t
+	 * So set it to zero so it will overlap to 0xffffffff when writen to register */
+	.period = 0,
+	.callback = nullptr,		// No update callback
+	.channels = {
 		{PWM_OUTPUT_DISABLED, hwTimerCallback},	// Channel 0 = timer callback, others unused
 		{PWM_OUTPUT_DISABLED, nullptr},
 		{PWM_OUTPUT_DISABLED, nullptr},
 		{PWM_OUTPUT_DISABLED, nullptr}
 	},
-	0,	// CR1
-	0	// CR2
+	.cr2 = 0,
+#if STM32_PWM_USE_ADVANCED
+	.bdtr = 0,
+#endif
+	.dier = 0
 };
 
 void portInitMicrosecondTimer() {


### PR DESCRIPTION
Driver sets (period - 1) to ARR (auto-reload register) So we need to set period to (1 << 32) to get maximum 0xffffffff value in ARR. But period is uint32_t.
So set it to 0 and it will ovelap to UINT32_MAX at `pwmp->tim->ARR  = pwmp->period - 1;`

```
859	  pwmp->tim->ARR  = pwmp->period - 1;
(gdb) 
860	  pwmp->tim->CR2  = pwmp->config->cr2;
(gdb) p/x *pwmp
$7 = {state = 0x1, config = 0x80b4b3c, period = 0x0, enabled = 0x0, channels = 0x4, clock = 0x66ff300, tim = 0x40000c00}
(gdb) p/x *pwmp->tim
$5 = {CR1 = 0x0, CR2 = 0x0, SMCR = 0x0, DIER = 0x0, SR = 0x0, EGR = 0x0, CCMR1 = 0x6868, CCMR2 = 0x6868, CCER = 0x0, CNT = 0x0, PSC = 0x1a, ARR = 0xffffffff, RCR = 0x0, CCR = {0x0, 0x0, 0x0, 0x0}, BDTR = 0x0, 
  DCR = 0x0, DMAR = 0x0, OR = 0x0, CCMR3 = 0x0, CCXR = {0x0, 0x0}}
```
