### PR TITLE
use rusEFI pruned ARM GCC 11.3

### DIFF
--- a/.github/workflows/build-firmware.yaml
+++ b/.github/workflows/build-firmware.yaml
@@ -319,7 +319,7 @@ jobs:
       env:
         ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
       run: |
-        sh ./firmware/provide_gcc.sh
+        ./firmware/provide_gcc.sh
         echo "::add-path::`pwd`/gcc-arm-none-eabi/bin"
 
     # Make sure the compiler we just downloaded works - just print out the version
@@ -440,7 +440,7 @@ jobs:
       env:
         ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
       run: |
-        sh ./firmware/provide_gcc.sh
+        ./firmware/provide_gcc.sh
         echo "::add-path::`pwd`/gcc-arm-none-eabi/bin"
 
     # Make sure the compiler we just downloaded works - just print out the version

--- a/firmware/provide_gcc.sh
+++ b/firmware/provide_gcc.sh
@@ -4,20 +4,31 @@
 
 set -e
 
+# URL to download original toolchain from
 URL="https://github.com/rusefi/build_support/raw/master/rusefi-arm-gnu-toolchain-11.3.rel1-x86_64-arm-none-eabi.tar.xz"
-ARCHIVE="${URL##*/}"
-DIR="gcc-arm-none-eabi"
+# colloquial directory name, to afford re-use of script
+COLLOQUIAL="gcc-arm-none-eabi"
+# temporary working directory
+TMP_DIR="/tmp/rusefi-provide_gcc"
 
-# Delete existing archive
-rm -rf ${ARCHIVE}
+archive="${URL##*/}"
+
+# Cleanup prior [failed] runs
+rm -rf "${TMP_DIR}"
 
 # Download and extract archive
-curl -L -o ${ARCHIVE} ${URL}
-tar -xavf ${ARCHIVE}
+echo Downloading and extracting ${archive}
+mkdir -p "${TMP_DIR}"
+cd "${TMP_DIR}"
+curl -L -o "${archive}" "${URL}"
+tar -xaf "${archive}"
+rm "${archive}"
 
 # Create colloquially named link
-ARCHIVE_DIR=$(tar --exclude="*/*" -tf ${ARCHIVE})
-ln -s ${ARCHIVE_DIR%/} ${DIR}
+archive_dir="$(echo *)"
+cd - >/dev/null
+mv "${TMP_DIR}/${archive_dir}" "$(pwd)"
+ln -s "${archive_dir%/}" "${COLLOQUIAL}"
 
 # Delete downloaded archive
-rm ${ARCHIVE}
+rm -rf "${TMP_DIR}"

--- a/firmware/provide_gcc.sh
+++ b/firmware/provide_gcc.sh
@@ -4,7 +4,7 @@
 
 set -e
 
-URL="https://github.com/rusefi/build_support/raw/master/arm-gnu-toolchain-11.3.rel1-x86_64-arm-none-eabi.tar.xz"
+URL="https://github.com/rusefi/build_support/raw/master/rusefi-arm-gnu-toolchain-11.3.rel1-x86_64-arm-none-eabi.tar.xz"
 ARCHIVE="${URL##*/}"
 DIR="gcc-arm-none-eabi"
 


### PR DESCRIPTION
target pruned rusEFI ARM GCC 11.3; also fixed up GCC provision script to avoid double decompression (via temporary directory) to speed CI