### PR TITLE
log deviation between actual tooth gap and expected tooth gap

### DIFF
--- a/firmware/controllers/trigger/trigger_central.h
+++ b/firmware/controllers/trigger/trigger_central.h
@@ -188,6 +188,10 @@ private:
 	Timer m_lastToothTimer;
 	// Phase of the last tooth relative to the sync point
 	float m_lastToothPhaseFromSyncPoint;
+
+	// At what engine phase do we expect the next tooth to arrive?
+	// Used for checking whether your trigger pattern is correct.
+	float expectedNextPhase;
 };
 
 void triggerInfo(void);

--- a/firmware/controllers/trigger/trigger_central.txt
+++ b/firmware/controllers/trigger/trigger_central.txt
@@ -13,5 +13,7 @@ int vvtCamCounter
 
     float autoscale currentEngineDecodedPhase;Engine Phase;"deg",1, 0, 0, 0, 0
 
+	float triggerToothAngleError;;"deg", 1, 0, -30, 30, 2
+
 end_struct
 


### PR DESCRIPTION
- We know when to expect the next tooth
- We know the actual angle of the current tooth
- Store the first thing and check it against the second thing!

Maybe some day this can tell us "your trigger is close enough to sync but you may get unpredictable ignition timing"

We could also in theory nudge the trigger teeth around to match reality. Trigger pattern is "close enough", and it gets fine-tuned by the running engine itself.

I guess related to  #2222