### PR TITLE
Don't download ARM Gnu toolchain if present

### DIFF
--- a/firmware/provide_gcc.sh
+++ b/firmware/provide_gcc.sh
@@ -6,7 +6,7 @@ set -e
 
 # URL to download original toolchain from
 URL="https://github.com/rusefi/build_support/raw/master/rusefi-arm-gnu-toolchain-11.3.rel1-x86_64-arm-none-eabi.tar.xz"
-# This is the md5sum of the /bin/ld executable within the archive, used for verifying we have the proper version.
+# This is the md5sum of the /bin/arm-none-eabi-ld executable within the archive, used for verifying we have the proper version.
 # If you change the above URL, you will need to update this checksum as well.
 MANIFEST_SUM="8e50ee1adb41acfd56fc38d74d6bb18e"
 # colloquial directory name, to afford re-use of script
@@ -19,8 +19,8 @@ archive="${URL##*/}"
 SWD="$PWD"
 
 # If the checksum file doesn't exist, or if its checksum doesn't match, then download and install the archive.
-if [ ! -f "${TMP_DIR}"/*/bin/ld ] ||\
-   [ "$MANIFEST_SUM" != "$(md5sum ${TMP_DIR}/*/bin/ld | cut -d ' ' -f 1)" ]; then
+if [ ! -f "${TMP_DIR}"/*/bin/arm-none-eabi-ld ] ||\
+   [ "$MANIFEST_SUM" != "$(md5sum ${TMP_DIR}/*/bin/arm-none-eabi-ld | cut -d ' ' -f 1)" ]; then
 	rm -rf "${TMP_DIR}"
 	# Download and extract archive
 	echo Downloading and extracting ${archive}

--- a/firmware/provide_gcc.sh
+++ b/firmware/provide_gcc.sh
@@ -18,7 +18,7 @@ if [ -d "${TMP_DIR}" ]; then
 	if [ "$(md5sum ${TMP_DIR}/*manifest.txt | cut -d ' ' -f 1)" = "$MANIFEST_SUM" ]; then
 		exit 0
 	else
-		rm -r "${TMP_DIR}"
+		rm -rf "${TMP_DIR}"
 	fi
 fi
 

--- a/firmware/provide_gcc.sh
+++ b/firmware/provide_gcc.sh
@@ -6,7 +6,8 @@ set -e
 
 # URL to download original toolchain from
 URL="https://github.com/rusefi/build_support/raw/master/rusefi-arm-gnu-toolchain-11.3.rel1-x86_64-arm-none-eabi.tar.xz"
-MANIFEST_SUM="e4b25a623445c9f02303eba63b1d2806"
+# This is the md5sum of the /bin/ld executable within the archive, used for verifying we have the proper version.
+MANIFEST_SUM="8e50ee1adb41acfd56fc38d74d6bb18e"
 # colloquial directory name, to afford re-use of script
 COLLOQUIAL="gcc-arm-none-eabi"
 # temporary working directory
@@ -16,7 +17,7 @@ archive="${URL##*/}"
 
 SWD="$PWD"
 
-if [ ! -f "${TMP_DIR}"/*/*manifest.txt ] || [ "$MANIFEST_SUM" != "$(md5sum ${TMP_DIR}/*/*manifest.txt | cut -d ' ' -f 1)" ]; then
+if [ ! -f "${TMP_DIR}/bin/ld" ] || [ "$MANIFEST_SUM" != "$(md5sum ${TMP_DIR}/bin/ld | cut -d ' ' -f 1)" ]; then
 	rm -rf "${TMP_DIR}"
 	# Download and extract archive
 	echo Downloading and extracting ${archive}

--- a/firmware/provide_gcc.sh
+++ b/firmware/provide_gcc.sh
@@ -17,6 +17,8 @@ archive="${URL##*/}"
 if [ -d "${TMP_DIR}" ]; then
 	if [ "$(md5sum ${TMP_DIR}/*manifest.txt | cut -d ' ' -f 1)" = "$MANIFEST_SUM" ]; then
 		exit 0
+	else
+		rm -r "${TMP_DIR}"
 	fi
 fi
 

--- a/firmware/provide_gcc.sh
+++ b/firmware/provide_gcc.sh
@@ -16,7 +16,7 @@ archive="${URL##*/}"
 
 SWD="$PWD"
 
-if [ ! -d "${TMP_DIR}" ] || ["$(md5sum ${TMP_DIR}/*manifest.txt | cut -d ' ' -f 1)" != "$MANIFEST_SUM" ]; then
+if [ ! -d "${TMP_DIR}" ] || [ "$MANIFEST_SUM" != "$(md5sum ${TMP_DIR}/*/*manifest.txt | cut -d ' ' -f 1)" ]; then
 	rm -rf "${TMP_DIR}"
 	# Download and extract archive
 	echo Downloading and extracting ${archive}

