### PR TITLE
Tweak simulator Makefile, scripting

### DIFF
--- a/simulator/Makefile
+++ b/simulator/Makefile
@@ -226,10 +226,10 @@ CPPC = $(CCPREFIX) $(TRGT)g++
 # Enable loading with g++ only if you need C++ runtime support.
 # NOTE: You can use C++ even without C++ support if you are careful. C++
 #       runtime support makes code size explode.
-#LD   = $(TRGT)gcc
-LD   = $(TRGT)g++
+#LD   = $(CC)
+LD   = $(CPPC)
 CP   = $(TRGT)objcopy
-AS   = $(TRGT)gcc -x assembler-with-cpp
+AS   = $(CC) -x assembler-with-cpp
 AR   = $(TRGT)ar
 OD   = $(TRGT)objdump
 SZ   = $(TRGT)size


### PR DESCRIPTION
I stumbled about ChibiOS's `CPPC` vs the standard `CXX`; initially I wanted to support `CXX` pass-through as `CPPC`, but this is intangible as `CXX` is always set: easier to just "get with" using `CPPC` ("be in the know").

`./compile.sh CC=gcc-11 CPPC=g++-11 USE_VERBOSE_COMPILE=yes`

Otherwise, this allows to pass arguments to make via `simulator/compile.sh`, and tidies some indentation that otherwise standardizing on tabs causes problems with make: (`<tab>$(info ...)` is interpreted as a recipe):
```
Makefile:64: *** recipe commences before first target.  Stop.
```

----

Note the firmware jobs will fail due to #4791 (see #4793).