### PR TITLE
remove idle timing deadzone

### DIFF
--- a/firmware/CHANGELOG.md
+++ b/firmware/CHANGELOG.md
@@ -43,6 +43,9 @@ Release template (copy/paste this for new release):
  - Slower than expected RPM information was slowing engine start #4629
  - Fix 36-2-1 trigger (Mitsubishi 4B11, etc) #4635
 
+### Removed
+ - Idle timing deadzone #4729
+
 ## September 2022 Release - "Day 203"
 
 ### Added

--- a/firmware/config/engines/mazda_miata_1_6.cpp
+++ b/firmware/config/engines/mazda_miata_1_6.cpp
@@ -373,7 +373,6 @@ void setMiataNA6_MAP_MRE() {
 	engineConfiguration->idleTimingPid.dFactor = 0.0;
 	engineConfiguration->idleTimingPid.minValue = -13;
 	engineConfiguration->idleTimingPid.maxValue = 13;
-	engineConfiguration->idleTimingPidDeadZone = 10;
 
 	// EFI_ADC_3: "22 - AN temp 4"
 	engineConfiguration->acSwitch = Gpio::A3;

--- a/firmware/controllers/actuators/idle_thread.cpp
+++ b/firmware/controllers/actuators/idle_thread.cpp
@@ -161,12 +161,6 @@ float IdleController::getIdleTimingAdjustment(int rpm, int targetRpm, Phase phas
 		return 0;
 	}
 
-	// If inside the deadzone, do nothing
-	if (absI(rpm - targetRpm) < engineConfiguration->idleTimingPidDeadZone) {
-		m_timingPid.reset();
-		return 0;
-	}
-
 	// We're now in the idle mode, and RPM is inside the Timing-PID regulator work zone!
 	return m_timingPid.getOutput(targetRpm, rpm, FAST_CALLBACK_PERIOD_MS / 1000.0f);
 }

--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -1385,7 +1385,8 @@ tChargeMode_e tChargeMode;
 	int16_t etb_iTermMax;iTerm max value;"", 1, 0, -30000, 30000, 0
 
 	pid_s idleTimingPid;See useIdleTimingPidControl
-	int16_t idleTimingPidDeadZone;If the RPM closer to target than this value, disable timing correction to prevent oscillation;"RPM", 1, 0, 0, 1000, 0
+
+	int16_t unused2496
 
 	int16_t tpsAccelFractionPeriod;A delay in cycles between fuel-enrich. portions;"cycles", 1, 0, 0, 500, 0
 	float tpsAccelFractionDivisor;A fraction divisor: 1 or less = entire portion at once, or split into diminishing fractions;"coef", 1, 0, 0, 100, 2

--- a/firmware/tunerstudio/rusefi.input
+++ b/firmware/tunerstudio/rusefi.input
@@ -3093,7 +3093,6 @@ cmd_set_engine_type_default					= "@@TS_IO_TEST_COMMAND_char@@@@ts_command_e_TS_
 	dialog = idleTimingPidCorrDialog, "", yAxis
 		field = ""
 		field = "Enable closed loop idle ignition timing",	useIdleTimingPidControl
-		field = "RPM deadzone", idleTimingPidDeadZone
 		field = ""
 		field = "#Gain is in degrees advance per rpm away from target"
 		field = "#A good starting point is 0.1 = 10 deg per 100 rpm"

--- a/unit_tests/tests/test_idle_controller.cpp
+++ b/unit_tests/tests/test_idle_controller.cpp
@@ -42,8 +42,6 @@ TEST(idle_v2, timingPid) {
 
 	engineConfiguration->useIdleTimingPidControl = true;
 
-	// Now check that the deadzone works
-	engineConfiguration->idleTimingPidDeadZone = 50;
 	EXPECT_FLOAT_EQ(5,    dut.getIdleTimingAdjustment(950,  1000, ICP::Idling));
 	EXPECT_FLOAT_EQ(2.5,  dut.getIdleTimingAdjustment(975,  1000, ICP::Idling));
 	EXPECT_FLOAT_EQ(0,    dut.getIdleTimingAdjustment(1000, 1000, ICP::Idling));

--- a/unit_tests/tests/test_idle_controller.cpp
+++ b/unit_tests/tests/test_idle_controller.cpp
@@ -44,11 +44,11 @@ TEST(idle_v2, timingPid) {
 
 	// Now check that the deadzone works
 	engineConfiguration->idleTimingPidDeadZone = 50;
-	EXPECT_FLOAT_EQ(5.1, dut.getIdleTimingAdjustment(949, 1000, ICP::Idling));
-	EXPECT_EQ(0, dut.getIdleTimingAdjustment(951, 1000, ICP::Idling));
-	EXPECT_EQ(0, dut.getIdleTimingAdjustment(1000, 1000, ICP::Idling));
-	EXPECT_EQ(0, dut.getIdleTimingAdjustment(1049, 1000, ICP::Idling));
-	EXPECT_FLOAT_EQ(-5.1, dut.getIdleTimingAdjustment(1051, 1000, ICP::Idling));
+	EXPECT_FLOAT_EQ(5,    dut.getIdleTimingAdjustment(950,  1000, ICP::Idling));
+	EXPECT_FLOAT_EQ(2.5,  dut.getIdleTimingAdjustment(975,  1000, ICP::Idling));
+	EXPECT_FLOAT_EQ(0,    dut.getIdleTimingAdjustment(1000, 1000, ICP::Idling));
+	EXPECT_FLOAT_EQ(-2.5, dut.getIdleTimingAdjustment(1025, 1000, ICP::Idling));
+	EXPECT_FLOAT_EQ(-5,   dut.getIdleTimingAdjustment(1050, 1000, ICP::Idling));
 }
 
 TEST(idle_v2, testTargetRpm) {


### PR DESCRIPTION
Deadzone on idle timing PD is a trap, as in no real scenario will it help make your idle more stable.

#4729