### PR TITLE
insist on setBoardConfigOverrides #4614

### DIFF
--- a/simulator/simulator/rusEfiFunctionalTest.cpp
+++ b/simulator/simulator/rusEfiFunctionalTest.cpp
@@ -181,6 +181,3 @@ CANDriver* detectCanDevice(brain_pin_e pinRx, brain_pin_e pinTx) {
 	return &CAND1;
 }
 #endif // HAL_USE_CAN
-
-void setBoardConfigOverrides() {
-}


### PR DESCRIPTION
@mck1117 here we are simulator build failure. Same for unit tests

A bit busy this weekend cannot investigate :( 