### PR TITLE
allow SD logging non-scaled_channel

### DIFF
--- a/firmware/console/binary/output_channels.txt
+++ b/firmware/console/binary/output_channels.txt
@@ -38,13 +38,13 @@ bit isTps2Error;
 bit isIdleClosedLoop;
 
 
-uint16_t autoscale RPMValue;@@GAUGE_NAME_RPM@@;"RPM",1, 0, 0, 8000, 0
+uint16_t RPMValue;@@GAUGE_NAME_RPM@@;"RPM",1, 0, 0, 8000, 0
 
-uint16_t autoscale rpmAcceleration;dRPM;"RPM/s",1, 0, 0, 5, 2
+uint16_t rpmAcceleration;dRPM;"RPM/s",1, 0, 0, 5, 2
 
 	uint16_t autoscale speedToRpmRatio;@@GAUGE_NAME_GEAR_RATIO@@;"value",{1/@@PACK_MULT_PERCENT@@}, 0, 0, 0, 2
-	uint8_t autoscale vehicleSpeedKph;@@GAUGE_NAME_VVS@@;"kph",1, 0, 0, 0, 1
-	int8_t autoscale internalMcuTemperature;@@GAUGE_NAME_CPU_TEMP@@;"deg C",1, 0, 0, 0, 0
+	uint8_t vehicleSpeedKph;@@GAUGE_NAME_VVS@@;"kph",1, 0, 0, 0, 1
+	int8_t internalMcuTemperature;@@GAUGE_NAME_CPU_TEMP@@;"deg C",1, 0, 0, 0, 0
 
 	int16_t autoscale coolant;@@GAUGE_NAME_CLT@@;"deg C",{1/@@PACK_MULT_TEMPERATURE@@}, 0, 0, 0, 1
 	int16_t autoscale intake;@@GAUGE_NAME_IAT@@;"deg C",{1/@@PACK_MULT_TEMPERATURE@@}, 0, 0, 0, 1
@@ -55,7 +55,7 @@ uint16_t autoscale rpmAcceleration;dRPM;"RPM/s",1, 0, 0, 5, 2
 	int16_t autoscale TPSValue;@@GAUGE_NAME_TPS@@;"%",{1/@@PACK_MULT_PERCENT@@}, 0, 0, 0, 2
 	int16_t autoscale throttlePedalPosition;@@GAUGE_NAME_THROTTLE_PEDAL@@;"%",{1/@@PACK_MULT_PERCENT@@}, 0, 0, 0, 2
 
-	uint16_t autoscale tpsADC;;"ADC", 1, 0, 0, 0, 0
+	uint16_t tpsADC;;"ADC", 1, 0, 0, 0, 0
 	uint16_t autoscale rawMaf;;"V",{1/@@PACK_MULT_VOLTAGE@@}, 0, 0, 5, 3
 
 	uint16_t autoscale mafMeasured;@@GAUGE_NAME_AIR_FLOW_MEASURED@@;"kg/h",{1/@@PACK_MULT_MASS_FLOW@@}, 0, 0, 0, 1
@@ -83,7 +83,7 @@ uint16_t autoscale rpmAcceleration;dRPM;"RPM/s",1, 0, 0, 5, 2
 
 	uint8_t autoscale injectorDutyCycle;@@GAUGE_NAME_FUEL_INJ_DUTY@@;"%",{1/2}, 0, 0, 0, 0
 	uint8_t autoscale veValue;@@GAUGE_NAME_FUEL_VE@@;"ratio",{1/2}, 0, 0, 0, 1
-	int16_t autoscale injectionOffset;;"deg", 1, 0, 0, 0, 0
+	int16_t injectionOffset;;"deg", 1, 0, 0, 0, 0
 
 	int16_t autoscale tCharge;;"deg C",{1/@@PACK_MULT_TEMPERATURE@@}, 0, 0, 0, 1
 
@@ -92,15 +92,15 @@ uint16_t autoscale rpmAcceleration;dRPM;"RPM/s",1, 0, 0, 5, 2
 	uint16_t autoscale injectorLagMs;@@GAUGE_NAME_INJECTOR_LAG@@;"ms",{1/@@PACK_MULT_MS@@}, 0, 0, 0, 3
 
 ! we want a hash of engineMake+engineCode+vehicleName in the log file in order to match TS logs to rusEFI Online tune
