### PR TITLE
build tweaks for size

### DIFF
--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -58,7 +58,7 @@ endif
 # yes we have two kinds of EXTRA_*PARAMS so that we can define those in two different places independently
 #
 ifeq ($(USE_OPT),)
-  USE_OPT = $(EXTRA_PARAMS) $(EXTRA_2_PARAMS) $(DEBUG_LEVEL_OPT) $(RFLAGS) -fomit-frame-pointer -falign-functions=16 -fsingle-precision-constant  -fno-inline-functions
+  USE_OPT = $(EXTRA_PARAMS) $(EXTRA_2_PARAMS) $(DEBUG_LEVEL_OPT) $(RFLAGS) -fomit-frame-pointer -fsingle-precision-constant  -fno-inline-functions
 endif
 
 # EFI_UNIT_TEST determines if we are running in a unit test (hide things from hw/sim)

--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -368,7 +368,7 @@ UINCDIR =
 ULIBDIR =
 
 # List all user libraries here
-ULIBS = -lm --specs=nano.specs
+ULIBS = -lm --specs=nano.specs -Wl,--sort-section=alignment
 
 #
 # End of user defines

--- a/firmware/controllers/algo/engine_configuration.cpp
+++ b/firmware/controllers/algo/engine_configuration.cpp
@@ -344,7 +344,7 @@ void setDefaultGppwmParameters() {
 	// Same config for all channels
 	for (size_t i = 0; i < efi::size(engineConfiguration->gppwm); i++) {
 		auto& cfg = engineConfiguration->gppwm[i];
-		snprintf(engineConfiguration->gpPwmNote[i], sizeof(engineConfiguration->gpPwmNote[0]), "GPPWM%d", i);
+		chsnprintf(engineConfiguration->gpPwmNote[i], sizeof(engineConfiguration->gpPwmNote[0]), "GPPWM%d", i);
 
 		cfg.pin = Gpio::Unassigned;
 		cfg.dutyIfError = 0;

--- a/firmware/controllers/lua/luaconf.h
+++ b/firmware/controllers/lua/luaconf.h
@@ -447,7 +447,7 @@ float strtof_rusefi(const char*, char**);
 ** macro must include the header 'locale.h'.)
 */
 #if !defined(lua_getlocaledecpoint)
-#define lua_getlocaledecpoint()		(localeconv()->decimal_point[0])
+#define lua_getlocaledecpoint()		'.'
 #endif
 
 

--- a/firmware/hw_layer/ports/stm32/stm32f7/hw_ports.mk
+++ b/firmware/hw_layer/ports/stm32/stm32f7/hw_ports.mk
@@ -6,6 +6,9 @@ HW_LAYER_EMS += $(PROJECT_DIR)/hw_layer/ports/stm32/stm32f7/stm32f7xx_hal_flash.
 HW_LAYER_EMS_CPP += $(PROJECT_DIR)/hw_layer/ports/stm32/stm32f7/mpu_util.cpp \
 					$(PROJECT_DIR)/hw_layer/ports/stm32/stm32_adc_v2.cpp \
 
+# This MCU has a cache, align functions to a cache line for maximum cache efficiency
+USE_OPT += -falign-functions=16
+
 DDEFS += -DSTM32F767xx
 MCU = cortex-m7
 LDSCRIPT = $(PROJECT_DIR)/hw_layer/ports/stm32/stm32f7/STM32F7.ld

--- a/firmware/hw_layer/ports/stm32/stm32h7/hw_ports.mk
+++ b/firmware/hw_layer/ports/stm32/stm32h7/hw_ports.mk
@@ -6,6 +6,9 @@ HW_LAYER_EMS += $(PROJECT_DIR)/hw_layer/ports/stm32/stm32h7/stm32h7xx_hal_flash.
 HW_LAYER_EMS_CPP += $(PROJECT_DIR)/hw_layer/ports/stm32/stm32h7/mpu_util.cpp \
 					$(PROJECT_DIR)/hw_layer/ports/stm32/stm32_adc_v4.cpp \
 
+# This MCU has a cache, align functions to a cache line for maximum cache efficiency
+USE_OPT += -falign-functions=16
+
 DDEFS += -DSTM32H743xx
 MCU = cortex-m7
 LDSCRIPT = $(PROJECT_DIR)/hw_layer/ports/stm32/stm32h7/STM32H743xI.ld

--- a/unit_tests/global.h
+++ b/unit_tests/global.h
@@ -75,3 +75,5 @@ namespace chibios_rt {
 #endif
 
 #define UNIT_TEST_BUSY_WAIT_CALLBACK() { 	timeNowUs++; }
+
+#define chsnprintf snprintf


### PR DESCRIPTION
- Turn off 16-byte function alignment on MCUs without a cache - saves 1-15 bytes added between functions for alignment
- use `chsnprintf` instead of `snprintf`
- Don't bother with trying to compute the locale-specific decimal point for lua (`lua_getlocaledecpoint`), just use `'.'`.
- Turn on section "sort by alignment", avoids useless fill gaps between linked objects.