### PR TITLE
improve iat ignition table

### DIFF
--- a/firmware/CHANGELOG.md
+++ b/firmware/CHANGELOG.md
@@ -28,6 +28,9 @@ Release template (copy/paste this for new release):
 
 ## Unreleased
 
+### Breaking Changes
+ - Change ignition IAT correction table to use IAT/load #4948
+
 ### Added
  - Electronic throttle supply voltage compensation, giving more consistent behavior as battery voltage changes #4838
  - VR trigger input oscilloscope for boards with "discrete VR" hardware (AlphaX ECUs, some Hellen) #4885

--- a/firmware/controllers/algo/advance_map.cpp
+++ b/firmware/controllers/algo/advance_map.cpp
@@ -105,7 +105,7 @@ static angle_t getRunningAdvance(int rpm, float engineLoad) {
 	return advanceAngle;
 }
 
-angle_t getAdvanceCorrections(int rpm) {
+static angle_t getAdvanceCorrections(float engineLoad) {
 	auto iat = Sensor::get(SensorType::Iat);
 
 	if (!iat) {
@@ -113,8 +113,8 @@ angle_t getAdvanceCorrections(int rpm) {
 	} else {
 		engine->engineState.timingIatCorrection = interpolate3d(
 			config->ignitionIatCorrTable,
-			config->ignitionIatCorrLoadBins, iat.Value,
-			config->ignitionIatCorrRpmBins, rpm
+			config->ignitionIatCorrLoadBins, engineLoad,
+			config->ignitionIatCorrTempBins, iat.Value
 		);
 	}
 
@@ -179,7 +179,7 @@ angle_t getAdvance(int rpm, float engineLoad) {
 		&& (!isCranking || engineConfiguration->useAdvanceCorrectionsForCranking);
 
 	if (allowCorrections) {
-		angle_t correction = getAdvanceCorrections(rpm);
+		angle_t correction = getAdvanceCorrections(engineLoad);
 		if (!cisnan(correction)) { // correction could be NaN during settings update
 			angle += correction;
 		}

--- a/firmware/controllers/algo/advance_map.h
+++ b/firmware/controllers/algo/advance_map.h
@@ -13,7 +13,6 @@ angle_t getAdvance(int rpm, float engineLoad);
 angle_t getCylinderIgnitionTrim(size_t cylinderNumber, int rpm, float ignitionLoad);
 float getInitialAdvance(int rpm, float map, float advanceMax);
 
-angle_t getAdvanceCorrections(int rpm);
 size_t getMultiSparkCount(int rpm);
 
 class IgnitionState : public ignition_state_s {

--- a/firmware/controllers/algo/defaults/default_ignition.cpp
+++ b/firmware/controllers/algo/defaults/default_ignition.cpp
@@ -14,39 +14,19 @@ static void setDefaultMultisparkParameters() {
 	engineConfiguration->multisparkMaxSparkingAngle = 30;
 }
 
-static constexpr float iatTimingRpmBins[] = { 880, 1260, 1640, 2020, 2400, 2780, 3000, 3380, 3760, 4140, 4520, 5000, 5700, 6500, 7200, 8000 };
-
 static void setDefaultIatTimingCorrection() {
-	setLinearCurve(config->ignitionIatCorrLoadBins, /*from*/CLT_CURVE_RANGE_FROM, 110, 1);
-#if IGN_LOAD_COUNT == DEFAULT_IGN_LOAD_COUNT
-	copyArray(config->ignitionIatCorrRpmBins, iatTimingRpmBins);
+	copyArray(config->ignitionIatCorrTempBins, { -40, 0, 10, 20, 30, 40, 50, 60});
+	setLinearCurve(config->ignitionIatCorrLoadBins, /*from=*/ 0, /*to*/ 140, 1);
 
-	static constexpr int8_t defaultIatCorr[16] = {
-		4,	// -40 deg
-		4,
-		3,
-		2,
-		0,	// 0 deg
-		0,
-		0,
-		0,
-		0,
-		-1,	// 50 deg
-		-2,
-		-4,
-		-4,
-		-4,
-		-4,
-		-4,	// 110 deg
-	};
-
-	// Set each row of the table to the same value (no rpm dependence by default)
-	for (size_t i = 0; i < efi::size(defaultIatCorr); i++) {
-		setArrayValues(config->ignitionIatCorrTable[i], defaultIatCorr[i]);
+	// top 5 rows are the same
+	for (size_t i = 3; i < 8; i++) {
+		//                                                         40  50  60 deg C
+		copyArray(config->ignitionIatCorrTable[i], {0, 0, 0, 0, 0, -1, -2, -3});
 	}
-#else
-	setLinearCurve(config->ignitionIatCorrLoadBins, /*from*/0, 6000, 1);
-#endif /* IGN_LOAD_COUNT == DEFAULT_IGN_LOAD_COUNT */
+
+	// 6th row tapers out
+	//                                                        40  50  60 deg C
+	copyArray(config->ignitionIatCorrTable[2], {0, 0, 0, 0, 0, 0, -1, -2});
 }
 
 static float getAdvanceForRpm(int rpm, float advanceMax) {

--- a/firmware/controllers/engine_controller.cpp
+++ b/firmware/controllers/engine_controller.cpp
@@ -525,7 +525,7 @@ bool validateConfig() {
 		ensureArrayIsAscending("Ignition CLT corr", config->cltTimingBins);
 
 		ensureArrayIsAscending("Ignition IAT corr IAT", config->ignitionIatCorrLoadBins);
-		ensureArrayIsAscending("Ignition IAT corr RPM", config->ignitionIatCorrRpmBins);
+		ensureArrayIsAscending("Ignition IAT corr Load", config->ignitionIatCorrLoadBins);
 	}
 
 	ensureArrayIsAscendingOrDefault("Map estimate TPS", config->mapEstimateTpsBins);

--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -93,7 +93,7 @@
 ! Any time an incompatible change is made to the configuration format stored in flash,
 ! update this string to the current date! It is required to also update TS_SIGNATURE above
 ! when this happens.
-#define FLASH_DATA_VERSION 10016
+#define FLASH_DATA_VERSION 10017
 
 ! this offset is part of console compatibility mechanism, please DO NOT change this offset
 #define TS_FILE_VERSION_OFFSET 124
@@ -1662,9 +1662,9 @@ float[CLT_CURVE_SIZE] cltIdleCorr;    CLT-based idle position multiplier for sim
 float[MAF_DECODING_COUNT] mafDecoding;Also known as MAF transfer function.\nkg/hour value.\nBy the way 2.081989116 kg/h = 1 ft3/m;"kg/hour", 1, 0, -500, 4000, 2
 float[MAF_DECODING_COUNT] mafDecodingBins;;"V", 1, 0, -5, 150, 2
 
-int16_t[IGN_RPM_COUNT x IGN_LOAD_COUNT] autoscale ignitionIatCorrTable;;"deg", 0.1, 0, -720, 720, 1
-float[IGN_LOAD_COUNT] ignitionIatCorrLoadBins;;"Temperature", 1, 0, -60, 200, 0
-uint16_t[IGN_RPM_COUNT] ignitionIatCorrRpmBins;;"RPM",	   1, 0, 0, 18000, 0
+int8_t[8 x 8] autoscale ignitionIatCorrTable;;"deg", 0.1, 0, -25, 25, 1
+int8_t[8] ignitionIatCorrTempBins;;"C", 1, 0, -40, 120, 0
+uint8_t[8] autoscale ignitionIatCorrLoadBins;;"Load", 5, 0, 0, 1000, 0
 
 int16_t[IGN_RPM_COUNT x IGN_LOAD_COUNT] injectionPhase;;"deg", 1, 0, -720, 720, 0
 uint16_t[FUEL_LOAD_COUNT] injPhaseLoadBins;;"Load", 1, 0, 0, 1000, 0

--- a/firmware/tunerstudio/rusefi.input
+++ b/firmware/tunerstudio/rusefi.input
@@ -924,8 +924,8 @@ curve = 32Curve, "3-2 Shift Solenoid Percent by Speed"
 
 	table = ignitionIatCorrTableTbl,  ignitionIatCorrTableMap,  "Ignition Intake Air Temp correction",	1
 		;		constant, variable
-		xBins		= ignitionIatCorrRpmBins,  RPMValue
-		yBins		= ignitionIatCorrLoadBins,  intake
+		xBins		= ignitionIatCorrTempBins,  intake
+		yBins		= ignitionIatCorrLoadBins,  ignitionLoad
 		zBins		= ignitionIatCorrTable
 ;		gridHeight  = 2.0
 		gridOrient  = 250,	0, 340 ; Space 123 rotation of grid in degrees.

--- a/unit_tests/tests/trigger/test_trigger_decoder.cpp
+++ b/unit_tests/tests/trigger/test_trigger_decoder.cpp
@@ -118,8 +118,8 @@ TEST(trigger, test1995FordInline6TriggerDecoder) {
 	IgnitionEventList *ecl = &engine->ignitionEvents;
 	ASSERT_EQ(true,  ecl->isReady) << "ford inline ignition events size";
 
-	EXPECT_NEAR(ecl->elements[0].dwellAngle, 7.960f, 1e-3);
-	EXPECT_NEAR(ecl->elements[5].dwellAngle, 607.960f, 1e-3);
+	EXPECT_NEAR(ecl->elements[0].dwellAngle, 8.960f, 1e-3);
+	EXPECT_NEAR(ecl->elements[5].dwellAngle, 608.960f, 1e-3);
 
 	ASSERT_FLOAT_EQ(0.5, engine->ignitionState.getSparkDwell(2000)) << "running dwell";
 }


### PR DESCRIPTION
Switch the ignition IAT correction table to use IAT/load instead of IAT/RPM.

This is what the OEMs do - very little RPM dependence, mostly dependent upon load/iat.

![image](https://user-images.githubusercontent.com/568254/211104409-8414861d-385d-4989-bceb-5e5657803f4f.png)

Also includes more sensible default values in the table.

![image](https://user-images.githubusercontent.com/568254/211104447-df14dc80-31c1-42fc-8ad3-c268a0042b8d.png)