-	uint16_t autoscale engineMakeCodeNameCrc16;@@GAUGE_NAME_ENGINE_CRC16@@;"crc16",1, 0, 0, 0, 0
+	uint16_t engineMakeCodeNameCrc16;@@GAUGE_NAME_ENGINE_CRC16@@;"crc16",1, 0, 0, 0, 0
 ! Wall model AE
 	uint16_t autoscale wallFuelAmount;@@GAUGE_NAME_FUEL_WALL_AMOUNT@@;"mg",{1/@@PACK_MULT_FUEL_MASS@@}, 0, 0, 0, 3
 	int16_t autoscale wallFuelCorrection;@@GAUGE_NAME_FUEL_WALL_CORRECTION@@;"mg",{1/@@PACK_MULT_FUEL_MASS@@}, 0, 0, 0, 3
 
-	uint16_t autoscale revolutionCounterSinceStart;;"",1, 0, 0, 0, 0
+	uint16_t revolutionCounterSinceStart;;"",1, 0, 0, 0, 0
 	int16_t autoscale deltaTps;@@GAUGE_NAME_FUEL_TPS_ROC@@;"ratio",{1/@@PACK_MULT_PERCENT@@}, 0, 0, 0, 0
 
-	uint16_t autoscale canReadCounter;;"",1, 0, 0, 0, 0
+	uint16_t canReadCounter;;"",1, 0, 0, 0, 0
 	int16_t autoscale tpsAccelFuel;@@GAUGE_NAME_FUEL_TPS_EXTRA@@;"ms",{1/@@PACK_MULT_MS@@}, 0, 0, 0, 3
 ! Ignition
 	int16_t autoscale ignitionAdvance;@@GAUGE_NAME_TIMING_ADVANCE@@;"deg",{1/@@PACK_MULT_ANGLE@@}, 0, 0, 0, 1
@@ -115,26 +115,26 @@ uint16_t autoscale rpmAcceleration;dRPM;"RPM/s",1, 0, 0, 5, 2
 ! Fuel system
 	int16_t autoscale fuelTankLevel;Fuel level;"%",{1/@@PACK_MULT_PERCENT@@}, 0, 0, 0, 0
 
-	uint16_t autoscale totalFuelConsumption;@@GAUGE_NAME_FUEL_CONSUMPTION@@;"grams",1, 0, 0, 0, 1
+	uint16_t totalFuelConsumption;@@GAUGE_NAME_FUEL_CONSUMPTION@@;"grams",1, 0, 0, 0, 1
 	uint16_t autoscale fuelFlowRate;@@GAUGE_NAME_FUEL_FLOW@@;"gram/s",{1/@@PACK_MULT_FUEL_FLOW@@}, 0, 0, 0, 3
 
 ! Y axis values for selectable tables
 	uint16_t autoscale veTableYAxis;;"%",{1/100}, 0, 0, 0, 0
 	uint16_t autoscale afrTableYAxis;;"%",{1/100}, 0, 0, 0, 0
 
-	float autoscale knockLevel;@@GAUGE_NAME_KNOCK_LEVEL@@;"Volts", 1, 0, 0, 0, 0
+	float knockLevel;@@GAUGE_NAME_KNOCK_LEVEL@@;"Volts", 1, 0, 0, 0, 0
 
 ! integration magic: TS requires exact 'seconds' name
