### PR TITLE
explicitly pass which edges we sync trigger on

### DIFF
--- a/firmware/controllers/algo/rusefi_enums.h
+++ b/firmware/controllers/algo/rusefi_enums.h
@@ -673,10 +673,4 @@ enum class SelectedGear : uint8_t {
 	Low = 11,
 };
 
-enum class SyncEdge : uint8_t {
-	Rise,
-	Fall,
-	Both
-};
-
 #endif // __cplusplus

--- a/firmware/controllers/algo/rusefi_enums.h
+++ b/firmware/controllers/algo/rusefi_enums.h
@@ -673,4 +673,10 @@ enum class SelectedGear : uint8_t {
 	Low = 11,
 };
 
+enum class SyncEdge : uint8_t {
+	Rise,
+	Fall,
+	Both
+};
+
 #endif // __cplusplus

--- a/firmware/controllers/trigger/decoders/auto_generated_sync_edge.cpp
+++ b/firmware/controllers/trigger/decoders/auto_generated_sync_edge.cpp
@@ -1,0 +1,18 @@
+#include "global.h"
+#include "sync_edge.h"
+// was generated automatically by rusEFI tool  from sync_edge.h // by enum2string.jar tool on Fri Sep 23 12:11:58 PDT 2022
+// see also gen_config_and_enums.bat
+
+
+
+const char *getSyncEdge(SyncEdge value){
+switch(value) {
+case SyncEdge::Both:
+  return "Both";
+case SyncEdge::Fall:
+  return "Fall";
+case SyncEdge::Rise:
+  return "Rise";
+  }
+ return NULL;
+}

--- a/firmware/controllers/trigger/decoders/auto_generated_sync_edge.h
+++ b/firmware/controllers/trigger/decoders/auto_generated_sync_edge.h
@@ -1,0 +1,10 @@
+// was generated automatically by rusEFI tool  from sync_edge.h // by enum2string.jar tool on Fri Sep 23 12:11:58 PDT 2022
+// see also gen_config_and_enums.bat
+
+
+
+#include "sync_edge.h"
+#pragma once
+#if __cplusplus
+const char *getSyncEdge(SyncEdge value);
+#endif //__cplusplus

--- a/firmware/controllers/trigger/decoders/sync_edge.h
+++ b/firmware/controllers/trigger/decoders/sync_edge.h
@@ -1,0 +1,7 @@
+#pragma once
+
+enum class SyncEdge : uint8_t {
+	Rise,
+	Fall,
+	Both
+};

