### PR TITLE
add fuel/spark cut codes to TS indicators

### DIFF
--- a/firmware/console/binary/output_channels.txt
+++ b/firmware/console/binary/output_channels.txt
@@ -10,8 +10,6 @@
 struct_no_prefix output_channels_s
 
 bit sd_present
-bit isIgnitionEnabledIndicator;
-bit isInjectionEnabledIndicator;
 bit sd_logging_internal
 bit unusedb4;
 bit unusedb5;

--- a/firmware/console/status_loop.cpp
+++ b/firmware/console/status_loop.cpp
@@ -657,9 +657,6 @@ static void updateFlags() {
 	engine->outputChannels.isFanOn = enginePins.fanRelay.getLogicValue();
 	engine->outputChannels.isFan2On = enginePins.fanRelay2.getLogicValue();
 	engine->outputChannels.isO2HeaterOn = enginePins.o2heater.getLogicValue();
-	// todo: eliminate state copy logic by giving limpManager it's owm limp_manager.txt and leveraging LiveData
-	engine->outputChannels.isIgnitionEnabledIndicator = engine->limpManager.allowIgnition().value;
-	engine->outputChannels.isInjectionEnabledIndicator = engine->limpManager.allowInjection().value;
 	// todo: eliminate state copy logic by giving DfcoController it's owm xxx.txt and leveraging LiveData
 	engine->outputChannels.dfcoActive = engine->module<DfcoController>()->cutFuel();
 

--- a/firmware/controllers/engine_cycle/main_trigger_callback.cpp
+++ b/firmware/controllers/engine_cycle/main_trigger_callback.cpp
@@ -226,6 +226,8 @@ static void handleFuel(uint32_t trgEventIndex, int rpm, efitick_t nowNt, float c
 	efiAssertVoid(CUSTOM_ERR_6628, trgEventIndex < getTriggerCentral()->engineCycleEventCount, "handleFuel/event index");
 
 	LimpState limitedFuelState = getLimpManager()->allowInjection();
+
+	// todo: eliminate state copy logic by giving limpManager it's owm limp_manager.txt and leveraging LiveData
 	engine->outputChannels.fuelCutReason = (int8_t)limitedFuelState.reason;
 	bool limitedFuel = !limitedFuelState.value;
 	if (limitedFuel) {

--- a/firmware/controllers/engine_cycle/spark_logic.cpp
+++ b/firmware/controllers/engine_cycle/spark_logic.cpp
@@ -434,6 +434,8 @@ void onTriggerEventSparkLogic(uint32_t trgEventIndex, int rpm, efitick_t edgeTim
 	}
 
 	LimpState limitedSparkState = engine->limpManager.allowIgnition();
+
+	// todo: eliminate state copy logic by giving limpManager it's owm limp_manager.txt and leveraging LiveData
 	engine->outputChannels.sparkCutReason = (int8_t)limitedSparkState.reason;
 	bool limitedSpark = !limitedSparkState.value;
 

--- a/firmware/controllers/limp_manager.h
+++ b/firmware/controllers/limp_manager.h
@@ -35,8 +35,10 @@ public:
 	}
 
 	void clear(ClearReason clearReason) {
-		m_value = false;
-		this->clearReason = clearReason;
+		if (m_value) {
+			m_value = false;
+			this->clearReason = clearReason;
+		}
 	}
 
 	operator bool() const {

--- a/firmware/controllers/limp_manager.h
+++ b/firmware/controllers/limp_manager.h
@@ -4,6 +4,7 @@
 
 #include <cstdint>
 
+// Keep this list in sync with fuelIgnCutCodeList in rusefi.input!
 enum class ClearReason : uint8_t {
 	None, // 0
 	Fatal,
@@ -18,7 +19,9 @@ enum class ClearReason : uint8_t {
 	InjectorDutyCycle, // 10
 	FloodClear, // 11
 	EnginePhase, // 12
-	KickStart,
+	KickStart, // 13
+
+	// Keep this list in sync with fuelIgnCutCodeList in rusefi.input!
 };
 
 // Only allows clearing the value, but never resetting it.

--- a/firmware/tunerstudio/rusefi.input
+++ b/firmware/tunerstudio/rusefi.input
@@ -234,7 +234,7 @@ enable2ndByteCanID = false
 
 	wboFaultCodeList = bits, U08, [0:3], "OK", "Unk", "Unk", "failed to heat", "overheat", "underheat", "no supply"
 
-	fuelIgnCutCodeList = bits, U08, [0:7], "None", "fatal error", "setting disabled", "RPM hard limit", "boost cut", "oil pressure", "stop requested", "ETB problem", "launch control", "max injector duty", "flood clear", "engine sync", "kickstart"
+	fuelIgnCutCodeList = bits, U08, [0:7], "None", "fatal error", "setting disabled", "RPM limit", "fault RPM limit", "boost cut", "oil pressure", "stop requested", "ETB problem", "launch control", "max injector duty", "flood clear", "engine sync", "kickstart"
 
 [ConstantsExtensions]
      ; defaultValue is used to provide TunerStudio with a value to use in the case of

--- a/firmware/tunerstudio/rusefi.input
+++ b/firmware/tunerstudio/rusefi.input
@@ -234,6 +234,8 @@ enable2ndByteCanID = false
 
 	wboFaultCodeList = bits, U08, [0:3], "OK", "Unk", "Unk", "failed to heat", "overheat", "underheat", "no supply"
 
+	fuelIgnCutCodeList = bits, U08, [0:7], "None", "fatal error", "setting disabled", "RPM hard limit", "boost cut", "oil pressure", "stop requested", "ETB problem", "launch control", "max injector duty", "flood clear", "engine sync", "kickstart"
+
 [ConstantsExtensions]
      ; defaultValue is used to provide TunerStudio with a value to use in the case of
      ; the constant not yet being initialized. This is primarily important if the
@@ -1400,8 +1402,8 @@ gaugeCategory = GPPWM Outputs
    indicator =                   { isWarnNow },        "No warnings",           "Warning",  white,  black, yellow,  black
    indicator =                 { checkEngine },    "No Check Engine",      "Check Engine",  white,  black,    red,  black
    indicator =               { isTriggerError},         "Trigger OK",       "Trigger ERR",  white,  black,    red,  black
-   indicator =  { isIgnitionEnabledIndicator },       "Ignition cut",       "Ignition OK", yellow,  black,  white,  black
-   indicator = { isInjectionEnabledIndicator },      "Injection cut",      "Injection OK", yellow,  black,  white,  black
+   indicator = { fuelCutReason  != 0 }, "Injection OK", { Fuel cut: bitStringValue(fuelIgnCutCodeList, fuelCutReason)}, white, black, yellow, black
+   indicator = { sparkCutReason != 0 }, "Ignition OK",  { Ign cut: bitStringValue(fuelIgnCutCodeList, sparkCutReason)}, white, black, yellow, black
 
    ; this is required so that the "config error" feature works in TS
    ; DO NOT CHANGE THIS LINE - TS is looking for an indicator with particular text/styling
@@ -1416,7 +1418,6 @@ gaugeCategory = GPPWM Outputs
    indicator =                    { isFanOn },             "Fan off",            "Fan on",  white,  black,  green,  black
    indicator =                   { isFan2On },           "Fan 2 off",          "Fan 2 on",  white,  black,  green,  black
    indicator =              { isMainRelayOn },      "Main relay off",     "Main relay on",  white,  black,  green,  black
-   indicator =        { fuelCutReason == 11 },          "No cleanup",       "Cyl cleanup",  white,  black, yellow,  black
    ; Line 2
    ;         =                     expression,             off-label,            on-label, off-bg, off-fg,  on-bg,  on-fg
    indicator =               { isFuelPumpOn },       "Fuel pump off",      "Fuel pump on",  white,  black,  green,  black


### PR DESCRIPTION
Indicators now show the actual spark/fuel cut reason, not just that its cut. That also means we no longer need to actually send the bit of "cut" vs "not cut", since that logic can be in TS instead of copying bits around on the ECU.