### PR TITLE
factor GCC provision script

### DIFF
--- a/.github/workflows/build-firmware.yaml
+++ b/.github/workflows/build-firmware.yaml
@@ -319,9 +319,8 @@ jobs:
       env:
         ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
       run: |
-        wget 'https://developer.arm.com/-/media/Files/downloads/gnu/11.3.rel1/binrel/arm-gnu-toolchain-11.3.rel1-x86_64-arm-none-eabi.tar.xz' --progress=dot:mega -O compiler.tar.xz
-        tar -xvf compiler.tar.xz
-        echo "::add-path::`pwd`/arm-gnu-toolchain-11.3.rel1-x86_64-arm-none-eabi/bin"
+        sh ./firmware/provide_gcc.sh
+        echo "::add-path::`pwd`/gcc-arm-none-eabi/bin"
 
     # Make sure the compiler we just downloaded works - just print out the version
     - name: Test Compiler
@@ -441,9 +440,8 @@ jobs:
       env:
         ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
       run: |
-        wget 'https://developer.arm.com/-/media/Files/downloads/gnu/11.3.rel1/binrel/arm-gnu-toolchain-11.3.rel1-x86_64-arm-none-eabi.tar.xz' --progress=dot:mega -O compiler.tar.xz
-        tar -xvf compiler.tar.xz
-        echo "::add-path::`pwd`/arm-gnu-toolchain-11.3.rel1-x86_64-arm-none-eabi/bin"
+        sh ./firmware/provide_gcc.sh
+        echo "::add-path::`pwd`/gcc-arm-none-eabi/bin"
 
     # Make sure the compiler we just downloaded works - just print out the version
     - name: Test Compiler

--- a/firmware/provide_gcc.sh
+++ b/firmware/provide_gcc.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# Download and extract GCC arm-none-eabi toolchain
+
+URL="https://developer.arm.com/-/media/Files/downloads/gnu/11.3.rel1/binrel/arm-gnu-toolchain-11.3.rel1-x86_64-arm-none-eabi.tar.xz"
+ARCHIVE="${URL##*/}"
+DIR="gcc-arm-none-eabi"
+
+# Delete existing archive
+rm -rf ${ARCHIVE}
+
+# Download and extract archive
+curl -L -o ${ARCHIVE} ${URL}
+tar -xavf ${ARCHIVE}
+
+# Create colloquially named link
+ARCHIVE_DIR=$(tar --exclude="*/*" -tf ${ARCHIVE})
+ln -s ${ARCHIVE_DIR%/} ${DIR}
+
+# Delete downloaded archive
+rm ${ARCHIVE}

--- a/firmware/setup_linux_environment.sh
+++ b/firmware/setup_linux_environment.sh
@@ -22,18 +22,11 @@ rm -rf ~/.rusefi-tools
 mkdir ~/.rusefi-tools
 cd ~/.rusefi-tools
 
-# in case not first execution
-rm -rf arm-none-eabi-gcc.tar.bz2
-
-# Download and extract GCC compiler
-curl -L -o arm-none-eabi-gcc.tar.xz https://developer.arm.com/-/media/Files/downloads/gnu/11.3.rel1/binrel/arm-gnu-toolchain-11.3.rel1-x86_64-arm-none-eabi.tar.xz
-tar -xavf arm-none-eabi-gcc.tar.xz
-
-# Delete downloaded image
-rm arm-none-eabi-gcc.tar.xz
+# provide GCC arm-none-eabi toolchain
+sh ./provide_gcc.sh
 
 # Add the compiler to your path
-echo 'export PATH=$PATH:$HOME/.rusefi-tools/arm-gnu-toolchain-11.3.rel1-x86_64-arm-none-eabi/bin' >> ~/.profile
+echo 'export PATH=$PATH:$HOME/.rusefi-tools/gcc-arm-none-eabi/bin' >> ~/.profile
 
 # Allow the current user to use serial ports
 sudo usermod -a -G dialout $USER


### PR DESCRIPTION
for #4759 -- uses some bash variable expansion magic which may prove problematic for certain systems
`provide_gcc.sh` downloads and extracts GCC toolchain and creates a colloquially named `gcc-arm-none-eabi` link for use; this could change to accept a variable for that name instead, but this colloquial name allows to encapsulate this term and avoid having to pass it back or require the use-sites to determine the name (which changes among releases/builds).