### PR TITLE
SD logging period -> frequency

### DIFF
--- a/firmware/CHANGELOG.md
+++ b/firmware/CHANGELOG.md
@@ -28,6 +28,9 @@ Release template (copy/paste this for new release):
 
 ## Unreleased
 
+### Breaking Changes
+ - SD logging rate is now set with hz instead of ms period #4553
+
 ## November 2022 Release - "Day 267"
 
 ### Added

--- a/firmware/controllers/algo/engine_configuration.cpp
+++ b/firmware/controllers/algo/engine_configuration.cpp
@@ -481,7 +481,7 @@ static void setDefaultEngineConfiguration() {
 	// Don't enable, but set default address
 	engineConfiguration->verboseCanBaseAddress = CAN_DEFAULT_BASE;
 
-	engineConfiguration->sdCardPeriodMs = 50;
+	engineConfiguration->sdCardLogFrequency = 50;
 
 	engineConfiguration->mapMinBufferLength = 1;
 	engineConfiguration->vvtActivationDelayMs = 6000;

--- a/firmware/hw_layer/mmc_card.cpp
+++ b/firmware/hw_layer/mmc_card.cpp
@@ -540,10 +540,15 @@ static THD_FUNCTION(MMCmonThread, arg) {
 			return;
 		}
 
-		auto period = engineConfiguration->sdCardPeriodMs;
-		if (period > 0) {
-			chThdSleepMilliseconds(period);
+		auto freq = engineConfiguration->sdCardLogFrequency;
+		if (freq > 250) {
+			freq = 250;
+		} else if (freq < 1) {
+			freq = 1;
 		}
+
+		auto period = 1e6 / freq;
+		chThdSleepMicroseconds((int)period);
 	}
 }
 

--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -93,7 +93,7 @@
 ! Any time an incompatible change is made to the configuration format stored in flash,
 ! update this string to the current date! It is required to also update TS_SIGNATURE above
 ! when this happens.
-#define FLASH_DATA_VERSION 10015
+#define FLASH_DATA_VERSION 10016
 
 ! this offset is part of console compatibility mechanism, please DO NOT change this offset
 #define TS_FILE_VERSION_OFFSET 124
@@ -834,7 +834,7 @@ output_pin_e acFanPin;Optional Radiator Fan used with A/C
 
 
 custom uart_device_e 1 bits, U08, @OFFSET@, [0:1], "Off", "UART1", "UART2", "UART3" 
-	int16_t sdCardPeriodMs;SD card logging period, in milliseconds;"ms", 1, 0, 0, 30000, 0
+	uint16_t sdCardLogFrequency;Rate the ECU will log to the SD card, in hz (log lines per second).;"hz", 1, 0, 1, 250, 0
 	adc_channel_e idlePositionSensor;
 	Gpio debugMapAveraging;
 	output_pin_e starterRelayDisablePin;

--- a/firmware/tunerstudio/rusefi.input
+++ b/firmware/tunerstudio/rusefi.input
@@ -3485,7 +3485,7 @@ cmd_set_engine_type_default					= "@@TS_IO_TEST_COMMAND_char@@@@ts_command_e_TS_
 		field = "Enable SD Card",						isSdCardEnabled
 		field = "CS Pin",								sdCardCsPin			@@if_ts_show_sd_pins
 		field = "SPI",									sdCardSpiDevice		@@if_ts_show_sd_pins
-		field = "Write Period",							sdCardPeriodMs
+		field = "SD logger rate",						sdCardLogFrequency
 
 	dialog = gpsReceiver, "GPS Receiver"
 		field = "gps RX",								gps_rx_pin


### PR DESCRIPTION
I decided to go ahead and make this a config break, since the user may have had some other value set there that produces unpredictable results when converted from ms to hz.

fix #4553