### PR TITLE
fix #4619

### DIFF
--- a/firmware/controllers/trigger/trigger_decoder.h
+++ b/firmware/controllers/trigger/trigger_decoder.h
@@ -184,10 +184,6 @@ private:
 	Timer m_timeSinceDecodeError;
 };
 
-// we only need 90 degrees of events so /4 or maybe even /8 should work?
-#define PRE_SYNC_EVENTS (PWM_PHASE_MAX_COUNT / 4)
-
-
 /**
  * the reason for sub-class is simply to save RAM but not having statistics in the trigger initialization instance
  */
@@ -213,8 +209,10 @@ public:
 	uint32_t timeOfLastEvent[PWM_PHASE_MAX_COUNT];
 
 	int spinningEventIndex = 0;
+
+	// we might need up to one full trigger cycle of events - which on 60-2 means storage for ~120
 	// todo: change the implementation to reuse 'timeOfLastEvent'
-	uint32_t spinningEvents[PRE_SYNC_EVENTS];
+	uint32_t spinningEvents[120];
 	/**
 	 * instant RPM calculated at this trigger wheel tooth
 	 */


### PR DESCRIPTION
- Use the correct trigger length when copying events from the pre-sync buffer
- Copy events in to the correct spot while in useOnlyRise mode (ie, skip empty slots for falling edge events)
- Embiggen the buffer a bit so that we can actually store enough events for 60-2
- Test instant RPM in "use only rise" mode

fix #4619