### PR TITLE
fix prometheus build options

### DIFF
--- a/firmware/config/boards/prometheus/compile_prometheus_469.sh
+++ b/firmware/config/boards/prometheus/compile_prometheus_469.sh
@@ -2,7 +2,4 @@
 
 # STM32F469 version of the firmware for https://rusefi.com/forum/viewtopic.php?f=4&t=1215
 
-export USE_BOOTLOADER=yes
-
 bash ../common_make.sh prometheus/f469 ARCH_STM32F4
-

--- a/firmware/config/boards/prometheus/f405/board.mk
+++ b/firmware/config/boards/prometheus/f405/board.mk
@@ -1,3 +1,3 @@
 PROMETHEUS_BOARD = 405
 
-include $(PROJECT_DIR)/config/boards/prometheus/prometheus-common.mk
+include $(PROJECT_DIR)/config/boards/prometheus/prometheus-common-board.mk

--- a/firmware/config/boards/prometheus/f405/config.mk
+++ b/firmware/config/boards/prometheus/f405/config.mk
@@ -1,0 +1,1 @@
+include $(PROJECT_DIR)/config/boards/prometheus/prometheus-common-config.mk

--- a/firmware/config/boards/prometheus/f469/board.mk
+++ b/firmware/config/boards/prometheus/f469/board.mk
@@ -1,3 +1,3 @@
 PROMETHEUS_BOARD = 469
 
-include $(PROJECT_DIR)/config/boards/prometheus/prometheus-common.mk
+include $(PROJECT_DIR)/config/boards/prometheus/prometheus-common-board.mk

--- a/firmware/config/boards/prometheus/f469/config.mk
+++ b/firmware/config/boards/prometheus/f469/config.mk
@@ -1,0 +1,1 @@
+include $(PROJECT_DIR)/config/boards/prometheus/prometheus-common-config.mk

--- a/firmware/config/boards/prometheus/prometheus-common-board.mk
+++ b/firmware/config/boards/prometheus/prometheus-common-board.mk
@@ -6,12 +6,6 @@ BOARDCPPSRC = $(PROJECT_DIR)/config/boards/Prometheus/board_configuration.cpp
 # Required include directories
 BOARDINC = $(PROJECT_DIR)/config/boards/prometheus
 
-# This board uses bootloader
-USE_BOOTLOADER = yes
-
-# include Prometheus bootloader code
-BOOTLOADERINC = $(PROJECT_DIR)/bootloader/prometheus/$(PROMETHEUS_BOARD)
-
 # Default to a release build - clear EXTRA_PARAMS from cmdline to build debug
 ifeq ($(EXTRA_PARAMS),)
 	EXTRA_PARAMS = -DEFI_ENABLE_ASSERTS=FALSE -DCH_DBG_ENABLE_ASSERTS=FALSE -DCH_DBG_ENABLE_STACK_CHECK=FALSE -DCH_DBG_FILL_THREADS=FALSE -DCH_DBG_THREADS_PROFILING=FALSE

--- a/firmware/config/boards/prometheus/prometheus-common-config.mk
+++ b/firmware/config/boards/prometheus/prometheus-common-config.mk
@@ -1,0 +1,5 @@
+# This board uses bootloader
+USE_BOOTLOADER = yes
+
+# include Prometheus bootloader code
+BOOTLOADERINC = $(PROJECT_DIR)/bootloader/prometheus/$(PROMETHEUS_BOARD)


### PR DESCRIPTION
The check for `USE_BOOTLOADER` is before the `include .../board.mk` in `firmware/Makefile`.  Either that check should be moved lower (and some cleanup from ...) or these fixes incorporated.  `config/boards/subaru_eg33/board.mk` is suspect too (`ifeq ($(USE_BOOTLOADER),yes)`); for one, `Makefile` uses inverted assertion (about `no`) so this condition brittle.

