### PR TITLE
more stack for TS

### DIFF
--- a/firmware/console/binary/tunerstudio.h
+++ b/firmware/console/binary/tunerstudio.h
@@ -47,7 +47,7 @@ typedef struct {
 } TunerStudioWriteChunkRequest;
 
 #if EFI_PROD_CODE || EFI_SIMULATOR
-#define CONNECTIVITY_THREAD_STACK (2 * UTILITY_THREAD_STACK_SIZE)
+#define CONNECTIVITY_THREAD_STACK (3 * UTILITY_THREAD_STACK_SIZE)
 
 class TunerstudioThread : public ThreadController<CONNECTIVITY_THREAD_STACK> {
 public:


### PR DESCRIPTION
I saw a low stack warning on the comms thread in a HW CI run, so give it some more stack.