### PR TITLE
firmware: fix ISO date-time parsing

### DIFF
--- a/firmware/controllers/settings.cpp
+++ b/firmware/controllers/settings.cpp
@@ -1107,12 +1107,15 @@ void printDateTime() {
 
 void setDateTime(const char * const isoDateTime) {
 #if EFI_RTC
-	if (strlen(isoDateTime) > 0) {
+	if (strlen(isoDateTime) >= 19 && isoDateTime[10] == 'T') {
 		efidatetime_t dateTime;
-		if (sscanf("%04u-%02u-%02uT%02u:%02u:%02u", isoDateTime,
-					&dateTime.year, &dateTime.month, &dateTime.day,
-					&dateTime.hour, &dateTime.minute, &dateTime.second)
-				== 6) { // 6 fields to properly scan
+		int scanned = sscanf(isoDateTime, "%4lu", &dateTime.year);
+		scanned += sscanf(isoDateTime + 5, "%2hhu", &dateTime.month);
+		scanned += sscanf(isoDateTime + 8, "%2hhu", &dateTime.day);
+		scanned += sscanf(isoDateTime + 11, "%2hhu", &dateTime.hour);
+		scanned += sscanf(isoDateTime + 14, "%2hhu", &dateTime.minute);
+		scanned += sscanf(isoDateTime + 17, "%2hhu", &dateTime.second);
+		if (scanned == 6) { // 6 fields to properly scan
 			setRtcDateTime(&dateTime);
 			return;
 		}


### PR DESCRIPTION
oopsie; fixes for #4662

```
I 221205 040811.572 [Commands Queue] BinaryProtocol - Sending [set date 2022-12-05T04:08:11.452]
I 221205 040811.653 [communication executor1] MessagesCentral - postMessage EngineState: date_set parsed: 2022-12-05T04:08:11
I 221205 040811.653 [communication executor1] MessagesCentral - postMessage EngineState: confirmation_set date 2022-12-05T04:08:11.452:32
```