### PR TITLE
support Toyota ETCS-i tps/pps

### DIFF
--- a/firmware/init/sensor/init_tps.cpp
+++ b/firmware/init/sensor/init_tps.cpp
@@ -101,7 +101,7 @@ public:
 	{
 	}
 
-	void init(bool isFordTps, RedundantFordTps* fordTps, const TpsConfig& primary, const TpsConfig& secondary) {
+	void init(bool isFordTps, RedundantFordTps* fordTps, float secondaryMaximum, const TpsConfig& primary, const TpsConfig& secondary) {
 		bool hasFirst = m_pri.init(primary);
 		if (!hasFirst) {
 			// no input if we have no first channel
@@ -125,7 +125,7 @@ public:
 
 		if (isFordTps && fordTps) {
 			// we have a secondary
-			fordTps->configure(5.0f, 52.6f);
+			fordTps->configure(5.0f, secondaryMaximum);
 			fordTps->Register();
 		} else {
 			// not ford TPS
@@ -161,6 +161,7 @@ static RedundantPair tps2(tps2p, tps2s, SensorType::Tps2);
 // Used only in case of weird Ford-style ETB TPS
 static RedundantFordTps fordTps1(SensorType::Tps1, SensorType::Tps1Primary, SensorType::Tps1Secondary);
 static RedundantFordTps fordTps2(SensorType::Tps2, SensorType::Tps2Primary, SensorType::Tps2Secondary);
+static RedundantFordTps fordPps(SensorType::AcceleratorPedal, SensorType::AcceleratorPedalPrimary, SensorType::AcceleratorPedalSecondary);
 
 // Pedal sensors and redundancy
 static FuncSensPair pedalPrimary(1, SensorType::AcceleratorPedalPrimary);
@@ -181,19 +182,32 @@ void initTps() {
 
 	if (!engineConfiguration->consumeObdSensors) {
 		bool isFordTps = engineConfiguration->useFordRedundantTps;
+		bool isFordPps = engineConfiguration->useFordRedundantPps;
 
-		tps1.init(isFordTps, &fordTps1,
+		float tpsSecondaryMaximum = engineConfiguration->tpsSecondaryMaximum;
+		if (tpsSecondaryMaximum < 10 || tpsSecondaryMaximum > 90) {
+			// most ford TPS seem to be ~52.6%, default to that if not set
+			tpsSecondaryMaximum = 52.6f;
+		}
+
+		tps1.init(isFordTps, &fordTps1, tpsSecondaryMaximum,
 			{ engineConfiguration->tps1_1AdcChannel, (float)engineConfiguration->tpsMin, (float)engineConfiguration->tpsMax, min, max },
 			{ engineConfiguration->tps1_2AdcChannel, (float)engineConfiguration->tps1SecondaryMin, (float)engineConfiguration->tps1SecondaryMax, min, max }
 		);
 
-		tps2.init(isFordTps, &fordTps2,
+		tps2.init(isFordTps, &fordTps2, tpsSecondaryMaximum,
 			{ engineConfiguration->tps2_1AdcChannel, (float)engineConfiguration->tps2Min, (float)engineConfiguration->tps2Max, min, max },
 			{ engineConfiguration->tps2_2AdcChannel, (float)engineConfiguration->tps2SecondaryMin, (float)engineConfiguration->tps2SecondaryMax, min, max }
 		);
 
+		float ppsSecondaryMaximum = engineConfiguration->ppsSecondaryMaximum;
+		if (ppsSecondaryMaximum < 10 || ppsSecondaryMaximum > 90) {
+			// most Toyota PPS seem to be ~65%, default to that if not set
+			ppsSecondaryMaximum = 65;
+		}
+
 		// Pedal sensors
-		pedal.init(false, nullptr,
+		pedal.init(isFordPps, &fordPps, ppsSecondaryMaximum,
 			{ engineConfiguration->throttlePedalPositionAdcChannel, engineConfiguration->throttlePedalUpVoltage, engineConfiguration->throttlePedalWOTVoltage, min, max },
 			{ engineConfiguration->throttlePedalPositionSecondAdcChannel, engineConfiguration->throttlePedalSecondaryUpVoltage, engineConfiguration->throttlePedalSecondaryWOTVoltage, min, max }
 		);

--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -445,7 +445,7 @@ end_struct
 injector_s injector
 
 bit isForcedInduction;Does the vehicle have a turbo or supercharger?
-bit useFordRedundantTps;On Ford vehicles one of the sensors is not linear on the full range, i.e. in the specific range of the positions we effectively have only one sensor.
+bit useFordRedundantTps;On some Ford and Toyota vehicles one of the throttle sensors is not linear on the full range, i.e. in the specific range of the positions we effectively have only one sensor.
 bit isVerboseAuxPid1
 bit overrideTriggerGaps
 bit enableFan1WithAc;Turn on this fan when AC is on.
@@ -474,7 +474,7 @@ bit enableMapEstimationTableFallback;If enabled, the MAP estimate table will be 
 bit usescriptTableForCanSniffingFiltering
 bit verboseCan,"Print all","Do not print";Print incoming and outgoing first bus CAN messages in rusEFI console
 bit artificialTestMisfire,"Danger Mode","No thank you";Experimental setting that will cause a misfire\nDO NOT ENABLE.
-bit issue_294_31,"si_example","nada_example"
+bit useFordRedundantPps;On some Ford and Toyota vehicles one of the pedal sensors is not linear on the full range, i.e. in the specific range of the positions we effectively have only one sensor.
 
 
 !todo: extract these two fields into a structure

--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -1552,8 +1552,8 @@ uint8_t alsMinPps;;"", 1, 0, 0, 20000, 0
 uint8_t alsMinTimeBetween;;"", 1, 0, 0, 20000, 0
 uint8_t alsEtbPosition;;"", 1, 0, 0, 20000, 0
 
-uint8_t autoscale tpsSecondaryMaximum;;"%", 0.5, 0, 0, 100, 1
-uint8_t autoscale ppsSecondaryMaximum;;"%", 0.5, 0, 0, 100, 1
+uint8_t autoscale tpsSecondaryMaximum;For Ford TPS, use 53%. For Toyota ETCS-i, use xxx%;"%", 0.5, 0, 0, 100, 1
+uint8_t autoscale ppsSecondaryMaximum;For Toyota ETCS-i, use xxx%;"%", 0.5, 0, 0, 100, 1
 
 uint8_t[122] mainUnusedEnd;;"units", 1, 0, 0, 1, 0
 

--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -1551,7 +1551,11 @@ uint8_t alsMaxClt;;"", 1, 0, 0, 20000, 0
 uint8_t alsMinPps;;"", 1, 0, 0, 20000, 0
 uint8_t alsMinTimeBetween;;"", 1, 0, 0, 20000, 0
 uint8_t alsEtbPosition;;"", 1, 0, 0, 20000, 0
-uint8_t[124] mainUnusedEnd;;"units", 1, 0, 0, 1, 0
+
+uint8_t autoscale tpsSecondaryMaximum;;"%", 0.5, 0, 0, 100, 1
+uint8_t autoscale ppsSecondaryMaximum;;"%", 0.5, 0, 0, 100, 1
+
+uint8_t[122] mainUnusedEnd;;"units", 1, 0, 0, 1, 0
 
 ! end of engine_configuration_s
 end_struct

--- a/firmware/tunerstudio/rusefi.input
+++ b/firmware/tunerstudio/rusefi.input
@@ -4258,7 +4258,12 @@ dialog = tcuControls, "Transmission Settings"
 		field = "showHumanReadableWarning (affects Burn)",	showHumanReadableWarning
 		field = "Warning Message",							warning_message
 		field = totalGearsCount,								totalGearsCount
+
 		field = "Ford redundant TPS mode",				useFordRedundantTps
+		field = "Secondary TPS maximum",				tpsSecondaryMaximum, {useFordRedundantTps}
+		field = "Ford redundant PPS mode",				useFordRedundantPps
+		field = "Secondary PPS maximum",				ppsSecondaryMaximum, {useFordRedundantPps}
+
 		field = "consumeObdSensors",						consumeObdSensors, { canReadEnabled == 1 && canWriteEnabled == 1}
 		field = "Artificial Misfire",						artificialTestMisfire
 		field = "Always use instant RPM",				alwaysInstantRpm


### PR DESCRIPTION
Toyota ETCS-i has similar behavior to the "Ford TPS" mode we already have where one of the sensors maxes out at partial travel, and the other fully linear.

This PR makes the "ford TPS" mode available to the PPS as well, and adds a config field for the "secondary maximum" value for each TPS and PPS.