### PR TITLE
GitHub actions use apt-spy2, retry apt-get update

### DIFF
--- a/.github/workflows/build-android.yaml
+++ b/.github/workflows/build-android.yaml
@@ -16,7 +16,9 @@ jobs:
           java-version: '8'
 
       - name: Install Tools
-        run: sudo apt-get install mtools
+        run: |
+          sudo apt-get -o Acquire::Retries=3 update
+          sudo apt-get install mtools
 
       - name: Generate Configs, Enums & Live Documentation
         working-directory: ./firmware/

--- a/.github/workflows/build-android.yaml
+++ b/.github/workflows/build-android.yaml
@@ -25,7 +25,6 @@ jobs:
         working-directory: ./firmware/
         run: ./gen_default_everything.sh
 
-
       - name: Test Compiler
         run: javac -version
 

--- a/.github/workflows/build-android.yaml
+++ b/.github/workflows/build-android.yaml
@@ -17,7 +17,7 @@ jobs:
 
       - name: Install Tools
         run: |
-          sudo sed -i 's/azure\.//' /etc/apt/sources.list
+          sudo gem install apt-spy2 && sudo time apt-spy2 fix --commit
           sudo apt-get -o Acquire::Retries=3 update
           sudo apt-get install mtools
 

--- a/.github/workflows/build-android.yaml
+++ b/.github/workflows/build-android.yaml
@@ -17,6 +17,7 @@ jobs:
 
       - name: Install Tools
         run: |
+          sudo sed -i 's/azure\.//' /etc/apt/sources.list
           sudo apt-get -o Acquire::Retries=3 update
           sudo apt-get install mtools
 

--- a/.github/workflows/build-firmware.yaml
+++ b/.github/workflows/build-firmware.yaml
@@ -293,7 +293,7 @@ jobs:
     - name: Install multilib, mingw, sshpass and mtools
       if: ${{ env.skip != 'true' }}
       run: |
-        sudo sed -i 's/azure\.//' /etc/apt/sources.list
+        sudo gem install apt-spy2 && sudo time apt-spy2 fix --commit
         sudo apt-get -o Acquire::Retries=3 update
         sudo apt-get install gcc-multilib g++-multilib g++-mingw-w64 gcc-mingw-w64 sshpass mtools
         sudo apt-get install zip
@@ -442,6 +442,7 @@ jobs:
 
     - name: Install multilib, mingw, and sshpass
       run: |
+        sudo gem install apt-spy2 && sudo time apt-spy2 fix --commit
         sudo apt-get -o Acquire:Retries=3 update
         sudo apt-get install gcc-multilib g++-multilib g++-mingw-w64 gcc-mingw-w64 sshpass mtools zip dosfstools
 

--- a/.github/workflows/build-firmware.yaml
+++ b/.github/workflows/build-firmware.yaml
@@ -293,7 +293,7 @@ jobs:
     - name: Install multilib, mingw, sshpass and mtools
       if: ${{ env.skip != 'true' }}
       run: |
-        sudo apt-get update
+        sudo apt-get -o Acquire::Retries=3 update
         sudo apt-get install gcc-multilib g++-multilib g++-mingw-w64 gcc-mingw-w64 sshpass mtools
         sudo apt-get install zip
         sudo apt-get install dosfstools
@@ -441,7 +441,7 @@ jobs:
 
     - name: Install multilib, mingw, and sshpass
       run: |
-        sudo apt-get update
+        sudo apt-get -o Acquire:Retries=3 update
         sudo apt-get install gcc-multilib g++-multilib g++-mingw-w64 gcc-mingw-w64 sshpass mtools zip dosfstools
 
     - name: Generate Enum Strings

--- a/.github/workflows/build-firmware.yaml
+++ b/.github/workflows/build-firmware.yaml
@@ -293,6 +293,7 @@ jobs:
     - name: Install multilib, mingw, sshpass and mtools
       if: ${{ env.skip != 'true' }}
       run: |
+        sudo sed -i 's/azure\.//' /etc/apt/sources.list
         sudo apt-get -o Acquire::Retries=3 update
         sudo apt-get install gcc-multilib g++-multilib g++-mingw-w64 gcc-mingw-w64 sshpass mtools
         sudo apt-get install zip

--- a/.github/workflows/build-rusEFI-console.yaml
+++ b/.github/workflows/build-rusEFI-console.yaml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Install Tools
         run: |
