### PR TITLE
add /usr/sbin to PATH in create_ini_image*.sh

### DIFF
--- a/firmware/hw_layer/mass_storage/create_ini_image.sh
+++ b/firmware/hw_layer/mass_storage/create_ini_image.sh
@@ -15,6 +15,9 @@ BOARD_SPECIFIC_URL=$5
 IMAGE=ramdisk.image
 ZIP=rusefi.ini.zip
 
+# mkfs.fat and fatlabel are privileged on some systems
+PATH="$PATH:/usr/sbin"
+
 echo "create_ini_image: ini $FULL_INI to $H_OUTPUT size $FS_SIZE for $SHORT_BOARDNAME [$BOARD_SPECIFIC_URL]"
 
 rm -f $ZIP $IMAGE

--- a/firmware/hw_layer/mass_storage/create_ini_image_compressed.sh
+++ b/firmware/hw_layer/mass_storage/create_ini_image_compressed.sh
@@ -14,6 +14,8 @@ BOARD_SPECIFIC_URL=$5
 
 IMAGE=ramdisk.image
 
+# mkfs.fat and fatlabel are privileged on some systems
+PATH="$PATH:/usr/sbin"
 
 echo "create_ini_image_compressed: ini $FULL_INI to $H_OUTPUT size $FS_SIZE for $SHORT_BOARDNAME [$BOARD_SPECIFIC_URL]"
 


### PR DESCRIPTION
e.g. `./gen_default_everything.sh` fails on Debian systems because e.g. `mkfs.fat` is not in regular user's `PATH`
```
hw_layer/mass_storage/create_ini_image.sh: line 26: mkfs.fat: command not found
```