### PR TITLE
fix instant rpm clearing bug

### DIFF
--- a/firmware/controllers/engine_cycle/rpm_calculator.cpp
+++ b/firmware/controllers/engine_cycle/rpm_calculator.cpp
@@ -209,11 +209,9 @@ uint32_t RpmCalculator::getRevolutionCounterM(void) const {
 }
 
 void RpmCalculator::onSlowCallback() {
-	/**
-	 * Update engine RPM state if needed (check timeouts).
-	 */
-	if (!checkIfSpinning(getTimeNowNt())) {
-		engine->rpmCalculator.setStopSpinning();
+	// Stop the engine if it's been too long since we got a trigger event
+	if (!engine->triggerCentral.engineMovedRecently(getTimeNowNt())) {
+		setStopSpinning();
 	}
 }
 

--- a/firmware/controllers/trigger/decoders/trigger_structure.h
+++ b/firmware/controllers/trigger/decoders/trigger_structure.h
@@ -294,5 +294,3 @@ void findTriggerPosition(
 void setToothedWheelConfiguration(TriggerWaveform *s, int total, int skipped, operation_mode_e operationMode);
 
 #define TRIGGER_WAVEFORM(x) getTriggerCentral()->triggerShape.x
-
-#define getTriggerSize() TRIGGER_WAVEFORM(wave.phaseCount)

--- a/firmware/controllers/trigger/trigger_decoder.cpp
+++ b/firmware/controllers/trigger/trigger_decoder.cpp
@@ -280,6 +280,8 @@ float PrimaryTriggerDecoder::calculateInstantRpm(
 	// now let's get precise angle for that event
 	angle_t prevIndexAngle = triggerFormDetails->eventAngles[prevIndex];
 	efitick_t time90ago = timeOfLastEvent[prevIndex];
+
+	// No previous timestamp, instant RPM isn't ready yet
 	if (time90ago == 0) {
 		return prevInstantRpmValue;
 	}
@@ -293,9 +295,10 @@ float PrimaryTriggerDecoder::calculateInstantRpm(
 	// Wrap the angle in to the correct range (ie, could be -630 when we want +90)
 	fixAngle(angleDiff, "angleDiff", CUSTOM_ERR_6561);
 
-	// just for safety
-	if (time == 0)
+	// just for safety, avoid divide-by-0
+	if (time == 0) {
 		return prevInstantRpmValue;
+	}
 
 	float instantRpm = (60000000.0 / 360 * US_TO_NT_MULTIPLIER) * angleDiff / time;
 	assertIsInBoundsWithResult(current_index, instantRpmValue, "instantRpmValue", 0);

--- a/unit_tests/tests/trigger/test_real_gm_24x.cpp
+++ b/unit_tests/tests/trigger/test_real_gm_24x.cpp
@@ -12,10 +12,23 @@ TEST(crankingGm24x, gmRealCrankingFromFile) {
 
 	eth.setTriggerType(TT_GM_24x);
 
+	int eventCount = 0;
+	bool gotRpm = false;
+
 	while (reader.haveMore()) {
 		reader.processLine(&eth);
+		eventCount++;
 
 		engine->rpmCalculator.onSlowCallback();
+
+		auto rpm = Sensor::getOrZero(SensorType::Rpm);
+		if (!gotRpm && rpm) {
+			gotRpm = true;
+
+			// We should get first RPM on exactly the first sync point - this means the instant RPM pre-sync event copy all worked OK
+			EXPECT_EQ(eventCount, 23);
+			EXPECT_NEAR(rpm, 77.0f, 0.1);
+		}
 	}
 
 	ASSERT_EQ( 0, eth.recentWarnings()->getCount())<< "warningCounter#vwRealCranking";


### PR DESCRIPTION
`checkIfSpinning` is too strict - we don't want to reset RPM state if we simply haven't seen a sync point yet, but only if we've stopped seeing trigger events.  With the old logic, we never got instant RPM on the first sync point, and didn't get it until the second sync point, slowing down engine sync by one or two whole crank revolutions!

Tested on a real car to actually improve starting, as we start firing inj/ign events one trigger cycle earlier.