-          sudo sed -i 's/azure\.//' /etc/apt/sources.list
+          sudo gem install apt-spy2 && sudo time apt-spy2 fix --commit
           sudo apt-get -o Acquire::Retries=3 update
           sudo apt-get install sshpass mtools
 

--- a/.github/workflows/build-rusEFI-console.yaml
+++ b/.github/workflows/build-rusEFI-console.yaml
@@ -21,6 +21,7 @@ jobs:
 
       - name: Install Tools
         run: |
+          sudo sed -i 's/azure\.//' /etc/apt/sources.list
           sudo apt-get -o Acquire::Retries=3 update
           sudo apt-get install sshpass mtools
 

--- a/.github/workflows/build-rusEFI-console.yaml
+++ b/.github/workflows/build-rusEFI-console.yaml
@@ -20,7 +20,9 @@ jobs:
         run: javac -version
 
       - name: Install Tools
-        run: sudo apt-get install sshpass mtools
+        run: |
+          sudo apt-get -o Acquire::Retries=3 update
+          sudo apt-get install sshpass mtools
 
       - name: Generate Configs, Enums & Live Documentation
         working-directory: ./firmware/

--- a/.github/workflows/build-simulator.yaml
+++ b/.github/workflows/build-simulator.yaml
@@ -22,7 +22,7 @@ jobs:
 
     - name: Install multilib
       run: |
-        sudo sed -i 's/azure\.//' /etc/apt/sources.list
+        sudo gem install apt-spy2 && sudo time apt-spy2 fix --commit
         sudo apt-get -o Acquire::Retries=3 update
         sudo apt-get install gcc-multilib g++-multilib mtools dosfstools zip
 

--- a/.github/workflows/build-simulator.yaml
+++ b/.github/workflows/build-simulator.yaml
@@ -22,6 +22,7 @@ jobs:
 
     - name: Install multilib
       run: |
+        sudo sed -i 's/azure\.//' /etc/apt/sources.list
         sudo apt-get -o Acquire::Retries=3 update
         sudo apt-get install gcc-multilib g++-multilib mtools dosfstools zip
 

--- a/.github/workflows/build-simulator.yaml
+++ b/.github/workflows/build-simulator.yaml
@@ -22,7 +22,7 @@ jobs:
 
     - name: Install multilib
       run: |
-        sudo apt-get update
+        sudo apt-get -o Acquire::Retries=3 update
         sudo apt-get install gcc-multilib g++-multilib mtools dosfstools zip
 
     - name: Generate Configs, Enums & Live Documentation

--- a/.github/workflows/build-tsplugin-body.yaml
+++ b/.github/workflows/build-tsplugin-body.yaml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Install Tools
         run: |
-          sudo sed -i 's/azure\.//' /etc/apt/sources.list
+          sudo gem install apt-spy2 && sudo time apt-spy2 fix --commit
           sudo apt-get -o Acquire::Retries=3 update
           sudo apt-get install sshpass
 

--- a/.github/workflows/build-tsplugin-body.yaml
+++ b/.github/workflows/build-tsplugin-body.yaml
@@ -19,7 +19,9 @@ jobs:
         run: javac -version
 
       - name: Install Tools
-        run: sudo apt-get install sshpass
+        run: |
+          sudo apt-get -o Acquire::Retries=3 update
+          sudo apt-get install sshpass
 
       - name: Build TS plugin body
         working-directory: ./java_tools/ts_plugin

--- a/.github/workflows/build-tsplugin-body.yaml
+++ b/.github/workflows/build-tsplugin-body.yaml
@@ -20,6 +20,7 @@ jobs:
 
       - name: Install Tools
         run: |
+          sudo sed -i 's/azure\.//' /etc/apt/sources.list
           sudo apt-get -o Acquire::Retries=3 update
           sudo apt-get install sshpass
 

--- a/.github/workflows/build-unit-tests.yaml
+++ b/.github/workflows/build-unit-tests.yaml
@@ -23,6 +23,7 @@ jobs:
     - name: Install required software (ubuntu)
       if: ${{ matrix.os != 'macos-latest' }}
       run: |
+        sudo sed -i 's/azure\.//' /etc/apt/sources.list
         sudo apt-get -o Acquire::Retries=3 update
         sudo apt-get install mtools zip dosfstools sshpass lcov valgrind
 

--- a/.github/workflows/build-unit-tests.yaml
+++ b/.github/workflows/build-unit-tests.yaml
@@ -23,7 +23,7 @@ jobs:
     - name: Install required software (ubuntu)
       if: ${{ matrix.os != 'macos-latest' }}
       run: |
