### PR TITLE
change triggers that need RiseOnly

### DIFF
--- a/firmware/controllers/trigger/decoders/trigger_chrysler.cpp
+++ b/firmware/controllers/trigger/decoders/trigger_chrysler.cpp
@@ -26,7 +26,7 @@ void initDodgeRam(TriggerWaveform *s) {
 }
 
 void configureNeon2003TriggerWaveformCrank(TriggerWaveform *s) {
-	s->initialize(FOUR_STROKE_CRANK_SENSOR, SyncEdge::Rise);
+	s->initialize(FOUR_STROKE_CRANK_SENSOR, SyncEdge::RiseOnly);
 
 	s->setTriggerSynchronizationGap(3);
 
@@ -321,7 +321,7 @@ gap=1.43/0.71
 }
 
 void configureDodgeStratusTriggerWaveform(TriggerWaveform *s) {
-	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::Rise);
+	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::RiseOnly);
 	s->tdcPosition = 150;
 
 	float w = 7;
@@ -467,7 +467,7 @@ void configureNeon1995TriggerWaveform(TriggerWaveform *s) {
 }
 
 void initJeep18_2_2_2(TriggerWaveform *s) {
-	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::Rise);
+	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::RiseOnly);
 	s->isSynchronizationNeeded = false;
 	s->tdcPosition = 581;
 
@@ -550,7 +550,7 @@ static void add4cylblock(int off, TriggerWaveform *s) {
 
 // TT_JEEP_4_CYL
 void initJeep_XJ_4cyl_2500(TriggerWaveform *s) {
-	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::Rise);
+	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::RiseOnly);
 	s->isSynchronizationNeeded = false;
 	s->tdcPosition = 720 - 236;
 
@@ -569,7 +569,7 @@ void initJeep_XJ_4cyl_2500(TriggerWaveform *s) {
 }
 
 void configureChryslerNGC_36_2_2(TriggerWaveform *s) {
-	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::Rise);
+	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::RiseOnly);
 
 	float wide = 30 * 2;
 	float narrow = 10 * 2;

--- a/firmware/controllers/trigger/decoders/trigger_gm.cpp
+++ b/firmware/controllers/trigger/decoders/trigger_gm.cpp
@@ -22,7 +22,7 @@ static float addTooth(float offset, TriggerWaveform *s) {
  * GM/Daewoo Distributor on the F8CV
  */
 void configureGm60_2_2_2(TriggerWaveform *s) {
-	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::Rise);
+	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::RiseOnly);
 	s->isSynchronizationNeeded = false;
 	s->isSecondWheelCam = true;
 
@@ -61,7 +61,7 @@ void configureGm60_2_2_2(TriggerWaveform *s) {
 }
 
 void configureGmTriggerWaveform(TriggerWaveform *s) {
-	s->initialize(FOUR_STROKE_CRANK_SENSOR, SyncEdge::Rise);
+	s->initialize(FOUR_STROKE_CRANK_SENSOR, SyncEdge::RiseOnly);
 
 	float w = 5;
 

--- a/firmware/controllers/trigger/decoders/trigger_honda.cpp
+++ b/firmware/controllers/trigger/decoders/trigger_honda.cpp
@@ -11,7 +11,7 @@
 #include "trigger_universal.h"
 
 void configureHondaCbr600(TriggerWaveform *s) {
-	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::Rise);
+	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::RiseOnly);
 	s->useOnlyPrimaryForSync = true;
 	s->setTriggerSynchronizationGap(6);
 
@@ -52,7 +52,7 @@ void configureHondaCbr600(TriggerWaveform *s) {
 }
 
 void configureOnePlus16(TriggerWaveform *s) {
-	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::Rise);
+	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::RiseOnly);
 
 	int count = 16;
 	float tooth = s->getCycleDuration() / count;
