### PR TITLE
simplify initializeSkippedToothTrigger

### DIFF
--- a/firmware/controllers/settings.cpp
+++ b/firmware/controllers/settings.cpp
@@ -326,23 +326,6 @@ static void setInjectorLag(float voltage, float value) {
 	setCurveValue(INJECTOR_LAG_CURVE, voltage, value);
 }
 
-/*
-static void setToothedWheel(int total, int skipped) {
-	if (total < 1 || skipped >= total) {
-		efiPrintf("invalid parameters %d %d", total, skipped);
-		return;
-	}
-	engineConfiguration->trigger.type = TT_TOOTHED_WHEEL;
-	engineConfiguration->trigger.customTotalToothCount = total;
-	engineConfiguration->trigger.customSkippedToothCount = skipped;
-
-	efiPrintf("toothed: total=%d/skipped=%d", total, skipped);
-	setToothedWheelConfiguration(&engine->triggerCentral.triggerShape, total, skipped, engineConfiguration->ambiguousOperationMode);
-	incrementGlobalConfigurationVersion();
-	doPrintConfiguration();
-}
-*/
-
 static void setGlobalFuelCorrection(float value) {
 	if (value < 0.01 || value > 50)
 		return;
@@ -1143,8 +1126,6 @@ void initSettings(void) {
 
 	addConsoleActionS(CMD_ENABLE, enable);
 	addConsoleActionS(CMD_DISABLE, disable);
-
-//	addConsoleActionII("set_toothed_wheel", setToothedWheel);
 
 	addConsoleActionFF("set_injector_lag", setInjectorLag);
 

--- a/firmware/controllers/trigger/decoders/trigger_structure.cpp
+++ b/firmware/controllers/trigger/decoders/trigger_structure.cpp
@@ -333,15 +333,6 @@ angle_t TriggerWaveform::getSwitchAngle(int index) const {
 	return getCycleDuration() * wave.getSwitchTime(index);
 }
 
-void setToothedWheelConfiguration(TriggerWaveform *s, int total, int skipped,
-		operation_mode_e operationMode) {
-#if EFI_ENGINE_CONTROL
-
-	initializeSkippedToothTriggerWaveformExt(s, total, skipped,
-			operationMode);
-#endif
-}
-
 void TriggerWaveform::setTriggerSynchronizationGap2(float syncRatioFrom, float syncRatioTo) {
 	setTriggerSynchronizationGap3(/*gapIndex*/0, syncRatioFrom, syncRatioTo);
 }
@@ -479,12 +470,8 @@ void TriggerWaveform::initializeTriggerWaveform(operation_mode_e triggerOperatio
 	switch (triggerConfig.TriggerType.type) {
 
 	case TT_TOOTHED_WHEEL:
-		/**
-		 * huh? why all know skipped wheel shapes use 'setToothedWheelConfiguration' method
-		 * which touches 'useRiseEdge' flag while here we do not touch it?!
-		 */
-		initializeSkippedToothTriggerWaveformExt(this, triggerConfig.TriggerType.customTotalToothCount,
-				triggerConfig.TriggerType.customSkippedToothCount, triggerOperationMode);
+		initializeSkippedToothTrigger(this, triggerConfig.TriggerType.customTotalToothCount,
+				triggerConfig.TriggerType.customSkippedToothCount, triggerOperationMode, SyncEdge::RiseOnly);
 		break;
 
 	case TT_MAZDA_MIATA_NA:
@@ -621,7 +608,7 @@ void TriggerWaveform::initializeTriggerWaveform(operation_mode_e triggerOperatio
 		break;
 
 	case TT_ONE:
-		setToothedWheelConfiguration(this, 1, 0, triggerOperationMode);
+		initializeSkippedToothTrigger(this, 1, 0, triggerOperationMode, SyncEdge::Rise);
 		break;
 
 	case TT_MAZDA_SOHC_4:
@@ -633,7 +620,7 @@ void TriggerWaveform::initializeTriggerWaveform(operation_mode_e triggerOperatio
 		break;
 
 	case TT_VVT_JZ:
-		setToothedWheelConfiguration(this, 3, 0, triggerOperationMode);
+		initializeSkippedToothTrigger(this, 3, 0, triggerOperationMode, SyncEdge::RiseOnly);
 		break;
 
 	case TT_36_2_1_1:
@@ -645,7 +632,7 @@ void TriggerWaveform::initializeTriggerWaveform(operation_mode_e triggerOperatio
 	    break;
 
 	case TT_TOOTHED_WHEEL_32_2:
-		setToothedWheelConfiguration(this, 32, 2, triggerOperationMode);
+		initializeSkippedToothTrigger(this, 32, 2, triggerOperationMode, SyncEdge::RiseOnly);
 		// todo: why is this 32/2 asking for third gap while 60/2 is happy with just two gaps?
 		// method above sets second gap, here we add third
 		// this third gap is not required to sync on perfect signal but is needed to handle to reject cranking transition noise
@@ -653,11 +640,11 @@ void TriggerWaveform::initializeTriggerWaveform(operation_mode_e triggerOperatio
 		break;
 
 	case TT_TOOTHED_WHEEL_60_2:
-		setToothedWheelConfiguration(this, 60, 2, triggerOperationMode);
+		initializeSkippedToothTrigger(this, 60, 2, triggerOperationMode, SyncEdge::RiseOnly);
 		break;
 
 	case TT_TOOTHED_WHEEL_36_2:
-		setToothedWheelConfiguration(this, 36, 2, triggerOperationMode);
+		initializeSkippedToothTrigger(this, 36, 2, triggerOperationMode, SyncEdge::RiseOnly);
 		setTriggerSynchronizationGap3(/*gapIndex*/0, /*from*/1.6, 3.5);
 		setTriggerSynchronizationGap3(/*gapIndex*/1, /*from*/0.7, 1.3); // second gap is not required to synch on perfect signal but is needed to handle to reject cranking transition noise
 		break;
@@ -667,7 +654,7 @@ void TriggerWaveform::initializeTriggerWaveform(operation_mode_e triggerOperatio
 		break;
 
 	case TT_TOOTHED_WHEEL_36_1:
-		setToothedWheelConfiguration(this, 36, 1, triggerOperationMode);
+		initializeSkippedToothTrigger(this, 36, 1, triggerOperationMode, SyncEdge::RiseOnly);
 		break;
 
 	case TT_VVT_BOSCH_QUICK_START:

--- a/firmware/controllers/trigger/decoders/trigger_structure.h
+++ b/firmware/controllers/trigger/decoders/trigger_structure.h
@@ -291,6 +291,4 @@ void findTriggerPosition(
 		event_trigger_position_s *position,
 		angle_t angle);
 
-void setToothedWheelConfiguration(TriggerWaveform *s, int total, int skipped, operation_mode_e operationMode);
-
 #define TRIGGER_WAVEFORM(x) getTriggerCentral()->triggerShape.x

--- a/firmware/controllers/trigger/decoders/trigger_universal.cpp
+++ b/firmware/controllers/trigger/decoders/trigger_universal.cpp
@@ -34,15 +34,17 @@ void addSkippedToothTriggerEvents(TriggerWheel wheel, TriggerWaveform *s, int to
 	s->addEventClamped(offset + engineCycle, wheel, TriggerValue::FALL, filterLeft, filterRight);
 }
 
-void initializeSkippedToothTriggerWaveformExt(TriggerWaveform *s, int totalTeethCount, int skippedCount,
-		operation_mode_e operationMode) {
+void initializeSkippedToothTrigger(TriggerWaveform *s, int totalTeethCount, int skippedCount,
+		operation_mode_e operationMode, SyncEdge syncEdge) {
 	if (totalTeethCount <= 0) {
 		firmwareError(CUSTOM_OBD_TRIGGER_WAVEFORM, "Invalid total tooth count for missing tooth decoder: %d", totalTeethCount);
 		s->setShapeDefinitionError(true);
 		return;
 	}
 	efiAssertVoid(CUSTOM_NULL_SHAPE, s != NULL, "TriggerWaveform is NULL");
-	s->initialize(operationMode, SyncEdge::RiseOnly);
+
+	s->initialize(operationMode, syncEdge);
+
 #if EFI_UNIT_TEST
 	s->knownOperationMode = false;
 #endif // EFI_UNIT_TEST

--- a/firmware/controllers/trigger/decoders/trigger_universal.h
+++ b/firmware/controllers/trigger/decoders/trigger_universal.h
@@ -18,7 +18,7 @@ void addSkippedToothTriggerEvents(TriggerWheel wheel, TriggerWaveform *s,
 		float offset, float engineCycle, float filterLeft, float filterRight);
 
 
-void initializeSkippedToothTriggerWaveformExt(TriggerWaveform *s, int totalTeethCount, int skippedCount, operation_mode_e operationMode);
+void initializeSkippedToothTrigger(TriggerWaveform *s, int totalTeethCount, int skippedCount, operation_mode_e operationMode, SyncEdge syncEdge);
 
 // TT_3_1_CAM
 void configure3_1_cam(TriggerWaveform *s);

--- a/unit_tests/tests/trigger/test_trigger_decoder.cpp
+++ b/unit_tests/tests/trigger/test_trigger_decoder.cpp
@@ -416,7 +416,7 @@ TEST(trigger, testTriggerDecoder) {
 	TriggerWaveform * s = &e.triggerCentral.triggerShape;
 
 	s->useOnlyRisingEdges = false;
-	initializeSkippedToothTriggerWaveformExt(s, 2, 0, FOUR_STROKE_CAM_SENSOR);
+	initializeSkippedToothTrigger(s, 2, 0, FOUR_STROKE_CAM_SENSOR, SyncEdge::Rise);
 	assertEqualsM("shape size", s->getSize(), 4);
 	ASSERT_EQ(s->wave.getSwitchTime(0), 0.25);
 	ASSERT_EQ(s->wave.getSwitchTime(1), 0.5);


### PR DESCRIPTION
We had two functions that do the same thing. Delete one of them.