### PR TITLE
infer useOnlyRisingEdge by trigger type

### DIFF
--- a/firmware/config/boards/hellen/hellen121nissan/board_configuration.cpp
+++ b/firmware/config/boards/hellen/hellen121nissan/board_configuration.cpp
@@ -135,8 +135,6 @@ void setBoardDefaultConfiguration() {
 	// Some sensible defaults for other options
 	setCrankOperationMode();
 
-	engineConfiguration->vvtCamSensorUseRise = true;
-	engineConfiguration->useOnlyRisingEdgeForTrigger = true;
 //	setAlgorithm(LM_SPEED_DENSITY);
     // at least this starts
 	engineConfiguration->fuelAlgorithm = LM_ALPHA_N;

--- a/firmware/config/boards/hellen/hellen154hyundai/board_configuration.cpp
+++ b/firmware/config/boards/hellen/hellen154hyundai/board_configuration.cpp
@@ -190,7 +190,6 @@ void setBoardDefaultConfiguration() {
 	setCrankOperationMode();
 
 	engineConfiguration->vvtCamSensorUseRise = true;
-	engineConfiguration->useOnlyRisingEdgeForTrigger = true;
 	setAlgorithm(LM_SPEED_DENSITY);
 
 	engineConfiguration->etb.pFactor = 8.8944;

--- a/firmware/config/boards/hellen/hellen154hyundai/board_configuration.cpp
+++ b/firmware/config/boards/hellen/hellen154hyundai/board_configuration.cpp
@@ -189,7 +189,6 @@ void setBoardDefaultConfiguration() {
 	// Some sensible defaults for other options
 	setCrankOperationMode();
 
-	engineConfiguration->vvtCamSensorUseRise = true;
 	setAlgorithm(LM_SPEED_DENSITY);
 
 	engineConfiguration->etb.pFactor = 8.8944;

--- a/firmware/config/boards/hellen/hellen88bmw/board_configuration.cpp
+++ b/firmware/config/boards/hellen/hellen88bmw/board_configuration.cpp
@@ -134,7 +134,6 @@ void setBoardDefaultConfiguration() {
 	// Some sensible defaults for other options
 	setCrankOperationMode();
 
-	engineConfiguration->vvtCamSensorUseRise = true;
 	setAlgorithm(LM_SPEED_DENSITY);
 
 

--- a/firmware/config/boards/hellen/hellen88bmw/board_configuration.cpp
+++ b/firmware/config/boards/hellen/hellen88bmw/board_configuration.cpp
@@ -135,14 +135,13 @@ void setBoardDefaultConfiguration() {
 	setCrankOperationMode();
 
 	engineConfiguration->vvtCamSensorUseRise = true;
-	engineConfiguration->useOnlyRisingEdgeForTrigger = true;
 	setAlgorithm(LM_SPEED_DENSITY);
 
 
 	// Bosch VQ40 VR56 VK56 0280158007
 	engineConfiguration->injector.flow = 296.2;
 
-	strcpy(engineConfiguration->engineMake, ENGINE_MAKE_NISSAN);
+	strcpy(engineConfiguration->engineMake, ENGINE_MAKE_BMW);
 
 	engineConfiguration->ignitionMode = IM_INDIVIDUAL_COILS; // IM_WASTED_SPARK
 	engineConfiguration->crankingInjectionMode = IM_SIMULTANEOUS;

--- a/firmware/config/engines/dodge_neon.cpp
+++ b/firmware/config/engines/dodge_neon.cpp
@@ -40,9 +40,6 @@ void setDodgeNeon1995EngineConfiguration() {
 	// set_rpm_hard_limit 4000
 	engineConfiguration->rpmHardLimit = 4000; // yes, 4k. let's play it safe for now
 
-
-//	engineConfiguration->useOnlyRisingEdgeForTrigger = true;
-
 	/**
 	 * that's 1995 config
 	 */

--- a/firmware/config/engines/mazda_miata_1_6.cpp
+++ b/firmware/config/engines/mazda_miata_1_6.cpp
@@ -153,7 +153,6 @@ static const uint8_t mapBased16IgnitionTable[16][16] = {
 
 void miataNAcommonEngineSettings() {
 	engineConfiguration->trigger.type = TT_MAZDA_MIATA_NA;
-	engineConfiguration->useOnlyRisingEdgeForTrigger = false;
 	engineConfiguration->specs.cylindersCount = 4;
 	engineConfiguration->specs.firingOrder = FO_1_3_4_2;
 	engineConfiguration->compressionRatio = 9.1;

--- a/firmware/config/engines/mazda_miata_vvt.cpp
+++ b/firmware/config/engines/mazda_miata_vvt.cpp
@@ -261,13 +261,11 @@ static void set4EC_AT() {
  */
 static void setCommonMazdaNB() {
 	engineConfiguration->displayLogicLevelsInEngineSniffer = true;
-	engineConfiguration->useOnlyRisingEdgeForTrigger = true;
 	engineConfiguration->trigger.type = TT_MIATA_VVT;
 
 	// set vvt_mode 3
 	engineConfiguration->vvtMode[0] = VVT_MIATA_NB;
 	engineConfiguration->vvtOffsets[0] = 98; // 2003 red car value
-	engineConfiguration->vvtCamSensorUseRise = true;
 
 	engineConfiguration->ignitionDwellForCrankingMs = 4;
 	// set cranking_fuel 27.5

--- a/firmware/config/engines/test_engine.cpp
+++ b/firmware/config/engines/test_engine.cpp
@@ -84,20 +84,14 @@ void setTestVVTEngineConfiguration() {
 void setTestEngineIssue366both() {
 	setTestCamEngineConfiguration();
 
-
-	engineConfiguration->useOnlyRisingEdgeForTrigger = false;
 	engineConfiguration->trigger.customTotalToothCount = 2;
 	engineConfiguration->trigger.customSkippedToothCount = 1;
 
 	engineConfiguration->trigger.type = TT_TOOTHED_WHEEL;
-
 }
 
 void setTestEngineIssue366rise() {
 	setTestEngineIssue366both();
-
-
-	engineConfiguration->useOnlyRisingEdgeForTrigger = true;
 }
 #endif /* EFI_UNIT_TEST */
 

--- a/firmware/config/engines/test_engine.cpp
+++ b/firmware/config/engines/test_engine.cpp
@@ -25,7 +25,6 @@ void setTestCamEngineConfiguration() {
 //	trigger_config_s *triggerConfig = &engineConfiguration->trigger;
 //	triggerConfig->customTotalToothCount = 60;
 //	triggerConfig->customSkippedToothCount = 0;
-	engineConfiguration->useOnlyRisingEdgeForTrigger = false;
 
 	engineConfiguration->mafAdcChannel = EFI_ADC_1;
 	engineConfiguration->tps1_1AdcChannel = EFI_ADC_2;

--- a/firmware/config/engines/toyota_jzs147.cpp
+++ b/firmware/config/engines/toyota_jzs147.cpp
@@ -52,8 +52,6 @@ static void common2jz() {
 	// chartsize 450
 	engineConfiguration->engineChartSize = 450;
 
-	//	engineConfiguration->useOnlyRisingEdgeForTrigger = true;
-
 	engineConfiguration->map.sensor.type = MT_CUSTOM;
 
 	engineConfiguration->injector.flow = 430;

--- a/firmware/config/engines/vw.cpp
+++ b/firmware/config/engines/vw.cpp
@@ -27,7 +27,6 @@ void setVwAba() {
 
 	setCrankOperationMode();
 	engineConfiguration->trigger.type = TT_TOOTHED_WHEEL_60_2;
-	engineConfiguration->useOnlyRisingEdgeForTrigger = true;
 
 	engineConfiguration->mafAdcChannel = EFI_ADC_1;
 

--- a/firmware/config/engines/vw_b6.cpp
+++ b/firmware/config/engines/vw_b6.cpp
@@ -63,7 +63,6 @@ static void commonPassatB6() {
 	engineConfiguration->throttlePedalSecondaryWOTVoltage = 4.30;
 
 	engineConfiguration->invertCamVVTSignal = true;
-	engineConfiguration->vvtCamSensorUseRise = true;
 
 	/**
 	 * PSS-140

--- a/firmware/controllers/algo/defaults/default_base_engine.cpp
+++ b/firmware/controllers/algo/defaults/default_base_engine.cpp
@@ -38,8 +38,6 @@ void setDefaultBaseEngine() {
 	// Trigger
 	engineConfiguration->trigger.type = TT_TOOTHED_WHEEL_60_2;
 
-	engineConfiguration->useOnlyRisingEdgeForTrigger = false;
-
 	engineConfiguration->globalTriggerAngleOffset = 0;
 
 	// Default this to on - if you want to diagnose, turn it off.

--- a/firmware/controllers/algo/engine2.cpp
+++ b/firmware/controllers/algo/engine2.cpp
@@ -218,13 +218,8 @@ void EngineState::updateTChargeK(int rpm, float tps) {
 #endif
 
 void TriggerConfiguration::update() {
-	UseOnlyRisingEdgeForTrigger = isUseOnlyRisingEdgeForTrigger();
 	VerboseTriggerSynchDetails = isVerboseTriggerSynchDetails();
 	TriggerType = getType();
-}
-
-bool PrimaryTriggerConfiguration::isUseOnlyRisingEdgeForTrigger() const {
-	return engineConfiguration->useOnlyRisingEdgeForTrigger;
 }
 
 trigger_config_s PrimaryTriggerConfiguration::getType() const {
@@ -233,10 +228,6 @@ trigger_config_s PrimaryTriggerConfiguration::getType() const {
 
 bool PrimaryTriggerConfiguration::isVerboseTriggerSynchDetails() const {
 	return engineConfiguration->verboseTriggerSynchDetails;
-}
-
-bool VvtTriggerConfiguration::isUseOnlyRisingEdgeForTrigger() const {
-	return engineConfiguration->vvtCamSensorUseRise;
 }
 
 trigger_config_s VvtTriggerConfiguration::getType() const {

--- a/firmware/controllers/math/engine_math.cpp
+++ b/firmware/controllers/math/engine_math.cpp
@@ -405,8 +405,7 @@ void prepareOutputSignals() {
 
 #if EFI_UNIT_TEST
 	if (verboseMode) {
-		printf("prepareOutputSignals %d onlyEdge=%s %s\r\n", engineConfiguration->trigger.type, boolToString(engineConfiguration->useOnlyRisingEdgeForTrigger),
-				getIgnition_mode_e(engineConfiguration->ignitionMode));
+		printf("prepareOutputSignals %d %s\r\n", engineConfiguration->trigger.type, getIgnition_mode_e(engineConfiguration->ignitionMode));
 	}
 #endif /* EFI_UNIT_TEST */
 

--- a/firmware/controllers/settings.cpp
+++ b/firmware/controllers/settings.cpp
@@ -920,8 +920,6 @@ static void getValue(const char *paramStr) {
 		efiPrintf("is_enabled_spi_2=%s", boolToString(engineConfiguration->is_enabled_spi_2));
 	} else if (strEqualCaseInsensitive(paramStr, "is_enabled_spi_3")) {
 		efiPrintf("is_enabled_spi_3=%s", boolToString(engineConfiguration->is_enabled_spi_3));
-	} else if (strEqualCaseInsensitive(paramStr, "vvtCamSensorUseRise")) {
-		efiPrintf("vvtCamSensorUseRise=%s", boolToString(engineConfiguration->vvtCamSensorUseRise));
 	} else if (strEqualCaseInsensitive(paramStr, "invertCamVVTSignal")) {
 		efiPrintf("invertCamVVTSignal=%s", boolToString(engineConfiguration->invertCamVVTSignal));
 	} else if (strEqualCaseInsensitive(paramStr, "isHip9011Enabled")) {
@@ -1105,8 +1103,6 @@ static void setValue(const char *paramStr, const char *valueStr) {
 		engineConfiguration->vvtOffsets[0] = valueF;
 	} else if (strEqualCaseInsensitive(paramStr, "vvt_mode")) {
 		engineConfiguration->vvtMode[0] = (vvt_mode_e)valueI;
-	} else if (strEqualCaseInsensitive(paramStr, "vvtCamSensorUseRise")) {
-		engineConfiguration->vvtCamSensorUseRise = valueI;
 	} else if (strEqualCaseInsensitive(paramStr, "wwaeTau")) {
 		engineConfiguration->wwaeTau = valueF;
 	} else if (strEqualCaseInsensitive(paramStr, "wwaeBeta")) {

--- a/firmware/controllers/settings.cpp
+++ b/firmware/controllers/settings.cpp
@@ -723,9 +723,6 @@ static void enableOrDisable(const char *param, bool isEnabled) {
 #endif /* EFI_PROD_CODE */
 	} else if (strEqualCaseInsensitive(param, "stepperidle")) {
 		engineConfiguration->useStepperIdle = isEnabled;
-	} else if (strEqualCaseInsensitive(param, "trigger_only_front")) {
-		engineConfiguration->useOnlyRisingEdgeForTrigger = isEnabled;
-		incrementGlobalConfigurationVersion();
 	} else if (strEqualCaseInsensitive(param, "two_wire_batch_injection")) {
 		engineConfiguration->twoWireBatchInjection = isEnabled;
 		incrementGlobalConfigurationVersion();
@@ -911,8 +908,6 @@ static void getValue(const char *paramStr) {
 #endif /* EFI_PROD_CODE */
 	} else if (strEqualCaseInsensitive(paramStr, "tps_min")) {
 		efiPrintf("tps_min=%d", engineConfiguration->tpsMin);
-	} else if (strEqualCaseInsensitive(paramStr, "trigger_only_front")) {
-		efiPrintf("trigger_only_front=%d", engineConfiguration->useOnlyRisingEdgeForTrigger);
 	} else if (strEqualCaseInsensitive(paramStr, "tps_max")) {
 		efiPrintf("tps_max=%d", engineConfiguration->tpsMax);
 	} else if (strEqualCaseInsensitive(paramStr, "global_trigger_offset_angle")) {

--- a/firmware/controllers/trigger/decoders/sync_edge.h
+++ b/firmware/controllers/trigger/decoders/sync_edge.h
@@ -1,7 +1,8 @@
 #pragma once
 
 enum class SyncEdge : uint8_t {
-	Rise,
-	Fall,
-	Both
+	Rise,		// Sync on rising edges, use rise+fall for phase info
+	Fall,		// Sync on falling edges, use rise+fall for phase info
+	RiseOnly,	// Completely ignore all falling edges (this used to be useOnlyRisingEdgeForTrigger=true etc)
+	Both		// Sync on both edges, use both for phase
 };

--- a/firmware/controllers/trigger/decoders/trigger_chrysler.cpp
+++ b/firmware/controllers/trigger/decoders/trigger_chrysler.cpp
@@ -321,7 +321,7 @@ gap=1.43/0.71
 }
 
 void configureDodgeStratusTriggerWaveform(TriggerWaveform *s) {
-	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::Rise);
+	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::RiseOnly);
 	s->tdcPosition = 150;
 
 	float w = 7;
@@ -467,7 +467,7 @@ void configureNeon1995TriggerWaveform(TriggerWaveform *s) {
 }
 
 void initJeep18_2_2_2(TriggerWaveform *s) {
-	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::Rise);
+	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::RiseOnly);
 	s->isSynchronizationNeeded = false;
 	s->tdcPosition = 581;
 
@@ -550,7 +550,7 @@ static void add4cylblock(int off, TriggerWaveform *s) {
 
 // TT_JEEP_4_CYL
 void initJeep_XJ_4cyl_2500(TriggerWaveform *s) {
-	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::Rise);
+	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::RiseOnly);
 	s->isSynchronizationNeeded = false;
 	s->tdcPosition = 720 - 236;
 
@@ -569,7 +569,7 @@ void initJeep_XJ_4cyl_2500(TriggerWaveform *s) {
 }
 
 void configureChryslerNGC_36_2_2(TriggerWaveform *s) {
-	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::Rise);
+	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::RiseOnly);
 
 	float wide = 30 * 2;
 	float narrow = 10 * 2;

--- a/firmware/controllers/trigger/decoders/trigger_gm.cpp
+++ b/firmware/controllers/trigger/decoders/trigger_gm.cpp
@@ -22,7 +22,7 @@ static float addTooth(float offset, TriggerWaveform *s) {
  * GM/Daewoo Distributor on the F8CV
  */
 void configureGm60_2_2_2(TriggerWaveform *s) {
-	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::Rise);
+	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::RiseOnly);
 	s->isSynchronizationNeeded = false;
 	s->isSecondWheelCam = true;
 
@@ -61,7 +61,7 @@ void configureGm60_2_2_2(TriggerWaveform *s) {
 }
 
 void configureGmTriggerWaveform(TriggerWaveform *s) {
-	s->initialize(FOUR_STROKE_CRANK_SENSOR, SyncEdge::Rise);
+	s->initialize(FOUR_STROKE_CRANK_SENSOR, SyncEdge::RiseOnly);
 
 	float w = 5;
 

--- a/firmware/controllers/trigger/decoders/trigger_honda.cpp
+++ b/firmware/controllers/trigger/decoders/trigger_honda.cpp
@@ -11,7 +11,7 @@
 #include "trigger_universal.h"
 
 void configureHondaCbr600(TriggerWaveform *s) {
-	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::Rise);
+	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::RiseOnly);
 	s->useOnlyPrimaryForSync = true;
 	s->setTriggerSynchronizationGap(6);
 
@@ -52,7 +52,7 @@ void configureHondaCbr600(TriggerWaveform *s) {
 }
 
 void configureOnePlus16(TriggerWaveform *s) {
-	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::Rise);
+	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::RiseOnly);
 
 	int count = 16;
 	float tooth = s->getCycleDuration() / count;
@@ -77,7 +77,7 @@ static void kseriesTooth(TriggerWaveform* s, float end) {
 
 // TT_HONDA_K_CRANK_12_1
 void configureHondaK_12_1(TriggerWaveform *s) {
-	s->initialize(FOUR_STROKE_CRANK_SENSOR, SyncEdge::Rise);
+	s->initialize(FOUR_STROKE_CRANK_SENSOR, SyncEdge::RiseOnly);
 
 	// nominal gap 0.33
 	s->setSecondTriggerSynchronizationGap2(0.2f, 0.5f);
@@ -100,7 +100,7 @@ void configureHondaK_12_1(TriggerWaveform *s) {
  * 2003 Honda Element
  */
 void configureHondaK_4_1(TriggerWaveform *s) {
-	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::Rise);
+	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::RiseOnly);
 
 	s->setTriggerSynchronizationGap3(/*gapIndex*/0, 1.11, 2.38);
 	s->setTriggerSynchronizationGap3(/*gapIndex*/1, 0.28, 0.474);

--- a/firmware/controllers/trigger/decoders/trigger_mazda.cpp
+++ b/firmware/controllers/trigger/decoders/trigger_mazda.cpp
@@ -62,7 +62,7 @@ void initializeMazdaMiataNb2Crank(TriggerWaveform *s) {
 	 * Note how we use 0..180 range while defining FOUR_STROKE_SYMMETRICAL_CRANK_SENSOR trigger
 	 * Note that only half of the physical wheel is defined here!
 	 */
-	s->initialize(FOUR_STROKE_SYMMETRICAL_CRANK_SENSOR, SyncEdge::Rise);
+	s->initialize(FOUR_STROKE_SYMMETRICAL_CRANK_SENSOR, SyncEdge::RiseOnly);
 
 	s->tdcPosition = 60 + 655;
 
@@ -145,7 +145,7 @@ void configureMazdaProtegeSOHC(TriggerWaveform *s) {
 }
 
 void configureMazdaProtegeLx(TriggerWaveform *s) {
-	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::Rise);
+	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::RiseOnly);
 	s->isSecondWheelCam = true;
 	/**
 	 * based on https://svn.code.sf.net/p/rusefi/code/trunk/misc/logs/1993_escort_gt/MAIN_rfi_report_2015-02-01%2017_39.csv
@@ -171,7 +171,7 @@ void configureMazdaProtegeLx(TriggerWaveform *s) {
 }
 
 void initializeMazdaMiataVVtCamShape(TriggerWaveform *s) {
-	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::Rise);
+	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::RiseOnly);
 
 	// Nominal gap is 8.92
 	s->setTriggerSynchronizationGap2(6, 20);

--- a/firmware/controllers/trigger/decoders/trigger_mazda.cpp
+++ b/firmware/controllers/trigger/decoders/trigger_mazda.cpp
@@ -191,7 +191,7 @@ void initializeMazdaMiataVVtCamShape(TriggerWaveform *s) {
 // https://rusefi.com/forum/viewtopic.php?f=17&t=2417
 // Cam pattern for intake/exhaust on all Skyactiv-G (and maybe -D/-X)
 void initializeMazdaSkyactivCam(TriggerWaveform *s) {
-	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::Rise);
+	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::RiseOnly);
 
     // wide
 	s->addEvent360(50, TriggerWheel::T_PRIMARY, TriggerValue::RISE);

--- a/firmware/controllers/trigger/decoders/trigger_misc.cpp
+++ b/firmware/controllers/trigger/decoders/trigger_misc.cpp
@@ -56,7 +56,7 @@ void configureTriTach(TriggerWaveform * s) {
  * based on https://www.w8ji.com/distributor_stabbing.htm
  */
 void configureFordPip(TriggerWaveform * s) {
-	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::Rise);
+	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::RiseOnly);
 
 	s->tdcPosition = 662.5;
 
@@ -79,7 +79,7 @@ void configureFordPip(TriggerWaveform * s) {
 }
 
 void configureFordST170(TriggerWaveform * s) {
-	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::Rise);
+	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::RiseOnly);
 	int width = 10;
 
 	int total = s->getCycleDuration() / 8;
@@ -123,7 +123,7 @@ void configureDaihatsu4(TriggerWaveform * s) {
 }
 
 void configureBarra3plus1cam(TriggerWaveform *s) {
-	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::Rise);
+	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::RiseOnly);
 
 	// This wheel has four teeth
 	// two short gaps, and two long gaps

--- a/firmware/controllers/trigger/decoders/trigger_misc.cpp
+++ b/firmware/controllers/trigger/decoders/trigger_misc.cpp
@@ -27,7 +27,7 @@ void configureFiatIAQ_P8(TriggerWaveform * s) {
 
 // TT_TRI_TACH
 void configureTriTach(TriggerWaveform * s) {
-	s->initialize(FOUR_STROKE_CRANK_SENSOR, SyncEdge::Rise);
+	s->initialize(FOUR_STROKE_CRANK_SENSOR, SyncEdge::RiseOnly);
 
 	s->isSynchronizationNeeded = false;
 

--- a/firmware/controllers/trigger/decoders/trigger_mitsubishi.cpp
+++ b/firmware/controllers/trigger/decoders/trigger_mitsubishi.cpp
@@ -11,7 +11,7 @@
 #include "trigger_universal.h"
 
 void configureFordAspireTriggerWaveform(TriggerWaveform * s) {
-	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::Rise);
+	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::RiseOnly);
 	s->isSynchronizationNeeded = false;
 	s->isSecondWheelCam = true;
 
@@ -55,7 +55,7 @@ void initializeMitsubishi4g18(TriggerWaveform *s) {
 }
 
 void initialize36_2_1_1(TriggerWaveform *s) {
-	s->initialize(FOUR_STROKE_CRANK_SENSOR, SyncEdge::Rise);
+	s->initialize(FOUR_STROKE_CRANK_SENSOR, SyncEdge::RiseOnly);
 	s->tdcPosition = 90;
 	int totalTeethCount = 36;
 
@@ -85,7 +85,7 @@ void initialize36_2_1_1(TriggerWaveform *s) {
 }
 
 void initialize36_2_1(TriggerWaveform *s) {
-	s->initialize(FOUR_STROKE_CRANK_SENSOR, SyncEdge::Rise);
+	s->initialize(FOUR_STROKE_CRANK_SENSOR, SyncEdge::RiseOnly);
 	s->tdcPosition = 90;
 	int totalTeethCount = 36;
 

--- a/firmware/controllers/trigger/decoders/trigger_mitsubishi.cpp
+++ b/firmware/controllers/trigger/decoders/trigger_mitsubishi.cpp
@@ -110,7 +110,7 @@ void initialize36_2_1(TriggerWaveform *s) {
 }
 
 void initializeVvt3A92(TriggerWaveform *s) {
-	s->initialize(FOUR_STROKE_CRANK_SENSOR, SyncEdge::Rise);
+	s->initialize(FOUR_STROKE_CRANK_SENSOR, SyncEdge::RiseOnly);
 
 	int w = 5;
 	s->addEvent360(120 - w, TriggerWheel::T_PRIMARY, TriggerValue::RISE);

--- a/firmware/controllers/trigger/decoders/trigger_nissan.cpp
+++ b/firmware/controllers/trigger/decoders/trigger_nissan.cpp
@@ -46,7 +46,7 @@ static void addPrimaryToothEndingAt(TriggerWaveform *s, float fallAngle) {
 }
 
 void initializeNissanVQvvt(TriggerWaveform *s) {
-	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::Rise);
+	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::RiseOnly);
 
 	int offset = 720 - 520;
 
@@ -77,7 +77,7 @@ void makeNissanPattern(TriggerWaveform* s, size_t halfCylinderCount, size_t tota
 }
 
 void initializeNissanVQ35crank(TriggerWaveform *s) {
-	s->initialize(FOUR_STROKE_THREE_TIMES_CRANK_SENSOR, SyncEdge::Rise);
+	s->initialize(FOUR_STROKE_THREE_TIMES_CRANK_SENSOR, SyncEdge::RiseOnly);
 
 	s->tdcPosition = 675;
 
@@ -89,7 +89,7 @@ void initializeNissanVQ35crank(TriggerWaveform *s) {
 }
 
 void initializeNissanMR18crank(TriggerWaveform *s) {
-	s->initialize(FOUR_STROKE_SYMMETRICAL_CRANK_SENSOR, SyncEdge::Rise);
+	s->initialize(FOUR_STROKE_SYMMETRICAL_CRANK_SENSOR, SyncEdge::RiseOnly);
 
 	s->tdcPosition = 80;
 
@@ -99,7 +99,7 @@ void initializeNissanMR18crank(TriggerWaveform *s) {
 }
 
 void initializeNissanQR25crank(TriggerWaveform *s) {
-	s->initialize(FOUR_STROKE_SYMMETRICAL_CRANK_SENSOR, SyncEdge::Rise);
+	s->initialize(FOUR_STROKE_SYMMETRICAL_CRANK_SENSOR, SyncEdge::RiseOnly);
 	s->setTriggerSynchronizationGap(0.33);
 	s->setSecondTriggerSynchronizationGap(3);
 
@@ -121,7 +121,7 @@ static void addvq30tooth(TriggerWaveform *s, float angle) {
 // yes, this is CAM shaft shape NOT crank shaft shape!
 // we will add crank shape once Pavel makes progress
 void initializeNissanVQ30cam(TriggerWaveform *s) {
-	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::Rise);
+	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::RiseOnly);
 
 	s->tdcPosition = 120;
 
@@ -160,7 +160,7 @@ void initializeNissanVQ30cam(TriggerWaveform *s) {
 }
 
 void initializeNissanMRvvt(TriggerWaveform *s) {
-	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::Rise);
+	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::RiseOnly);
 	s->tdcPosition = 0;
 
 	int x = 73;

--- a/firmware/controllers/trigger/decoders/trigger_renix.cpp
+++ b/firmware/controllers/trigger/decoders/trigger_renix.cpp
@@ -32,12 +32,12 @@ static void commonRenix(TriggerWaveform *s) {
 
 // TT_RENIX_44_2_2
 void initializeRenix44_2_2(TriggerWaveform *s) {
-	s->initialize(FOUR_STROKE_SYMMETRICAL_CRANK_SENSOR, SyncEdge::Rise);
+	s->initialize(FOUR_STROKE_SYMMETRICAL_CRANK_SENSOR, SyncEdge::RiseOnly);
 	commonRenix(s);
 }
 
 // TT_RENIX_66_2_2_2
 void initializeRenix66_2_2(TriggerWaveform *s) {
-	s->initialize(FOUR_STROKE_THREE_TIMES_CRANK_SENSOR, SyncEdge::Rise);
+	s->initialize(FOUR_STROKE_THREE_TIMES_CRANK_SENSOR, SyncEdge::RiseOnly);
 	commonRenix(s);
 }

--- a/firmware/controllers/trigger/decoders/trigger_rover.cpp
+++ b/firmware/controllers/trigger/decoders/trigger_rover.cpp
@@ -14,7 +14,7 @@
  * https://en.wikipedia.org/wiki/Rover_K-series_engine
  */
 void initializeRoverK(TriggerWaveform *s) {
-	s->initialize(FOUR_STROKE_CRANK_SENSOR, SyncEdge::Rise);
+	s->initialize(FOUR_STROKE_CRANK_SENSOR, SyncEdge::RiseOnly);
 
 	float tooth = 20;
 

--- a/firmware/controllers/trigger/decoders/trigger_structure.cpp
+++ b/firmware/controllers/trigger/decoders/trigger_structure.cpp
@@ -59,6 +59,9 @@ void TriggerWaveform::initialize(operation_mode_e operationMode, SyncEdge syncEd
 	needSecondTriggerInput = false;
 	shapeWithoutTdc = false;
 
+	// If RiseOnly, ignore falling edges completely.
+	useOnlyRisingEdges = syncEdge == SyncEdge::RiseOnly;
+
 	setTriggerSynchronizationGap(2);
 	for (int gapIndex = 1; gapIndex < GAP_TRACKING_LENGTH ; gapIndex++) {
 		// NaN means do not use this gap ratio
@@ -191,8 +194,8 @@ size_t TriggerWaveform::getExpectedEventCount(TriggerWheel channelIndex) const {
 	return expectedEventCount[(int)channelIndex];
 }
 
-void TriggerWaveform::calculateExpectedEventCounts(bool useOnlyRisingEdgeForTrigger) {
-	if (!useOnlyRisingEdgeForTrigger) {
+void TriggerWaveform::calculateExpectedEventCounts() {
+	if (!useOnlyRisingEdges) {
 		for (size_t i = 0; i < efi::size(expectedEventCount); i++) {
 			if (getExpectedEventCount((TriggerWheel)i) % 2 != 0) {
 				firmwareError(ERROR_TRIGGER_DRAMA, "Trigger: should be even number of events index=%d count=%d", i, getExpectedEventCount((TriggerWheel)i));
@@ -200,7 +203,7 @@ void TriggerWaveform::calculateExpectedEventCounts(bool useOnlyRisingEdgeForTrig
 		}
 	}
 
-	bool isSingleToothOnPrimaryChannel = useOnlyRisingEdgeForTrigger ? getExpectedEventCount(TriggerWheel::T_PRIMARY) == 1 : getExpectedEventCount(TriggerWheel::T_PRIMARY) == 2;
+	bool isSingleToothOnPrimaryChannel = useOnlyRisingEdges ? getExpectedEventCount(TriggerWheel::T_PRIMARY) == 1 : getExpectedEventCount(TriggerWheel::T_PRIMARY) == 2;
 	// todo: next step would be to set 'isSynchronizationNeeded' automatically based on the logic we have here
 	if (!shapeWithoutTdc && isSingleToothOnPrimaryChannel != !isSynchronizationNeeded) {
 		firmwareError(ERROR_TRIGGER_DRAMA, "shapeWithoutTdc isSynchronizationNeeded isSingleToothOnPrimaryChannel constraint violation");
@@ -259,7 +262,7 @@ void TriggerWaveform::addEvent(angle_t angle, TriggerWheel const channelIndex, T
 	// todo: the whole 'useOnlyRisingEdgeForTrigger' parameter and logic should not be here
 	// todo: see calculateExpectedEventCounts
 	// related calculation should be done once trigger is initialized outside of trigger shape scope
-	if (!useOnlyRisingEdgeForTriggerTemp || state == TriggerValue::RISE) {
+	if (!useOnlyRisingEdges || state == TriggerValue::RISE) {
 		expectedEventCount[(int)channelIndex]++;
 	}
 
@@ -388,7 +391,7 @@ uint16_t TriggerWaveform::findAngleIndex(TriggerFormDetails *details, angle_t ta
 		}
 	} while (left <= right);
 	left -= 1;
-	if (useOnlyRisingEdgeForTriggerTemp) {
+	if (useOnlyRisingEdges) {
 		left &= ~1U;
 	}
 	return left;
@@ -474,11 +477,7 @@ void TriggerWaveform::initializeTriggerWaveform(operation_mode_e triggerOperatio
 
 	shapeDefinitionError = false;
 
-	bool useOnlyRisingEdgeForTrigger = triggerConfig.UseOnlyRisingEdgeForTrigger;
-	this->useOnlyRisingEdgeForTriggerTemp = useOnlyRisingEdgeForTrigger;
-
 	switch (triggerConfig.TriggerType.type) {
-
 	case TT_TOOTHED_WHEEL:
 		/**
 		 * huh? why all know skipped wheel shapes use 'setToothedWheelConfiguration' method
@@ -789,22 +788,15 @@ void TriggerWaveform::initializeTriggerWaveform(operation_mode_e triggerOperatio
 		setShapeDefinitionError(true);
 		warning(CUSTOM_ERR_NO_SHAPE, "initializeTriggerWaveform() not implemented: %d", triggerConfig.TriggerType.type);
 	}
+
 	/**
 	 * Feb 2019 suggestion: it would be an improvement to remove 'expectedEventCount' logic from 'addEvent'
 	 * and move it here, after all events were added.
 	 */
-	calculateExpectedEventCounts(useOnlyRisingEdgeForTrigger);
+	calculateExpectedEventCounts();
 	version++;
 
 	if (!shapeDefinitionError) {
 		wave.checkSwitchTimes(getCycleDuration());
-	}
-
-	if (syncEdge == SyncEdge::Both && useOnlyRisingEdgeForTrigger) {
-#if EFI_PROD_CODE || EFI_SIMULATOR
-		firmwareError(CUSTOM_ERR_BOTH_FRONTS_REQUIRED, "trigger: both fronts required");
-#else
-		warning(CUSTOM_ERR_BOTH_FRONTS_REQUIRED, "trigger: both fronts required");
-#endif
 	}
 }

--- a/firmware/controllers/trigger/decoders/trigger_structure.h
+++ b/firmware/controllers/trigger/decoders/trigger_structure.h
@@ -146,7 +146,9 @@ public:
 	// Which edge(s) to consider for finding the sync point: rise, fall, or both
 	SyncEdge syncEdge;
 
-	void calculateExpectedEventCounts(bool useOnlyRisingEdgeForTrigger);
+	bool useOnlyRisingEdges;
+
+	void calculateExpectedEventCounts();
 
 	size_t getExpectedEventCount(TriggerWheel channelIndex) const;
 
@@ -179,8 +181,6 @@ public:
 	pin_state_t initialState[PWM_PHASE_MAX_WAVE_PER_PWM];
 
 	bool isRiseEvent[PWM_PHASE_MAX_COUNT];
-
-	bool useOnlyRisingEdgeForTriggerTemp;
 
 	/* (0..1] angle range */
 	void addEvent(angle_t angle, TriggerWheel const channelIndex, TriggerValue const state);

--- a/firmware/controllers/trigger/decoders/trigger_subaru.cpp
+++ b/firmware/controllers/trigger/decoders/trigger_subaru.cpp
@@ -10,7 +10,7 @@
 #include "trigger_subaru.h"
 
 static void initialize_one_of_36_2_2_2(TriggerWaveform *s, int firstCount, int secondCount, bool hasRotaryRelevance) {
-	s->initialize(FOUR_STROKE_CRANK_SENSOR, SyncEdge::Rise);
+	s->initialize(FOUR_STROKE_CRANK_SENSOR, SyncEdge::RiseOnly);
 
 #if EFI_UNIT_TEST
 	// placed on 'cam' on '2-stroke' rotary
@@ -66,7 +66,7 @@ void initializeSubaruEZ30(TriggerWaveform *s) {
 }
 
 static void initializeSubaru7_6(TriggerWaveform *s, bool withCrankWheel) {
-	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::Rise);
+	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::RiseOnly);
 
 	/* To make trigger decoder happy last event should be exactly at 720
 	 * This code generates two trigger patterns: crank+cam (7+6) and

--- a/firmware/controllers/trigger/decoders/trigger_suzuki.cpp
+++ b/firmware/controllers/trigger/decoders/trigger_suzuki.cpp
@@ -10,7 +10,7 @@
 #include "trigger_suzuki.h"
 
 void initializeSuzukiG13B(TriggerWaveform *s) {
-	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::Rise);
+	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::RiseOnly);
 
 	float w = 5;
 	float specialTooth = 20;

--- a/firmware/controllers/trigger/decoders/trigger_universal.cpp
+++ b/firmware/controllers/trigger/decoders/trigger_universal.cpp
@@ -42,7 +42,9 @@ void initializeSkippedToothTriggerWaveformExt(TriggerWaveform *s, int totalTeeth
 		return;
 	}
 	efiAssertVoid(CUSTOM_NULL_SHAPE, s != NULL, "TriggerWaveform is NULL");
-	s->initialize(operationMode, SyncEdge::Rise);
+
+	// TODO: is this logic correct?
+	s->initialize(operationMode, skippedCount == 0 ? SyncEdge::Rise : SyncEdge::RiseOnly);
 #if EFI_UNIT_TEST
 	s->knownOperationMode = false;
 #endif // EFI_UNIT_TEST
@@ -74,7 +76,7 @@ void configureOnePlusOne(TriggerWaveform *s) {
 }
 
 void configure3_1_cam(TriggerWaveform *s) {
-	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::Rise);
+	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::RiseOnly);
 
 
 	const float crankW = 360 / 3 / 2;
@@ -153,7 +155,7 @@ void configureQuickStartSenderWheel(TriggerWaveform *s) {
 // - Honda 24+1 (set this on crank primary, single tooth cam)
 // - AEM 24+1 CAS wheel (same config as Honda)
 void configure12ToothCrank(TriggerWaveform* s) {
-	s->initialize(FOUR_STROKE_TWELVE_TIMES_CRANK_SENSOR, SyncEdge::Rise);
+	s->initialize(FOUR_STROKE_TWELVE_TIMES_CRANK_SENSOR, SyncEdge::RiseOnly);
 
 	s->shapeWithoutTdc = true;
 

--- a/firmware/controllers/trigger/trigger_central.cpp
+++ b/firmware/controllers/trigger/trigger_central.cpp
@@ -473,7 +473,7 @@ void handleShaftSignal(int signalIndex, bool isRising, efitick_t timestamp) {
 	// for effective noise filtering, we need both signal edges, 
 	// so we pass them to handleShaftSignal() and defer this test
 	if (!engineConfiguration->useNoiselessTriggerDecoder) {
-		if (!isUsefulSignal(signal, getTriggerCentral()->primaryTriggerConfiguration)) {
+		if (!isUsefulSignal(signal, getTriggerCentral()->triggerShape)) {
 			/**
 			 * no need to process VR falls further
 			 */
@@ -660,7 +660,7 @@ void TriggerCentral::handleShaftSignal(trigger_event_e signal, efitick_t timesta
 		if (!noiseFilter.noiseFilter(timestamp, &triggerState, signal)) {
 			return;
 		}
-		if (!isUsefulSignal(signal, primaryTriggerConfiguration)) {
+		if (!isUsefulSignal(signal, triggerShape)) {
 			return;
 		}
 	}

--- a/firmware/controllers/trigger/trigger_decoder.cpp
+++ b/firmware/controllers/trigger/trigger_decoder.cpp
@@ -195,7 +195,7 @@ void TriggerFormDetails::prepareEventAngles(TriggerWaveform *shape) {
 			// Wrap the angle back in to [0, 720)
 			fixAngle(angle, "trgSync", CUSTOM_TRIGGER_SYNC_ANGLE_RANGE);
 
-			if (engineConfiguration->useOnlyRisingEdgeForTrigger) {
+			if (shape->useOnlyRisingEdges) {
 				efiAssertVoid(OBD_PCM_Processor_Fault, triggerDefinitionIndex < triggerShapeLength, "trigger shape fail");
 				assertIsInBounds(triggerDefinitionIndex, shape->isRiseEvent, "isRise");
 
@@ -517,6 +517,7 @@ static bool shouldConsiderEdge(const TriggerWaveform& triggerShape, TriggerWheel
 
 	switch (triggerShape.syncEdge) {
 		case SyncEdge::Both: return true;
+		case SyncEdge::RiseOnly:
 		case SyncEdge::Rise: return edge == TriggerValue::RISE;
 		case SyncEdge::Fall: return edge == TriggerValue::FALL;
 	}
@@ -555,7 +556,7 @@ expected<TriggerDecodeResult> TriggerDecoderBase::decodeTriggerEvent(
 		}
 	}
 
-	bool useOnlyRisingEdgeForTrigger = triggerConfiguration.UseOnlyRisingEdgeForTrigger;
+	bool useOnlyRisingEdgeForTrigger = triggerShape.useOnlyRisingEdges;
 
 	efiAssert(CUSTOM_TRIGGER_UNEXPECTED, signal <= SHAFT_SECONDARY_RISING, "unexpected signal", unexpected);
 
@@ -697,7 +698,7 @@ expected<TriggerDecodeResult> TriggerDecoderBase::decodeTriggerEvent(
 			 * in case of noise the counter could be above the expected number of events, that's why 'more or equals' and not just 'equals'
 			 */
 
-			unsigned int endOfCycleIndex = triggerShape.getSize() - (triggerConfiguration.UseOnlyRisingEdgeForTrigger ? 2 : 1);
+			unsigned int endOfCycleIndex = triggerShape.getSize() - (useOnlyRisingEdgeForTrigger ? 2 : 1);
 
 			isSynchronizationPoint = !getShaftSynchronized() || (currentCycle.current_index >= endOfCycleIndex);
 

--- a/firmware/controllers/trigger/trigger_decoder.h
+++ b/firmware/controllers/trigger/trigger_decoder.h
@@ -31,12 +31,10 @@ public:
 	void update();
 
 	const char* const PrintPrefix;
-	bool UseOnlyRisingEdgeForTrigger;
 	bool VerboseTriggerSynchDetails;
 	trigger_config_s TriggerType;
 
 protected:
-	virtual bool isUseOnlyRisingEdgeForTrigger() const = 0;
 	virtual bool isVerboseTriggerSynchDetails() const = 0;
 	virtual trigger_config_s getType() const = 0;
 };
@@ -46,7 +44,6 @@ public:
 	PrimaryTriggerConfiguration() : TriggerConfiguration("TRG ") {}
 
 protected:
-	bool isUseOnlyRisingEdgeForTrigger() const override;
 	bool isVerboseTriggerSynchDetails() const override;
 	trigger_config_s getType() const override;
 };
@@ -59,7 +56,6 @@ public:
 	}
 
 protected:
-	bool isUseOnlyRisingEdgeForTrigger() const override;
 	bool isVerboseTriggerSynchDetails() const override;
 	trigger_config_s getType() const override;
 };

--- a/firmware/controllers/trigger/trigger_simulator.cpp
+++ b/firmware/controllers/trigger/trigger_simulator.cpp
@@ -21,8 +21,8 @@ static const bool isRisingEdge[HW_EVENT_TYPES] = { false, true, false, true, fal
  * todo: should this method be invoked somewhere deeper? at the moment we have too many usages too high
  * @return true if front should be decoded further, false if we are not interested
  */
-bool isUsefulSignal(trigger_event_e signal, const TriggerConfiguration& triggerConfiguration) {
-	return !triggerConfiguration.UseOnlyRisingEdgeForTrigger || isRisingEdge[(int) signal];
+bool isUsefulSignal(trigger_event_e signal, const TriggerWaveform& shape) {
+	return !shape.useOnlyRisingEdges || isRisingEdge[(int) signal];
 }
 
 #if EFI_UNIT_TEST
@@ -77,7 +77,7 @@ void TriggerStimulatorHelper::feedSimulatedEvent(
 		if (needEvent(stateIndex, multiChannelStateSequence, i)) {
 			pin_state_t currentValue = multiChannelStateSequence.getChannelState(/*phaseIndex*/i, stateIndex);
 			trigger_event_e event = (currentValue == TriggerValue::RISE ? riseEvents : fallEvents)[i];
-			if (isUsefulSignal(event, triggerConfiguration)) {
+			if (isUsefulSignal(event, shape)) {
 				state.decodeTriggerEvent(
 					"sim",
 						shape,
@@ -139,6 +139,6 @@ uint32_t TriggerStimulatorHelper::findTriggerSyncPoint(
 		}
 	}
 	shape.setShapeDefinitionError(true);
-	warning(CUSTOM_ERR_TRIGGER_SYNC, "findTriggerZeroEventIndex() failed");
+	firmwareError(CUSTOM_ERR_TRIGGER_SYNC, "findTriggerZeroEventIndex() failed");
 	return EFI_ERROR_CODE;
 }

--- a/firmware/controllers/trigger/trigger_simulator.h
+++ b/firmware/controllers/trigger/trigger_simulator.h
@@ -37,4 +37,4 @@ public:
 			int i);
 };
 
-bool isUsefulSignal(trigger_event_e signal, const TriggerConfiguration& triggerConfiguration);
+bool isUsefulSignal(trigger_event_e signal, const TriggerWaveform& shape);

--- a/unit_tests/tests/actuators/test_tacho.cpp
+++ b/unit_tests/tests/actuators/test_tacho.cpp
@@ -21,7 +21,6 @@ TEST(Actuators, Tachometer) {
 	engineConfiguration->trigger.type = TT_TOOTHED_WHEEL;
     engineConfiguration->trigger.customTotalToothCount = 8;
     engineConfiguration->trigger.customSkippedToothCount = 0;
-    engineConfiguration->useOnlyRisingEdgeForTrigger = false;
     setCamOperationMode();
 	eth.applyTriggerWaveform();
 

--- a/unit_tests/tests/ignition_injection/test_fuel_map.cpp
+++ b/unit_tests/tests/ignition_injection/test_fuel_map.cpp
@@ -86,7 +86,6 @@ TEST(misc, testFuelMap) {
 
 static void configureFordAspireTriggerWaveform(TriggerWaveform * s) {
 	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::Rise);
-	s->useOnlyRisingEdgeForTriggerTemp = false;
 
 	s->addEvent720(53.747, TriggerWheel::T_SECONDARY, TriggerValue::RISE);
 	s->addEvent720(121.90, TriggerWheel::T_SECONDARY, TriggerValue::FALL);

--- a/unit_tests/tests/ignition_injection/test_fuel_wall_wetting.cpp
+++ b/unit_tests/tests/ignition_injection/test_fuel_wall_wetting.cpp
@@ -66,7 +66,6 @@ TEST(fuel, testWallWettingEnrichmentScheduling) {
 	engineConfiguration->isFasterEngineSpinUpEnabled = false;
 
 	setCrankOperationMode();
-	engineConfiguration->useOnlyRisingEdgeForTrigger = true;
 
 	eth.setTriggerType(TT_ONE);
 

--- a/unit_tests/tests/ignition_injection/test_one_cylinder_logic.cpp
+++ b/unit_tests/tests/ignition_injection/test_one_cylinder_logic.cpp
@@ -14,7 +14,6 @@ TEST(issues, issueOneCylinderSpecialCase968) {
 	engineConfiguration->injectionMode = IM_SEQUENTIAL;
 
 	setCrankOperationMode();
-	engineConfiguration->useOnlyRisingEdgeForTrigger = true;
 
 	eth.setTriggerType(TT_ONE);
 

--- a/unit_tests/tests/test_accel_enrichment.cpp
+++ b/unit_tests/tests/test_accel_enrichment.cpp
@@ -43,7 +43,6 @@ TEST(fuel, testTpsAccelEnrichmentScheduling) {
 	EngineTestHelper eth(FORD_ASPIRE_1996);
 
 	setCrankOperationMode();
-	engineConfiguration->useOnlyRisingEdgeForTrigger = true;
 
 	engineConfiguration->tpsAccelEnrichmentThreshold = 5;
 	engineConfiguration->tpsAccelLookback = 2;

--- a/unit_tests/tests/trigger/test_cam_vvt_input.cpp
+++ b/unit_tests/tests/trigger/test_cam_vvt_input.cpp
@@ -125,8 +125,6 @@ TEST(trigger, testNB2CamInput) {
 
 	engineConfiguration->isFasterEngineSpinUpEnabled = false;
 
-	engineConfiguration->useOnlyRisingEdgeForTrigger = true;
-
 	ASSERT_EQ( 0,  round(Sensor::getOrZero(SensorType::Rpm)));
 	for (int i = 0; i < 6;i++) {
 		eth.fireRise(25 * 70 / 180);
@@ -177,5 +175,5 @@ TEST(trigger, testNB2CamInput) {
 	// actually position based on VVT!
 	ASSERT_EQ(totalRevolutionCountBeforeVvtSync + 3, engine->triggerCentral.triggerState.getCrankSynchronizationCounter());
 
-	EXPECT_EQ(40, waveChart.getSize());
+	EXPECT_EQ(24, waveChart.getSize());
 }

--- a/unit_tests/tests/trigger/test_cam_vvt_input.cpp
+++ b/unit_tests/tests/trigger/test_cam_vvt_input.cpp
@@ -175,5 +175,5 @@ TEST(trigger, testNB2CamInput) {
 	// actually position based on VVT!
 	ASSERT_EQ(totalRevolutionCountBeforeVvtSync + 3, engine->triggerCentral.triggerState.getCrankSynchronizationCounter());
 
-	EXPECT_EQ(24, waveChart.getSize());
+	EXPECT_EQ(40, waveChart.getSize());
 }

--- a/unit_tests/tests/trigger/test_issue_898.cpp
+++ b/unit_tests/tests/trigger/test_issue_898.cpp
@@ -10,7 +10,6 @@
 static void boardConfigurationForIssue898(engine_configuration_s *engineConfiguration) {
 	setCrankOperationMode();
 	engineConfiguration->trigger.type = TT_TOOTHED_WHEEL_60_2;
-	engineConfiguration->useOnlyRisingEdgeForTrigger = true;
 }
 
 TEST(issues, issue898) {

--- a/unit_tests/tests/trigger/test_quad_cam.cpp
+++ b/unit_tests/tests/trigger/test_quad_cam.cpp
@@ -23,7 +23,6 @@ TEST(trigger, testQuadCam) {
 	// this crank trigger would be easier to test, crank shape is less important for this test
 	eth.setTriggerType(TT_ONE);
 
-	engineConfiguration->useOnlyRisingEdgeForTrigger = true;
 	engineConfiguration->vvtCamSensorUseRise = true;
 
 	ASSERT_EQ(0, Sensor::getOrZero(SensorType::Rpm));

--- a/unit_tests/tests/trigger/test_quad_cam.cpp
+++ b/unit_tests/tests/trigger/test_quad_cam.cpp
@@ -23,8 +23,6 @@ TEST(trigger, testQuadCam) {
 	// this crank trigger would be easier to test, crank shape is less important for this test
 	eth.setTriggerType(TT_ONE);
 
-	engineConfiguration->vvtCamSensorUseRise = true;
-
 	ASSERT_EQ(0, Sensor::getOrZero(SensorType::Rpm));
 
 	eth.fireRise(25);

--- a/unit_tests/tests/trigger/test_real_cranking_nissan_vq40.cpp
+++ b/unit_tests/tests/trigger/test_real_cranking_nissan_vq40.cpp
@@ -46,7 +46,7 @@ static void test(int engineSyncCam, float camOffsetAdd) {
 
 	EXPECT_NEAR(engine->triggerCentral.getVVTPosition(/*bankIndex*/0, /*camIndex*/0), -45.64, 1e-2);
 	EXPECT_NEAR(engine->triggerCentral.getVVTPosition(/*bankIndex*/1, /*camIndex*/0), -45.45, 1e-2);
-	ASSERT_EQ(101, round(Sensor::getOrZero(SensorType::Rpm)))<< reader.lineIndex();
+	ASSERT_EQ(102, round(Sensor::getOrZero(SensorType::Rpm)))<< reader.lineIndex();
 
 	// TODO: why warnings?
 	ASSERT_EQ(2, eth.recentWarnings()->getCount());

--- a/unit_tests/tests/trigger/test_trigger_decoder.cpp
+++ b/unit_tests/tests/trigger/test_trigger_decoder.cpp
@@ -419,7 +419,6 @@ TEST(trigger, testTriggerDecoder) {
 	EngineTestHelperBase base(&e, &c.engineConfiguration, &c);
 	TriggerWaveform * s = &e.triggerCentral.triggerShape;
 
-	s->useOnlyRisingEdgeForTriggerTemp = false;
 	initializeSkippedToothTriggerWaveformExt(s, 2, 0, FOUR_STROKE_CAM_SENSOR);
 	assertEqualsM("shape size", s->getSize(), 4);
 	ASSERT_EQ(s->wave.getSwitchTime(0), 0.25);

--- a/unit_tests/tests/trigger/test_trigger_decoder.cpp
+++ b/unit_tests/tests/trigger/test_trigger_decoder.cpp
@@ -460,7 +460,6 @@ TEST(trigger, testTriggerDecoder) {
 		EngineTestHelper eth(MITSU_4G93);
 
 
-		eth.persistentConfig.engineConfiguration.useOnlyRisingEdgeForTrigger = false;
 		eth.persistentConfig.engineConfiguration.sensorChartMode = SC_DETAILED_RPM;
 		applyNonPersistentConfiguration();
 
@@ -476,7 +475,6 @@ TEST(trigger, testTriggerDecoder) {
 		EngineTestHelper eth(DODGE_NEON_2003_CRANK);
 
 		printf("!!!!!!!!!!!!!!!!!! Now trying with only rising edges !!!!!!!!!!!!!!!!!\r\n");
-		engineConfiguration->useOnlyRisingEdgeForTrigger = true;
 
 		applyNonPersistentConfiguration();
 		prepareOutputSignals();
@@ -1058,7 +1056,6 @@ TEST(big, testSparkReverseOrderBug319) {
 	engineConfiguration->isFasterEngineSpinUpEnabled = false;
 	engine->tdcMarkEnabled = false;
 
-	engineConfiguration->useOnlyRisingEdgeForTrigger = false;
 	engineConfiguration->isInjectionEnabled = false;
 	engineConfiguration->specs.cylindersCount = 4;
 	engineConfiguration->ignitionMode = IM_INDIVIDUAL_COILS;
@@ -1162,7 +1159,6 @@ TEST(big, testMissedSpark299) {
 
 	EngineTestHelper eth(TEST_ENGINE);
 	engineConfiguration->ignitionMode = IM_WASTED_SPARK;
-	engineConfiguration->useOnlyRisingEdgeForTrigger = false;
 	setupSimpleTestEngineWithMafAndTT_ONE_trigger(&eth);
 	engineConfiguration->isIgnitionEnabled = true;
 	engineConfiguration->isInjectionEnabled = false;

--- a/unit_tests/tests/trigger/test_trigger_decoder_2.cpp
+++ b/unit_tests/tests/trigger/test_trigger_decoder_2.cpp
@@ -5,17 +5,12 @@ using ::testing::StrictMock;
 
 class MockTriggerConfiguration : public TriggerConfiguration {
 public:
-	MockTriggerConfiguration(bool useOnlyRise, trigger_config_s type)
+	MockTriggerConfiguration(trigger_config_s type)
 		: TriggerConfiguration("Mock")
-		, m_useOnlyRise(useOnlyRise)
 		, m_type(type)
 	{ }
 
 protected:
-	bool isUseOnlyRisingEdgeForTrigger() const override {
-		return m_useOnlyRise;
-	}
-
 	bool isVerboseTriggerSynchDetails() const override {
 		return false;
 	}
@@ -25,7 +20,6 @@ protected:
 	}
 
 private:
-	const bool m_useOnlyRise;
 	const trigger_config_s m_type;
 };
 
@@ -47,7 +41,7 @@ static auto makeTriggerShape(operation_mode_e mode, const TriggerConfiguration& 
 #define doTooth(dut, shape, cfg, t) dut.decodeTriggerEvent("", shape, nullptr, cfg, SHAFT_PRIMARY_RISING, t)
 
 TEST(TriggerDecoder, FindsFirstSyncPoint) {
-	MockTriggerConfiguration cfg(true, {TT_TOOTHED_WHEEL, 4, 1});
+	MockTriggerConfiguration cfg({TT_TOOTHED_WHEEL, 4, 1});
 	cfg.update();
 
 	auto shape = makeTriggerShape(FOUR_STROKE_CAM_SENSOR, cfg);
@@ -90,7 +84,7 @@ TEST(TriggerDecoder, FindsFirstSyncPoint) {
 
 
 TEST(TriggerDecoder, FindsSyncPointMultipleRevolutions) {
-	MockTriggerConfiguration cfg(true, {TT_TOOTHED_WHEEL, 4, 1});
+	MockTriggerConfiguration cfg({TT_TOOTHED_WHEEL, 4, 1});
 	cfg.update();
 
 	auto shape = makeTriggerShape(FOUR_STROKE_CAM_SENSOR, cfg);
@@ -140,7 +134,7 @@ TEST(TriggerDecoder, FindsSyncPointMultipleRevolutions) {
 }
 
 TEST(TriggerDecoder, TooManyTeeth_CausesError) {
-	MockTriggerConfiguration cfg(true, {TT_TOOTHED_WHEEL, 4, 1});
+	MockTriggerConfiguration cfg({TT_TOOTHED_WHEEL, 4, 1});
 	cfg.update();
 
 	auto shape = makeTriggerShape(FOUR_STROKE_CAM_SENSOR, cfg);
@@ -218,7 +212,7 @@ TEST(TriggerDecoder, TooManyTeeth_CausesError) {
 }
 
 TEST(TriggerDecoder, NotEnoughTeeth_CausesError) {
-	MockTriggerConfiguration cfg(true, {TT_TOOTHED_WHEEL, 4, 1});
+	MockTriggerConfiguration cfg({TT_TOOTHED_WHEEL, 4, 1});
 	cfg.update();
 
 	auto shape = makeTriggerShape(FOUR_STROKE_CAM_SENSOR, cfg);
@@ -295,7 +289,7 @@ TEST(TriggerDecoder, NotEnoughTeeth_CausesError) {
 }
 
 TEST(TriggerDecoder, PrimaryDecoderNoDisambiguation) {
-	MockTriggerConfiguration cfg(true, {TT_TOOTHED_WHEEL, 4, 1});
+	MockTriggerConfiguration cfg({TT_TOOTHED_WHEEL, 4, 1});
 	cfg.update();
 
 	auto shape = makeTriggerShape(FOUR_STROKE_CAM_SENSOR, cfg);
@@ -326,7 +320,7 @@ TEST(TriggerDecoder, PrimaryDecoderNoDisambiguation) {
 }
 
 TEST(TriggerDecoder, PrimaryDecoderNeedsDisambiguation) {
-	MockTriggerConfiguration cfg(true, {TT_TOOTHED_WHEEL, 4, 1});
+	MockTriggerConfiguration cfg({TT_TOOTHED_WHEEL, 4, 1});
 	cfg.update();
 
 	auto shape = makeTriggerShape(FOUR_STROKE_CRANK_SENSOR, cfg);

--- a/unit_tests/tests/trigger/test_trigger_input_adc.cpp
+++ b/unit_tests/tests/trigger/test_trigger_input_adc.cpp
@@ -75,7 +75,6 @@ TEST(big, testTriggerInputAdc) {
 	EngineTestHelper eth(TEST_ENGINE);
 
 	engineConfiguration->ignitionMode = IM_WASTED_SPARK;
-	engineConfiguration->useOnlyRisingEdgeForTrigger = true;
 
 	engineConfiguration->adcVcc = 3.3f;
 	engineConfiguration->analogInputDividerCoefficient = 2.0f;

--- a/unit_tests/tests/trigger/test_trigger_multi_sync.cpp
+++ b/unit_tests/tests/trigger/test_trigger_multi_sync.cpp
@@ -10,7 +10,9 @@
 
 TEST(trigger, miataNA) {
 	TriggerWaveform naShape;
-	naShape.useOnlyRisingEdgeForTriggerTemp = false;
+
+	// TODO: why?
+	//naShape.useOnlyRisingEdgeForTriggerTemp = false;
 	initializeMazdaMiataNaShape(&naShape);
 
 	EngineTestHelper eth(FRANKENSO_MIATA_NA6_MAP);

--- a/unit_tests/tests/trigger/test_trigger_noiseless.cpp
+++ b/unit_tests/tests/trigger/test_trigger_noiseless.cpp
@@ -164,7 +164,6 @@ TEST(trigger, noiselessDecoder) {
 	EngineTestHelper eth(TEST_ENGINE);
 
 	engineConfiguration->ignitionMode = IM_WASTED_SPARK;
-	engineConfiguration->useOnlyRisingEdgeForTrigger = true;
 
 	// we'll test on 60-2 wheel
 	eth.setTriggerType(TT_TOOTHED_WHEEL_60_2);


### PR DESCRIPTION
We don't need to let the user pick this - we can infer it from the trigger type. We've had a few issues recently where users shot themselves in the foot with an unexpected selection on this option.

There are three categories of trigger with different "use only rise" behavior:

1. Old engines with obscure triggers
2. Modern engines with high tooth count (24-1, 60-2, etc)
3. VR sensors (or hall with one useless edge, ex Miata NB)

Why does this change work with each:

1. has a specific trigger implementation for that engine/sensor/pattern combination, so we can safely hard-code whether to useOnlyRise
2. doesn't need the added precision from falling edges, and would just add unnecessary CPU load, so we can force it off.
3. doesn't have useful falling edges anyway. This category fully overlaps with 1 and 2: 'weird' triggers we know the right answer, and skipped-tooth doesn't need the falling edge.

fix #4470
more completely fix #4606 