@@ -77,7 +77,7 @@ static void kseriesTooth(TriggerWaveform* s, float end) {
 
 // TT_HONDA_K_CRANK_12_1
 void configureHondaK_12_1(TriggerWaveform *s) {
-	s->initialize(FOUR_STROKE_CRANK_SENSOR, SyncEdge::Rise);
+	s->initialize(FOUR_STROKE_CRANK_SENSOR, SyncEdge::RiseOnly);
 
 	// nominal gap 0.33
 	s->setSecondTriggerSynchronizationGap2(0.2f, 0.5f);
@@ -100,7 +100,7 @@ void configureHondaK_12_1(TriggerWaveform *s) {
  * 2003 Honda Element
  */
 void configureHondaK_4_1(TriggerWaveform *s) {
-	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::Rise);
+	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::RiseOnly);
 
 	s->setTriggerSynchronizationGap3(/*gapIndex*/0, 1.5, 4.5);	// nominal 2.27
 	s->setTriggerSynchronizationGap3(/*gapIndex*/1, 0.1, 0.5);	// nominal 0.28

--- a/firmware/controllers/trigger/decoders/trigger_mazda.cpp
+++ b/firmware/controllers/trigger/decoders/trigger_mazda.cpp
@@ -62,7 +62,7 @@ void initializeMazdaMiataNb2Crank(TriggerWaveform *s) {
 	 * Note how we use 0..180 range while defining FOUR_STROKE_SYMMETRICAL_CRANK_SENSOR trigger
 	 * Note that only half of the physical wheel is defined here!
 	 */
-	s->initialize(FOUR_STROKE_SYMMETRICAL_CRANK_SENSOR, SyncEdge::Rise);
+	s->initialize(FOUR_STROKE_SYMMETRICAL_CRANK_SENSOR, SyncEdge::RiseOnly);
 
 	s->tdcPosition = 60 + 655;
 
@@ -145,7 +145,7 @@ void configureMazdaProtegeSOHC(TriggerWaveform *s) {
 }
 
 void configureMazdaProtegeLx(TriggerWaveform *s) {
-	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::Rise);
+	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::RiseOnly);
 	s->isSecondWheelCam = true;
 	/**
 	 * based on https://svn.code.sf.net/p/rusefi/code/trunk/misc/logs/1993_escort_gt/MAIN_rfi_report_2015-02-01%2017_39.csv
@@ -171,7 +171,7 @@ void configureMazdaProtegeLx(TriggerWaveform *s) {
 }
 
 void initializeMazdaMiataVVtCamShape(TriggerWaveform *s) {
-	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::Rise);
+	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::RiseOnly);
 
 	// Nominal gap is 8.92
 	s->setTriggerSynchronizationGap2(6, 20);
@@ -191,7 +191,7 @@ void initializeMazdaMiataVVtCamShape(TriggerWaveform *s) {
 // https://rusefi.com/forum/viewtopic.php?f=17&t=2417
 // Cam pattern for intake/exhaust on all Skyactiv-G (and maybe -D/-X)
 void initializeMazdaSkyactivCam(TriggerWaveform *s) {
-	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::Rise);
+	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::RiseOnly);
 
     // wide
 	s->addEvent360(50, TriggerWheel::T_PRIMARY, TriggerValue::RISE);

--- a/firmware/controllers/trigger/decoders/trigger_misc.cpp
+++ b/firmware/controllers/trigger/decoders/trigger_misc.cpp
@@ -27,7 +27,7 @@ void configureFiatIAQ_P8(TriggerWaveform * s) {
 
 // TT_TRI_TACH
 void configureTriTach(TriggerWaveform * s) {
-	s->initialize(FOUR_STROKE_CRANK_SENSOR, SyncEdge::Rise);
+	s->initialize(FOUR_STROKE_CRANK_SENSOR, SyncEdge::RiseOnly);
 
 	s->isSynchronizationNeeded = false;
 
@@ -79,7 +79,7 @@ void configureFordPip(TriggerWaveform * s) {
 }
 
 void configureFordST170(TriggerWaveform * s) {
-	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::Rise);
+	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::RiseOnly);
 	int width = 10;
 
 	int total = s->getCycleDuration() / 8;
@@ -101,7 +101,7 @@ void configureFordST170(TriggerWaveform * s) {
 }
 
 void configureDaihatsu4(TriggerWaveform * s) {
-	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::Rise);
+	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::RiseOnly);
 
 	int width = 10;
 
@@ -123,7 +123,7 @@ void configureDaihatsu4(TriggerWaveform * s) {
 }
 
 void configureBarra3plus1cam(TriggerWaveform *s) {
-	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::Rise);
+	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::RiseOnly);
 
 	// This wheel has four teeth
 	// two short gaps, and two long gaps

--- a/firmware/controllers/trigger/decoders/trigger_mitsubishi.cpp
+++ b/firmware/controllers/trigger/decoders/trigger_mitsubishi.cpp
@@ -11,7 +11,7 @@
 #include "trigger_universal.h"
 
 void configureFordAspireTriggerWaveform(TriggerWaveform * s) {
-	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::Rise);
+	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::RiseOnly);
 	s->isSynchronizationNeeded = false;
 	s->isSecondWheelCam = true;
 
@@ -55,7 +55,7 @@ void initializeMitsubishi4g18(TriggerWaveform *s) {
 }
 
 void initialize36_2_1_1(TriggerWaveform *s) {
-	s->initialize(FOUR_STROKE_CRANK_SENSOR, SyncEdge::Rise);
+	s->initialize(FOUR_STROKE_CRANK_SENSOR, SyncEdge::RiseOnly);
 	s->tdcPosition = 90;
 	int totalTeethCount = 36;
 
@@ -85,7 +85,7 @@ void initialize36_2_1_1(TriggerWaveform *s) {
 }
 
 void initialize36_2_1(TriggerWaveform *s) {
-	s->initialize(FOUR_STROKE_CRANK_SENSOR, SyncEdge::Rise);
+	s->initialize(FOUR_STROKE_CRANK_SENSOR, SyncEdge::RiseOnly);
 	s->tdcPosition = 90;
 	int totalTeethCount = 36;
 
@@ -110,7 +110,7 @@ void initialize36_2_1(TriggerWaveform *s) {
 }
 
 void initializeVvt3A92(TriggerWaveform *s) {
-	s->initialize(FOUR_STROKE_CRANK_SENSOR, SyncEdge::Rise);
+	s->initialize(FOUR_STROKE_CRANK_SENSOR, SyncEdge::RiseOnly);
 
 	int w = 5;
 	s->addEvent360(120 - w, TriggerWheel::T_PRIMARY, TriggerValue::RISE);

--- a/firmware/controllers/trigger/decoders/trigger_nissan.cpp
+++ b/firmware/controllers/trigger/decoders/trigger_nissan.cpp
@@ -46,7 +46,7 @@ static void addPrimaryToothEndingAt(TriggerWaveform *s, float fallAngle) {
 }
 
 void initializeNissanVQvvt(TriggerWaveform *s) {
-	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::Rise);
+	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::RiseOnly);
 
 	int offset = 720 - 520;
 
@@ -77,7 +77,7 @@ void makeNissanPattern(TriggerWaveform* s, size_t halfCylinderCount, size_t tota
 }
 
 void initializeNissanVQ35crank(TriggerWaveform *s) {
-	s->initialize(FOUR_STROKE_THREE_TIMES_CRANK_SENSOR, SyncEdge::Rise);
+	s->initialize(FOUR_STROKE_THREE_TIMES_CRANK_SENSOR, SyncEdge::RiseOnly);
 
 	s->tdcPosition = 675;
 
@@ -89,7 +89,7 @@ void initializeNissanVQ35crank(TriggerWaveform *s) {
 }
 
 void initializeNissanMR18crank(TriggerWaveform *s) {
-	s->initialize(FOUR_STROKE_SYMMETRICAL_CRANK_SENSOR, SyncEdge::Rise);
+	s->initialize(FOUR_STROKE_SYMMETRICAL_CRANK_SENSOR, SyncEdge::RiseOnly);
 
 	s->tdcPosition = 80;
 
@@ -99,7 +99,7 @@ void initializeNissanMR18crank(TriggerWaveform *s) {
 }
 
 void initializeNissanQR25crank(TriggerWaveform *s) {
-	s->initialize(FOUR_STROKE_SYMMETRICAL_CRANK_SENSOR, SyncEdge::Rise);
+	s->initialize(FOUR_STROKE_SYMMETRICAL_CRANK_SENSOR, SyncEdge::RiseOnly);
 	s->setTriggerSynchronizationGap(0.33);
 	s->setSecondTriggerSynchronizationGap(3);
 
@@ -121,7 +121,7 @@ static void addvq30tooth(TriggerWaveform *s, float angle) {
 // yes, this is CAM shaft shape NOT crank shaft shape!
 // we will add crank shape once Pavel makes progress
 void initializeNissanVQ30cam(TriggerWaveform *s) {
-	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::Rise);
+	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::RiseOnly);
 
 	s->tdcPosition = 120;
 
@@ -160,7 +160,7 @@ void initializeNissanVQ30cam(TriggerWaveform *s) {
 }
 
 void initializeNissanMRvvt(TriggerWaveform *s) {
-	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::Rise);
+	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::RiseOnly);
 	s->tdcPosition = 0;
 
 	int x = 73;

--- a/firmware/controllers/trigger/decoders/trigger_renix.cpp
+++ b/firmware/controllers/trigger/decoders/trigger_renix.cpp
@@ -32,12 +32,12 @@ static void commonRenix(TriggerWaveform *s) {
 
 // TT_RENIX_44_2_2
 void initializeRenix44_2_2(TriggerWaveform *s) {
-	s->initialize(FOUR_STROKE_SYMMETRICAL_CRANK_SENSOR, SyncEdge::Rise);
+	s->initialize(FOUR_STROKE_SYMMETRICAL_CRANK_SENSOR, SyncEdge::RiseOnly);
 	commonRenix(s);
 }
 
 // TT_RENIX_66_2_2_2
 void initializeRenix66_2_2(TriggerWaveform *s) {
-	s->initialize(FOUR_STROKE_THREE_TIMES_CRANK_SENSOR, SyncEdge::Rise);
+	s->initialize(FOUR_STROKE_THREE_TIMES_CRANK_SENSOR, SyncEdge::RiseOnly);
 	commonRenix(s);
 }

--- a/firmware/controllers/trigger/decoders/trigger_rover.cpp
+++ b/firmware/controllers/trigger/decoders/trigger_rover.cpp
@@ -14,7 +14,7 @@
  * https://en.wikipedia.org/wiki/Rover_K-series_engine
  */
 void initializeRoverK(TriggerWaveform *s) {
-	s->initialize(FOUR_STROKE_CRANK_SENSOR, SyncEdge::Rise);
+	s->initialize(FOUR_STROKE_CRANK_SENSOR, SyncEdge::RiseOnly);
 
 	float tooth = 20;
 

--- a/firmware/controllers/trigger/decoders/trigger_structure.cpp
+++ b/firmware/controllers/trigger/decoders/trigger_structure.cpp
@@ -476,6 +476,10 @@ void TriggerWaveform::initializeTriggerWaveform(operation_mode_e triggerOperatio
 
 	this->useOnlyRisingEdges = triggerConfig.UseOnlyRisingEdgeForTrigger;
 
+	if (syncEdge == SyncEdge::RiseOnly && !this->useOnlyRisingEdges) {
+		// firmwareError(OBD_PCM_Processor_Fault, "useOnlyRise must be set");
+	}
+
 	switch (triggerConfig.TriggerType.type) {
 
 	case TT_TOOTHED_WHEEL:

--- a/firmware/controllers/trigger/decoders/trigger_structure.cpp
+++ b/firmware/controllers/trigger/decoders/trigger_structure.cpp
@@ -476,10 +476,6 @@ void TriggerWaveform::initializeTriggerWaveform(operation_mode_e triggerOperatio
 
 	this->useOnlyRisingEdges = triggerConfig.UseOnlyRisingEdgeForTrigger;
 
-	if (syncEdge == SyncEdge::RiseOnly && !this->useOnlyRisingEdges) {
-		// firmwareError(OBD_PCM_Processor_Fault, "useOnlyRise must be set");
-	}
-
 	switch (triggerConfig.TriggerType.type) {
 
 	case TT_TOOTHED_WHEEL:

--- a/firmware/controllers/trigger/decoders/trigger_subaru.cpp
+++ b/firmware/controllers/trigger/decoders/trigger_subaru.cpp
@@ -9,8 +9,8 @@
 
 #include "trigger_subaru.h"
 
-static void initialize_one_of_36_2_2_2(TriggerWaveform *s, int firstCount, int secondCount, bool hasRotaryRelevance) {
-	s->initialize(FOUR_STROKE_CRANK_SENSOR, SyncEdge::Rise);
+static void initialize_one_of_36_2_2_2(TriggerWaveform *s, int firstCount, int secondCount) {
+	s->initialize(FOUR_STROKE_CRANK_SENSOR, SyncEdge::RiseOnly);
 
 #if EFI_UNIT_TEST
 	// placed on 'cam' on '2-stroke' rotary
@@ -50,7 +50,7 @@ static void initialize_one_of_36_2_2_2(TriggerWaveform *s, int firstCount, int s
  * https://rusefi.com/forum/viewtopic.php?f=2&t=1932
  */
 void initialize36_2_2_2(TriggerWaveform *s) {
-	initialize_one_of_36_2_2_2(s, 12, 15, true);
+	initialize_one_of_36_2_2_2(s, 12, 15);
 
 	s->setTriggerSynchronizationGap(0.333f);
 	s->setSecondTriggerSynchronizationGap(1.0f);
@@ -58,7 +58,7 @@ void initialize36_2_2_2(TriggerWaveform *s) {
 }
 
 void initializeSubaruEZ30(TriggerWaveform *s) {
-	initialize_one_of_36_2_2_2(s, 18, 9, true);
+	initialize_one_of_36_2_2_2(s, 18, 9);
 
 	s->setTriggerSynchronizationGap3(/*gapIndex*/0, 0.25, 0.5);
 	s->setTriggerSynchronizationGap3(/*gapIndex*/1, 0.7, 1.5);
@@ -66,7 +66,7 @@ void initializeSubaruEZ30(TriggerWaveform *s) {
 }
 
 static void initializeSubaru7_6(TriggerWaveform *s, bool withCrankWheel) {
-	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::Rise);
+	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::RiseOnly);
 
 	/* To make trigger decoder happy last event should be exactly at 720
 	 * This code generates two trigger patterns: crank+cam (7+6) and
@@ -223,6 +223,8 @@ void initializeSubaru_SVX(TriggerWaveform *s) {
 #endif
 
 		/* we should use only falling edges */
+	// TODO: this trigger needs to be converted to SyncEdge::RiseOnly, so invert all rise/fall events!
+	// see https://github.com/rusefi/rusefi/issues/4624
 	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::Fall);
 	s->isSynchronizationNeeded = false;
 	s->useOnlyPrimaryForSync = true;

--- a/firmware/controllers/trigger/decoders/trigger_suzuki.cpp
+++ b/firmware/controllers/trigger/decoders/trigger_suzuki.cpp
@@ -10,7 +10,7 @@
 #include "trigger_suzuki.h"
 
 void initializeSuzukiG13B(TriggerWaveform *s) {
-	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::Rise);
+	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::RiseOnly);
 
 	float w = 5;
 	float specialTooth = 20;

--- a/firmware/controllers/trigger/decoders/trigger_universal.cpp
+++ b/firmware/controllers/trigger/decoders/trigger_universal.cpp
@@ -42,7 +42,7 @@ void initializeSkippedToothTriggerWaveformExt(TriggerWaveform *s, int totalTeeth
 		return;
 	}
 	efiAssertVoid(CUSTOM_NULL_SHAPE, s != NULL, "TriggerWaveform is NULL");
-	s->initialize(operationMode, SyncEdge::Rise);
+	s->initialize(operationMode, SyncEdge::RiseOnly);
 #if EFI_UNIT_TEST
 	s->knownOperationMode = false;
 #endif // EFI_UNIT_TEST

--- a/firmware/controllers/trigger/decoders/trigger_universal.cpp
+++ b/firmware/controllers/trigger/decoders/trigger_universal.cpp
@@ -74,7 +74,7 @@ void configureOnePlusOne(TriggerWaveform *s) {
 }
 
 void configure3_1_cam(TriggerWaveform *s) {
-	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::Rise);
+	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::RiseOnly);
 
 
 	const float crankW = 360 / 3 / 2;
@@ -153,7 +153,7 @@ void configureQuickStartSenderWheel(TriggerWaveform *s) {
 // - Honda 24+1 (set this on crank primary, single tooth cam)
 // - AEM 24+1 CAS wheel (same config as Honda)
 void configure12ToothCrank(TriggerWaveform* s) {
-	s->initialize(FOUR_STROKE_TWELVE_TIMES_CRANK_SENSOR, SyncEdge::Rise);
+	s->initialize(FOUR_STROKE_TWELVE_TIMES_CRANK_SENSOR, SyncEdge::RiseOnly);
 
 	s->shapeWithoutTdc = true;
 

--- a/firmware/controllers/trigger/decoders/trigger_vw.cpp
+++ b/firmware/controllers/trigger/decoders/trigger_vw.cpp
@@ -26,7 +26,7 @@ void setSkodaFavorit(TriggerWaveform *s) {
 }
 
 void setVwConfiguration(TriggerWaveform *s) {
-	s->initialize(FOUR_STROKE_CRANK_SENSOR, SyncEdge::Rise);
+	s->initialize(FOUR_STROKE_CRANK_SENSOR, SyncEdge::RiseOnly);
 
 	int totalTeethCount = 60;
 	int skippedCount = 2;


### PR DESCRIPTION
Part of #4621: set trigger types that are rising-edge-only. Doesn't change logic yet, as `::Rise` and `::RiseOnly` currently behave the same.