### PR TITLE
GHA/build-firmware: pin agents to Ubuntu 20.04

### DIFF
--- a/.github/workflows/build-firmware.yaml
+++ b/.github/workflows/build-firmware.yaml
@@ -4,7 +4,7 @@ on: [push, pull_request, workflow_dispatch]
 
 jobs:
   build-firmware:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     strategy:
       # Let all builds finish even if one fails early
@@ -406,7 +406,7 @@ jobs:
 
   # here we build f407-discovery
   build-primary-bundle:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
       with:


### PR DESCRIPTION
resolves #4791