### PR TITLE
without ValueProvider3D interface how do we mock?

### DIFF
--- a/firmware/controllers/algo/fuel/fuel_computer.cpp
+++ b/firmware/controllers/algo/fuel/fuel_computer.cpp
@@ -23,8 +23,6 @@ mass_t FuelComputerBase::getCycleFuel(mass_t airmass, int rpm, float load) {
 	return airmass / afr;
 }
 
-FuelComputer::FuelComputer(const ValueProvider3D& lambdaTable) : m_lambdaTable(&lambdaTable) {}
-
 float FuelComputer::getStoichiometricRatio() const {
 	float primary = engineConfiguration->stoichRatioPrimary;
 
@@ -57,10 +55,13 @@ float FuelComputer::getStoichiometricRatio() const {
 	return interpolateClamped(0, primary, 100, secondary, flex.Value);
 }
 
-float FuelComputer::getTargetLambda(int rpm, float load) const {
-	efiAssert(OBD_PCM_Processor_Fault, m_lambdaTable != nullptr, "AFR table null", 0);
 
-	return m_lambdaTable->getValue(rpm, load);
+float FuelComputer::getTargetLambda(int rpm, float load) const {
+	return interpolate3d(
+		config->lambdaTable,
+		config->lambdaLoadBins, load,
+		config->lambdaRpmBins, rpm
+	);
 }
 
 float FuelComputer::getTargetLambdaLoadAxis(float defaultLoad) const {

--- a/firmware/controllers/algo/fuel/fuel_computer.h
+++ b/firmware/controllers/algo/fuel/fuel_computer.h
@@ -30,14 +30,9 @@ public:
 // This class is a usable implementation of a fuel model that reads real configuration
 class FuelComputer final : public FuelComputerBase {
 public:
-	FuelComputer(const ValueProvider3D& lambdaTable);
-
 	float getStoichiometricRatio() const override;
 	float getTargetLambda(int rpm, float load) const override;
 	float getTargetLambdaLoadAxis(float defaultLoad) const override;
-
-private:
-	const ValueProvider3D* const m_lambdaTable;
 };
 
 float getLoadOverride(float defaultLoad, load_override_e overrideMode);

--- a/firmware/controllers/algo/fuel_math.cpp
+++ b/firmware/controllers/algo/fuel_math.cpp
@@ -35,7 +35,6 @@
 #include "lua_hooks.h"
 
 extern fuel_Map3D_t veMap;
-extern lambda_Map3D_t lambdaMap;
 static mapEstimate_Map3D_t mapEstimationTable;
 
 #if EFI_ENGINE_CONTROL
@@ -331,7 +330,7 @@ float getInjectionMass(int rpm) {
 #endif
 }
 
-static FuelComputer fuelComputer(lambdaMap);
+static FuelComputer fuelComputer;
 
 /**
  * @brief	Initialize fuel map data structure

--- a/firmware/controllers/math/speed_density.cpp
+++ b/firmware/controllers/math/speed_density.cpp
@@ -26,7 +26,6 @@
 #define rpmMax 8000
 
 fuel_Map3D_t veMap;
-lambda_Map3D_t lambdaMap;
 
 #define tpMin 0
 #define tpMax 100
@@ -119,6 +118,4 @@ temperature_t IFuelComputer::getTCharge(int rpm, float tps) {
 
 void initSpeedDensity() {
 	veMap.init(config->veTable, config->veLoadBins, config->veRpmBins);
-//	ve2Map.init(engineConfiguration->ve2Table, engineConfiguration->ve2LoadBins, engineConfiguration->ve2RpmBins);
-	lambdaMap.init(config->lambdaTable, config->lambdaLoadBins, config->lambdaRpmBins);
 }

--- a/unit_tests/tests/ignition_injection/test_fuel_computer.cpp
+++ b/unit_tests/tests/ignition_injection/test_fuel_computer.cpp
@@ -29,21 +29,10 @@ TEST(FuelComputer, getCycleFuel) {
 	EXPECT_FLOAT_EQ(result, 7.0f / (5 * 3));
 }
 
-TEST(FuelComputer, LambdaLookup) {
-	MockVp3d lambdaTable;
-	FuelComputer dut(lambdaTable);
-
-	EXPECT_CALL(lambdaTable, getValue(1500, FloatEq(0.7f)))
-		.WillOnce(Return(0.85f));
-
-	EXPECT_FLOAT_EQ(dut.getTargetLambda(1500, 0.7f), 0.85f);
-}
-
 TEST(FuelComputer, FlexFuel) {
 	EngineTestHelper eth(TEST_ENGINE);
 
-	MockVp3d lambdaTable;
-	FuelComputer dut(lambdaTable);
+	FuelComputer dut;
 
 	// easier values for testing
 	engineConfiguration->stoichRatioPrimary = 15;


### PR DESCRIPTION
We can inline ValueProvider3D and get rid of constructor argument but would that mean wiping out test?