### PR TITLE
LTS - one way of doing things

### DIFF
--- a/.github/workflows/build-firmware.yaml
+++ b/.github/workflows/build-firmware.yaml
@@ -374,12 +374,12 @@ jobs:
 
     # Build rusEFI console
     - name: Build console
-      if: ${{( github.event_name == 'push' && github.ref == 'refs/heads/master' && env.skip != 'true' ) || inputs.lts == 'true' }}
+      if: ${{( github.event_name == 'push' && github.ref == 'refs/heads/master' && env.skip != 'true' ) || inputs.lts }}
       run: bash misc/jenkins/build_java_console.sh
 
     # Build the simulator
     - name: Build simulator
-      if: ${{( github.event_name == 'push' && github.ref == 'refs/heads/master' && env.skip != 'true' ) || inputs.lts == 'true' }}
+      if: ${{( github.event_name == 'push' && github.ref == 'refs/heads/master' && env.skip != 'true' ) || inputs.lts }}
       # 'OS="Windows_NT"' allows us to build Windows executable on unix
       run: OS="Windows_NT" bash misc/jenkins/build_simulator.sh
 
@@ -389,24 +389,24 @@ jobs:
       run: bash misc/jenkins/compile_other_versions/compile.sh ${{matrix.folder}} ${{matrix.build-target}} ${{matrix.ini-file}} ${{matrix.console-settings}}
 
     - name: Package Bundle
-      if: ${{( github.event_name == 'push' && github.ref == 'refs/heads/master' && env.skip != 'true' ) || inputs.lts == 'true' }}
+      if: ${{( github.event_name == 'push' && github.ref == 'refs/heads/master' && env.skip != 'true' ) || inputs.lts }}
       run: bash misc/jenkins/compile_other_versions/prepare_bundle.sh ${{matrix.build-target}} ${{matrix.ini-file}} ${{ inputs.lts }}
 
     - name: Upload .ini files
-      if: ${{( github.event_name == 'push' && github.ref == 'refs/heads/master' && env.skip != 'true' ) || inputs.lts == 'true' }}
+      if: ${{( github.event_name == 'push' && github.ref == 'refs/heads/master' && env.skip != 'true' ) || inputs.lts }}
       working-directory: ./firmware/tunerstudio/generated
       run: |
         ../upload_ini.sh ${{matrix.ini-file}} ${{ secrets.RUSEFI_ONLINE_FTP_USER }} ${{ secrets.RUSEFI_ONLINE_FTP_PASS }} ${{ secrets.RUSEFI_FTP_SERVER }}
 
     - name: Upload build elf
-      if: ${{ github.event_name != 'push' || github.ref != 'refs/heads/master' && env.skip != 'true' && inputs.lts == 'true' }}
+      if: ${{ github.event_name != 'push' || github.ref != 'refs/heads/master' && env.skip != 'true' && inputs.lts }}
       uses: actions/upload-artifact@v3
       with:
         name: rusefi_${{matrix.build-target}}.elf
         path: ./firmware/build/rusefi.elf
 
     - name: Upload build bin
-      if: ${{ github.event_name != 'push' || github.ref != 'refs/heads/master' && env.skip != 'true' && inputs.lts == 'true' }}
+      if: ${{ github.event_name != 'push' || github.ref != 'refs/heads/master' && env.skip != 'true' && inputs.lts }}
       uses: actions/upload-artifact@v3
       with:
         name: rusefi_${{matrix.build-target}}.bin
@@ -427,14 +427,14 @@ jobs:
         path: ./firmware/deliver/rusefi*.dfu
 
     - name: Upload bundle
-      if: ${{( github.event_name == 'push' && github.ref == 'refs/heads/master' && env.skip != 'true' ) || inputs.lts == 'true' }}
+      if: ${{( github.event_name == 'push' && github.ref == 'refs/heads/master' && env.skip != 'true' ) || inputs.lts }}
       uses: actions/upload-artifact@v3
       with:
         name: rusefi_bundle_${{matrix.build-target}}.zip
         path: ./artifacts/rusefi_bundle*.zip
 
     - name: Upload autoupdate bundle
-      if: ${{( github.event_name == 'push' && github.ref == 'refs/heads/master' && env.skip != 'true' ) || inputs.lts == 'true' }}
+      if: ${{( github.event_name == 'push' && github.ref == 'refs/heads/master' && env.skip != 'true' ) || inputs.lts }}
       uses: actions/upload-artifact@v3
       with:
         name: rusefi_bundle_${{matrix.build-target}}_autoupdate.zip
@@ -497,7 +497,7 @@ jobs:
       run: OS="Windows_NT" bash misc/jenkins/functional_test_and_build_bundle/build_current_bundle.sh
 
     - name: Package Bundle