--- a/firmware/provide_gcc.sh
+++ b/firmware/provide_gcc.sh
@@ -7,6 +7,7 @@ set -e
 # URL to download original toolchain from
 URL="https://github.com/rusefi/build_support/raw/master/rusefi-arm-gnu-toolchain-11.3.rel1-x86_64-arm-none-eabi.tar.xz"
 # This is the md5sum of the /bin/ld executable within the archive, used for verifying we have the proper version.
+# If you change the above URL, you will need to update this checksum as well.
 MANIFEST_SUM="8e50ee1adb41acfd56fc38d74d6bb18e"
 # colloquial directory name, to afford re-use of script
 COLLOQUIAL="gcc-arm-none-eabi"
@@ -17,6 +18,7 @@ archive="${URL##*/}"
 
 SWD="$PWD"
 
+# If the checksum file doesn't exist, or if its checksum doesn't match, then download and install the archive.
 if [ ! -f "${TMP_DIR}/bin/ld" ] || [ "$MANIFEST_SUM" != "$(md5sum ${TMP_DIR}/bin/ld | cut -d ' ' -f 1)" ]; then
 	rm -rf "${TMP_DIR}"
 	# Download and extract archive
@@ -26,6 +28,8 @@ if [ ! -f "${TMP_DIR}/bin/ld" ] || [ "$MANIFEST_SUM" != "$(md5sum ${TMP_DIR}/bin
 	curl -L -o "${archive}" "${URL}"
 	tar -xaf "${archive}"
 	rm "${archive}"
+else
+	echo "Toolkit already present"
 fi
 
 # Create colloquially named link

--- a/firmware/provide_gcc.sh
+++ b/firmware/provide_gcc.sh
@@ -14,24 +14,21 @@ TMP_DIR="/tmp/rusefi-provide_gcc"
 
 archive="${URL##*/}"
 
-if [ -d "${TMP_DIR}" ]; then
-	if [ "$(md5sum ${TMP_DIR}/*manifest.txt | cut -d ' ' -f 1)" = "$MANIFEST_SUM" ]; then
-		exit 0
-	else
-		rm -rf "${TMP_DIR}"
-	fi
+SWD="$PWD"
+
+if [ ! -d "${TMP_DIR}" ] || ["$(md5sum ${TMP_DIR}/*manifest.txt | cut -d ' ' -f 1)" != "$MANIFEST_SUM" ]; then
+	rm -rf "${TMP_DIR}"
+	# Download and extract archive
+	echo Downloading and extracting ${archive}
+	mkdir -p "${TMP_DIR}"
+	cd "${TMP_DIR}"
+	curl -L -o "${archive}" "${URL}"
+	tar -xaf "${archive}"
+	rm "${archive}"
 fi
 
-# Download and extract archive
-echo Downloading and extracting ${archive}
-mkdir -p "${TMP_DIR}"
-cd "${TMP_DIR}"
-curl -L -o "${archive}" "${URL}"
-tar -xaf "${archive}"
-rm "${archive}"
-
 # Create colloquially named link
-archive_dir="$(echo *)"
-cd - >/dev/null
+archive_dir="$(ls "$TMP_DIR")"
+cd "$SWD"
 mv "${TMP_DIR}/${archive_dir}" "$(pwd)"
 ln -s "${archive_dir%/}" "${COLLOQUIAL}"

--- a/firmware/provide_gcc.sh
+++ b/firmware/provide_gcc.sh
@@ -16,7 +16,7 @@ archive="${URL##*/}"
 
 SWD="$PWD"
 
-if [ ! -f "${TMP_DIR}/*/*manifest.txt" ] || [ "$MANIFEST_SUM" != "$(md5sum ${TMP_DIR}/*/*manifest.txt | cut -d ' ' -f 1)" ]; then
+if [ ! -f "${TMP_DIR}"/*/*manifest.txt ] || [ "$MANIFEST_SUM" != "$(md5sum ${TMP_DIR}/*/*manifest.txt | cut -d ' ' -f 1)" ]; then
 	rm -rf "${TMP_DIR}"
 	# Download and extract archive
 	echo Downloading and extracting ${archive}

--- a/firmware/provide_gcc.sh
+++ b/firmware/provide_gcc.sh
@@ -6,6 +6,7 @@ set -e
 
 # URL to download original toolchain from
 URL="https://github.com/rusefi/build_support/raw/master/rusefi-arm-gnu-toolchain-11.3.rel1-x86_64-arm-none-eabi.tar.xz"
+MANIFEST_SUM="e4b25a623445c9f02303eba63b1d2806"
 # colloquial directory name, to afford re-use of script
 COLLOQUIAL="gcc-arm-none-eabi"
 # temporary working directory
@@ -13,8 +14,11 @@ TMP_DIR="/tmp/rusefi-provide_gcc"
 
 archive="${URL##*/}"
 
-# Cleanup prior [failed] runs
-rm -rf "${TMP_DIR}"
+if [ -d "${TMP_DIR}" ]; then
+	if [ "$(md5sum ${TMP_DIR}/*manifest.txt | cut -d ' ' -f 1)" = "$MANIFEST_SUM" ]; then
+		exit 0
+	fi
+fi
 
 # Download and extract archive
 echo Downloading and extracting ${archive}
@@ -29,6 +33,3 @@ archive_dir="$(echo *)"
 cd - >/dev/null
 mv "${TMP_DIR}/${archive_dir}" "$(pwd)"
 ln -s "${archive_dir%/}" "${COLLOQUIAL}"
-
-# Delete downloaded archive
-rm -rf "${TMP_DIR}"

--- a/firmware/provide_gcc.sh
+++ b/firmware/provide_gcc.sh
@@ -29,4 +29,4 @@ fi
 
 # Create colloquially named link
 cd "$SWD"
-ln -s "${TMP_DIR}" "${COLLOQUIAL}"
+ln -s "${TMP_DIR}"/* "${COLLOQUIAL}"

--- a/firmware/provide_gcc.sh
+++ b/firmware/provide_gcc.sh
@@ -29,4 +29,4 @@ fi
 
 # Create colloquially named link
 cd "$SWD"
-ln -s "${TMP_DIR}/*" "${COLLOQUIAL}"
+ln -s "${TMP_DIR}" "${COLLOQUIAL}"

--- a/firmware/provide_gcc.sh
+++ b/firmware/provide_gcc.sh
@@ -16,7 +16,7 @@ archive="${URL##*/}"
 
 SWD="$PWD"
 