#### `make PROJECT_BOARD=prometheus/f405`
```
No CCACHE_DIR
PROJECT_BOARD: prometheus/f405
PROJECT_CPU:   ARCH_STM32F4
CONFDIR:       ./hw_layer/ports/stm32/stm32f4/cfg
LDSCRIPT:      ./hw_layer/ports/stm32/stm32f4/STM32F4.ld
Compiler Options
arm-none-eabi-gcc -c -mcpu=cortex-m4 -mthumb -DEFI_ENABLE_ASSERTS=FALSE -DCH_DBG_ENABLE_ASSERTS=FALSE -DCH_DBG_ENABLE_STACK_CHECK=FALSE -DCH_DBG_FILL_THREADS=FALSE -DCH_DBG_THREADS_PROFILING=FALSE -O2 -ggdb -g -fomit-frame-pointer -fsingle-precision-constant -fno-inline-functions -Werror -Wno-error=unused-function -Wno-error=unused-variable -Wno-error=sign-compare -Wno-error=unused-parameter -DEFI_UNIT_TEST=0 -DEFI_PROD_CODE=1 -DEFI_SIMULATOR=0 -Wl,--defsym=BOOTLOADER=1 -ffunction-sections -fdata-sections -fno-common -flto -mfloat-abi=hard -mfpu=fpv4-sp-d16 -fgnu89-inline -std=gnu99 -Wno-error=implicit-fallthrough -Wall -Wextra -Wstrict-prototypes -Wa,-alms=build/lst/ -DFIRMWARE_ID="prometeus405" -DSHORT_BOARD_NAME=prometheus_405 -DSTM32F407xx -DEFI_BOOTLOADER_INCLUDE_CODE=TRUE -DCORTEX_VTOR_INIT=0x8000 -DCORTEX_USE_FPU=TRUE -MD -MP -MF .dep/build.d -I. -I./pch -I./config/boards/prometheus -IChibiOS/os/license -IChibiOS/os/common/portability/GCC -IChibiOS/os/common/startup/ARMCMx/compilers/GCC -IChibiOS/os/common/startup/ARMCMx/devices/STM32F4xx -IChibiOS/os/common/ext/ARM/CMSIS/Core/Include -IChibiOS/os/common/ext/ST/STM32F4xx -IChibiOS/os/hal/include -IChibiOS-Contrib/os/hal/include -IChibiOS/os/hal/ports/common/ARMCMx -IChibiOS/os/hal/ports/STM32/STM32F4xx -IChibiOS/os/hal/ports/STM32/LLD/ADCv2 -IChibiOS/os/hal/ports/STM32/LLD/CANv1 -IChibiOS/os/hal/ports/STM32/LLD/CRYPv1 -IChibiOS/os/hal/ports/STM32/LLD/DACv1 -IChibiOS/os/hal/ports/STM32/LLD/DMAv2 -IChibiOS/os/hal/ports/STM32/LLD/EXTIv1 -IChibiOS/os/hal/ports/STM32/LLD/GPIOv2 -IChibiOS/os/hal/ports/STM32/LLD/I2Cv1 -IChibiOS/os/hal/ports/STM32/LLD/MACv1 -IChibiOS/os/hal/ports/STM32/LLD/OTGv1 -IChibiOS/os/hal/ports/STM32/LLD/QUADSPIv1 -IChibiOS/os/hal/ports/STM32/LLD/RTCv2 -IChibiOS/os/hal/ports/STM32/LLD/SPIv1 -IChibiOS/os/hal/ports/STM32/LLD/SDIOv1 -IChibiOS/os/hal/ports/STM32/LLD/TIMv1 -IChibiOS/os/hal/ports/STM32/LLD/USARTv1 -IChibiOS/os/hal/ports/STM32/LLD/xWDGv1 -IChibiOS-Contrib/os/hal/ports/STM32/LLD/CRCv1 -IChibiOS-Contrib/os/hal/ports/STM32/LLD/DMA2Dv1 -IChibiOS-Contrib/os/hal/ports/STM32/LLD/FSMCv1 -IChibiOS-Contrib/os/hal/ports/STM32/LLD/TIMv1 -IChibiOS-Contrib/os/hal/ports/STM32/LLD/LTDCv1 -IChibiOS-Contrib/os/hal/ports/STM32/LLD/USBHv1 -IChibiOS/os/hal/osal/rt-nil -IChibiOS/os/rt/include -IChibiOS/os/oslib/include -IChibiOS/os/common/ports/ARMCMx -IChibiOS/os/common/ports/ARMCMx/compilers/GCC -IChibiOS/os/ex/include -IChibiOS/os/ex/devices/ST -IChibiOS/os/hal/lib/streams -IChibiOS/os/various/cpp_wrappers -IChibiOS/os/hal/lib/complex/mfs -I./ext -I./ext/uzlib/src -I./controllers/lua -I./controllers/lua/luaaa -I./ext/lua -I./config/stm32f4ems -I./console/binary -I./console -I./console/binary_log -I./development -I./config/engines -I./config/boards/ -I./hw_layer/algo -I./init -I./ext_algo -I./hw_layer/drivers -I./hw_layer/drivers/gpio -I./hw_layer/drivers/can -I./hw_layer/drivers/sent -I./hw_layer/drivers/serial -I./hw_layer/drivers/i2c -I./hw_layer/drivers/lcd -I./hw_layer -I./hw_layer/adc -I./hw_layer/digital_input -I./hw_layer/digital_input/trigger -I./hw_layer/microsecond_timer -I./hw_layer/sensors -I./util -I./util/containers -I./util/math -I./controllers -I./controllers/system -I./controllers/system/timer -I./controllers/algo -I./controllers/algo/airmass -I./controllers/algo/defaults -I./controllers/algo/fuel -I./controllers/engine_cycle -I./controllers/trigger/decoders -I./controllers/tcu -I./controllers/trigger -I./controllers/sensors -I./controllers/sensors/converters -I./controllers/can -I./controllers/core -I./controllers/gauges -I./controllers/math -I./controllers/generated -I./controllers/actuators -I./controllers/actuators/gppwm -I./controllers/serial -I./console/binary/generated -I./bootloader/prometheus/405 -IChibiOS/os/various -IChibiOS/os/hal/lib/peripherals/sensors -I./libfirmware/util/include -I./libfirmware/pt2001/include -I./libfirmware/pt2001/project/rusefi/sample_code -I./hw_layer/ports/stm32/stm32f4/cfg -Iext/FatFS -I./hw_layer/mass_storage -I./hw_layer/serial_over_usb -I./hw_layer/lcd -I./hw_layer/mass_storage -Ihw_layer/ports/stm32/stm32f4 -I./hw_layer/ports -I./hw_layer/ports/stm32 -I./hw_layer/ports/stm32/serial_over_usb -Idevelopment/hw_layer -Idevelopment/test -IChibiOS-Contrib/os/various main.c -o main.o

...

   text	  data	   bss	   dec	   hex	filename
 471216	 18912	191832	681960	 a67e8	build/rusefi.elf
Creating build/rusefi.list

Done
Creating build/rusefi.srec
bss Total size: 91773
ram4 Total size: 0
text Total size: 345270
data Total size: 3634
rodata Total size: 113196
 20 .ram4         0000fc10  10000000  0807bf74  000a0000  2**3
```

