### PR TITLE
enable proteus, select compiler in script

### DIFF
--- a/.github/workflows/build-firmware.yaml
+++ b/.github/workflows/build-firmware.yaml
@@ -317,7 +317,7 @@ jobs:
       run: | # Compiler hosted on our other git repo - avoids having to download from the nice folks at ARM every time
         wget 'https://github.com/rusefi/build_support/raw/master/gcc-arm-none-eabi-9-2020-q2-update-x86_64-linux.tar.xz' -O compiler.tar.xz
         tar -xvf compiler.tar.xz
-        echo "`pwd`/.rusefi-tools/gcc-arm-none-eabi-9-2020-q2-update/bin" >> $GITHUB_PATH
+        echo "`pwd`/gcc-arm-none-eabi-9-2020-q2-update/bin" >> $GITHUB_PATH
 
     # Make sure the compiler we just downloaded works - just print out the version
     - name: Test Compiler

--- a/.github/workflows/build-firmware.yaml
+++ b/.github/workflows/build-firmware.yaml
@@ -317,7 +317,7 @@ jobs:
       run: | # Compiler hosted on our other git repo - avoids having to download from the nice folks at ARM every time
         wget 'https://github.com/rusefi/build_support/raw/master/gcc-arm-none-eabi-9-2020-q2-update-x86_64-linux.tar.xz' -O compiler.tar.xz
         tar -xvf compiler.tar.xz
-        run: echo "`pwd`/.rusefi-tools/gcc-arm-none-eabi-9-2020-q2-update/bin" >> $GITHUB_PATH
+        echo "`pwd`/.rusefi-tools/gcc-arm-none-eabi-9-2020-q2-update/bin" >> $GITHUB_PATH
 
     # Make sure the compiler we just downloaded works - just print out the version
     - name: Test Compiler

--- a/.github/workflows/build-firmware.yaml
+++ b/.github/workflows/build-firmware.yaml
@@ -317,7 +317,7 @@ jobs:
       run: | # Compiler hosted on our other git repo - avoids having to download from the nice folks at ARM every time
         wget 'https://github.com/rusefi/build_support/raw/master/gcc-arm-none-eabi-9-2020-q2-update-x86_64-linux.tar.xz' -O compiler.tar.xz
         tar -xvf compiler.tar.xz
-        echo "::add-path::`pwd`/gcc-arm-none-eabi-9-2020-q2-update/bin"
+        run: echo "`pwd`/.rusefi-tools/gcc-arm-none-eabi-9-2020-q2-update/bin" >> $GITHUB_PATH
 
     # Make sure the compiler we just downloaded works - just print out the version
     - name: Test Compiler

--- a/.github/workflows/hardware-ci.yaml
+++ b/.github/workflows/hardware-ci.yaml
@@ -8,7 +8,7 @@ jobs:
       # Let all builds finish even if one fails early
       fail-fast: false
       matrix:
-        build-target: [f407-discovery]
+        build-target: [f407-discovery, proteus_f4]
 
         include:
           - build-target: f407-discovery
@@ -18,12 +18,12 @@ jobs:
             config-name: all
             ini-file: rusefi_f4-disco.ini
 
-#          - build-target: proteus_f4
-#            script: hardware_ci_proteus
-#            runs-on: hw-ci-proteus
-#            folder: proteus
-#            config-name: proteus_f4
-#            ini-file: rusefi_proteus_f4.ini
+          - build-target: proteus_f4
+            script: hardware_ci_proteus
+            runs-on: hw-ci-proteus
+            folder: proteus
+            config-name: proteus_f4
+            ini-file: rusefi_proteus_f4.ini
 
     runs-on: ${{matrix.runs-on}}
 
@@ -52,8 +52,11 @@ jobs:
       working-directory: ./firmware/
       run: ./gen_live_documentation.sh
 
+    - name: Add compiler to PATH
+      run: echo "::add-path::$HOME/.rusefi-tools/gcc-arm-none-eabi-9-2020-q2-update/bin"
+
     # Make sure the compiler works
-    - name: Test Compiler
+    - name: Test/Identify Compiler
       run: arm-none-eabi-gcc -v
 
     # We aren't guaranteed a clean machine every time, so manually clean the output

--- a/.github/workflows/hardware-ci.yaml
+++ b/.github/workflows/hardware-ci.yaml
@@ -53,7 +53,7 @@ jobs:
       run: ./gen_live_documentation.sh
 
     - name: Add compiler to PATH
-      run: echo "::add-path::$HOME/.rusefi-tools/gcc-arm-none-eabi-9-2020-q2-update/bin"
+      run: echo "$HOME/.rusefi-tools/gcc-arm-none-eabi-9-2020-q2-update/bin" >> $GITHUB_PATH
 
     # Make sure the compiler works
     - name: Test/Identify Compiler

--- a/firmware/init/sensor/init_sensors.cpp
+++ b/firmware/init/sensor/init_sensors.cpp
@@ -74,9 +74,8 @@ void initNewSensors() {
 	// Init CLI functionality for sensors (mocking)
 	initSensorCli();
 
-#ifdef HARDWARE_CI
-
-	chThdSleepMilliseconds(10);
+#if defined(HARDWARE_CI) && !defined(HW_PROTEUS)
+	chThdSleepMilliseconds(100);
 
 	if (Sensor::getOrZero(SensorType::BatteryVoltage) < 8) {
 		// Fake that we have battery voltage, some tests rely on it

--- a/java_console/autotest/src/main/java/com/rusefi/proteus/ProteusAnalogTest.java
+++ b/java_console/autotest/src/main/java/com/rusefi/proteus/ProteusAnalogTest.java
@@ -22,8 +22,6 @@ public class ProteusAnalogTest extends RusefiTestBase {
     public void testVbatt() {
         double vbatt = SensorCentral.getInstance().getValue(Sensor.VBATT);
 
-        System.out.println("******** vbatt is: " + vbatt);
-
         // allow some tolerance for the supply voltage...
         assertTrue(vbatt > 11);
         assertTrue(vbatt < 13);

--- a/java_console/autotest/src/main/java/com/rusefi/proteus/ProteusAnalogTest.java
+++ b/java_console/autotest/src/main/java/com/rusefi/proteus/ProteusAnalogTest.java
@@ -22,6 +22,8 @@ public class ProteusAnalogTest extends RusefiTestBase {
     public void testVbatt() {
         double vbatt = SensorCentral.getInstance().getValue(Sensor.VBATT);
 
+        System.out.println("******** vbatt is: " + vbatt);
+
         // allow some tolerance for the supply voltage...
         assertTrue(vbatt > 11);
         assertTrue(vbatt < 13);


### PR DESCRIPTION
Re-enable proteus CI.

fix #4668

Set the compiler in `$PATH`, so that #4641 can use gcc10 in hardware CI without manually adjusting the hw ci machines (side by side gcc9 + gcc10)