-        sudo apt-get update
+        sudo apt-get -o Acquire::Retries=3 update
         sudo apt-get install mtools zip dosfstools sshpass lcov valgrind
 
     - name: Install required software (macos)

--- a/.github/workflows/build-unit-tests.yaml
+++ b/.github/workflows/build-unit-tests.yaml
@@ -23,7 +23,7 @@ jobs:
     - name: Install required software (ubuntu)
       if: ${{ matrix.os != 'macos-latest' }}
       run: |
-        sudo sed -i 's/azure\.//' /etc/apt/sources.list
+        sudo gem install apt-spy2 && sudo time apt-spy2 fix --commit
         sudo apt-get -o Acquire::Retries=3 update
         sudo apt-get install mtools zip dosfstools sshpass lcov valgrind
 

--- a/.github/workflows/gen-configs.yaml
+++ b/.github/workflows/gen-configs.yaml
@@ -17,6 +17,7 @@ jobs:
 
     - name: Install Tools
       run: |
+        sudo sed -i 's/azure\.//' /etc/apt/sources.list
         sudo apt-get -o Acquire::Retries=3 update
         sudo apt-get install sshpass sshpass mtools
 

--- a/.github/workflows/gen-configs.yaml
+++ b/.github/workflows/gen-configs.yaml
@@ -17,7 +17,7 @@ jobs:
 
     - name: Install Tools
       run: |
-        sudo sed -i 's/azure\.//' /etc/apt/sources.list
+        sudo gem install apt-spy2 && sudo time apt-spy2 fix --commit
         sudo apt-get -o Acquire::Retries=3 update
         sudo apt-get install sshpass sshpass mtools
 

--- a/.github/workflows/gen-configs.yaml
+++ b/.github/workflows/gen-configs.yaml
@@ -16,7 +16,9 @@ jobs:
         fetch-depth: 0
 
     - name: Install Tools
-      run: sudo apt-get install sshpass sshpass mtools
+      run: |
+        sudo apt-get -o Acquire::Retries=3 update
+        sudo apt-get install sshpass sshpass mtools
 
     - name: Generate Enum Strings
       working-directory: ./firmware/

--- a/.github/workflows/gen-diffs.yaml
+++ b/.github/workflows/gen-diffs.yaml
@@ -17,7 +17,7 @@ jobs:
 
     - name: Install sshpass, kicad, and tk bindings
       run: |
-        sudo sed -i 's/azure\.//' /etc/apt/sources.list
+        sudo gem install apt-spy2 && sudo time apt-spy2 fix --commit
         sudo add-apt-repository --yes ppa:kicad/kicad-6.0-releases
         sudo apt-get -o Acquire::Retries=3 update
         sudo apt-get install sshpass kicad python3-pip python3-tk scour librsvg2-bin

--- a/.github/workflows/gen-diffs.yaml
+++ b/.github/workflows/gen-diffs.yaml
@@ -18,7 +18,7 @@ jobs:
     - name: Install sshpass, kicad, and tk bindings
       run: |
         sudo add-apt-repository --yes ppa:kicad/kicad-6.0-releases
-        sudo apt-get update
+        sudo apt-get -o Acquire::Retries=3 update
         sudo apt-get install sshpass kicad python3-pip python3-tk scour librsvg2-bin
         pip install python-dateutil pygubu
 

--- a/.github/workflows/gen-diffs.yaml
+++ b/.github/workflows/gen-diffs.yaml
@@ -17,6 +17,7 @@ jobs:
 
     - name: Install sshpass, kicad, and tk bindings
       run: |
+        sudo sed -i 's/azure\.//' /etc/apt/sources.list
         sudo add-apt-repository --yes ppa:kicad/kicad-6.0-releases
         sudo apt-get -o Acquire::Retries=3 update
         sudo apt-get install sshpass kicad python3-pip python3-tk scour librsvg2-bin

--- a/.github/workflows/gen-docs.yaml
+++ b/.github/workflows/gen-docs.yaml
@@ -15,7 +15,7 @@ jobs:
 
     - name: Install prerequisite software
       run: |
-        sudo sed -i 's/azure\.//' /etc/apt/sources.list
+        sudo gem install apt-spy2 && sudo time apt-spy2 fix --commit
         sudo apt-get -o Acquire::Retries=3 update
         sudo apt-get install doxygen graphviz sshpass
 

