### PR TITLE
Let's admit it's time to move to gradle #3014

### DIFF
--- a/.github/workflows/hardware-ci.yaml
+++ b/.github/workflows/hardware-ci.yaml
@@ -78,5 +78,5 @@ jobs:
 
     # This both compiles and runs HW CI tests
     - name: Run Hardware CI
-      run: java -cp java_console/autotest/build/libs/autotest-all.jar com.rusefi.HwCiF4Proteus ${{matrix.test-suite}}
+      run: java -cp java_console/autotest/build/libs/autotest-all.jar ${{matrix.test-suite}}
 

--- a/.github/workflows/hardware-ci.yaml
+++ b/.github/workflows/hardware-ci.yaml
@@ -12,7 +12,6 @@ jobs:
 
         include:
           - build-target: f407-discovery
-            script: hardware_ci_f4_discovery
             runs-on: hw-ci-f4-discovery
             test-suite: com.rusefi.HwCiF4Discovery
             folder: config/boards/f407-discovery
@@ -20,7 +19,6 @@ jobs:
             serial-device: /dev/serial/by-id/usb-rusEFI_LLC_rusEFI_Engine_Management_ECU_2B003B000A51343033393930-if01
 
           - build-target: proteus_f4
-            script: hardware_ci_proteus
             runs-on: hw-ci-proteus
             test-suite: com.rusefi.HwCiF4Proteus
             folder: config/boards/proteus
@@ -80,6 +78,5 @@ jobs:
 
     # This both compiles and runs HW CI tests
     - name: Run Hardware CI
-      working-directory: ./java_console
-      run: ant ${{matrix.script}}
+      run: java -cp java_console/autotest/build/libs/autotest-all.jar com.rusefi.HwCiF4Proteus ${{matrix.test-suite}}
 

--- a/java_console/build.xml
+++ b/java_console/build.xml
@@ -184,48 +184,6 @@
 
     </target>
 
-    <target name="hardware_ci_f4_discovery" depends="jar">
-        <mkdir dir="${hw_tests}"/>
-        <junit fork="no"
-               maxmemory="512m"
-               printsummary="yes"
-               showoutput="true"
-               haltonfailure="yes">
-
-            <jvmarg value="-ea"/>
-            <jvmarg value="-XX:+HeapDumpOnOutOfMemoryError"/>
-            <formatter type="brief"/>
-            <classpath
-                    path="build/classes:lib/junit.jar:${lib_list}:lib/commons-logging.jar"/>
-            <batchtest todir="${hw_tests}">
-                <fileset dir="autotest/src/main/java" includes="**/common/*.java"/>
-                <fileset dir="autotest/src/main/java" includes="**/f4discovery/*.java"/>
-            </batchtest>
-            <formatter type="plain" usefile="false" /> <!-- to screen -->
-        </junit>
-    </target>
-
-    <target name="hardware_ci_proteus" depends="jar">
-        <mkdir dir="${hw_tests}"/>
-        <junit fork="no"
-               maxmemory="512m"
-               printsummary="yes"
-               showoutput="true"
-               haltonfailure="yes">
-
-            <jvmarg value="-ea"/>
-            <jvmarg value="-XX:+HeapDumpOnOutOfMemoryError"/>
-            <formatter type="brief"/>
-            <classpath
-                    path="build/classes:lib/junit.jar:${lib_list}:lib/commons-logging.jar"/>
-            <batchtest todir="${hw_tests}">
-                <fileset dir="autotest/src/main/java" includes="**/common/*.java"/>
-                <fileset dir="autotest/src/main/java" includes="**/proteus/*.java"/>
-            </batchtest>
-            <formatter type="plain" usefile="false" /> <!-- to screen -->
-        </junit>
-    </target>
-
     <target name="before_IDEA_Build">
         <copy todir=".">
             <fileset dir="../firmware/tunerstudio" includes="rusefi.ini"/>


### PR DESCRIPTION
running HW CI explicitly without ant junit runner as a step on our ant to gradle migration

expected: this change makes zero functional difference
actual: HW CI does not like this change?