### PR TITLE
simulator: add missing stdc++ include to CAN HAL LLD

### DIFF
--- a/simulator/simulator/can/hal_can_lld.cpp
+++ b/simulator/simulator/can/hal_can_lld.cpp
@@ -30,6 +30,7 @@
 #include <net/if.h>
 #include <sys/ioctl.h>
 
+#include <algorithm>
 #include <cstring>
 #include <queue>
 


### PR DESCRIPTION
for std::remove -- GCC 12 exposes this issue