### PR TITLE
[LTS] Put branch in bundle name (please read caveats)

### DIFF
--- a/java_console/autoupdate/src/main/java/com/rusefi/autoupdate/Autoupdate.java
+++ b/java_console/autoupdate/src/main/java/com/rusefi/autoupdate/Autoupdate.java
@@ -82,7 +82,7 @@ public class Autoupdate {
 
     private static void handleBundle(String bundleFullName, UpdateMode mode, String baseUrl) {
         try {
-            String boardName = bundleFullName.split(".")[2]
+            String boardName = bundleFullName.split(".")[2];
             String zipFileName = "rusefi_bundle_" + boardName + "_autoupdate" + ".zip";
             ConnectionAndMeta connectionAndMeta = new ConnectionAndMeta(zipFileName).invoke(baseUrl);
             System.out.println("Remote file " + zipFileName);

--- a/java_console/autoupdate/src/main/java/com/rusefi/autoupdate/Autoupdate.java
+++ b/java_console/autoupdate/src/main/java/com/rusefi/autoupdate/Autoupdate.java
@@ -40,7 +40,12 @@ public class Autoupdate {
                 System.out.println("Snapshot requested");
                 if (bundleFullName != null) {
                     System.out.println("Handling " + bundleFullName);
-                    handleBundle(bundleFullName, mode, ConnectionAndMeta.BASE_URL_LATEST);
+                    String branchName = bundleFullName.split(".")[1];
+                    if ( branchName == "snapshot" ) {
+                        handleBundle(bundleFullName, mode, ConnectionAndMeta.BASE_URL_LATEST);
+                    } else {
+                        handleBundle(bundleFullName, mode, String.format(ConnectionAndMeta.BASE_URL_LTS, branchName));
+                    }
                 } else {
                     System.err.println("ERROR: Autoupdate: unable to perform without bundleFullName");
                 }
@@ -77,7 +82,8 @@ public class Autoupdate {
 
     private static void handleBundle(String bundleFullName, UpdateMode mode, String baseUrl) {
         try {
-            String zipFileName = bundleFullName + "_autoupdate" + ".zip";
+            String boardName = bundleFullName.split(".")[2]
+            String zipFileName = "rusefi_bundle_" + boardName + "_autoupdate" + ".zip";
             ConnectionAndMeta connectionAndMeta = new ConnectionAndMeta(zipFileName).invoke(baseUrl);
             System.out.println("Remote file " + zipFileName);
             System.out.println("Server has " + connectionAndMeta.getCompleteFileSize() + " from " + new Date(connectionAndMeta.getLastModified()));

--- a/java_console/bin/switch_bundle.sh
+++ b/java_console/bin/switch_bundle.sh
@@ -10,11 +10,16 @@ if [ -z "$1" ]; then
 fi
 
 BUNDLE=$1
-
-echo $BUNDLE > bundle_name.txt
-
+CURRENT=${PWD##*/}
+CURRENT=${CURRENT:-/}
+CURRENT_BRANCH=$(echo "$CURRENT" | cut -d '.' -f 2)
+CURRENT_BUNDLE=$(echo "$CURRENT" | cut -d '.' -f 3)
+cd ..
+mv "rusefi.${CURRENT_BRANCH}.${CURRENT_BUNDLE}" "rusefi.${CURRENT_BRANCH}.${BUNDLE}"
+cd "rusefi.${CURRENT_BRANCH}.${BUNDLE}"
 
 rm -rf rusefi*bin
 rm -rf rusefi*hex
 rm -rf rusefi*dfu
 rm -rf rusefi*ini
+bash

--- a/java_console/shared_io/src/main/java/com/rusefi/core/io/BundleUtil.java
+++ b/java_console/shared_io/src/main/java/com/rusefi/core/io/BundleUtil.java
@@ -6,25 +6,25 @@ import org.jetbrains.annotations.Nullable;
 import java.io.BufferedReader;
 import java.io.FileReader;
 import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.FileSystemNotFoundException;
 import java.util.Date;
 
 public class BundleUtil {
-    private static final String BUNDLE_NAME_FILE = "../bundle_name.txt";
-
     /**
      * @return null in case of error
      */
     @Nullable
     public static String readBundleFullName() {
         try {
-            BufferedReader r = new BufferedReader(new FileReader(BUNDLE_NAME_FILE));
-            String fullName = r.readLine();
-            fullName = fullName.trim();
+            Path path = Paths.get("..");
+            String fullName = path.getFileName().toString();
             if (fullName.length() < 3)
                 return null; // just paranoia check
             return fullName;
-        } catch (IOException e) {
-            System.err.println(new Date() + ": BundleUtil: Error reading " + BUNDLE_NAME_FILE);
+        } catch (FileSystemNotFoundException e) {
+            System.err.println(new Date() + ": BundleUtil: Error reading bundle name");
             return null;
         }
     }

--- a/java_console/shared_io/src/main/java/com/rusefi/core/net/ConnectionAndMeta.java
+++ b/java_console/shared_io/src/main/java/com/rusefi/core/net/ConnectionAndMeta.java
@@ -13,6 +13,7 @@ import java.util.Objects;
 public class ConnectionAndMeta {
     public static final String BASE_URL_RELEASE = "https://github.com/rusefi/rusefi/releases/latest/download/";
     public static final String BASE_URL_LATEST = "https://rusefi.com/build_server/autoupdate/";
+    public static final String BASE_URL_LTS = "https://rusefi.com/build_server/lts/%s/autoupdate/";
 
     private static final int BUFFER_SIZE = 32 * 1024;
     public static final int CENTUM = 100;

--- a/misc/jenkins/build_working_folder.sh
+++ b/misc/jenkins/build_working_folder.sh
@@ -19,7 +19,6 @@ pwd
 # This working folder name starts with 'temp/'
 echo "$SCRIPT_NAME: Working folder: $FOLDER"
 mkdir $FOLDER
-echo $BUNDLE_FULL_NAME > $FOLDER/bundle_name.txt
 
 CONSOLE_FOLDER="$FOLDER/console"
 DRIVERS_FOLDER="$FOLDER/drivers"


### PR DESCRIPTION
This will fix #4992 and #4993.
- Removed date from bundle name
- I chose the approach of using the name of the folder rather than putting the info in bundle_name.txt
  I chose this because I thought it would be simpler, but the exception to that is switch_bundle.sh, which got a little more complicated - see Caveats below. I'm not set on doing things this way.
- The bundle names are `rusefi.<branch name>.<bundle>`
  If the branch is master, then the `<branch name>` is "snapshot".
  Examples:
  `rusefi.snapshot.proteus_f7`
  `rusefi.lts_foo.mre_f4`
- I chose to use `.` instead of `_` because `_` is often used in board names which makes parsing difficult.
- I chose to move `rusefi` to the beginning of the bundle name to make them easier for the end user to find. By this I mean that they'll be together in an alphabetically-sorted directory listing/file explorer window.

Caveats:
- I haven't tested the autoupdater, because I'm too lazy to set up a webserver etc.
- I don't know Java, so I don't know if my "string templating" method is the correct one. See "BASE_URL_LTS" in the diff.
- Likewise, I don't know if "FileSystemNotFoundException" is the correct one to catch in BundeUtil.java
- switch_bundle.sh moves the directory to the new name, and has to launch a subshell to put the user in the correct (new) directory. I'm not sure what the use case of this script is, so I don't know if that could be a problem. As far as I can think, the only things the user would notice would be not having history from the original shell, and having to exit twice to close the shell.
- Because I use the `.` for parsing, we can't have `.` in branch names. E.g. `lts-2023.01` will break things. Maybe we could just use a space instead?

Questions:
- Using the name of the directory gives us the power to switch branches as well - e.g. switch from one LTS branch to another. Would you like me to write a script to do that?