### PR TITLE
build f7 with -Os, fits in 512k

### DIFF
--- a/firmware/config/boards/proteus/board.mk
+++ b/firmware/config/boards/proteus/board.mk
@@ -45,6 +45,7 @@ endif
 
 ifeq ($(PROJECT_CPU),ARCH_STM32F7)
 	DDEFS += -DSHORT_BOARD_NAME=proteus_f7
+	DEBUG_LEVEL_OPT = -Os -ggdb -g
 else ifeq ($(PROJECT_CPU),ARCH_STM32F4)
 	DDEFS += -DSHORT_BOARD_NAME=proteus_f4
 else ifeq ($(PROJECT_CPU),ARCH_STM32H7)

--- a/firmware/hw_layer/ports/stm32/stm32f7/STM32F7.ld
+++ b/firmware/hw_layer/ports/stm32/stm32f7/STM32F7.ld
@@ -26,7 +26,7 @@
  */
 
  /* TODO: 512k flash limit is a mitigation for https://github.com/rusefi/rusefi/issues/3566 and https://github.com/rusefi/rusefi/issues/3775 */
-flash_size = DEFINED(FLASH_SIZE) ? FLASH_SIZE : 768k;
+flash_size = DEFINED(FLASH_SIZE) ? FLASH_SIZE : 512k;
 
 /* OpenBLT <-> main FW shared area */
 _OpenBLT_Shared_Params_Size = DEFINED(BOOTLOADER) ? 16 : 0;


### PR DESCRIPTION
go back to 512k for #3566 since stm programmer is still not fixed

Os vs O2 performance hit is very small, F7 is plenty fast, and it knocks ~53k off the binary. Probably mostly due to loop unrolling not happening like it does at O2.