### PR TITLE
SENT fixes

### DIFF
--- a/firmware/hw_layer/drivers/sent/sent.cpp
+++ b/firmware/hw_layer/drivers/sent/sent.cpp
@@ -472,10 +472,12 @@ void sent_channel::Info(void)
 	efiPrintf("Total pulses %d", pulseCounter);
 	efiPrintf("Last fast msg Status 0x%01x Sig0 0x%03x Sig1 0x%03x", stat, sig0, sig1);
 
-	efiPrintf("Slow channels:");
-	for (i = 0; i < SENT_SLOW_CHANNELS_MAX; i++) {
-		if (scMsgFlags & BIT(i)) {
-			efiPrintf(" ID %d: %d", scMsg[i].id, scMsg[i].data);
+	if (scMsgFlags) {
+		efiPrintf("Slow channels:");
+		for (i = 0; i < SENT_SLOW_CHANNELS_MAX; i++) {
+			if (scMsgFlags & BIT(i)) {
+				efiPrintf(" ID %d: %d", scMsg[i].id, scMsg[i].data);
+			}
 		}
 	}
 

--- a/firmware/hw_layer/drivers/sent/sent.cpp
+++ b/firmware/hw_layer/drivers/sent/sent.cpp
@@ -507,7 +507,7 @@ void sent_channel::Info(void)
 	#if SENT_STATISTIC_COUNTERS
 		efiPrintf("Restarts %d", statistic.RestartCnt);
 		efiPrintf("Interval errors %d short, %d long", statistic.ShortIntervalErr, statistic.LongIntervalErr);
-		efiPrintf("Total frames %d with crc error %d", statistic.FrameCnt, statistic.CrcErrCnt);
+		efiPrintf("Total frames %d with crc error %d (%f %%)", statistic.FrameCnt, statistic.CrcErrCnt, statistic.CrcErrCnt * 100.0 / statistic.FrameCnt);
 		efiPrintf("Sync errors %d", statistic.SyncErr);
 	#endif
 }

--- a/firmware/hw_layer/drivers/sent/sent.cpp
+++ b/firmware/hw_layer/drivers/sent/sent.cpp
@@ -29,6 +29,9 @@
 /* Status + two 12-bit signals + CRC */
 #define SENT_MSG_PAYLOAD_SIZE   (1 + SENT_MSG_DATA_SIZE + 1)  // Size of payload
 
+/* use 3 full frames + one additional pulse for unit time calibration */
+#define SENT_CALIBRATION_PULSES	(1 + 3 * SENT_MSG_PAYLOAD_SIZE)
+
 /*==========================================================================*/
 /* Decoder configuration													*/
 /*==========================================================================*/
@@ -161,12 +164,13 @@ int sent_channel::Decoder(uint16_t clocks)
 
 	/* special case - tick time calculation */
 	if (state == SENT_STATE_CALIB) {
-		/* Find longes pulse ... */
+		/* Find longes pulse */
 		if (clocks > tickPerUnit) {
 			tickPerUnit = clocks;
 		}
-		/* ... of 9 pulses */
-		if (pulseCounter >= (SENT_MSG_PAYLOAD_SIZE + 1)) {
+		/* ...this should be SYNC pulse */
+		if (pulseCounter >= SENT_CALIBRATION_PULSES) {
+			/* calculate Unit time from SYNC pulse */
 			tickPerUnit = (tickPerUnit + (SENT_SYNC_INTERVAL + SENT_OFFSET_INTERVAL) / 2) /
 							(SENT_SYNC_INTERVAL + SENT_OFFSET_INTERVAL);
 			pulseCounter = 0;

--- a/firmware/hw_layer/drivers/sent/sent.cpp
+++ b/firmware/hw_layer/drivers/sent/sent.cpp
@@ -448,20 +448,20 @@ uint8_t sent_channel::crc4(uint8_t* pdata, uint16_t ndata)
 /* TODO: double check and use same CRC routine? */
 uint8_t sent_channel::crc4_gm(uint8_t* pdata, uint16_t ndata)
 {
+	size_t i;
+	uint8_t crc = SENT_CRC_SEED; // initialize checksum with seed "0101"
 	const uint8_t CrcLookup[16] = {0, 13, 7, 10, 14, 3, 9, 4, 1, 12, 6, 11, 15, 2, 8, 5};
-	uint8_t calculatedCRC, i;
-
-	calculatedCRC = SENT_CRC_SEED; // initialize checksum with seed "0101"
 
 	for (i = 0; i < ndata; i++)
 	{
-		calculatedCRC = CrcLookup[calculatedCRC];
-		calculatedCRC = (calculatedCRC ^ pdata[i]) & 0x0F;
+		crc = CrcLookup[crc];
+		crc = (crc ^ pdata[i]) & 0x0F;
+		//crc = pdata[i] ^ CrcLookup[crc];
 	}
 	// One more round with 0 as input
-	calculatedCRC = CrcLookup[calculatedCRC];
+	//crc = CrcLookup[crc];
 
-	return calculatedCRC;
+	return crc;
 }
 
 void sent_channel::Info(void)

--- a/firmware/hw_layer/drivers/sent/sent.cpp
+++ b/firmware/hw_layer/drivers/sent/sent.cpp
@@ -225,7 +225,8 @@ int sent_channel::Decoder(uint16_t clocks)
 			if (interval == SENT_SYNC_INTERVAL)
 			{// sync interval - 56 ticks
 				/* measured tick interval will be used until next sync pulse */
-				tickPerUnit = (clocks + 56 / 2) / (SENT_SYNC_INTERVAL + SENT_OFFSET_INTERVAL);
+				tickPerUnit = (clocks + (SENT_SYNC_INTERVAL + SENT_OFFSET_INTERVAL) / 2) /
+								(SENT_SYNC_INTERVAL + SENT_OFFSET_INTERVAL);
 				state = SENT_STATE_STATUS;
 			}
 			else

--- a/firmware/hw_layer/drivers/sent/sent.cpp
+++ b/firmware/hw_layer/drivers/sent/sent.cpp
@@ -482,7 +482,7 @@ void sent_channel::Info(void)
 	#if SENT_STATISTIC_COUNTERS
 		efiPrintf("Restarts %d", statistic.RestartCnt);
 		efiPrintf("Interval errors %d short, %d long", statistic.ShortIntervalErr, statistic.LongIntervalErr);
-		efiPrintf("Total frames %d with crc erorr %d", statistic.FrameCnt, statistic.CrcErrCnt);
+		efiPrintf("Total frames %d with crc error %d", statistic.FrameCnt, statistic.CrcErrCnt);
 		efiPrintf("Sync errors %d", statistic.SyncErr);
 	#endif
 }


### PR DESCRIPTION
Implement another one CRC check that is compatible with GM throttle.
Use more pulses for Unit time calculation.
Fix debug output.

```
2022-10-23_00_39_41_668: EngineState: ---- SENT ch 0 ----
2022-10-23_00_39_41_669: EngineState: Unit time 275 timer ticks
2022-10-23_00_39_41_669: EngineState: Total pulses 2363816
2022-10-23_00_39_41_670: EngineState: Last fast msg Status 0x0 Sig0 0xAD4 Sig1 0x52B
2022-10-23_00_39_41_670: EngineState: Restarts 0
2022-10-23_00_39_41_670: EngineState: Interval errors 441 short, 7845 long
2022-10-23_00_39_41_672: EngineState: Total frames 248023 with crc error 208 (0.083863192 %)
2022-10-23_00_39_41_672: EngineState: Sync errors 441
2022-10-23_00_39_41_672: EngineState: --------------------
```