--- a/.github/workflows/gen-docs.yaml
+++ b/.github/workflows/gen-docs.yaml
@@ -15,6 +15,7 @@ jobs:
 
     - name: Install prerequisite software
       run: |
+        sudo sed -i 's/azure\.//' /etc/apt/sources.list
         sudo apt-get -o Acquire::Retries=3 update
         sudo apt-get install doxygen graphviz sshpass
 

--- a/.github/workflows/gen-docs.yaml
+++ b/.github/workflows/gen-docs.yaml
@@ -15,7 +15,7 @@ jobs:
 
     - name: Install prerequisite software
       run: |
-        sudo apt-get update
+        sudo apt-get -o Acquire::Retries=3 update
         sudo apt-get install doxygen graphviz sshpass
 
     - name: Set FTP variables

--- a/.github/workflows/gen-ibom.yaml
+++ b/.github/workflows/gen-ibom.yaml
@@ -17,7 +17,7 @@ jobs:
     - name: Install prerequisite software
       run: |
         sudo add-apt-repository ppa:kicad/kicad-5.1-releases
-        sudo apt-get update
+        sudo apt-get -o Acquire::Retries=3 update
         sudo apt-get install kicad sshpass
 
     - name: Set SSH variables

--- a/.github/workflows/gen-ibom.yaml
+++ b/.github/workflows/gen-ibom.yaml
@@ -16,6 +16,7 @@ jobs:
 
     - name: Install prerequisite software
       run: |
+        sudo sed -i 's/azure\.//' /etc/apt/sources.list
         sudo add-apt-repository ppa:kicad/kicad-5.1-releases
         sudo apt-get -o Acquire::Retries=3 update
         sudo apt-get install kicad sshpass

--- a/.github/workflows/gen-ibom.yaml
+++ b/.github/workflows/gen-ibom.yaml
@@ -16,7 +16,7 @@ jobs:
 
     - name: Install prerequisite software
       run: |
-        sudo sed -i 's/azure\.//' /etc/apt/sources.list
+        sudo gem install apt-spy2 && sudo time apt-spy2 fix --commit
         sudo add-apt-repository ppa:kicad/kicad-5.1-releases
         sudo apt-get -o Acquire::Retries=3 update
         sudo apt-get install kicad sshpass

--- a/.github/workflows/set-date.yaml
+++ b/.github/workflows/set-date.yaml
@@ -22,7 +22,9 @@ jobs:
         fetch-depth: 0
 
     - name: Install Tools
-      run: sudo apt-get install subversion
+      run: |
+        sudo apt-get -o Acquire::Retries=3 update
+        sudo apt-get install subversion
 
     - name: Update version header in git
       working-directory: ./firmware/

--- a/.github/workflows/set-date.yaml
+++ b/.github/workflows/set-date.yaml
@@ -23,6 +23,7 @@ jobs:
 
     - name: Install Tools
       run: |
+        sudo sed -i 's/azure\.//' /etc/apt/sources.list
         sudo apt-get -o Acquire::Retries=3 update
         sudo apt-get install subversion
 

--- a/.github/workflows/set-date.yaml
+++ b/.github/workflows/set-date.yaml
@@ -23,7 +23,7 @@ jobs:
 
     - name: Install Tools
       run: |
-        sudo sed -i 's/azure\.//' /etc/apt/sources.list
+        sudo gem install apt-spy2 && sudo time apt-spy2 fix --commit
         sudo apt-get -o Acquire::Retries=3 update
         sudo apt-get install subversion
 


### PR DESCRIPTION
Many actions are failing currently, unable to communicate with `azure.archive.ubuntu.com`, for unknown reasons.

```
Err:1 http://azure.archive.ubuntu.com/ubuntu jammy-updates/main amd64 libc6-dev-i386 amd64 2.35-0ubuntu3.1
Could not connect to azure.archive.ubuntu.com:80 (40.119.46.219), connection timed out [IP: 40.119.46.219 80]
```

Some solutions:
1. avoid azure archive, a la https://github.com/actions/runner-images/issues/675#issuecomment-610483420
  - `sed -i 's/azure\.//' /etc/apt/sources.list && apt-get update`
2. use a tool to find a suitable mirror, a la https://github.com/actions/runner-images/issues/675#issuecomment-609780588
  - `gem install apt-spy2 && apt-spy2 check && apt-spy2 fix && apt-get update`
3. add retryability to apt-get, a la https://github.com/actions/runner-images/issues/675#issuecomment-609281055
  - `apt-get -o Acquire::Retries=3 update`