### PR TITLE
dual ADC wideband support

### DIFF
--- a/firmware/controllers/sensors/ego.cpp
+++ b/firmware/controllers/sensors/ego.cpp
@@ -106,7 +106,7 @@ bool hasAfrSensor() {
 
 extern float InnovateLC2AFR;
 
-float getAfr() {
+float getAfr(SensorType type) {
 #if EFI_AUX_SERIAL
 	if (engineConfiguration->enableInnovateLC2)
 		return InnovateLC2AFR;
@@ -119,11 +119,11 @@ float getAfr() {
 #endif /* EFI_CJ125 && HAL_USE_SPI */
 	afr_sensor_s * sensor = &engineConfiguration->afr;
 
-	if (!isAdcChannelValid(engineConfiguration->afr.hwChannel)) {
+	if (!isAdcChannelValid(type == SensorType::Lambda1 ? engineConfiguration->afr.hwChannel : engineConfiguration->afr.hwChannel2)) {
 		return 0;
 	}
 
-	float volts = getVoltageDivided("ego", sensor->hwChannel);
+	float volts = getVoltageDivided("ego", type == SensorType::Lambda1 ? sensor->hwChannel : sensor->hwChannel2);
 
 	if (engineConfiguration->afr_type == ES_NarrowBand) {
 		float afr = interpolate2d(volts, config->narrowToWideOxygenBins, config->narrowToWideOxygen);

--- a/firmware/controllers/sensors/ego.h
+++ b/firmware/controllers/sensors/ego.h
@@ -12,7 +12,7 @@
 #include "global.h"
 #include "engine_configuration.h"
 
-float getAfr();
+float getAfr(SensorType type);
 bool hasAfrSensor();
 void setEgoSensor(ego_sensor_e type);
 void initEgoAveraging();

--- a/firmware/init/sensor/init_lambda.cpp
+++ b/firmware/init/sensor/init_lambda.cpp
@@ -7,7 +7,10 @@
 
 struct GetAfrWrapper {
 	float getLambda() {
-		return getAfr() / 14.7f;
+		return getAfr(SensorType::Lambda1) / 14.7f;
+	};
+	float getLambda2() {
+		return getAfr(SensorType::Lambda2) / 14.7f;
 	}
 };
 

--- a/firmware/init/sensor/init_lambda.cpp
+++ b/firmware/init/sensor/init_lambda.cpp
@@ -21,6 +21,11 @@ static FunctionPointerSensor lambdaSensor(SensorType::Lambda1,
 	return afrWrapper.getLambda();
 });
 
+static FunctionPointerSensor lambdaSensor2(SensorType::Lambda2,
+[]() {
+	return afrWrapper.getLambda2();
+});
+
 #include "AemXSeriesLambda.h"
 
 #if EFI_CAN_SUPPORT
@@ -57,4 +62,5 @@ void initLambda() {
 #endif
 
 	lambdaSensor.Register();
+	lambdaSensor2.Register();
 }

--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -609,6 +609,7 @@ float globalFuelCorrection;set global_fuel_correction X;"coef", 1, 0, 0, 1000, 2
 	
 struct afr_sensor_s
 	adc_channel_e hwChannel;
+	adc_channel_e hwChannel2;
 	float v1;;"volts", 1, 0, 0, 10, 2
 	float value1;;"AFR", 1, 0, 0, 1000, 2
 	float v2;;"volts", 1, 0, 0, 10, 2

--- a/firmware/tunerstudio/rusefi.input
+++ b/firmware/tunerstudio/rusefi.input
@@ -2679,6 +2679,7 @@ cmd_set_engine_type_default					= "@@TS_IO_TEST_COMMAND_char@@@@ts_command_e_TS_
 		field = "MAF ADC input",						mafAdcChannel
 		field = "MAF 2 ADC input",						maf2AdcChannel
 		field = "AFR ADC input",						afr_hwChannel
+		field = "AFR 2 ADC input",						afr_hwChannel2
 		field = "Baro ADC input",						baroSensor_hwChannel
 		field = "MAP ADC input",						map_sensor_hwChannel
 		field = "Fuel Level input",					fuelLevelSensor
@@ -3026,14 +3027,19 @@ cmd_set_engine_type_default					= "@@TS_IO_TEST_COMMAND_char@@@@ts_command_e_TS_
 		field = "high value",							afr_value2
 		field = "Correction",							egoValueShift
 
-	dialog = egoSettings_IO,	"EGO Sensor I/O"
+	dialog = egoSettings_IO1,	"EGO Sensor 1 I/O"
 		field = "Input channel",						afr_hwChannel
 		field = "Heater output",						o2heaterPin
+
+	dialog = egoSettings_IO2,	"EGO Sensor 2 I/O"
+		field = "Input channel",						afr_hwChannel2
+		field = "Heater output",						o2heaterPin, {afr_hwChannel2 != 0}
 
 	dialog = egoSettings, "", yAxis
 		field = "Enable CAN Wideband",			enableAemXSeries, { canReadEnabled }
 		field = "Enable Innovate LC-2 Serial",			enableInnovateLC2, { auxSerialRxPin && auxSerialTxPin }
-		panel = egoSettings_IO
+		panel = egoSettings_IO1
+		panel = egoSettings_IO2, {afr_hwChannel != @@ADC_CHANNEL_NONE@@ && enableAemXSeries == 0 && !auxSerialRxPin && !auxSerialTxPin}
 		panel = egoSettings_sensor, {afr_hwChannel != @@ADC_CHANNEL_NONE@@ && enableAemXSeries == 0 && !auxSerialRxPin && !auxSerialTxPin}
 
 ;			Engine->EGT inputs

--- a/firmware/tunerstudio/rusefi.input
+++ b/firmware/tunerstudio/rusefi.input
@@ -3033,7 +3033,6 @@ cmd_set_engine_type_default					= "@@TS_IO_TEST_COMMAND_char@@@@ts_command_e_TS_
 
 	dialog = egoSettings_IO2,	"EGO Sensor 2 I/O"
 		field = "Input channel",						afr_hwChannel2
-		field = "Heater output",						o2heaterPin, {afr_hwChannel2 != 0}
 
 	dialog = egoSettings, "", yAxis
 		field = "Enable CAN Wideband",			enableAemXSeries, { canReadEnabled }


### PR DESCRIPTION
Initial work on dual ADC wideband support under single calibration (same type controllers)

Have Audi 4.2 v8 and MB m113 NA engines with each bank exhausts merging very far so no option to run single wideband support. I know FW can support dual CAN wideband so would be good to add support for dual ADC wideband based on single calibration set. My core8 ECU has built-in dual 14point7 controllers so they can share the same calibration ranges. 

Done just initial work:
1. TS rusefi.input added EGO 2 panel
2. rusefi_config.txt added hwChannel2 to store input pin
3. updated getAfr in ego.cpp/.h to provide sensor as a parameter to read ADC from 
4. used sensor to read volts from hwChannel or hwChannel2 based on provided sensor type.
5. init_lambda.cpp updated getLambda wrapper to use Lambda1 senor also added getLambda2 wrapper to do same for Lambda2 sensor.
![image](https://user-images.githubusercontent.com/12942077/215092308-04a3eda5-3765-4282-8446-3d8ed410fc59.png)

So now is a question of how and where to go from here. 

I can see FunctionPointerSensor lambdaSensor is getting lambda reading from sensor 1. so I think I need to replicate this for sensor 2. But I'm stuck on where and how to read it per bank now.

If you think that is a useful addon could you please point me in the right direction?


UPDATED:::::::

I think it works at least on the bench reads correctly the second sensor.

![image](https://user-images.githubusercontent.com/12942077/215139024-26724621-325e-4574-9136-a6ab57f23d2c.png)



Thank you.