### PR TITLE
two modes trigger scheduler

### DIFF
--- a/firmware/controllers/algo/event_registry.h
+++ b/firmware/controllers/algo/event_registry.h
@@ -13,15 +13,30 @@
 #include "fl_stack.h"
 #include "trigger_structure.h"
 
-class AngleBasedEvent {
-public:
+struct AngleBasedEventBase {
 	scheduling_s scheduling;
-	event_trigger_position_s position;
 	action_s action;
 	/**
 	 * Trigger-based scheduler maintains a linked list of all pending tooth-based events.
 	 */
-	AngleBasedEvent *nextToothEvent = nullptr;
+	AngleBasedEventBase *nextToothEvent = nullptr;
+
+	virtual bool shouldSchedule(uint32_t trgEventIndex, float currentPhase, float nextPhase) const = 0;
+	virtual float getAngleFromNow(float currentPhase) const = 0;
+};
+
+struct AngleBasedEventOld : public AngleBasedEventBase {
+	event_trigger_position_s position;
+
+	bool shouldSchedule(uint32_t trgEventIndex, float currentPhase, float nextPhase) const override;
+	float getAngleFromNow(float currentPhase) const override;
+};
+
+struct AngleBasedEventNew : public AngleBasedEventBase {
+	float enginePhase;
+
+	bool shouldSchedule(uint32_t trgEventIndex, float currentPhase, float nextPhase) const override;
+	float getAngleFromNow(float currentPhase) const override;
 };
 
 #define MAX_OUTPUTS_FOR_IGNITION 2
@@ -31,7 +46,7 @@ public:
 	IgnitionEvent();
 	IgnitionOutputPin *outputs[MAX_OUTPUTS_FOR_IGNITION];
 	scheduling_s dwellStartTimer;
-	AngleBasedEvent sparkEvent;
+	AngleBasedEventOld sparkEvent;
 
 	scheduling_s trailingSparkCharge;
 	scheduling_s trailingSparkFire;
@@ -79,8 +94,8 @@ public:
 	int valveIndex;
 	angle_t extra;
 
-	AngleBasedEvent open;
-	AngleBasedEvent close;
+	AngleBasedEventOld open;
+	AngleBasedEventOld close;
 };
 
 

--- a/firmware/controllers/engine_cycle/high_pressure_fuel_pump.h
+++ b/firmware/controllers/engine_cycle/high_pressure_fuel_pump.h
@@ -84,7 +84,7 @@ public:
 #if !EFI_UNIT_TEST
 private:
 #endif // EFI_UNIT_TEST
-	AngleBasedEvent m_event;
+	AngleBasedEventOld m_event;
 
 	HpfpQuantity m_quantity;
 	HpfpLobe     m_lobe;

--- a/firmware/controllers/engine_cycle/main_trigger_callback.cpp
+++ b/firmware/controllers/engine_cycle/main_trigger_callback.cpp
@@ -302,7 +302,7 @@ void mainTriggerCallback(uint32_t trgEventIndex, efitick_t edgeTimestamp, angle_
 	handleFuel(trgEventIndex, rpm, edgeTimestamp, currentPhase, nextPhase);
 
 	engine->module<TriggerScheduler>()->scheduleEventsUntilNextTriggerTooth(
-		rpm, trgEventIndex, edgeTimestamp);
+		rpm, trgEventIndex, edgeTimestamp, currentPhase, nextPhase);
 
 	/**
 	 * For spark we schedule both start of coil charge and actual spark based on trigger angle

--- a/firmware/controllers/system/timer/trigger_scheduler.h
+++ b/firmware/controllers/system/timer/trigger_scheduler.h
@@ -4,7 +4,13 @@
 
 class TriggerScheduler : public EngineModule {
 public:
-	bool scheduleOrQueue(AngleBasedEvent *event,
+	bool scheduleOrQueue(AngleBasedEventOld *event,
+			     uint32_t trgEventIndex,
+			     efitick_t edgeTimestamp,
+			     angle_t angle,
+			     action_s action);
+
+	bool scheduleOrQueue(AngleBasedEventNew *event,
 			     uint32_t trgEventIndex,
 			     efitick_t edgeTimestamp,
 			     angle_t angle,
@@ -12,13 +18,14 @@ public:
 
 	void scheduleEventsUntilNextTriggerTooth(int rpm,
 						 uint32_t trgEventIndex,
-						 efitick_t edgeTimestamp);
+						 efitick_t edgeTimestamp,
+						 float currentPhase, float nextPhase);
 
 	// For unit tests
-	AngleBasedEvent * getElementAtIndexForUnitTest(int index);
+	AngleBasedEventBase * getElementAtIndexForUnitTest(int index);
 
 private:
-	bool assertNotInList(AngleBasedEvent *head, AngleBasedEvent *element);
+	bool assertNotInList(AngleBasedEventBase *head, AngleBasedEventBase *element);
 
 	/**
 	 * That's the linked list of pending events scheduled in relation to trigger
@@ -26,5 +33,5 @@ private:
 	 * trigger index We can make it an array of lists per trigger index, but that would take
 	 * some RAM and probably not needed yet.
 	 */
-	AngleBasedEvent *m_angleBasedEventsHead = nullptr;
+	AngleBasedEventBase *m_angleBasedEventsHead = nullptr;
 };

--- a/unit_tests/engine_test_helper.cpp
+++ b/unit_tests/engine_test_helper.cpp
@@ -308,12 +308,14 @@ scheduling_s * EngineTestHelper::assertEvent5(const char *msg, int index, void *
 	return event;
 }
 
-AngleBasedEvent * EngineTestHelper::assertTriggerEvent(const char *msg,
-		int index, AngleBasedEvent *expected,
+AngleBasedEventBase * EngineTestHelper::assertTriggerEvent(const char *msg,
+		int index, AngleBasedEventBase *expected,
 		void *callback,
 		int triggerEventIndex, angle_t angleOffsetFromTriggerEvent) {
-	AngleBasedEvent * event =
+	AngleBasedEventBase * event2 =
 		engine.module<TriggerScheduler>()->getElementAtIndexForUnitTest(index);
+
+	auto event = event2->asOld();
 
 	assertEqualsM4(msg, " callback up/down", (void*)event->action.getCallback() == (void*) callback, 1);
 

--- a/unit_tests/engine_test_helper.h
+++ b/unit_tests/engine_test_helper.h
@@ -84,7 +84,7 @@ public:
 	scheduling_s * assertEvent5(const char *msg, int index, void *callback, efitimeus_t expectedTimestamp);
 	scheduling_s * assertScheduling(const char *msg, int index, scheduling_s *expected, void *callback, efitimeus_t expectedTimestamp);
 
-	AngleBasedEvent * assertTriggerEvent(const char *msg, int index, AngleBasedEvent *expected, void *callback, int triggerEventIndex, angle_t angleOffsetFromTriggerEvent);
+	AngleBasedEventBase * assertTriggerEvent(const char *msg, int index, AngleBasedEventBase *expected, void *callback, int triggerEventIndex, angle_t angleOffsetFromTriggerEvent);
 
 	void assertEvent(const char *msg, int index, void *callback, efitimeus_t momentX, InjectionEvent *event);
 	void assertInjectorUpEvent(const char *msg, int eventIndex, efitimeus_t momentX, long injectorIndex);


### PR DESCRIPTION
Stub out an implementation of `AngleBasedEvent` etc that uses just engine phase, instead of trigger teeth.

prerequisite for full implementation of #4513