### PR TITLE
remove ignitionPin

### DIFF
--- a/firmware/controllers/algo/engine.cpp
+++ b/firmware/controllers/algo/engine.cpp
@@ -270,7 +270,6 @@ void Engine::reset() {
 	 * it's important for fixAngle() that engineCycle field never has zero
 	 */
 	engineState.engineCycle = getEngineCycle(FOUR_STROKE_CRANK_SENSOR);
-	memset(&ignitionPin, 0, sizeof(ignitionPin));
 	resetLua();
 }
 

--- a/firmware/controllers/algo/engine.h
+++ b/firmware/controllers/algo/engine.h
@@ -271,13 +271,6 @@ public:
 
 	void resetEngineSnifferIfInTestMode();
 
-	/**
-	 * pre-calculated reference to which output pin should be used for
-	 * given sequence index within engine cycle
-	 * todo: update documentation
-	 */
-	int ignitionPin[MAX_CYLINDER_COUNT];
-
 	EngineState engineState;
 	/**
 	 * idle blip is a development tool: alternator PID research for instance have benefited from a repetitive change of RPM

--- a/firmware/controllers/math/engine_math.cpp
+++ b/firmware/controllers/math/engine_math.cpp
@@ -375,39 +375,6 @@ size_t getNextFiringCylinderId(size_t prevCylinderId) {
 }
 
 /**
- * @param cylinderIndex from 0 to cylinderCount, not cylinder number
- */
-static int getIgnitionPinForIndex(int cylinderIndex) {
-	switch (getCurrentIgnitionMode()) {
-	case IM_ONE_COIL:
-		return 0;
-	case IM_WASTED_SPARK: {
-		if (engineConfiguration->specs.cylindersCount == 1) {
-			// we do not want to divide by zero
-			return 0;
-		}
-		return cylinderIndex % (engineConfiguration->specs.cylindersCount / 2);
-	}
-	case IM_INDIVIDUAL_COILS:
-		return cylinderIndex;
-	case IM_TWO_COILS:
-		return cylinderIndex % 2;
-
-	default:
-		firmwareError(CUSTOM_OBD_IGNITION_MODE, "Invalid ignition mode getIgnitionPinForIndex(): %d", engineConfiguration->ignitionMode);
-		return 0;
-	}
-}
-
-void prepareIgnitionPinIndices() {
-#if EFI_ENGINE_CONTROL
-	for (size_t cylinderIndex = 0; cylinderIndex < engineConfiguration->specs.cylindersCount; cylinderIndex++) {
-		engine->ignitionPin[cylinderIndex] = getIgnitionPinForIndex(cylinderIndex);
-	}
-#endif /* EFI_ENGINE_CONTROL */
-}
-
-/**
  * @return IM_WASTED_SPARK if in SPINNING mode and IM_INDIVIDUAL_COILS setting
  * @return engineConfiguration->ignitionMode otherwise
  */
@@ -415,7 +382,8 @@ ignition_mode_e getCurrentIgnitionMode() {
 	ignition_mode_e ignitionMode = engineConfiguration->ignitionMode;
 #if EFI_SHAFT_POSITION_INPUT
 	// In spin-up cranking mode we don't have full phase sync info yet, so wasted spark mode is better
-	if (ignitionMode == IM_INDIVIDUAL_COILS) {
+	// However, only do this on even cylinder count engines: odd cyl count doesn't fire at all
+	if (ignitionMode == IM_INDIVIDUAL_COILS && (engineConfiguration->specs.cylindersCount % 2 == 0)) {
 		bool missingPhaseInfoForSequential = 
 			!engine->triggerCentral.triggerState.hasSynchronizedPhase();
 
@@ -441,8 +409,6 @@ void prepareOutputSignals() {
 				getIgnition_mode_e(engineConfiguration->ignitionMode));
 	}
 #endif /* EFI_UNIT_TEST */
-
-	prepareIgnitionPinIndices();
 
 	engine->triggerCentral.triggerShape.prepareShape(engine->triggerCentral.triggerFormDetails);
 

--- a/firmware/controllers/math/engine_math.h
+++ b/firmware/controllers/math/engine_math.h
@@ -46,12 +46,6 @@ floatms_t getSparkDwell(int rpm);
 
 ignition_mode_e getCurrentIgnitionMode();
 
-/**
- * This lightweight method is invoked in case of a configuration change or initialization.
- * But also it's used for "Spinning-up to Cranking" transition.
- */
-void prepareIgnitionPinIndices();
-
 size_t getCylinderId(size_t index);
 size_t getNextFiringCylinderId(size_t prevCylinderId);
 


### PR DESCRIPTION
Caching `ignitionPin` causes various problems if the ignition mode changes while the engine is running: for example, if we get full phase sync, it switches from wasted -> sequential. Besides, it's just not worth it for the tiny bit of math done in `getIgnitionPinForIndex` to save that data instead of calculating it on the fly.

probably fix #4513