#### `make PROJECT_BOARD=prometheus/f46`
```
No CCACHE_DIR
PROJECT_BOARD: prometheus/f469
PROJECT_CPU:   ARCH_STM32F4
CONFDIR:       ./hw_layer/ports/stm32/stm32f4/cfg
LDSCRIPT:      ./hw_layer/ports/stm32/stm32f4/STM32F4.ld
Compiler Options
arm-none-eabi-gcc -c -mcpu=cortex-m4 -mthumb -DEFI_ENABLE_ASSERTS=FALSE -DCH_DBG_ENABLE_ASSERTS=FALSE -DCH_DBG_ENABLE_STACK_CHECK=FALSE -DCH_DBG_FILL_THREADS=FALSE -DCH_DBG_THREADS_PROFILING=FALSE -O2 -ggdb -g -fomit-frame-pointer -fsingle-precision-constant -fno-inline-functions -Werror -Wno-error=unused-function -Wno-error=unused-variable -Wno-error=sign-compare -Wno-error=unused-parameter -DEFI_UNIT_TEST=0 -DEFI_PROD_CODE=1 -DEFI_SIMULATOR=0 -Wl,--defsym=BOOTLOADER=1 -ffunction-sections -fdata-sections -fno-common -flto -mfloat-abi=hard -mfpu=fpv4-sp-d16 -fgnu89-inline -std=gnu99 -Wno-error=implicit-fallthrough -Wall -Wextra -Wstrict-prototypes -Wa,-alms=build/lst/ -DFIRMWARE_ID="prometeus469" -DSHORT_BOARD_NAME=prometheus_469 -DSTM32F407xx -DEFI_BOOTLOADER_INCLUDE_CODE=TRUE -DCORTEX_VTOR_INIT=0x8000 -DCORTEX_USE_FPU=TRUE -MD -MP -MF .dep/build.d -I. -I./pch -I./config/boards/prometheus -IChibiOS/os/license -IChibiOS/os/common/portability/GCC -IChibiOS/os/common/startup/ARMCMx/compilers/GCC -IChibiOS/os/common/startup/ARMCMx/devices/STM32F4xx -IChibiOS/os/common/ext/ARM/CMSIS/Core/Include -IChibiOS/os/common/ext/ST/STM32F4xx -IChibiOS/os/hal/include -IChibiOS-Contrib/os/hal/include -IChibiOS/os/hal/ports/common/ARMCMx -IChibiOS/os/hal/ports/STM32/STM32F4xx -IChibiOS/os/hal/ports/STM32/LLD/ADCv2 -IChibiOS/os/hal/ports/STM32/LLD/CANv1 -IChibiOS/os/hal/ports/STM32/LLD/CRYPv1 -IChibiOS/os/hal/ports/STM32/LLD/DACv1 -IChibiOS/os/hal/ports/STM32/LLD/DMAv2 -IChibiOS/os/hal/ports/STM32/LLD/EXTIv1 -IChibiOS/os/hal/ports/STM32/LLD/GPIOv2 -IChibiOS/os/hal/ports/STM32/LLD/I2Cv1 -IChibiOS/os/hal/ports/STM32/LLD/MACv1 -IChibiOS/os/hal/ports/STM32/LLD/OTGv1 -IChibiOS/os/hal/ports/STM32/LLD/QUADSPIv1 -IChibiOS/os/hal/ports/STM32/LLD/RTCv2 -IChibiOS/os/hal/ports/STM32/LLD/SPIv1 -IChibiOS/os/hal/ports/STM32/LLD/SDIOv1 -IChibiOS/os/hal/ports/STM32/LLD/TIMv1 -IChibiOS/os/hal/ports/STM32/LLD/USARTv1 -IChibiOS/os/hal/ports/STM32/LLD/xWDGv1 -IChibiOS-Contrib/os/hal/ports/STM32/LLD/CRCv1 -IChibiOS-Contrib/os/hal/ports/STM32/LLD/DMA2Dv1 -IChibiOS-Contrib/os/hal/ports/STM32/LLD/FSMCv1 -IChibiOS-Contrib/os/hal/ports/STM32/LLD/TIMv1 -IChibiOS-Contrib/os/hal/ports/STM32/LLD/LTDCv1 -IChibiOS-Contrib/os/hal/ports/STM32/LLD/USBHv1 -IChibiOS/os/hal/osal/rt-nil -IChibiOS/os/rt/include -IChibiOS/os/oslib/include -IChibiOS/os/common/ports/ARMCMx -IChibiOS/os/common/ports/ARMCMx/compilers/GCC -IChibiOS/os/ex/include -IChibiOS/os/ex/devices/ST -IChibiOS/os/hal/lib/streams -IChibiOS/os/various/cpp_wrappers -IChibiOS/os/hal/lib/complex/mfs -I./ext -I./ext/uzlib/src -I./controllers/lua -I./controllers/lua/luaaa -I./ext/lua -I./config/stm32f4ems -I./console/binary -I./console -I./console/binary_log -I./development -I./config/engines -I./config/boards/ -I./hw_layer/algo -I./init -I./ext_algo -I./hw_layer/drivers -I./hw_layer/drivers/gpio -I./hw_layer/drivers/can -I./hw_layer/drivers/sent -I./hw_layer/drivers/serial -I./hw_layer/drivers/i2c -I./hw_layer/drivers/lcd -I./hw_layer -I./hw_layer/adc -I./hw_layer/digital_input -I./hw_layer/digital_input/trigger -I./hw_layer/microsecond_timer -I./hw_layer/sensors -I./util -I./util/containers -I./util/math -I./controllers -I./controllers/system -I./controllers/system/timer -I./controllers/algo -I./controllers/algo/airmass -I./controllers/algo/defaults -I./controllers/algo/fuel -I./controllers/engine_cycle -I./controllers/trigger/decoders -I./controllers/tcu -I./controllers/trigger -I./controllers/sensors -I./controllers/sensors/converters -I./controllers/can -I./controllers/core -I./controllers/gauges -I./controllers/math -I./controllers/generated -I./controllers/actuators -I./controllers/actuators/gppwm -I./controllers/serial -I./console/binary/generated -I./bootloader/prometheus/469 -IChibiOS/os/various -IChibiOS/os/hal/lib/peripherals/sensors -I./libfirmware/util/include -I./libfirmware/pt2001/include -I./libfirmware/pt2001/project/rusefi/sample_code -I./hw_layer/ports/stm32/stm32f4/cfg -Iext/FatFS -I./hw_layer/mass_storage -I./hw_layer/serial_over_usb -I./hw_layer/lcd -I./hw_layer/mass_storage -Ihw_layer/ports/stm32/stm32f4 -I./hw_layer/ports -I./hw_layer/ports/stm32 -I./hw_layer/ports/stm32/serial_over_usb -Idevelopment/hw_layer -Idevelopment/test -IChibiOS-Contrib/os/various main.c -o main.o

...

   text	  data	   bss	   dec	   hex	filename
 471216	 19008	191832	682056	 a6848	build/rusefi.elf
Creating build/rusefi.list

Done
Creating build/rusefi.srec
bss Total size: 91773
ram4 Total size: 0
text Total size: 345270
data Total size: 3634
rodata Total size: 113196
 20 .ram4         0000fc10  10000000  0807bf74  000a0000  2**3
```