### PR TITLE
terrible horrible typo

### DIFF
--- a/firmware/controllers/trigger/trigger_decoder.h
+++ b/firmware/controllers/trigger/trigger_decoder.h
@@ -157,7 +157,7 @@ public:
 			);
 
 	bool someSortOfTriggerError() const {
-		return !m_timeSinceDecodeError.getElapsedSeconds(1);
+		return !m_timeSinceDecodeError.hasElapsedSec(1);
 	}
 
 protected:


### PR DESCRIPTION
Horrible terrible typo that causes `someSortOfTriggerError` to get stuck `true` forever after an error.