### PR TITLE
fix vvt logging logic

### DIFF
--- a/unit_tests/tests/trigger/test_cam_vvt_input.cpp
+++ b/unit_tests/tests/trigger/test_cam_vvt_input.cpp
@@ -110,7 +110,7 @@ TEST(trigger, testCamInput) {
 
 	for (int i = 0; i < 600;i++) {
 		eth.moveTimeForwardUs(MS2US(10));
-		hwHandleVvtCamSignal(TriggerValue::FALL, getTimeNowNt(), 0);
+		hwHandleVvtCamSignal(TriggerValue::RISE, getTimeNowNt(), 0);
 		eth.moveTimeForwardUs(MS2US(40));
 		eth.firePrimaryTriggerRise();
 	}
@@ -177,5 +177,5 @@ TEST(trigger, testNB2CamInput) {
 	// actually position based on VVT!
 	ASSERT_EQ(totalRevolutionCountBeforeVvtSync + 3, engine->triggerCentral.triggerState.getCrankSynchronizationCounter());
 
-	EXPECT_EQ(40, waveChart.getSize());
+	EXPECT_EQ(39, waveChart.getSize());
 }

--- a/unit_tests/tests/trigger/test_real_nb2_cranking.cpp
+++ b/unit_tests/tests/trigger/test_real_nb2_cranking.cpp
@@ -30,8 +30,8 @@ TEST(realCrankingNB2, normalCranking) {
 
 	EXPECT_EQ(3, eth.recentWarnings()->getCount());
 	EXPECT_EQ(CUSTOM_OUT_OF_ORDER_COIL, eth.recentWarnings()->get(0).Code);
-	EXPECT_EQ(CUSTOM_CAM_TOO_MANY_TEETH, eth.recentWarnings()->get(1).Code);
-	EXPECT_EQ(CUSTOM_PRIMARY_NOT_ENOUGH_TEETH, eth.recentWarnings()->get(2).Code);
+	EXPECT_EQ(CUSTOM_PRIMARY_NOT_ENOUGH_TEETH, eth.recentWarnings()->get(1).Code);
+	EXPECT_EQ(CUSTOM_CAM_TOO_MANY_TEETH, eth.recentWarnings()->get(2).Code);
 }
 
 TEST(realCrankingNB2, crankingMissingInjector) {
@@ -52,7 +52,7 @@ TEST(realCrankingNB2, crankingMissingInjector) {
 
 	EXPECT_EQ(4, eth.recentWarnings()->getCount());
 	EXPECT_EQ(CUSTOM_OUT_OF_ORDER_COIL, eth.recentWarnings()->get(0).Code);
-	EXPECT_EQ(CUSTOM_CAM_TOO_MANY_TEETH, eth.recentWarnings()->get(1).Code);
-	EXPECT_EQ(CUSTOM_PRIMARY_NOT_ENOUGH_TEETH, eth.recentWarnings()->get(2).Code);
+	EXPECT_EQ(CUSTOM_PRIMARY_NOT_ENOUGH_TEETH, eth.recentWarnings()->get(1).Code);
+	EXPECT_EQ(CUSTOM_CAM_TOO_MANY_TEETH, eth.recentWarnings()->get(2).Code);
 	EXPECT_EQ(CUSTOM_PRIMARY_TOO_MANY_TEETH, eth.recentWarnings()->get(3).Code);
 }


### PR DESCRIPTION
Make VVT logging logic do the right thing (fix the todo in #4621). It shouldn't be looking at `engineConfiguration->vvtCamSensorUseRise` at all.