### PR TITLE
minor priming refactor

### DIFF
--- a/firmware/controllers/engine_controller.cpp
+++ b/firmware/controllers/engine_controller.cpp
@@ -194,8 +194,6 @@ static void doPeriodicSlowCallback() {
 
 	if (engine->rpmCalculator.isStopped()) {
 		resetAccel();
-	} else {
-		updatePrimeInjectionPulseState();
 	}
 
 	if (engine->versionForConfigurationListeners.isOld(engine->getGlobalConfigurationVersion())) {

--- a/firmware/controllers/engine_cycle/prime_injection.h
+++ b/firmware/controllers/engine_cycle/prime_injection.h
@@ -12,6 +12,7 @@
 class PrimeController : public EngineModule {
 public:
 	void onIgnitionStateChanged(bool ignitionOn) override;
+	void onSlowCallback() override;
 
 	floatms_t getPrimeDuration() const;
 
@@ -35,7 +36,7 @@ private:
 	static void onPrimeEndAdapter(PrimeController* instance) {
 		instance->onPrimeEnd();
 	}
-};
 
-// reset injection switch counter if the engine started spinning
-void updatePrimeInjectionPulseState();
+	uint32_t getKeyCycleCounter() const;
+	void setKeyCycleCounter(uint32_t count);
+};


### PR DESCRIPTION
- code style
- fix bug where prime reset could only happen once per ECU power cycle (ignition start/run cycles with USB connected didn't re-prime on subsequent starts)
- use `onSlowCallback` instead of calling from `engine_controller.cpp`