-	uint32_t autoscale seconds;@@GAUGE_NAME_UPTIME@@;"sec", 1, 0, 0, 0, 0
-	uint32_t autoscale engineMode;Engine Mode;"em", 1, 0, 0, 0, 0
-	uint32_t autoscale firmwareVersion;@@GAUGE_NAME_VERSION@@;"version_f", 1, 0, 0, 0, 0
+	uint32_t seconds;@@GAUGE_NAME_UPTIME@@;"sec", 1, 0, 0, 0, 0
+	uint32_t engineMode;Engine Mode;"em", 1, 0, 0, 0, 0
+	uint32_t firmwareVersion;@@GAUGE_NAME_VERSION@@;"version_f", 1, 0, 0, 0, 0
 
 	int16_t autoscale rawIdlePositionSensor;;"V",{1/@@PACK_MULT_VOLTAGE@@}, 0, 0, 5, 3
 	int16_t autoscale rawWastegatePosition;;"V",{1/@@PACK_MULT_VOLTAGE@@}, 0, 0, 5, 3
 
 ! todo: this not needed in light of TS_SIGNATURE but rusEFI console still uses it. Need to migrate
 ! rusEFI console from TS_FILE_VERSION to TS_SIGNATURE :(
-	uint32_t autoscale tsConfigVersion;;"", 1, 0, 0, 0, 0
+	uint32_t tsConfigVersion;;"", 1, 0, 0, 0, 0
 
 
 	! These two fields indicate to TS that we'd like to set a particular field to a particular value
@@ -147,34 +147,34 @@ uint16_t autoscale rpmAcceleration;dRPM;"RPM/s",1, 0, 0, 5, 2
 	! back to TunerStudio, getting around the problem of setting values on the controller without TS's knowledge.
 	! The ECU simply has to sequentially set a mode/value, wait briefly, then repeat until all the values
 	! it wants to send have been sent.
-	float autoscale calibrationValue;;"", 1, 0, 0, 0, 0
-	uint8_t autoscale calibrationMode;;"", 1, 0, 0, 0, 0
-	uint8_t autoscale idleTargetPosition;;"", 1, 0, 0, 0, 0
+	float calibrationValue;;"", 1, 0, 0, 0, 0
+	uint8_t calibrationMode;;"", 1, 0, 0, 0, 0
+	uint8_t idleTargetPosition;;"", 1, 0, 0, 0, 0
 
 ! Errors
-	uint32_t autoscale totalTriggerErrorCounter;@@GAUGE_NAME_TRG_ERR@@;"counter",1, 0, 0, 0, 0
-	uint32_t autoscale orderingErrorCounter;;"",1, 0, 0, 0, 0
+	uint32_t totalTriggerErrorCounter;@@GAUGE_NAME_TRG_ERR@@;"counter",1, 0, 0, 0, 0
+	uint32_t orderingErrorCounter;;"",1, 0, 0, 0, 0
 
-	uint16_t autoscale warningCounter;@@GAUGE_NAME_WARNING_COUNTER@@;"count",1, 0, 0, 0, 0
-	uint16_t autoscale lastErrorCode;@@GAUGE_NAME_WARNING_LAST@@;"error",1, 0, 0, 0, 0
+	uint16_t warningCounter;@@GAUGE_NAME_WARNING_COUNTER@@;"count",1, 0, 0, 0, 0
+	uint16_t lastErrorCode;@@GAUGE_NAME_WARNING_LAST@@;"error",1, 0, 0, 0, 0
 
 ! todo: re-implement enableLogErrorList
 	uint16_t[8 iterate] recentErrorCode;;"error", 1, 0, 0, 0, 0
 
 ! todo: re-implement enableLogDebugChannels
-	float autoscale debugFloatField1;;"val", 1, 0, 0, 0, 3
-	float autoscale debugFloatField2;;"val", 1, 0, 0, 0, 3
-	float autoscale debugFloatField3;;"val", 1, 0, 0, 0, 3
-	float autoscale debugFloatField4;;"val", 1, 0, 0, 0, 3
-	float autoscale debugFloatField5;;"val", 1, 0, 0, 0, 3
-	float autoscale debugFloatField6;;"val", 1, 0, 0, 0, 3
-	float autoscale debugFloatField7;;"val", 1, 0, 0, 0, 3
+	float debugFloatField1;;"val", 1, 0, 0, 0, 3
+	float debugFloatField2;;"val", 1, 0, 0, 0, 3
+	float debugFloatField3;;"val", 1, 0, 0, 0, 3
+	float debugFloatField4;;"val", 1, 0, 0, 0, 3
+	float debugFloatField5;;"val", 1, 0, 0, 0, 3
+	float debugFloatField6;;"val", 1, 0, 0, 0, 3
+	float debugFloatField7;;"val", 1, 0, 0, 0, 3
 
-	uint32_t autoscale debugIntField1;;"val", 1, 0, 0, 0, 0
-	uint32_t autoscale debugIntField2;;"val", 1, 0, 0, 0, 0
-	uint32_t autoscale debugIntField3;;"val", 1, 0, 0, 0, 0
-	int16_t autoscale debugIntField4;;"val", 1, 0, 0, 0, 0
-	int16_t autoscale debugIntField5;;"val", 1, 0, 0, 0, 0
+	uint32_t debugIntField1;;"val", 1, 0, 0, 0, 0
+	uint32_t debugIntField2;;"val", 1, 0, 0, 0, 0
+	uint32_t debugIntField3;;"val", 1, 0, 0, 0, 0
+	int16_t debugIntField4;;"val", 1, 0, 0, 0, 0
+	int16_t debugIntField5;;"val", 1, 0, 0, 0, 0
 
 ! todo: reimplement { LIS302DLCsPin != 0 || imuType != 0  }
 	int16_t autoscale accelerationX;@@GAUGE_NAME_ACCEL_X@@;"G",{1/@@PACK_MULT_PERCENT@@}, 0, 0, 0, 2
@@ -191,15 +191,15 @@ uint16_t autoscale rpmAcceleration;dRPM;"RPM/s",1, 0, 0, 5, 2
 	int16_t autoscale rawIat;;"V",{1/@@PACK_MULT_VOLTAGE@@}, 0, 0, 5, 3
 	int16_t autoscale rawOilPressure;;"V",{1/@@PACK_MULT_VOLTAGE@@}, 0, 0, 5, 3
 
-	uint16_t autoscale tuneCrc16;@@GAUGE_NAME_TUNE_CRC16@@;"crc16", 1, 0, 0, 0, 0
-	uint8_t autoscale fuelClosedLoopBinIdx;;"", 1, 0, 0, 0, 0
-	int8_t autoscale tcuCurrentGear;@@GAUGE_NAME_CURRENT_GEAR@@;"gear", 1, 0, -1, 10, 0
+	uint16_t tuneCrc16;@@GAUGE_NAME_TUNE_CRC16@@;"crc16", 1, 0, 0, 0, 0
+	uint8_t fuelClosedLoopBinIdx;;"", 1, 0, 0, 0, 0
+	int8_t tcuCurrentGear;@@GAUGE_NAME_CURRENT_GEAR@@;"gear", 1, 0, -1, 10, 0
 
 	int16_t autoscale rawPpsSecondary;;"V",{1/@@PACK_MULT_VOLTAGE@@}, 0, 0, 5, 3
 
-	int8_t[12 iterate] autoscale knock;;"dBv",1, 0, 0, 0, 0
+	int8_t[12 iterate] knock;;"dBv",1, 0, 0, 0, 0
 
-	int8_t autoscale tcuDesiredGear;@@GAUGE_NAME_DESIRED_GEAR@@;"gear",1, 0, -1, 10, 0
+	int8_t tcuDesiredGear;@@GAUGE_NAME_DESIRED_GEAR@@;"gear",1, 0, -1, 10, 0
 	uint8_t autoscale flexPercent;@@GAUGE_NAME_FLEX@@;"%",{1/2}, 0, 0, 0, 1
 
 	int16_t autoscale wastegatePositionSensor;@@GAUGE_NAME_WG_POSITION@@;"%",{1/@@PACK_MULT_PERCENT@@}, 0, 0, 0, 2
@@ -228,18 +228,18 @@ uint16_t autoscale rpmAcceleration;dRPM;"RPM/s",1, 0, 0, 5, 2
 	int16_t autoscale rawTps2Primary;;"V",{1/@@PACK_MULT_VOLTAGE@@}, 0, 0, 5, 3
 
 	int16_t autoscale rawTps2Secondary;;"V",{1/@@PACK_MULT_VOLTAGE@@}, 0, 0, 5, 3
-	uint16_t autoscale knockCount;@@GAUGE_NAME_KNOCK_COUNTER@@;"",1, 0, 0, 0, 0
+	uint16_t knockCount;@@GAUGE_NAME_KNOCK_COUNTER@@;"",1, 0, 0, 0, 0
 
 	int16_t autoscale accelerationZ;@@GAUGE_NAME_ACCEL_Z@@;"G",{1/@@PACK_MULT_PERCENT@@}, 0, 0, 0, 0
 	int16_t autoscale accelerationRoll;@@GAUGE_NAME_ACCEL_ROLL@@;"G",{1/@@PACK_MULT_PERCENT@@}, 0, 0, 0, 0
 	int16_t autoscale accelerationYaw;@@GAUGE_NAME_ACCEL_YAW@@;"G",{1/@@PACK_MULT_PERCENT@@}, 0, 0, 0, 0
 
-	int8_t[4 iterate] autoscale vvtTargets;;"deg",1, 0, 0, 0, 0
+	int8_t[4 iterate] vvtTargets;;"deg",1, 0, 0, 0, 0
 	uint16_t turboSpeed;@@GAUGE_NAME_TURBO_SPEED@@;"hz",1, 0, 0, 0, 0
 
 ! fun fact: we have a separate pid_state.txt file for a bit of a different structure huh?
     struct pid_status_s
-    	float autoscale pTerm;;"", 1, 0, -50000, 50000, 2
+    	float pTerm;;"", 1, 0, -50000, 50000, 2
     	int16_t autoscale iTerm;;"", 0.01, 0, -327, 327, 2
     	int16_t autoscale dTerm;;"", 0.01, 0, -327, 327, 2
     	int16_t autoscale output;;"", 0.01, 0, -327, 327, 2
@@ -252,8 +252,8 @@ uint16_t autoscale rpmAcceleration;dRPM;"RPM/s",1, 0, 0, 5, 2
 	int16_t autoscale tps12Split;;"%",{1/@@PACK_MULT_PERCENT@@}, 0, 0, 0, 0
 	int16_t autoscale accPedalSplit;;"%",{1/@@PACK_MULT_PERCENT@@}, 0, 0, 0, 0
 
-    int8_t autoscale sparkCutReason;Spark Cut Code;"code",1, 0, 0, 0, 0
-    int8_t autoscale fuelCutReason;Fuel Cut Code;"code",1, 0, 0, 0, 0
+    int8_t sparkCutReason;Spark Cut Code;"code",1, 0, 0, 0, 0
+    int8_t fuelCutReason;Fuel Cut Code;"code",1, 0, 0, 0, 0
 
 	uint16_t autoscale mafEstimate;@@GAUGE_NAME_AIR_FLOW_ESTIMATE@@;"kg/h",{1/@@PACK_MULT_MASS_FLOW@@}, 0, 0, 0, 0
 	uint16_t instantRpm;;"rpm", 1, 0, 0, 0, 0
@@ -266,7 +266,7 @@ uint16_t autoscale rpmAcceleration;dRPM;"RPM/s",1, 0, 0, 5, 2
 	uint8_t tpsAccelFrom;;"%", 1, 0, 0, 100, 0
 	uint8_t tpsAccelTo;;"%", 1, 0, 0, 100, 0
 
-	float autoscale calibrationValue2;;"", 1, 0, 0, 0, 0
+	float calibrationValue2;;"", 1, 0, 0, 0, 0
     bit isMainRelayOn;
     bit isUsbConnected;Original reason for this is to check if USB is connected from Lua
 
@@ -325,7 +325,7 @@ uint16_t autoscale rpmAcceleration;dRPM;"RPM/s",1, 0, 0, 5, 2
 	uint16_t auxSpeed1;aux speed 1;"s",1, 0, 0, 0, 0
 	uint16_t auxSpeed2;aux speed 2;"s",1, 0, 0, 0, 0
 
-	uint16_t autoscale ISSValue;@@GAUGE_NAME_ISS@@;"RPM",1, 0, 0, 8000, 0
+	uint16_t ISSValue;@@GAUGE_NAME_ISS@@;"RPM",1, 0, 0, 8000, 0
 
 	int16_t[AUX_ANALOG_INPUT_COUNT iterate] autoscale rawAnalogInput;;"V",{1/@@PACK_MULT_VOLTAGE@@}, 0, 0, 5, 3
 	uint8_t[4 iterate] autoscale gppwmOutput;GPPWM Output;"%", 0.5, 0, 0, 100, 2

--- a/firmware/console/binary_log/log_field.h
+++ b/firmware/console/binary_log/log_field.h
@@ -20,6 +20,19 @@ public:
 	{
 	}
 
+	template <typename TValue, typename = typename std::enable_if<std::is_arithmetic_v<TValue>>::type>
+	constexpr LogField(TValue& toRead,
+			   const char* name, const char* units, int8_t digits)
+		: m_multiplier(1)
+		, m_addr(&toRead)
+		, m_type(resolveType<TValue>())
+		, m_digits(digits)
+		, m_size(sizeForType(resolveType<TValue>()))
+		, m_name(name)
+		, m_units(units)
+	{
+	}
+
 	enum class Type : uint8_t {
 		U08 = 0,
 		S08 = 1,
@@ -61,7 +74,7 @@ private:
 	}
 
 	const float m_multiplier;
-	const char* const m_addr;
+	const void* const m_addr;
 	const Type m_type;
 	const int8_t m_digits;
 	const uint8_t m_size;

--- a/firmware/console/binary_log/log_field.h
+++ b/firmware/console/binary_log/log_field.h
@@ -7,6 +7,7 @@
 struct Writer;
 class LogField {
 public:
+	// Scaled channels, memcpys data directly and describes format in header
 	template <typename TValue, int TMult, int TDiv>
 	constexpr LogField(const scaled_channel<TValue, TMult, TDiv>& toRead,
 			   const char* name, const char* units, int8_t digits)
@@ -20,6 +21,7 @@ public:
 	{
 	}
 
+	// Non-scaled channel, works for plain arithmetic types (int, float, uint8_t, etc)
 	template <typename TValue, typename = typename std::enable_if<std::is_arithmetic_v<TValue>>::type>
 	constexpr LogField(TValue& toRead,
 			   const char* name, const char* units, int8_t digits)

--- a/firmware/controllers/sensors/wideband_state.txt
+++ b/firmware/controllers/sensors/wideband_state.txt
@@ -1,8 +1,8 @@
 struct_no_prefix wideband_state_s
 	uint8_t faultCode
 
-	uint8_t autoscale heaterDuty;;"%", 1, 0, 0, 100, 0
-	uint8_t autoscale pumpDuty;;"%", 1, 0, 0, 100, 0
+	uint8_t heaterDuty;;"%", 1, 0, 0, 100, 0
+	uint8_t pumpDuty;;"%", 1, 0, 0, 100, 0
 
 	uint16_t tempC;;"C", 1, 0, 500, 1000, 0
 	uint16_t autoscale nernstVoltage;;"V", 0.001, 0, 0, 1, 3

--- a/firmware/development/logic_analyzer.cpp
+++ b/firmware/development/logic_analyzer.cpp
@@ -257,40 +257,32 @@ void stopLogicAnalyzerPins() {
 	}
 }
 
-static void getChannelFreqAndDuty(int index, scaled_channel<float> *duty, scaled_channel<uint32_t> *freq) {
-	float high, period;
-
-	if ((duty == nullptr) || (freq == nullptr)) {
-		return;
-	}
-
+template <typename TFreq>
+static void getChannelFreqAndDuty(int index, float& duty, TFreq& freq) {
 	if (readers[index].line == 0) {
-		*duty = 0.0;
-		*freq = 0;
+		duty = 0.0;
+		freq = 0;
 	} else {
-		high = getSignalOnTime(index);
-		period = getSignalPeriodMs(index);
+		float high = getSignalOnTime(index);
+		float period = getSignalPeriodMs(index);
 
 		if (period != 0) {
 
-			*duty = (high * 1000.0f) /(period * 10.0f);
-			*freq = (int)(1 / (period / 1000.0f));
+			duty = (high * 1000.0f) /(period * 10.0f);
+			freq = (int)(1 / (period / 1000.0f));
 		} else {		
-			*duty = 0.0;
-			*freq = 0;
+			duty = 0.0;
+			freq = 0;
 		}
 	}
-
 }
 
 void reportLogicAnalyzerToTS() {
-#if EFI_TUNER_STUDIO	
-	scaled_channel<uint32_t> tmp;
-	getChannelFreqAndDuty(0,&engine->outputChannels.debugFloatField1, &engine->outputChannels.debugIntField1);
-	getChannelFreqAndDuty(1,&engine->outputChannels.debugFloatField2, &engine->outputChannels.debugIntField2);
-	getChannelFreqAndDuty(2,&engine->outputChannels.debugFloatField3, &engine->outputChannels.debugIntField3);
-	getChannelFreqAndDuty(3,&engine->outputChannels.debugFloatField4, &tmp);
-	engine->outputChannels.debugIntField4 = (uint16_t)tmp;
+#if EFI_TUNER_STUDIO
+	getChannelFreqAndDuty(0, engine->outputChannels.debugFloatField1, engine->outputChannels.debugIntField1);
+	getChannelFreqAndDuty(1, engine->outputChannels.debugFloatField2, engine->outputChannels.debugIntField2);
+	getChannelFreqAndDuty(2, engine->outputChannels.debugFloatField3, engine->outputChannels.debugIntField3);
+	getChannelFreqAndDuty(3, engine->outputChannels.debugFloatField4, engine->outputChannels.debugIntField4);
 #endif	
 }
 

--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -1585,7 +1585,7 @@ uint8_t[BOOST_RPM_COUNT x BOOST_LOAD_COUNT] autoscale boostTableOpenLoop;;"", {1
 uint8_t[BOOST_RPM_COUNT] autoscale boostRpmBins;;"RPM", 100, 0, 0, 25000, 0
 
 uint8_t[BOOST_RPM_COUNT x BOOST_LOAD_COUNT] autoscale boostTableClosedLoop;;"", 2, 0, 0, 3000, 0
-uint8_t[BOOST_LOAD_COUNT] autoscale boostTpsBins;;"%", 1, 0, 0, 100, 0
+uint8_t[BOOST_LOAD_COUNT] boostTpsBins;;"%", 1, 0, 0, 100, 0
 
 uint8_t[PEDAL_TO_TPS_SIZE x PEDAL_TO_TPS_SIZE] pedalToTpsTable;;"%", 1, 0, 0, 100, 0
 uint8_t[PEDAL_TO_TPS_SIZE] pedalToTpsPedalBins;;"%", 1, 0, 0, 120, 0
@@ -1597,7 +1597,7 @@ float[CLT_CRANKING_CURVE_SIZE] cltCrankingCorr    ;CLT-based cranking position m
 uint8_t[IDLE_ADVANCE_CURVE_SIZE] autoscale idleAdvanceBins;Optional timing advance table for Idle (see useSeparateAdvanceForIdle);"RPM", 50, 0, 0, 12000, 0
 float[IDLE_ADVANCE_CURVE_SIZE] idleAdvance    ;Optional timing advance table for Idle (see useSeparateAdvanceForIdle);"deg", 1, 0, -20, 90, 1
 uint8_t[IDLE_VE_SIZE] autoscale idleVeRpmBins;;"RPM", 10, 0, 0, 2500, 0
-uint8_t[IDLE_VE_SIZE] autoscale idleVeLoadBins;;"load", 1, 0, 0, 100, 0
+uint8_t[IDLE_VE_SIZE] idleVeLoadBins;;"load", 1, 0, 0, 100, 0
 uint16_t[IDLE_VE_SIZE x IDLE_VE_SIZE] autoscale idleVeTable;;"%", 0.1, 0, 0, 999, 1
 
 #define LUA_SCRIPT_SIZE 8000


### PR DESCRIPTION
- Allow `LogField` to accept plain integer/float, instead of requiring `scaled_channel`.
- Remove `autoscale` in places where we have 1:1 scaling, using the new logic.

useful for #3985