### PR TITLE
setup_linux_environment.sh tar uses --auto-compress

### DIFF
--- a/firmware/setup_linux_environment.sh
+++ b/firmware/setup_linux_environment.sh
@@ -27,7 +27,7 @@ rm -rf arm-none-eabi-gcc.tar.bz2
 
 # Download and extract GCC compiler
 curl -L -o arm-none-eabi-gcc.tar.xz https://developer.arm.com/-/media/Files/downloads/gnu/11.2-2022.02/binrel/gcc-arm-11.2-2022.02-x86_64-arm-none-eabi.tar.xz
-tar -xjvf arm-none-eabi-gcc.tar.xz
+tar -xavf arm-none-eabi-gcc.tar.xz
 
 # Delete downloaded image
 rm arm-none-eabi-gcc.tar.xz


### PR DESCRIPTION
avoids e.g.:

```
bzip2: (stdin) is not a bzip2 file.
tar: Child returned status 2
tar: Error is not recoverable: exiting now
```