--- a/firmware/controllers/trigger/decoders/trigger_chrysler.cpp
+++ b/firmware/controllers/trigger/decoders/trigger_chrysler.cpp
@@ -385,6 +385,8 @@ void configureDodgeStratusTriggerWaveform(TriggerWaveform *s) {
 }
 
 static void configureNeon1995TriggerWaveformCommon(bool withCam, TriggerWaveform *s) {
+	s->useOnlyPrimaryForSync = withCam;
+	
 	TriggerWheel crank = withCam ? TriggerWheel::T_SECONDARY : TriggerWheel::T_PRIMARY;
 
 	// voodoo magic - we always need 720 at the end

--- a/firmware/controllers/trigger/decoders/trigger_chrysler.cpp
+++ b/firmware/controllers/trigger/decoders/trigger_chrysler.cpp
@@ -12,8 +12,7 @@
 
 void initDodgeRam(TriggerWaveform *s) {
 
-	s->initialize(FOUR_STROKE_CAM_SENSOR);
-	s->useRiseEdge = true;
+	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::Rise);
 
 	s->isSynchronizationNeeded = false;
 
@@ -27,8 +26,7 @@ void initDodgeRam(TriggerWaveform *s) {
 }
 
 void configureNeon2003TriggerWaveformCrank(TriggerWaveform *s) {
-	s->initialize(FOUR_STROKE_CRANK_SENSOR);
-	s->useRiseEdge = true;
+	s->initialize(FOUR_STROKE_CRANK_SENSOR, SyncEdge::Rise);
 
 	s->setTriggerSynchronizationGap(3);
 
@@ -103,8 +101,7 @@ void configureNeon2003TriggerWaveformCam(TriggerWaveform *s) {
 // todo: move sync point so that two channel does not have false trigger issues
 	bool useOnlyPrimary = true;
 
-	s->initialize(FOUR_STROKE_CAM_SENSOR);
-	s->useRiseEdge = true;
+	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::Rise);
 
 	s->tdcPosition = 496;
 
@@ -126,7 +123,6 @@ gap=1.43/0.71
 
 	float EPS_ANGLE = 0.3;
 
-	s->useOnlyPrimaryForSync = true;
 
 	if (useOnlyPrimary) {
 		s->addEvent720(144, TriggerWheel::T_PRIMARY, TriggerValue::RISE);
@@ -153,6 +149,8 @@ gap=1.43/0.71
 		 * 64 secondary (one wide + 15 narrow + 16 narrow + one wide + 15 narrow + 16 narrow)
 		 *
 		 */
+
+		s->useOnlyPrimaryForSync = true;
 
 		s->addEvent720(25, TriggerWheel::T_SECONDARY, TriggerValue::FALL);
 		s->addEvent720(30, TriggerWheel::T_SECONDARY, TriggerValue::RISE);
@@ -323,7 +321,7 @@ gap=1.43/0.71
 }
 
 void configureDodgeStratusTriggerWaveform(TriggerWaveform *s) {
-	s->initialize(FOUR_STROKE_CAM_SENSOR);
+	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::Rise);
 	s->tdcPosition = 150;
 
 	float w = 7;
@@ -447,7 +445,7 @@ static void configureNeon1995TriggerWaveformCommon(bool withCam, TriggerWaveform
 }
 
 void configureNeon1995TriggerWaveformOnlyCrank(TriggerWaveform *s) {
-	s->initialize(FOUR_STROKE_CRANK_SENSOR);
+	s->initialize(FOUR_STROKE_CRANK_SENSOR, SyncEdge::Rise);
 	s->setTriggerSynchronizationGap(3.79);
 
 	s->tdcPosition = 279;
@@ -457,22 +455,17 @@ void configureNeon1995TriggerWaveformOnlyCrank(TriggerWaveform *s) {
 
 
 void configureNeon1995TriggerWaveform(TriggerWaveform *s) {
-	s->initialize(FOUR_STROKE_CAM_SENSOR);
+	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::Fall);
 
 	s->setTriggerSynchronizationGap(0.8227);
-
-	s->useRiseEdge = false;
-
 
 	s->initialState[(int)TriggerWheel::T_PRIMARY] = TriggerValue::RISE;
 
 	configureNeon1995TriggerWaveformCommon(true, s);
-
-	s->useOnlyPrimaryForSync = true;
 }
 
 void initJeep18_2_2_2(TriggerWaveform *s) {
-	s->initialize(FOUR_STROKE_CAM_SENSOR);
+	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::Rise);
 	s->isSynchronizationNeeded = false;
 	s->tdcPosition = 581;
 
@@ -555,7 +548,7 @@ static void add4cylblock(int off, TriggerWaveform *s) {
 
 // TT_JEEP_4_CYL
 void initJeep_XJ_4cyl_2500(TriggerWaveform *s) {
-	s->initialize(FOUR_STROKE_CAM_SENSOR);
+	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::Rise);
 	s->isSynchronizationNeeded = false;
 	s->tdcPosition = 720 - 236;
 
@@ -574,7 +567,7 @@ void initJeep_XJ_4cyl_2500(TriggerWaveform *s) {
 }
 
 void configureChryslerNGC_36_2_2(TriggerWaveform *s) {
-	s->initialize(FOUR_STROKE_CAM_SENSOR);
+	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::Rise);
 
 	float wide = 30 * 2;
 	float narrow = 10 * 2;
@@ -607,5 +600,4 @@ void configureChryslerNGC_36_2_2(TriggerWaveform *s) {
 	// one small tooth at the end of the engine cycle
 	s->addEventAngle(s->getCycleDuration() - narrow / 2, TriggerWheel::T_PRIMARY, TriggerValue::RISE);
 	s->addEventAngle(s->getCycleDuration(), TriggerWheel::T_PRIMARY, TriggerValue::FALL);
-	s->useOnlyPrimaryForSync = true;
 }

--- a/firmware/controllers/trigger/decoders/trigger_gm.cpp
+++ b/firmware/controllers/trigger/decoders/trigger_gm.cpp
@@ -22,7 +22,7 @@ static float addTooth(float offset, TriggerWaveform *s) {
  * GM/Daewoo Distributor on the F8CV
  */
 void configureGm60_2_2_2(TriggerWaveform *s) {
-	s->initialize(FOUR_STROKE_CAM_SENSOR);
+	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::Rise);
 	s->isSynchronizationNeeded = false;
 	s->isSecondWheelCam = true;
 
@@ -61,7 +61,7 @@ void configureGm60_2_2_2(TriggerWaveform *s) {
 }
 
 void configureGmTriggerWaveform(TriggerWaveform *s) {
-	s->initialize(FOUR_STROKE_CRANK_SENSOR);
+	s->initialize(FOUR_STROKE_CRANK_SENSOR, SyncEdge::Rise);
 
 	float w = 5;
 
@@ -110,7 +110,7 @@ static int gm_tooth_pair(float startAngle, bool isShortLong, TriggerWaveform* s,
  * based on data in https://rusefi.com/forum/viewtopic.php?f=3&t=936&p=30303#p30285
  */
 static void initGmLS24(TriggerWaveform *s, float shortToothWidth) {
-	s->initialize(FOUR_STROKE_CRANK_SENSOR);
+	s->initialize(FOUR_STROKE_CRANK_SENSOR, SyncEdge::Rise);
 
 	/* 
 	 * Okay, here's how this magic works:
@@ -151,8 +151,6 @@ static void initGmLS24(TriggerWaveform *s, float shortToothWidth) {
 
 		angle = gm_tooth_pair(angle, bit, s, CRANK_MODE_MULTIPLIER, shortToothWidth);
 	}
-
-	s->useOnlyPrimaryForSync = true;
 }
 
 // TT_GM_24x

--- a/firmware/controllers/trigger/decoders/trigger_honda.cpp
+++ b/firmware/controllers/trigger/decoders/trigger_honda.cpp
@@ -11,7 +11,7 @@
 #include "trigger_universal.h"
 
 void configureHondaCbr600(TriggerWaveform *s) {
-	s->initialize(FOUR_STROKE_CAM_SENSOR);
+	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::Rise);
 	s->useOnlyPrimaryForSync = true;
 	s->setTriggerSynchronizationGap(6);
 
@@ -52,7 +52,7 @@ void configureHondaCbr600(TriggerWaveform *s) {
 }
 
 void configureOnePlus16(TriggerWaveform *s) {
-	s->initialize(FOUR_STROKE_CAM_SENSOR);
+	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::Rise);
 
 	int count = 16;
 	float tooth = s->getCycleDuration() / count;
@@ -77,7 +77,7 @@ static void kseriesTooth(TriggerWaveform* s, float end) {
 
 // TT_HONDA_K_12_1
 void configureHondaK_12_1(TriggerWaveform *s) {
-	s->initialize(FOUR_STROKE_CRANK_SENSOR);
+	s->initialize(FOUR_STROKE_CRANK_SENSOR, SyncEdge::Rise);
 
 	// nominal gap 0.33
 	s->setSecondTriggerSynchronizationGap2(0.2f, 0.5f);
@@ -100,7 +100,7 @@ void configureHondaK_12_1(TriggerWaveform *s) {
  * 2003 Honda Element
  */
 void configureHondaK_4_1(TriggerWaveform *s) {
-	s->initialize(FOUR_STROKE_CAM_SENSOR);
+	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::Rise);
 
 	s->setTriggerSynchronizationGap3(/*gapIndex*/0, 1.11, 2.38);
 	s->setTriggerSynchronizationGap3(/*gapIndex*/1, 0.28, 0.474);

--- a/firmware/controllers/trigger/decoders/trigger_mazda.cpp
+++ b/firmware/controllers/trigger/decoders/trigger_mazda.cpp
@@ -25,18 +25,13 @@
 #define NB_CRANK_MAGIC 70
 
 void initializeMazdaMiataNaShape(TriggerWaveform *s) {
-	s->initialize(FOUR_STROKE_CAM_SENSOR);
+	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::Both);
 	s->isSecondWheelCam = true;
 
 	// nominal gap is 0.325
 	s->setTriggerSynchronizationGap2(0.1, 0.5);
 	// nominal gap is ~1.52
 	s->setSecondTriggerSynchronizationGap2(0.5, 2.3);
-
-	s->useRiseEdge = false;
-
-	s->bothFrontsRequired = true;
-	s->gapBothDirections = true;
 
 	s->tdcPosition = 5.181;
 
@@ -67,7 +62,7 @@ void initializeMazdaMiataNb2Crank(TriggerWaveform *s) {
 	 * Note how we use 0..180 range while defining FOUR_STROKE_SYMMETRICAL_CRANK_SENSOR trigger
 	 * Note that only half of the physical wheel is defined here!
 	 */
-	s->initialize(FOUR_STROKE_SYMMETRICAL_CRANK_SENSOR);
+	s->initialize(FOUR_STROKE_SYMMETRICAL_CRANK_SENSOR, SyncEdge::Rise);
 
 	s->tdcPosition = 60 + 655;
 
@@ -89,11 +84,9 @@ static void addNBCrankTooth(TriggerWaveform *s, angle_t angle, TriggerWheel cons
 }
 
 static void initializeMazdaMiataNb1ShapeWithOffset(TriggerWaveform *s, float offset) {
-	s->initialize(FOUR_STROKE_CAM_SENSOR);
+	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::Fall);
 	s->setTriggerSynchronizationGap3(0, 0.065, 0.17f);
-	s->useRiseEdge = false;
 	s->useOnlyPrimaryForSync = true;
-	efiAssertVoid(OBD_PCM_Processor_Fault, s->gapBothDirections == false, "NB1 trigger measures on FALL events");
 
 	s->tdcPosition = 276;
 
@@ -126,13 +119,11 @@ void initializeMazdaMiataVVtTestShape(TriggerWaveform *s) {
 }
 
 void configureMazdaProtegeSOHC(TriggerWaveform *s) {
-	s->initialize(FOUR_STROKE_CAM_SENSOR);
+	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::Both);
 //	s->initialState[0] = 1;
 
 //	float w = 720 / 4 * 0.215;
 	float a = 5;
-
-	s->bothFrontsRequired = true;
 
 	float z = 0.093;
 	a = 180;
@@ -154,7 +145,7 @@ void configureMazdaProtegeSOHC(TriggerWaveform *s) {
 }
 
 void configureMazdaProtegeLx(TriggerWaveform *s) {
-	s->initialize(FOUR_STROKE_CAM_SENSOR);
+	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::Rise);
 	s->isSecondWheelCam = true;
 	/**
 	 * based on https://svn.code.sf.net/p/rusefi/code/trunk/misc/logs/1993_escort_gt/MAIN_rfi_report_2015-02-01%2017_39.csv
@@ -180,7 +171,7 @@ void configureMazdaProtegeLx(TriggerWaveform *s) {
 }
 
 void initializeMazdaMiataVVtCamShape(TriggerWaveform *s) {
-	s->initialize(FOUR_STROKE_CAM_SENSOR);
+	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::Rise);
 
 	// Nominal gap is 8.92
 	s->setTriggerSynchronizationGap2(6, 20);
@@ -200,7 +191,7 @@ void initializeMazdaMiataVVtCamShape(TriggerWaveform *s) {
 // https://rusefi.com/forum/viewtopic.php?f=17&t=2417
 // Cam pattern for intake/exhaust on all Skyactiv-G (and maybe -D/-X)
 void initializeMazdaSkyactivCam(TriggerWaveform *s) {
-	s->initialize(FOUR_STROKE_CAM_SENSOR);
+	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::Rise);
 
     // wide
 	s->addEvent360(50, TriggerWheel::T_PRIMARY, TriggerValue::RISE);

--- a/firmware/controllers/trigger/decoders/trigger_mercedes.cpp
+++ b/firmware/controllers/trigger/decoders/trigger_mercedes.cpp
@@ -4,7 +4,7 @@
 #include "trigger_structure.h"
 
 void setMercedesTwoSegment(TriggerWaveform* s) {
-	s->initialize(FOUR_STROKE_CRANK_SENSOR);
+	s->initialize(FOUR_STROKE_CRANK_SENSOR, SyncEdge::Rise);
 
 	s->addEvent360(180 - 10, TriggerWheel::T_PRIMARY, TriggerValue::RISE);
 	s->addEvent360(180, TriggerWheel::T_PRIMARY, TriggerValue::FALL);

--- a/firmware/controllers/trigger/decoders/trigger_misc.cpp
+++ b/firmware/controllers/trigger/decoders/trigger_misc.cpp
@@ -12,7 +12,7 @@
 
 // TT_FIAT_IAW_P8
 void configureFiatIAQ_P8(TriggerWaveform * s) {
-	s->initialize(FOUR_STROKE_CAM_SENSOR);
+	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::Rise);
 
 	int width = 60;
 	s->tdcPosition = width;
@@ -27,7 +27,7 @@ void configureFiatIAQ_P8(TriggerWaveform * s) {
 
 // TT_TRI_TACH
 void configureTriTach(TriggerWaveform * s) {
-	s->initialize(FOUR_STROKE_CRANK_SENSOR);
+	s->initialize(FOUR_STROKE_CRANK_SENSOR, SyncEdge::Rise);
 
 	s->isSynchronizationNeeded = false;
 
@@ -56,7 +56,7 @@ void configureTriTach(TriggerWaveform * s) {
  * based on https://www.w8ji.com/distributor_stabbing.htm
  */
 void configureFordPip(TriggerWaveform * s) {
-	s->initialize(FOUR_STROKE_CAM_SENSOR);
+	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::Rise);
 
 	s->tdcPosition = 662.5;
 
@@ -79,7 +79,7 @@ void configureFordPip(TriggerWaveform * s) {
 }
 
 void configureFordST170(TriggerWaveform * s) {
-	s->initialize(FOUR_STROKE_CAM_SENSOR);
+	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::Rise);
 	int width = 10;
 
 	int total = s->getCycleDuration() / 8;
@@ -101,7 +101,7 @@ void configureFordST170(TriggerWaveform * s) {
 }
 
 void configureDaihatsu4(TriggerWaveform * s) {
-	s->initialize(FOUR_STROKE_CAM_SENSOR);
+	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::Rise);
 
 	int width = 10;
 
@@ -123,10 +123,7 @@ void configureDaihatsu4(TriggerWaveform * s) {
 }
 
 void configureBarra3plus1cam(TriggerWaveform *s) {
-	s->initialize(FOUR_STROKE_CAM_SENSOR);
-
-	s->useRiseEdge = true;
-	// TODO: gapBothDirections?
+	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::Rise);
 
 	// This wheel has four teeth
 	// two short gaps, and two long gaps

--- a/firmware/controllers/trigger/decoders/trigger_mitsubishi.cpp
+++ b/firmware/controllers/trigger/decoders/trigger_mitsubishi.cpp
@@ -11,7 +11,7 @@
 #include "trigger_universal.h"
 
 void configureFordAspireTriggerWaveform(TriggerWaveform * s) {
-	s->initialize(FOUR_STROKE_CAM_SENSOR);
+	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::Rise);
 	s->isSynchronizationNeeded = false;
 	s->isSecondWheelCam = true;
 
@@ -35,8 +35,7 @@ void configureFordAspireTriggerWaveform(TriggerWaveform * s) {
  * TT_MITSUBISHI = 11
  */
 void initializeMitsubishi4g18(TriggerWaveform *s) {
-	s->initialize(FOUR_STROKE_CAM_SENSOR);
-	s->useRiseEdge = false;
+	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::Fall);
 
 	s->setTriggerSynchronizationGap(1.6666);
 
@@ -56,7 +55,7 @@ void initializeMitsubishi4g18(TriggerWaveform *s) {
 }
 
 void initialize36_2_1_1(TriggerWaveform *s) {
-	s->initialize(FOUR_STROKE_CRANK_SENSOR);
+	s->initialize(FOUR_STROKE_CRANK_SENSOR, SyncEdge::Rise);
 	s->tdcPosition = 90;
 	int totalTeethCount = 36;
 
@@ -86,7 +85,7 @@ void initialize36_2_1_1(TriggerWaveform *s) {
 }
 
 void initialize36_2_1(TriggerWaveform *s) {
-	s->initialize(FOUR_STROKE_CRANK_SENSOR);
+	s->initialize(FOUR_STROKE_CRANK_SENSOR, SyncEdge::Rise);
 	s->tdcPosition = 90;
 	int totalTeethCount = 36;
 
@@ -111,7 +110,7 @@ void initialize36_2_1(TriggerWaveform *s) {
 }
 
 void initializeVvt3A92(TriggerWaveform *s) {
-	s->initialize(FOUR_STROKE_CRANK_SENSOR);
+	s->initialize(FOUR_STROKE_CRANK_SENSOR, SyncEdge::Rise);
 
 	int w = 5;
 	s->addEvent360(120 - w, TriggerWheel::T_PRIMARY, TriggerValue::RISE);

--- a/firmware/controllers/trigger/decoders/trigger_nissan.cpp
+++ b/firmware/controllers/trigger/decoders/trigger_nissan.cpp
@@ -16,9 +16,7 @@
  * 8,2,2,2 Nissan pattern
  */
 void initializeNissanSR20VE_4(TriggerWaveform *s) {
-	s->initialize(FOUR_STROKE_CAM_SENSOR);
-	s->gapBothDirections = true;
-	s->useOnlyPrimaryForSync = true;
+	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::Both);
 
 	s->tdcPosition = 630;
 
@@ -48,7 +46,7 @@ static void addPrimaryToothEndingAt(TriggerWaveform *s, float fallAngle) {
 }
 
 void initializeNissanVQvvt(TriggerWaveform *s) {
-	s->initialize(FOUR_STROKE_CAM_SENSOR);
+	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::Rise);
 
 	int offset = 720 - 520;
 
@@ -79,10 +77,9 @@ void makeNissanPattern(TriggerWaveform* s, size_t halfCylinderCount, size_t tota
 }
 
 void initializeNissanVQ35crank(TriggerWaveform *s) {
-	s->initialize(FOUR_STROKE_THREE_TIMES_CRANK_SENSOR);
+	s->initialize(FOUR_STROKE_THREE_TIMES_CRANK_SENSOR, SyncEdge::Rise);
 
 	s->tdcPosition = 675;
-	s->useRiseEdge = true;
 
 	// 6 cylinder = 36 tooth wheel, missing 2 teeth in 3 spots
 	makeNissanPattern(s, 3, 36, 2);
@@ -92,7 +89,7 @@ void initializeNissanVQ35crank(TriggerWaveform *s) {
 }
 
 void initializeNissanMR18crank(TriggerWaveform *s) {
-	s->initialize(FOUR_STROKE_SYMMETRICAL_CRANK_SENSOR);
+	s->initialize(FOUR_STROKE_SYMMETRICAL_CRANK_SENSOR, SyncEdge::Rise);
 
 	s->tdcPosition = 80;
 
@@ -102,7 +99,7 @@ void initializeNissanMR18crank(TriggerWaveform *s) {
 }
 
 void initializeNissanQR25crank(TriggerWaveform *s) {
-	s->initialize(FOUR_STROKE_SYMMETRICAL_CRANK_SENSOR);
+	s->initialize(FOUR_STROKE_SYMMETRICAL_CRANK_SENSOR, SyncEdge::Rise);
 	s->setTriggerSynchronizationGap(0.33);
 	s->setSecondTriggerSynchronizationGap(3);
 
@@ -124,7 +121,7 @@ static void addvq30tooth(TriggerWaveform *s, float angle) {
 // yes, this is CAM shaft shape NOT crank shaft shape!
 // we will add crank shape once Pavel makes progress
 void initializeNissanVQ30cam(TriggerWaveform *s) {
-	s->initialize(FOUR_STROKE_CAM_SENSOR);
+	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::Rise);
 
 	s->tdcPosition = 120;
 
@@ -163,7 +160,7 @@ void initializeNissanVQ30cam(TriggerWaveform *s) {
 }
 
 void initializeNissanMRvvt(TriggerWaveform *s) {
-	s->initialize(FOUR_STROKE_CAM_SENSOR);
+	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::Rise);
 	s->tdcPosition = 0;
 
 	int x = 73;

--- a/firmware/controllers/trigger/decoders/trigger_renix.cpp
+++ b/firmware/controllers/trigger/decoders/trigger_renix.cpp
@@ -32,12 +32,12 @@ static void commonRenix(TriggerWaveform *s) {
 
 // TT_RENIX_44_2_2
 void initializeRenix44_2_2(TriggerWaveform *s) {
-	s->initialize(FOUR_STROKE_SYMMETRICAL_CRANK_SENSOR);
+	s->initialize(FOUR_STROKE_SYMMETRICAL_CRANK_SENSOR, SyncEdge::Rise);
 	commonRenix(s);
 }
 
 // TT_RENIX_66_2_2_2
 void initializeRenix66_2_2(TriggerWaveform *s) {
-	s->initialize(FOUR_STROKE_THREE_TIMES_CRANK_SENSOR);
+	s->initialize(FOUR_STROKE_THREE_TIMES_CRANK_SENSOR, SyncEdge::Rise);
 	commonRenix(s);
 }

--- a/firmware/controllers/trigger/decoders/trigger_rover.cpp
+++ b/firmware/controllers/trigger/decoders/trigger_rover.cpp
@@ -14,7 +14,7 @@
  * https://en.wikipedia.org/wiki/Rover_K-series_engine
  */
 void initializeRoverK(TriggerWaveform *s) {
-	s->initialize(FOUR_STROKE_CRANK_SENSOR);
+	s->initialize(FOUR_STROKE_CRANK_SENSOR, SyncEdge::Rise);
 
 	float tooth = 20;
 

--- a/firmware/controllers/trigger/decoders/trigger_structure.h
+++ b/firmware/controllers/trigger/decoders/trigger_structure.h
@@ -64,6 +64,12 @@ class TriggerDecoderBase;
 class TriggerFormDetails;
 class TriggerConfiguration;
 
+enum class SyncEdge : uint8_t {
+	Rise,
+	Fall,
+	Both
+};
+
 /**
  * @brief Trigger shape has all the fields needed to describe and decode trigger signal.
  * @see TriggerState for trigger decoder state which works based on this trigger shape model

--- a/firmware/controllers/trigger/decoders/trigger_structure.h
+++ b/firmware/controllers/trigger/decoders/trigger_structure.h
@@ -64,12 +64,6 @@ class TriggerDecoderBase;
 class TriggerFormDetails;
 class TriggerConfiguration;
 
-enum class SyncEdge {
-	Rise,
-	Fall,
-	Both
-};
-
 /**
  * @brief Trigger shape has all the fields needed to describe and decode trigger signal.
  * @see TriggerState for trigger decoder state which works based on this trigger shape model

--- a/firmware/controllers/trigger/decoders/trigger_structure.h
+++ b/firmware/controllers/trigger/decoders/trigger_structure.h
@@ -64,11 +64,7 @@ class TriggerDecoderBase;
 class TriggerFormDetails;
 class TriggerConfiguration;
 
-enum class SyncEdge : uint8_t {
-	Rise,
-	Fall,
-	Both
-};
+#include "sync_edge.h"
 
 /**
  * @brief Trigger shape has all the fields needed to describe and decode trigger signal.

--- a/firmware/controllers/trigger/decoders/trigger_structure.h
+++ b/firmware/controllers/trigger/decoders/trigger_structure.h
@@ -64,6 +64,11 @@ class TriggerDecoderBase;
 class TriggerFormDetails;
 class TriggerConfiguration;
 
+enum class SyncEdge {
+	Rise,
+	Fall,
+	Both
+};
 
 /**
  * @brief Trigger shape has all the fields needed to describe and decode trigger signal.
@@ -105,16 +110,6 @@ public:
 	bool shapeDefinitionError = false;
 
 	/**
-	 * https://github.com/rusefi/rusefi/issues/898
-	 * User can choose for example Miata trigger which is not compatible with useOnlyRisingEdgeForTrigger option
-	 * Such contradictory configuration causes a very hard to identify issue and for the sake of usability it's better to
-	 * just crash with a very visible fatal error
-	 *
-	 * One day a nicer implementation could be simply ignoring 'useOnlyRisingEdgeForTrigger' in case of 'bothFrontsRequired'
-	 */
-	bool bothFrontsRequired = false;
-
-	/**
 	 * this variable is incremented after each trigger shape redefinition
 	 */
 	int version = 0;
@@ -151,17 +146,9 @@ public:
 	 * See also gapBothDirections
 	 */
 	bool useOnlyPrimaryForSync;
-	/**
-	 * Should we use falls or rises for gap ratio detection?
-	 * See also useOnlyRisingEdgeForTrigger
-	 */
-	bool useRiseEdge;
-	/**
-	 * This is about selecting signal edges within particular trigger channels.
-	 * Should we measure gaps with both fall and rise signal edges?
-	 * See also useOnlyPrimaryForSync
-	 */
-	bool gapBothDirections;
+
+	// Which edge(s) to consider for finding the sync point: rise, fall, or both
+	SyncEdge syncEdge;
 
 	void calculateExpectedEventCounts(bool useOnlyRisingEdgeForTrigger);
 
@@ -226,7 +213,7 @@ public:
 	void addEventClamped(angle_t angle, TriggerWheel const channelIndex, TriggerValue const stateParam, float filterLeft, float filterRight);
 	operation_mode_e getWheelOperationMode() const;
 
-	void initialize(operation_mode_e operationMode);
+	void initialize(operation_mode_e operationMode, SyncEdge syncEdge);
 	void setTriggerSynchronizationGap(float syncRatio);
 	void setTriggerSynchronizationGap3(int index, float syncRatioFrom, float syncRatioTo);
 	void setTriggerSynchronizationGap2(float syncRatioFrom, float syncRatioTo);

--- a/firmware/controllers/trigger/decoders/trigger_subaru.cpp
+++ b/firmware/controllers/trigger/decoders/trigger_subaru.cpp
@@ -10,7 +10,7 @@
 #include "trigger_subaru.h"
 
 static void initialize_one_of_36_2_2_2(TriggerWaveform *s, int firstCount, int secondCount, bool hasRotaryRelevance) {
-	s->initialize(FOUR_STROKE_CRANK_SENSOR);
+	s->initialize(FOUR_STROKE_CRANK_SENSOR, SyncEdge::Rise);
 
 #if EFI_UNIT_TEST
 	// placed on 'cam' on '2-stroke' rotary
@@ -43,7 +43,6 @@ static void initialize_one_of_36_2_2_2(TriggerWaveform *s, int firstCount, int s
 
 	s->addEvent720(720 - wide / 2, TriggerWheel::T_PRIMARY, TriggerValue::FALL);
 	s->addEvent720(720, TriggerWheel::T_PRIMARY, TriggerValue::RISE);
-	s->useOnlyPrimaryForSync = true;
 }
 
 /**
@@ -67,7 +66,7 @@ void initializeSubaruEZ30(TriggerWaveform *s) {
 }
 
 static void initializeSubaru7_6(TriggerWaveform *s, bool withCrankWheel) {
-	s->initialize(FOUR_STROKE_CAM_SENSOR);
+	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::Rise);
 
 	/* To make trigger decoder happy last event should be exactly at 720
 	 * This code generates two trigger patterns: crank+cam (7+6) and
@@ -152,7 +151,7 @@ static void initializeSubaru7_6(TriggerWaveform *s, bool withCrankWheel) {
 	s->setTriggerSynchronizationGap2(6.53 * TRIGGER_GAP_DEVIATION_LOW, 10.4 * TRIGGER_GAP_DEVIATION_HIGH);
 	s->setTriggerSynchronizationGap3(1, 0.8 * TRIGGER_GAP_DEVIATION_LOW, 1 * TRIGGER_GAP_DEVIATION_HIGH);
 
-	s->useOnlyPrimaryForSync = true;
+	s->useOnlyPrimaryForSync = withCrankWheel;
 }
 
 void initializeSubaruOnly7(TriggerWaveform *s) {
@@ -223,10 +222,8 @@ void initializeSubaru_SVX(TriggerWaveform *s) {
 	#define SUBARU_SVX_CRANK2_PULSE(n)	(void)(n)
 #endif
 
-	s->initialize(FOUR_STROKE_CAM_SENSOR);
-
-	/* we should use only falling edges */
-	s->useRiseEdge = false;
+		/* we should use only falling edges */
+	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::Fall);
 	s->isSynchronizationNeeded = false;
 	s->useOnlyPrimaryForSync = true;
 

--- a/firmware/controllers/trigger/decoders/trigger_suzuki.cpp
+++ b/firmware/controllers/trigger/decoders/trigger_suzuki.cpp
@@ -10,7 +10,7 @@
 #include "trigger_suzuki.h"
 
 void initializeSuzukiG13B(TriggerWaveform *s) {
-	s->initialize(FOUR_STROKE_CAM_SENSOR);
+	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::Rise);
 
 	float w = 5;
 	float specialTooth = 20;

--- a/firmware/controllers/trigger/decoders/trigger_toyota.cpp
+++ b/firmware/controllers/trigger/decoders/trigger_toyota.cpp
@@ -18,7 +18,7 @@
  */
 
 void initialize2jzGE1_12(TriggerWaveform *s) {
-	s->initialize(FOUR_STROKE_CAM_SENSOR);
+	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::Rise);
 
 	float crankD = 360 / 12 / 2; // 15
 
@@ -55,7 +55,7 @@ void initialize2jzGE1_12(TriggerWaveform *s) {
  * https://rusefi.com/forum/viewtopic.php?f=5&t=1720
  */
 void initialize2jzGE3_34_simulation_shape(TriggerWaveform *s) {
-	s->initialize(FOUR_STROKE_CAM_SENSOR);
+	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::Rise);
 
 	float camD = 720 / 6; // 120
 
@@ -125,8 +125,7 @@ void initialize2jzGE3_34_simulation_shape(TriggerWaveform *s) {
 }
 
 void initializeToyota4_1(TriggerWaveform *s) {
-	s->initialize(FOUR_STROKE_CAM_SENSOR);
-	s->useRiseEdge = false;
+	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::Fall);
 
 	int w = 10;
 

--- a/firmware/controllers/trigger/decoders/trigger_universal.cpp
+++ b/firmware/controllers/trigger/decoders/trigger_universal.cpp
@@ -42,7 +42,7 @@ void initializeSkippedToothTriggerWaveformExt(TriggerWaveform *s, int totalTeeth
 		return;
 	}
 	efiAssertVoid(CUSTOM_NULL_SHAPE, s != NULL, "TriggerWaveform is NULL");
-	s->initialize(operationMode);
+	s->initialize(operationMode, SyncEdge::Rise);
 #if EFI_UNIT_TEST
 	s->knownOperationMode = false;
 #endif // EFI_UNIT_TEST
@@ -61,7 +61,7 @@ void initializeSkippedToothTriggerWaveformExt(TriggerWaveform *s, int totalTeeth
 }
 
 void configureOnePlusOne(TriggerWaveform *s) {
-	s->initialize(FOUR_STROKE_CAM_SENSOR);
+	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::Rise);
 
 	s->addEvent360( 90, TriggerWheel::T_PRIMARY, TriggerValue::RISE);
 	s->addEvent360(180, TriggerWheel::T_PRIMARY, TriggerValue::FALL);
@@ -74,7 +74,7 @@ void configureOnePlusOne(TriggerWaveform *s) {
 }
 
 void configure3_1_cam(TriggerWaveform *s) {
-	s->initialize(FOUR_STROKE_CAM_SENSOR);
+	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::Rise);
 
 
 	const float crankW = 360 / 3 / 2;
@@ -114,7 +114,7 @@ void configure3_1_cam(TriggerWaveform *s) {
  */
 void configureKawaKX450F(TriggerWaveform *s) {
 	float engineCycle = FOUR_STROKE_ENGINE_CYCLE;
-	s->initialize(FOUR_STROKE_CRANK_SENSOR);
+	s->initialize(FOUR_STROKE_CRANK_SENSOR, SyncEdge::Rise);
 
 	s->setTriggerSynchronizationGap(2.28);
 
@@ -128,9 +128,7 @@ void configureKawaKX450F(TriggerWaveform *s) {
 }
 
 void configureQuickStartSenderWheel(TriggerWaveform *s) {
-	s->initialize(FOUR_STROKE_CAM_SENSOR);
-
-	s->useRiseEdge = false;
+	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::Fall);
 
 	int offset = 20;
 
@@ -155,9 +153,8 @@ void configureQuickStartSenderWheel(TriggerWaveform *s) {
 // - Honda 24+1 (set this on crank primary, single tooth cam)
 // - AEM 24+1 CAS wheel (same config as Honda)
 void configure12ToothCrank(TriggerWaveform* s) {
-	s->initialize(FOUR_STROKE_TWELVE_TIMES_CRANK_SENSOR);
+	s->initialize(FOUR_STROKE_TWELVE_TIMES_CRANK_SENSOR, SyncEdge::Rise);
 
-	s->useRiseEdge = true;
 	s->shapeWithoutTdc = true;
 
 	// Sync after 3 good teeth

--- a/firmware/controllers/trigger/decoders/trigger_vw.cpp
+++ b/firmware/controllers/trigger/decoders/trigger_vw.cpp
@@ -10,7 +10,7 @@
 #include "trigger_universal.h"
 
 void setSkodaFavorit(TriggerWaveform *s) {
-	s->initialize(FOUR_STROKE_CRANK_SENSOR);
+	s->initialize(FOUR_STROKE_CRANK_SENSOR, SyncEdge::Rise);
 
 	s->addEvent360(46, TriggerWheel::T_PRIMARY, TriggerValue::RISE);
 	s->addEvent360(177, TriggerWheel::T_PRIMARY, TriggerValue::FALL);
@@ -26,7 +26,7 @@ void setSkodaFavorit(TriggerWaveform *s) {
 }
 
 void setVwConfiguration(TriggerWaveform *s) {
-	s->initialize(FOUR_STROKE_CRANK_SENSOR);
+	s->initialize(FOUR_STROKE_CRANK_SENSOR, SyncEdge::Rise);
 
 	int totalTeethCount = 60;
 	int skippedCount = 2;

--- a/firmware/controllers/trigger/trigger.mk
+++ b/firmware/controllers/trigger/trigger.mk
@@ -4,6 +4,7 @@ TRIGGER_DECODERS_SRC_CPP = \
 	$(CONTROLLERS_DIR)/trigger/decoders/trigger_mazda.cpp \
 	$(CONTROLLERS_DIR)/trigger/decoders/trigger_chrysler.cpp \
 	$(CONTROLLERS_DIR)/trigger/decoders/trigger_structure.cpp \
+	$(CONTROLLERS_DIR)/trigger/decoders/auto_generated_sync_edge.cpp \
 	$(CONTROLLERS_DIR)/trigger/trigger_decoder.cpp \
 	$(CONTROLLERS_DIR)/trigger/trigger_simulator.cpp \
 	$(CONTROLLERS_DIR)/trigger/decoders/trigger_mitsubishi.cpp \

--- a/firmware/controllers/trigger/trigger_central.cpp
+++ b/firmware/controllers/trigger/trigger_central.cpp
@@ -770,7 +770,7 @@ static void triggerShapeInfo() {
 #if EFI_PROD_CODE || EFI_SIMULATOR
 	TriggerWaveform *shape = &getTriggerCentral()->triggerShape;
 	TriggerFormDetails *triggerFormDetails = &getTriggerCentral()->triggerFormDetails;
-	efiPrintf("useRise=%s", boolToString(TRIGGER_WAVEFORM(useRiseEdge)));
+	efiPrintf("syncEdge=%s", getSyncEdge(TRIGGER_WAVEFORM(syncEdge)));
 	efiPrintf("gap from %.2f to %.2f", TRIGGER_WAVEFORM(syncronizationRatioFrom[0]), TRIGGER_WAVEFORM(syncronizationRatioTo[0]));
 
 	for (size_t i = 0; i < shape->getSize(); i++) {
@@ -796,10 +796,10 @@ void triggerInfo(void) {
 
 #endif /* HAL_TRIGGER_USE_PAL */
 
-	efiPrintf("Template %s (%d) trigger %s (%d) useRiseEdge=%s onlyFront=%s tdcOffset=%.2f",
+	efiPrintf("Template %s (%d) trigger %s (%d) syncEdge=%s useRiseEdge=%s tdcOffset=%.2f",
 			getEngine_type_e(engineConfiguration->engineType), engineConfiguration->engineType,
 			getTrigger_type_e(engineConfiguration->trigger.type), engineConfiguration->trigger.type,
-			boolToString(TRIGGER_WAVEFORM(useRiseEdge)), boolToString(engineConfiguration->useOnlyRisingEdgeForTrigger),
+			getSyncEdge(TRIGGER_WAVEFORM(syncEdge)), boolToString(engineConfiguration->useOnlyRisingEdgeForTrigger),
 			TRIGGER_WAVEFORM(tdcPosition));
 
 	if (engineConfiguration->trigger.type == TT_TOOTHED_WHEEL) {

--- a/firmware/controllers/trigger/trigger_central.cpp
+++ b/firmware/controllers/trigger/trigger_central.cpp
@@ -25,6 +25,7 @@
 #include "main_trigger_callback.h"
 #include "status_loop.h"
 #include "engine_sniffer.h"
+#include "auto_generated_sync_edge.h"
 
 #if EFI_TUNER_STUDIO
 #include "tunerstudio.h"

--- a/firmware/gen_enum_to_string.sh
+++ b/firmware/gen_enum_to_string.sh
@@ -32,6 +32,14 @@ java -DSystemOut.name=logs/gen_enum_to_string \
 
 java -DSystemOut.name=logs/gen_enum_to_string \
 	-jar ../java_tools/enum2string.jar \
+	-outputPath controllers/trigger/decoders \
+	-generatedFile sync_edge \
+	-enumInputFile controllers/trigger/decoders/sync_edge.h
+
+[ $? -eq 0 ] || { echo "ERROR generating enums"; exit 1; }
+
+java -DSystemOut.name=logs/gen_enum_to_string \
+	-jar ../java_tools/enum2string.jar \
 	-outputPath controllers/algo \
 	-generatedFile enginetypes \
 	-enumInputFile controllers/algo/engine_types.h

--- a/unit_tests/tests/ignition_injection/test_fuel_map.cpp
+++ b/unit_tests/tests/ignition_injection/test_fuel_map.cpp
@@ -85,7 +85,7 @@ TEST(misc, testFuelMap) {
 
 
 static void configureFordAspireTriggerWaveform(TriggerWaveform * s) {
-	s->initialize(FOUR_STROKE_CAM_SENSOR);
+	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::Rise);
 	s->useOnlyRisingEdgeForTriggerTemp = false;
 
 	s->addEvent720(53.747, TriggerWheel::T_SECONDARY, TriggerValue::RISE);


### PR DESCRIPTION
Previously there was a constellation of booleans you could set to determine rise/fall/both, with some unclear defaults. Now an enum must be passed to `initialize()` to set which edges are looked at for finding the sync point.