-if [ ! -d "${TMP_DIR}" ] || [ "$MANIFEST_SUM" != "$(md5sum ${TMP_DIR}/*/*manifest.txt | cut -d ' ' -f 1)" ]; then
+if [ ! -f "${TMP_DIR}/*/*manifest.txt" ] || [ "$MANIFEST_SUM" != "$(md5sum ${TMP_DIR}/*/*manifest.txt | cut -d ' ' -f 1)" ]; then
 	rm -rf "${TMP_DIR}"
 	# Download and extract archive
 	echo Downloading and extracting ${archive}

--- a/firmware/provide_gcc.sh
+++ b/firmware/provide_gcc.sh
@@ -28,7 +28,5 @@ if [ ! -d "${TMP_DIR}" ] || ["$(md5sum ${TMP_DIR}/*manifest.txt | cut -d ' ' -f 
 fi
 
 # Create colloquially named link
-archive_dir="$(ls "$TMP_DIR")"
 cd "$SWD"
-mv "${TMP_DIR}/${archive_dir}" "$(pwd)"
-ln -s "${archive_dir%/}" "${COLLOQUIAL}"
+ln -s "${TMP_DIR}/*" "${COLLOQUIAL}"

--- a/firmware/provide_gcc.sh
+++ b/firmware/provide_gcc.sh
@@ -19,7 +19,8 @@ archive="${URL##*/}"
 SWD="$PWD"
 
 # If the checksum file doesn't exist, or if its checksum doesn't match, then download and install the archive.
-if [ ! -f "${TMP_DIR}/bin/ld" ] || [ "$MANIFEST_SUM" != "$(md5sum ${TMP_DIR}/bin/ld | cut -d ' ' -f 1)" ]; then
+if [ ! -f "${TMP_DIR}/$(basename "$archive" .tar.xz)/bin/ld" ] ||\
+   [ "$MANIFEST_SUM" != "$(md5sum ${TMP_DIR}/$(basename "$archive" .tar.xz)/bin/ld | cut -d ' ' -f 1)" ]; then
 	rm -rf "${TMP_DIR}"
 	# Download and extract archive
 	echo Downloading and extracting ${archive}

--- a/firmware/provide_gcc.sh
+++ b/firmware/provide_gcc.sh
@@ -19,8 +19,8 @@ archive="${URL##*/}"
 SWD="$PWD"
 
 # If the checksum file doesn't exist, or if its checksum doesn't match, then download and install the archive.
-if [ ! -f "${TMP_DIR}/$(basename "$archive" .tar.xz)/bin/ld" ] ||\
-   [ "$MANIFEST_SUM" != "$(md5sum ${TMP_DIR}/$(basename "$archive" .tar.xz)/bin/ld | cut -d ' ' -f 1)" ]; then
+if [ ! -f "${TMP_DIR}"/*/bin/ld ] ||\
+   [ "$MANIFEST_SUM" != "$(md5sum ${TMP_DIR}/*/bin/ld | cut -d ' ' -f 1)" ]; then
 	rm -rf "${TMP_DIR}"
 	# Download and extract archive
 	echo Downloading and extracting ${archive}


### PR DESCRIPTION
This enables self-hosted runners to pre-download the arm-none-eabi toolchain at build time.
The script checks the checksum of one of the executables, so that we are sure to be running the correct toolchain version.