-      if: ${{( github.event_name == 'push' && github.ref == 'refs/heads/master' ) || inputs.lts == 'true' }}
+      if: ${{( github.event_name == 'push' && github.ref == 'refs/heads/master' ) || inputs.lts }}
       run: bash misc/jenkins/compile_other_versions/prepare_bundle.sh default default ${{ inputs.lts }}
 
     - name: Attach console junit results
@@ -508,13 +508,13 @@ jobs:
         path: ./java_console/build/*.txt
 
     - name: Upload 'all' .ini files
-      if: ${{( github.event_name == 'push' && github.ref == 'refs/heads/master' && env.skip != 'true' ) || inputs.lts == 'true' }}
+      if: ${{( github.event_name == 'push' && github.ref == 'refs/heads/master' && env.skip != 'true' ) || inputs.lts }}
       working-directory: ./firmware/tunerstudio/generated
       run: |
         ../upload_ini.sh rusefi.ini ${{ secrets.RUSEFI_ONLINE_FTP_USER }} ${{ secrets.RUSEFI_ONLINE_FTP_PASS }} ${{ secrets.RUSEFI_FTP_SERVER }}
 
     - name: Upload primary bundle
-      if: ${{( github.event_name == 'push' && github.ref == 'refs/heads/master' ) || inputs.lts == 'true' }}
+      if: ${{( github.event_name == 'push' && github.ref == 'refs/heads/master' ) || inputs.lts }}
       uses: actions/upload-artifact@v3
       with:
         name: rusefi_bundle.zip

--- a/.github/workflows/build-firmware.yaml
+++ b/.github/workflows/build-firmware.yaml
@@ -1,7 +1,14 @@
 name: Firmware at GHA
 
-on: [push, pull_request, workflow_dispatch]
-
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      lts:
+        description: 'LTS Build'
+        required: false
+        type: boolean
 jobs:
   build-firmware:
     runs-on: ubuntu-latest
@@ -383,7 +390,7 @@ jobs:
 
     - name: Package Bundle
       if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' && env.skip != 'true' }}
-      run: bash misc/jenkins/compile_other_versions/prepare_bundle.sh ${{matrix.build-target}} ${{matrix.ini-file}}
+      run: bash misc/jenkins/compile_other_versions/prepare_bundle.sh ${{matrix.build-target}} ${{matrix.ini-file}} ${{ inputs.lts }}
 
     - name: Upload .ini files
       if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' && env.skip != 'true' }}
@@ -491,7 +498,7 @@ jobs:
 
     - name: Package Bundle
       if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
-      run: bash misc/jenkins/compile_other_versions/prepare_bundle.sh default
+      run: bash misc/jenkins/compile_other_versions/prepare_bundle.sh default default ${{ inputs.lts }}
 
     - name: Attach console junit results
       if: always()

--- a/.github/workflows/build-firmware.yaml
+++ b/.github/workflows/build-firmware.yaml
@@ -366,7 +366,7 @@ jobs:
       env:
         ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
       run: |
-        if [ "${{github.event_name}}" = "push" ] && [ "${{github.ref}}" = "refs/heads/master" ] || [ "${{inputs.lts}}" = "true" ]; then
+        if [ "${{github.event_name}}" = "push" ] && [ "${{github.ref}}" = "refs/heads/master" ] || [ "${{toJSON(inputs.lts)}}" = "true" ]; then
           echo "::set-env name=RUSEFI_SSH_SERVER::${{secrets.RUSEFI_SSH_SERVER}}";
           echo "::set-env name=RUSEFI_SSH_USER::${{secrets.RUSEFI_SSH_USER}}";
           echo "::set-env name=RUSEFI_SSH_PASS::${{secrets.RUSEFI_SSH_PASS}}";
@@ -390,7 +390,7 @@ jobs:
 
     - name: Package Bundle
       if: ${{( github.event_name == 'push' && github.ref == 'refs/heads/master' && env.skip != 'true' ) || inputs.lts }}
-      run: bash misc/jenkins/compile_other_versions/prepare_bundle.sh ${{matrix.build-target}} ${{matrix.ini-file}} ${{ inputs.lts }}
+      run: bash misc/jenkins/compile_other_versions/prepare_bundle.sh ${{matrix.build-target}} ${{matrix.ini-file}} ${{ toJSON(inputs.lts) }}
 
     - name: Upload .ini files
       if: ${{( github.event_name == 'push' && github.ref == 'refs/heads/master' && env.skip != 'true' ) || inputs.lts }}
@@ -399,28 +399,28 @@ jobs:
         ../upload_ini.sh ${{matrix.ini-file}} ${{ secrets.RUSEFI_ONLINE_FTP_USER }} ${{ secrets.RUSEFI_ONLINE_FTP_PASS }} ${{ secrets.RUSEFI_FTP_SERVER }}
 
     - name: Upload build elf
-      if: ${{ github.event_name != 'push' || github.ref != 'refs/heads/master' && env.skip != 'true' && inputs.lts }}
+      if: ${{ github.event_name != 'push' || github.ref != 'refs/heads/master' && env.skip != 'true' && !inputs.lts }}
       uses: actions/upload-artifact@v3
       with:
         name: rusefi_${{matrix.build-target}}.elf
         path: ./firmware/build/rusefi.elf
 
     - name: Upload build bin
-      if: ${{ github.event_name != 'push' || github.ref != 'refs/heads/master' && env.skip != 'true' && inputs.lts }}
+      if: ${{ github.event_name != 'push' || github.ref != 'refs/heads/master' && env.skip != 'true' && !inputs.lts }}
       uses: actions/upload-artifact@v3
       with:
         name: rusefi_${{matrix.build-target}}.bin
         path: ./firmware/deliver/rusefi*.bin
 
     - name: Upload build hex
-      if: ${{ github.event_name != 'push' || github.ref != 'refs/heads/master' && env.skip != 'true' && inputs.lts != 'true' }}
+      if: ${{ github.event_name != 'push' || github.ref != 'refs/heads/master' && env.skip != 'true' && !inputs.lts }}
       uses: actions/upload-artifact@v3
       with:
         name: rusefi_${{matrix.build-target}}.hex
         path: ./firmware/deliver/rusefi*.hex
 
     - name: Upload build dfu
-      if: ${{ github.event_name != 'push' || github.ref != 'refs/heads/master' && env.skip != 'true' && inputs.lts != 'true' }}
+      if: ${{ github.event_name != 'push' || github.ref != 'refs/heads/master' && env.skip != 'true' && !inputs.lts }}
       uses: actions/upload-artifact@v3
       with:
         name: rusefi_${{matrix.build-target}}.dfu
@@ -486,7 +486,7 @@ jobs:
       env:
         ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
       run: |
-        if [ "${{github.event_name}}" = "push" ] && [ "${{github.ref}}" = "refs/heads/master" ] || [ "${{inputs.lts}}" = "true" ]; then
+        if [ "${{github.event_name}}" = "push" ] && [ "${{github.ref}}" = "refs/heads/master" ] || [ "${{toJSON(inputs.lts)}}" = "true" ]; then
           echo "::set-env name=RUSEFI_SSH_SERVER::${{secrets.RUSEFI_SSH_SERVER}}";
           echo "::set-env name=RUSEFI_SSH_USER::${{secrets.RUSEFI_SSH_USER}}";
           echo "::set-env name=RUSEFI_SSH_PASS::${{secrets.RUSEFI_SSH_PASS}}";
@@ -498,7 +498,7 @@ jobs:
 
     - name: Package Bundle
       if: ${{( github.event_name == 'push' && github.ref == 'refs/heads/master' ) || inputs.lts }}
-      run: bash misc/jenkins/compile_other_versions/prepare_bundle.sh default default ${{ inputs.lts }}
+      run: bash misc/jenkins/compile_other_versions/prepare_bundle.sh default default ${{ toJSON(inputs.lts) }}
 
     - name: Attach console junit results
       if: always()

--- a/.github/workflows/build-firmware.yaml
+++ b/.github/workflows/build-firmware.yaml
@@ -366,7 +366,7 @@ jobs:
       env:
         ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
       run: |
-        if [ "${{github.event_name}}" = "push" ] && [ "${{github.ref}}" = "refs/heads/master" ]; then
+        if [ "${{github.event_name}}" = "push" ] && [ "${{github.ref}}" = "refs/heads/master" ] || [ "${{inputs.lts}}" = "true" ]; then
           echo "::set-env name=RUSEFI_SSH_SERVER::${{secrets.RUSEFI_SSH_SERVER}}";
           echo "::set-env name=RUSEFI_SSH_USER::${{secrets.RUSEFI_SSH_USER}}";
           echo "::set-env name=RUSEFI_SSH_PASS::${{secrets.RUSEFI_SSH_PASS}}";
@@ -374,12 +374,12 @@ jobs:
 
     # Build rusEFI console
     - name: Build console
-      if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' && env.skip != 'true' }}
+      if: ${{${{ github.event_name == 'push' && github.ref == 'refs/heads/master' && env.skip != 'true' }} || inputs.lts == "true" }}
       run: bash misc/jenkins/build_java_console.sh
   
     # Build the simulator
     - name: Build simulator
-      if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' && env.skip != 'true' }}
+      if: ${{${{ github.event_name == 'push' && github.ref == 'refs/heads/master' && env.skip != 'true' }} || inputs.lts == "true" }}
       # 'OS="Windows_NT"' allows us to build Windows executable on unix
       run: OS="Windows_NT" bash misc/jenkins/build_simulator.sh
 
@@ -389,52 +389,52 @@ jobs:
       run: bash misc/jenkins/compile_other_versions/compile.sh ${{matrix.folder}} ${{matrix.build-target}} ${{matrix.ini-file}} ${{matrix.console-settings}}
 
     - name: Package Bundle
-      if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' && env.skip != 'true' }}
+      if: ${{${{ github.event_name == 'push' && github.ref == 'refs/heads/master' && env.skip != 'true' }} || inputs.lts == "true" }}
       run: bash misc/jenkins/compile_other_versions/prepare_bundle.sh ${{matrix.build-target}} ${{matrix.ini-file}} ${{ inputs.lts }}
 
     - name: Upload .ini files
-      if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' && env.skip != 'true' }}
+      if: ${{${{ github.event_name == 'push' && github.ref == 'refs/heads/master' && env.skip != 'true' }} || inputs.lts == "true" }}
       working-directory: ./firmware/tunerstudio/generated
       run: |
         ../upload_ini.sh ${{matrix.ini-file}} ${{ secrets.RUSEFI_ONLINE_FTP_USER }} ${{ secrets.RUSEFI_ONLINE_FTP_PASS }} ${{ secrets.RUSEFI_FTP_SERVER }}
 
     - name: Upload build elf
-      if: ${{ github.event_name != 'push' || github.ref != 'refs/heads/master' && env.skip != 'true' }}
+      if: ${{ github.event_name != 'push' || github.ref != 'refs/heads/master' && env.skip != 'true' && inputs.lts == "true" }}
       uses: actions/upload-artifact@v3
       with:
         name: rusefi_${{matrix.build-target}}.elf
         path: ./firmware/build/rusefi.elf
 
     - name: Upload build bin
-      if: ${{ github.event_name != 'push' || github.ref != 'refs/heads/master' && env.skip != 'true' }}
+      if: ${{ github.event_name != 'push' || github.ref != 'refs/heads/master' && env.skip != 'true' && inputs.lts == "true" }}
       uses: actions/upload-artifact@v3
       with:
         name: rusefi_${{matrix.build-target}}.bin
         path: ./firmware/deliver/rusefi*.bin
 
     - name: Upload build hex
-      if: ${{ github.event_name != 'push' || github.ref != 'refs/heads/master' && env.skip != 'true' }}
+      if: ${{ github.event_name != 'push' || github.ref != 'refs/heads/master' && env.skip != 'true' && inputs.lts != "true" }}
       uses: actions/upload-artifact@v3
       with:
         name: rusefi_${{matrix.build-target}}.hex
         path: ./firmware/deliver/rusefi*.hex
 
     - name: Upload build dfu
-      if: ${{ github.event_name != 'push' || github.ref != 'refs/heads/master' && env.skip != 'true' }}
+      if: ${{ github.event_name != 'push' || github.ref != 'refs/heads/master' && env.skip != 'true' && inputs.lts != "true" }}
       uses: actions/upload-artifact@v3
       with:
         name: rusefi_${{matrix.build-target}}.dfu
         path: ./firmware/deliver/rusefi*.dfu
 
     - name: Upload bundle
-      if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' && env.skip != 'true' }}
+      if: ${{${{ github.event_name == 'push' && github.ref == 'refs/heads/master' && env.skip != 'true' }} || inputs.lts == "true" }}
       uses: actions/upload-artifact@v3
       with:
         name: rusefi_bundle_${{matrix.build-target}}.zip
         path: ./artifacts/rusefi_bundle*.zip
 
     - name: Upload autoupdate bundle
-      if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' && env.skip != 'true' }}
+      if: ${{${{ github.event_name == 'push' && github.ref == 'refs/heads/master' && env.skip != 'true' }} || inputs.lts == "true" }}
       uses: actions/upload-artifact@v3
       with:
         name: rusefi_bundle_${{matrix.build-target}}_autoupdate.zip
@@ -486,7 +486,7 @@ jobs:
       env:
         ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
       run: |
-        if [ "${{github.event_name}}" = "push" ] && [ "${{github.ref}}" = "refs/heads/master" ]; then
+        if [ "${{github.event_name}}" = "push" ] && [ "${{github.ref}}" = "refs/heads/master" ] || [ "${{inputs.lts}}" = "true" ]; then
           echo "::set-env name=RUSEFI_SSH_SERVER::${{secrets.RUSEFI_SSH_SERVER}}";
           echo "::set-env name=RUSEFI_SSH_USER::${{secrets.RUSEFI_SSH_USER}}";
           echo "::set-env name=RUSEFI_SSH_PASS::${{secrets.RUSEFI_SSH_PASS}}";
@@ -497,7 +497,7 @@ jobs:
       run: OS="Windows_NT" bash misc/jenkins/functional_test_and_build_bundle/build_current_bundle.sh
 
     - name: Package Bundle
-      if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+      if: ${{${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }} || inputs.lts == "true" }}
       run: bash misc/jenkins/compile_other_versions/prepare_bundle.sh default default ${{ inputs.lts }}
 
     - name: Attach console junit results
@@ -508,13 +508,13 @@ jobs:
         path: ./java_console/build/*.txt
 
     - name: Upload 'all' .ini files
-      if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' && env.skip != 'true' }}
+      if: ${{${{ github.event_name == 'push' && github.ref == 'refs/heads/master' && env.skip != 'true' }} || inputs.lts == "true" }}
       working-directory: ./firmware/tunerstudio/generated
       run: |
         ../upload_ini.sh rusefi.ini ${{ secrets.RUSEFI_ONLINE_FTP_USER }} ${{ secrets.RUSEFI_ONLINE_FTP_PASS }} ${{ secrets.RUSEFI_FTP_SERVER }}
 
     - name: Upload primary bundle
-      if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+      if: ${{${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }} || inputs.lts == "true" }}
       uses: actions/upload-artifact@v3
       with:
         name: rusefi_bundle.zip

--- a/.github/workflows/build-firmware.yaml
+++ b/.github/workflows/build-firmware.yaml
@@ -374,12 +374,12 @@ jobs:
 
     # Build rusEFI console
     - name: Build console
-      if: ${{( github.event_name == 'push' && github.ref == 'refs/heads/master' && env.skip != 'true' ) || inputs.lts == "true" }}
+      if: ${{( github.event_name == 'push' && github.ref == 'refs/heads/master' && env.skip != 'true' ) || inputs.lts == 'true' }}
       run: bash misc/jenkins/build_java_console.sh
 
     # Build the simulator
     - name: Build simulator
-      if: ${{( github.event_name == 'push' && github.ref == 'refs/heads/master' && env.skip != 'true' ) || inputs.lts == "true" }}
+      if: ${{( github.event_name == 'push' && github.ref == 'refs/heads/master' && env.skip != 'true' ) || inputs.lts == 'true' }}
       # 'OS="Windows_NT"' allows us to build Windows executable on unix
       run: OS="Windows_NT" bash misc/jenkins/build_simulator.sh
 
@@ -389,52 +389,52 @@ jobs:
       run: bash misc/jenkins/compile_other_versions/compile.sh ${{matrix.folder}} ${{matrix.build-target}} ${{matrix.ini-file}} ${{matrix.console-settings}}
 
     - name: Package Bundle
-      if: ${{( github.event_name == 'push' && github.ref == 'refs/heads/master' && env.skip != 'true' ) || inputs.lts == "true" }}
+      if: ${{( github.event_name == 'push' && github.ref == 'refs/heads/master' && env.skip != 'true' ) || inputs.lts == 'true' }}
       run: bash misc/jenkins/compile_other_versions/prepare_bundle.sh ${{matrix.build-target}} ${{matrix.ini-file}} ${{ inputs.lts }}
 
     - name: Upload .ini files
-      if: ${{( github.event_name == 'push' && github.ref == 'refs/heads/master' && env.skip != 'true' ) || inputs.lts == "true" }}
+      if: ${{( github.event_name == 'push' && github.ref == 'refs/heads/master' && env.skip != 'true' ) || inputs.lts == 'true' }}
       working-directory: ./firmware/tunerstudio/generated
       run: |
         ../upload_ini.sh ${{matrix.ini-file}} ${{ secrets.RUSEFI_ONLINE_FTP_USER }} ${{ secrets.RUSEFI_ONLINE_FTP_PASS }} ${{ secrets.RUSEFI_FTP_SERVER }}
 
     - name: Upload build elf
-      if: ${{ github.event_name != 'push' || github.ref != 'refs/heads/master' && env.skip != 'true' && inputs.lts == "true" }}
+      if: ${{ github.event_name != 'push' || github.ref != 'refs/heads/master' && env.skip != 'true' && inputs.lts == 'true' }}
       uses: actions/upload-artifact@v3
       with:
         name: rusefi_${{matrix.build-target}}.elf
         path: ./firmware/build/rusefi.elf
 
     - name: Upload build bin
-      if: ${{ github.event_name != 'push' || github.ref != 'refs/heads/master' && env.skip != 'true' && inputs.lts == "true" }}
+      if: ${{ github.event_name != 'push' || github.ref != 'refs/heads/master' && env.skip != 'true' && inputs.lts == 'true' }}
       uses: actions/upload-artifact@v3
       with:
         name: rusefi_${{matrix.build-target}}.bin
         path: ./firmware/deliver/rusefi*.bin
 
     - name: Upload build hex
-      if: ${{ github.event_name != 'push' || github.ref != 'refs/heads/master' && env.skip != 'true' && inputs.lts != "true" }}
+      if: ${{ github.event_name != 'push' || github.ref != 'refs/heads/master' && env.skip != 'true' && inputs.lts != 'true' }}
       uses: actions/upload-artifact@v3
       with:
         name: rusefi_${{matrix.build-target}}.hex
         path: ./firmware/deliver/rusefi*.hex
 
     - name: Upload build dfu
-      if: ${{ github.event_name != 'push' || github.ref != 'refs/heads/master' && env.skip != 'true' && inputs.lts != "true" }}
+      if: ${{ github.event_name != 'push' || github.ref != 'refs/heads/master' && env.skip != 'true' && inputs.lts != 'true' }}
       uses: actions/upload-artifact@v3
       with:
         name: rusefi_${{matrix.build-target}}.dfu
         path: ./firmware/deliver/rusefi*.dfu
 
     - name: Upload bundle
-      if: ${{( github.event_name == 'push' && github.ref == 'refs/heads/master' && env.skip != 'true' ) || inputs.lts == "true" }}
+      if: ${{( github.event_name == 'push' && github.ref == 'refs/heads/master' && env.skip != 'true' ) || inputs.lts == 'true' }}
       uses: actions/upload-artifact@v3
       with:
         name: rusefi_bundle_${{matrix.build-target}}.zip
         path: ./artifacts/rusefi_bundle*.zip
 
     - name: Upload autoupdate bundle
-      if: ${{( github.event_name == 'push' && github.ref == 'refs/heads/master' && env.skip != 'true' ) || inputs.lts == "true" }}
+      if: ${{( github.event_name == 'push' && github.ref == 'refs/heads/master' && env.skip != 'true' ) || inputs.lts == 'true' }}
       uses: actions/upload-artifact@v3
       with:
         name: rusefi_bundle_${{matrix.build-target}}_autoupdate.zip
@@ -497,7 +497,7 @@ jobs:
       run: OS="Windows_NT" bash misc/jenkins/functional_test_and_build_bundle/build_current_bundle.sh
 
     - name: Package Bundle
-      if: ${{( github.event_name == 'push' && github.ref == 'refs/heads/master' ) || inputs.lts == "true" }}
+      if: ${{( github.event_name == 'push' && github.ref == 'refs/heads/master' ) || inputs.lts == 'true' }}
       run: bash misc/jenkins/compile_other_versions/prepare_bundle.sh default default ${{ inputs.lts }}
 
     - name: Attach console junit results
@@ -508,13 +508,13 @@ jobs:
         path: ./java_console/build/*.txt
 
     - name: Upload 'all' .ini files
-      if: ${{( github.event_name == 'push' && github.ref == 'refs/heads/master' && env.skip != 'true' ) || inputs.lts == "true" }}
+      if: ${{( github.event_name == 'push' && github.ref == 'refs/heads/master' && env.skip != 'true' ) || inputs.lts == 'true' }}
       working-directory: ./firmware/tunerstudio/generated
       run: |
         ../upload_ini.sh rusefi.ini ${{ secrets.RUSEFI_ONLINE_FTP_USER }} ${{ secrets.RUSEFI_ONLINE_FTP_PASS }} ${{ secrets.RUSEFI_FTP_SERVER }}
 
     - name: Upload primary bundle
-      if: ${{( github.event_name == 'push' && github.ref == 'refs/heads/master' ) || inputs.lts == "true" }}
+      if: ${{( github.event_name == 'push' && github.ref == 'refs/heads/master' ) || inputs.lts == 'true' }}
       uses: actions/upload-artifact@v3
       with:
         name: rusefi_bundle.zip

--- a/.github/workflows/build-firmware.yaml
+++ b/.github/workflows/build-firmware.yaml
@@ -374,12 +374,12 @@ jobs:
 
     # Build rusEFI console
     - name: Build console
-      if: ${{${{ github.event_name == 'push' && github.ref == 'refs/heads/master' && env.skip != 'true' }} || inputs.lts == "true" }}
+      if: ${{( github.event_name == 'push' && github.ref == 'refs/heads/master' && env.skip != 'true' ) || inputs.lts == "true" }}
       run: bash misc/jenkins/build_java_console.sh
-  
+
     # Build the simulator
     - name: Build simulator
-      if: ${{${{ github.event_name == 'push' && github.ref == 'refs/heads/master' && env.skip != 'true' }} || inputs.lts == "true" }}
+      if: ${{( github.event_name == 'push' && github.ref == 'refs/heads/master' && env.skip != 'true' ) || inputs.lts == "true" }}
       # 'OS="Windows_NT"' allows us to build Windows executable on unix
       run: OS="Windows_NT" bash misc/jenkins/build_simulator.sh
 
@@ -389,11 +389,11 @@ jobs:
       run: bash misc/jenkins/compile_other_versions/compile.sh ${{matrix.folder}} ${{matrix.build-target}} ${{matrix.ini-file}} ${{matrix.console-settings}}
 
     - name: Package Bundle
-      if: ${{${{ github.event_name == 'push' && github.ref == 'refs/heads/master' && env.skip != 'true' }} || inputs.lts == "true" }}
+      if: ${{( github.event_name == 'push' && github.ref == 'refs/heads/master' && env.skip != 'true' ) || inputs.lts == "true" }}
       run: bash misc/jenkins/compile_other_versions/prepare_bundle.sh ${{matrix.build-target}} ${{matrix.ini-file}} ${{ inputs.lts }}
 
     - name: Upload .ini files
-      if: ${{${{ github.event_name == 'push' && github.ref == 'refs/heads/master' && env.skip != 'true' }} || inputs.lts == "true" }}
+      if: ${{( github.event_name == 'push' && github.ref == 'refs/heads/master' && env.skip != 'true' ) || inputs.lts == "true" }}
       working-directory: ./firmware/tunerstudio/generated
       run: |
         ../upload_ini.sh ${{matrix.ini-file}} ${{ secrets.RUSEFI_ONLINE_FTP_USER }} ${{ secrets.RUSEFI_ONLINE_FTP_PASS }} ${{ secrets.RUSEFI_FTP_SERVER }}
@@ -427,14 +427,14 @@ jobs:
         path: ./firmware/deliver/rusefi*.dfu
 
     - name: Upload bundle
-      if: ${{${{ github.event_name == 'push' && github.ref == 'refs/heads/master' && env.skip != 'true' }} || inputs.lts == "true" }}
+      if: ${{( github.event_name == 'push' && github.ref == 'refs/heads/master' && env.skip != 'true' ) || inputs.lts == "true" }}
       uses: actions/upload-artifact@v3
       with:
         name: rusefi_bundle_${{matrix.build-target}}.zip
         path: ./artifacts/rusefi_bundle*.zip
 
     - name: Upload autoupdate bundle
-      if: ${{${{ github.event_name == 'push' && github.ref == 'refs/heads/master' && env.skip != 'true' }} || inputs.lts == "true" }}
+      if: ${{( github.event_name == 'push' && github.ref == 'refs/heads/master' && env.skip != 'true' ) || inputs.lts == "true" }}
       uses: actions/upload-artifact@v3
       with:
         name: rusefi_bundle_${{matrix.build-target}}_autoupdate.zip
@@ -497,7 +497,7 @@ jobs:
       run: OS="Windows_NT" bash misc/jenkins/functional_test_and_build_bundle/build_current_bundle.sh
 
     - name: Package Bundle
-      if: ${{${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }} || inputs.lts == "true" }}
+      if: ${{( github.event_name == 'push' && github.ref == 'refs/heads/master' ) || inputs.lts == "true" }}
       run: bash misc/jenkins/compile_other_versions/prepare_bundle.sh default default ${{ inputs.lts }}
 
     - name: Attach console junit results
@@ -508,13 +508,13 @@ jobs:
         path: ./java_console/build/*.txt
 
     - name: Upload 'all' .ini files
-      if: ${{${{ github.event_name == 'push' && github.ref == 'refs/heads/master' && env.skip != 'true' }} || inputs.lts == "true" }}
+      if: ${{( github.event_name == 'push' && github.ref == 'refs/heads/master' && env.skip != 'true' ) || inputs.lts == "true" }}
       working-directory: ./firmware/tunerstudio/generated
       run: |
         ../upload_ini.sh rusefi.ini ${{ secrets.RUSEFI_ONLINE_FTP_USER }} ${{ secrets.RUSEFI_ONLINE_FTP_PASS }} ${{ secrets.RUSEFI_FTP_SERVER }}
 
     - name: Upload primary bundle
-      if: ${{${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }} || inputs.lts == "true" }}
+      if: ${{( github.event_name == 'push' && github.ref == 'refs/heads/master' ) || inputs.lts == "true" }}
       uses: actions/upload-artifact@v3
       with:
         name: rusefi_bundle.zip

--- a/misc/jenkins/build_working_folder.sh
+++ b/misc/jenkins/build_working_folder.sh
@@ -115,8 +115,14 @@ ls -l $FULL_BUNDLE_FILE
 
 if [ -n "$RUSEFI_SSH_USER" ]; then
  echo "$SCRIPT_NAME: Uploading full bundle"
- tar -czf - $FULL_BUNDLE_FILE  | sshpass -p $RUSEFI_SSH_PASS ssh -o StrictHostKeyChecking=no $RUSEFI_SSH_USER@$RUSEFI_SSH_SERVER "tar -xzf - -C build_server"
- retVal=$?
+ retVal=0
+ if [ "$1" = "true" ]; then
+   tar -czf - $FULL_BUNDLE_FILE  | sshpass -p $RUSEFI_SSH_PASS ssh -o StrictHostKeyChecking=no $RUSEFI_SSH_USER@$RUSEFI_SSH_SERVER "tar -xzf - -C build_server/lts"
+   retVal=$?
+ else
+   tar -czf - $FULL_BUNDLE_FILE  | sshpass -p $RUSEFI_SSH_PASS ssh -o StrictHostKeyChecking=no $RUSEFI_SSH_USER@$RUSEFI_SSH_SERVER "tar -xzf - -C build_server"
+   retVal=$?
+ fi
  if [ $retVal -ne 0 ]; then
   echo "full bundle upload failed"
   exit 1
@@ -143,14 +149,8 @@ zip -r ../$UPDATE_BUNDLE_FILE *
 cd ..
 ls -l $UPDATE_BUNDLE_FILE
 if [ -n "$RUSEFI_SSH_USER" ]; then
- retVal=0
- if [ "$3" == "true" ]; then
-   tar -czf - $UPDATE_BUNDLE_FILE  | sshpass -p $RUSEFI_SSH_PASS ssh -o StrictHostKeyChecking=no $RUSEFI_SSH_USER@$RUSEFI_SSH_SERVER "tar -xzf - -C build_server/autoupdate/lts"
-   retVal=$?
- else
-   tar -czf - $UPDATE_BUNDLE_FILE  | sshpass -p $RUSEFI_SSH_PASS ssh -o StrictHostKeyChecking=no $RUSEFI_SSH_USER@$RUSEFI_SSH_SERVER "tar -xzf - -C build_server/autoupdate"
-   retVal=$?
- fi
+ tar -czf - $UPDATE_BUNDLE_FILE  | sshpass -p $RUSEFI_SSH_PASS ssh -o StrictHostKeyChecking=no $RUSEFI_SSH_USER@$RUSEFI_SSH_SERVER "tar -xzf - -C build_server/autoupdate"
+ retVal=$?
  if [ $retVal -ne 0 ]; then
   echo "autoupdate upload failed"
   exit 1

--- a/misc/jenkins/build_working_folder.sh
+++ b/misc/jenkins/build_working_folder.sh
@@ -143,8 +143,14 @@ zip -r ../$UPDATE_BUNDLE_FILE *
 cd ..
 ls -l $UPDATE_BUNDLE_FILE
 if [ -n "$RUSEFI_SSH_USER" ]; then
- tar -czf - $UPDATE_BUNDLE_FILE  | sshpass -p $RUSEFI_SSH_PASS ssh -o StrictHostKeyChecking=no $RUSEFI_SSH_USER@$RUSEFI_SSH_SERVER "tar -xzf - -C build_server/autoupdate"
- retVal=$?
+ retVal=0
+ if [ "$3" == "true" ]; then
+   tar -czf - $UPDATE_BUNDLE_FILE  | sshpass -p $RUSEFI_SSH_PASS ssh -o StrictHostKeyChecking=no $RUSEFI_SSH_USER@$RUSEFI_SSH_SERVER "tar -xzf - -C build_server/autoupdate/lts"
+   retVal=$?
+ else
+   tar -czf - $UPDATE_BUNDLE_FILE  | sshpass -p $RUSEFI_SSH_PASS ssh -o StrictHostKeyChecking=no $RUSEFI_SSH_USER@$RUSEFI_SSH_SERVER "tar -xzf - -C build_server/autoupdate"
+   retVal=$?
+ fi
  if [ $retVal -ne 0 ]; then
   echo "autoupdate upload failed"
   exit 1

--- a/misc/jenkins/compile_other_versions/prepare_bundle.sh
+++ b/misc/jenkins/compile_other_versions/prepare_bundle.sh
@@ -12,7 +12,7 @@ export FOLDER="temp/snapshot_${TIMESTAMP}_${BUNDLE_NAME}_rusefi"
 
 export BUNDLE_FULL_NAME="rusefi_bundle_${BUNDLE_NAME}"
 
-bash misc/jenkins/build_working_folder.sh
+bash misc/jenkins/build_working_folder.sh "$3"
 
 pwd
 echo "exiting $SCRIPT_NAME"


### PR DESCRIPTION
This expects/requires a 'lts' subdirectory of build-server.
How to use:
1. Go to the '[Firmware at GHA](https://github.com/rusefi/rusefi/actions/workflows/build-firmware.yaml)' action
2. Click "Run Workflow"
3. Select your LTS branch (assuming you have a special branch; if not, master works too)
4. Check "LTS Build" toggle
5. Click green "Run Workflow" button
![Screenshot_20230121_113257](https://user-images.githubusercontent.com/1531127/213883171-d001ff14-8774-4071-a3f2-b713378c3820.png)

If this workflow isn't to your liking, we can probably find a different way. This just seemed simplest to me.