### PR TITLE
Added new pin mapping for clutch

### DIFF
--- a/firmware/config/boards/hellen/hellen72/connectors/main.yaml
+++ b/firmware/config/boards/hellen/hellen72/connectors/main.yaml
@@ -311,10 +311,17 @@ pins:
     function: Neutral Switch
 
   - pin: 4I
-  # H144_IN_RES3 
+  # H176_IN_RES3 
     id: F8
     class: switch_inputs
-    ts_name: 4I - Clutch (A8)
+    ts_name: 4I - Clutch rev D
+    function: Clutch Switch
+    
+  - pin: 4I
+  # H176_IN_D1 
+    id: E13
+    class: switch_inputs
+    ts_name: 4I - Clutch rev E/F
     function: Clutch Switch
 
   - pin: 4J


### PR DESCRIPTION
While diagnosing a users issue with clutch input, i found that the pin changed on the 176 from res3 to D1 at revE.