### PR TITLE
Logging asserts

### DIFF
--- a/firmware/util/loggingcentral.cpp
+++ b/firmware/util/loggingcentral.cpp
@@ -182,11 +182,6 @@ void efiPrintfInternal(const char *format, ...) {
 	}
 #endif
 #if (EFI_PROD_CODE || EFI_SIMULATOR) && EFI_TEXT_LOGGING
-	for (unsigned int i = 0; i < strlen(format); i++) {
-		// todo: open question which layer would not handle CR/LF properly?
-		efiAssertVoid(OBD_PCM_Processor_Fault, format[i] != '\n', "No CRLF please");
-	}
-
 	LogLineBuffer* lineBuffer;
 	msg_t msg;
 
@@ -209,6 +204,11 @@ void efiPrintfInternal(const char *format, ...) {
 
 	// Ensure that the string is comma-terminated in case it overflowed
 	lineBuffer->buffer[sizeof(lineBuffer->buffer) - 1] = LOG_DELIMITER[0];
+
+	for (unsigned int i = 0; i < strlen(lineBuffer->buffer); i++) {
+		// todo: open question which layer would not handle CR/LF properly?
+		efiAssertVoid(OBD_PCM_Processor_Fault, lineBuffer->buffer[i] != '\n', "No CRLF please");
+	}
 
 	{
 		// Push the buffer in to the written list so it can be written back

--- a/firmware/util/loggingcentral.cpp
+++ b/firmware/util/loggingcentral.cpp
@@ -202,13 +202,15 @@ void efiPrintfInternal(const char *format, ...) {
 	// Write the formatted string to the output buffer
 	va_list ap;
 	va_start(ap, format);
-	chvsnprintf(lineBuffer->buffer, sizeof(lineBuffer->buffer), format, ap);
+	size_t len = chvsnprintf(lineBuffer->buffer, sizeof(lineBuffer->buffer), format, ap);
 	va_end(ap);
 
 	// Ensure that the string is comma-terminated in case it overflowed
-	lineBuffer->buffer[sizeof(lineBuffer->buffer) - 1] = LOG_DELIMITER[0];
+	if (len > sizeof(lineBuffer->buffer) - 1)
+		len = sizeof(lineBuffer->buffer) - 1;
+	lineBuffer->buffer[len] = LOG_DELIMITER[0];
 
-	for (unsigned int i = 0; i < strlen(lineBuffer->buffer); i++) {
+	for (size_t i = 0; i < len; i++) {
 		/* just replace all non-printable chars with space
 		 * TODO: is there any other "prohibited" chars? */
 		if (isprint(lineBuffer->buffer[i]) == 0)

--- a/firmware/util/loggingcentral.cpp
+++ b/firmware/util/loggingcentral.cpp
@@ -207,7 +207,7 @@ void efiPrintfInternal(const char *format, ...) {
 
 	for (unsigned int i = 0; i < strlen(lineBuffer->buffer); i++) {
 		// todo: open question which layer would not handle CR/LF properly?
-		efiAssertVoid(OBD_PCM_Processor_Fault, lineBuffer->buffer[i] != '\n', "No CRLF please");
+		efiAssertVoid(OBD_PCM_Processor_Fault, (lineBuffer->buffer[i] != '\n') && (lineBuffer->buffer[i] != '\r'), "No CRLF please");
 	}
 
 	{

--- a/firmware/util/loggingcentral.cpp
+++ b/firmware/util/loggingcentral.cpp
@@ -26,6 +26,9 @@
 
 #include "thread_controller.h"
 
+/* for isprint() */
+#include <ctype.h>
+
 template <size_t TBufferSize>
 void LogBuffer<TBufferSize>::writeLine(LogLineBuffer* line) {
 	writeInternal(line->buffer);
@@ -206,8 +209,10 @@ void efiPrintfInternal(const char *format, ...) {
 	lineBuffer->buffer[sizeof(lineBuffer->buffer) - 1] = LOG_DELIMITER[0];
 
 	for (unsigned int i = 0; i < strlen(lineBuffer->buffer); i++) {
-		// todo: open question which layer would not handle CR/LF properly?
-		efiAssertVoid(OBD_PCM_Processor_Fault, (lineBuffer->buffer[i] != '\n') && (lineBuffer->buffer[i] != '\r'), "No CRLF please");
+		/* just replace all non-printable chars with space
+		 * TODO: is there any other "prohibited" chars? */
+		if (isprint(lineBuffer->buffer[i]) == 0)
+			lineBuffer->buffer[i] = ' ';
 	}
 
 	{


### PR DESCRIPTION
Related to https://github.com/rusefi/rusefi/issues/4651
Wrong symbol can still come from one of arguments, like:
`efiPrintf("This is test %s", "this is wrong char\r\n");`
So check should be done for final buffer.
Also check for '\r' too.
Or just simply replace all not-allowed chars with space.

@rusefillc please cherry-pick at least first patch at this series.