### PR TITLE
Lean submodule fetching (don't merge until all green)

### DIFF
--- a/.github/workflows/build-android.yaml
+++ b/.github/workflows/build-android.yaml
@@ -12,6 +12,7 @@ jobs:
       - name: Checkout Submodules
         run: |
           git submodule update --init --depth=1 unit_tests/googletest
+          git submodule update --init --depth=1 firmware/libfirmware
 
       - uses: actions/setup-java@v3
         with:

--- a/.github/workflows/build-android.yaml
+++ b/.github/workflows/build-android.yaml
@@ -8,8 +8,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-        with:
-          submodules: recursive
+
       - uses: actions/setup-java@v3
         with:
           distribution: 'zulu'

--- a/.github/workflows/build-android.yaml
+++ b/.github/workflows/build-android.yaml
@@ -13,6 +13,9 @@ jobs:
         run: |
           git submodule update --init --depth=1 unit_tests/googletest
           git submodule update --init --depth=1 firmware/libfirmware
+          git submodule update --init --depth=1 firmware/ext/lua
+          git submodule update --init --depth=1 firmware/controllers/lua/luaaa
+          git submodule update --init --depth=1 firmware/controllers/can/wideband_firmware
 
       - uses: actions/setup-java@v3
         with:

--- a/.github/workflows/build-android.yaml
+++ b/.github/workflows/build-android.yaml
@@ -9,6 +9,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Checkout Submodules
+        run: |
+          git submodule update --init --depth=1 unit_tests/googletest
+
       - uses: actions/setup-java@v3
         with:
           distribution: 'zulu'

--- a/.github/workflows/build-firmware.yaml
+++ b/.github/workflows/build-firmware.yaml
@@ -296,8 +296,6 @@ jobs:
 
     - uses: actions/checkout@v3
       if: ${{ env.skip != 'true' }}
-      with:
-        submodules: recursive
 
     - uses: actions/setup-java@v3
       if: ${{ env.skip != 'true' }}
@@ -451,8 +449,6 @@ jobs:
       if: ${{ contains(github.ref_name, '.') }}
       run: echo '::error::Branch names must not contain ".", this breaks firmware autoupdates.' && exit 1
     - uses: actions/checkout@v3
-      with:
-        submodules: recursive
     - uses: actions/setup-java@v3
       with:
         distribution: 'zulu'

--- a/.github/workflows/build-firmware.yaml
+++ b/.github/workflows/build-firmware.yaml
@@ -305,6 +305,7 @@ jobs:
         git submodule update --init --depth=1 firmware/libfirmware
         git submodule update --init --depth=1 firmware/ext/lua
         git submodule update --init --depth=1 firmware/ext/uzlib
+        git submodule update --init --depth=1 firmware/controllers/lua/luaaa
 
     - uses: actions/setup-java@v3
       if: ${{ env.skip != 'true' }}
@@ -467,6 +468,7 @@ jobs:
         git submodule update --init --depth=1 firmware/libfirmware
         git submodule update --init --depth=1 firmware/ext/lua
         git submodule update --init --depth=1 firmware/ext/uzlib
+        git submodule update --init --depth=1 firmware/controllers/lua/luaaa
 
     - uses: actions/setup-java@v3
       with:

--- a/.github/workflows/build-firmware.yaml
+++ b/.github/workflows/build-firmware.yaml
@@ -297,6 +297,11 @@ jobs:
     - uses: actions/checkout@v3
       if: ${{ env.skip != 'true' }}
 
+    - name: Checkout Submodules
+      run: |
+        git checkout --init firmware/ChibiOS
+        git checkout --init firmware/ChibiOS-Contrib
+
     - uses: actions/setup-java@v3
       if: ${{ env.skip != 'true' }}
       with:
@@ -448,7 +453,14 @@ jobs:
     - name: Check branch name
       if: ${{ contains(github.ref_name, '.') }}
       run: echo '::error::Branch names must not contain ".", this breaks firmware autoupdates.' && exit 1
+
     - uses: actions/checkout@v3
+
+    - name: Checkout Submodules
+      run: |
+        git checkout --init firmware/ChibiOS
+        git checkout --init firmware/ChibiOS-Contrib
+
     - uses: actions/setup-java@v3
       with:
         distribution: 'zulu'

--- a/.github/workflows/build-firmware.yaml
+++ b/.github/workflows/build-firmware.yaml
@@ -306,6 +306,7 @@ jobs:
         git submodule update --init --depth=1 firmware/ext/lua
         git submodule update --init --depth=1 firmware/ext/uzlib
         git submodule update --init --depth=1 firmware/controllers/lua/luaaa
+        git submodule update --init --depth=1 firmware/controllers/can/wideband_firmware
 
     - uses: actions/setup-java@v3
       if: ${{ env.skip != 'true' }}
@@ -469,6 +470,7 @@ jobs:
         git submodule update --init --depth=1 firmware/ext/lua
         git submodule update --init --depth=1 firmware/ext/uzlib
         git submodule update --init --depth=1 firmware/controllers/lua/luaaa
+        git submodule update --init --depth=1 firmware/controllers/can/wideband_firmware
 
     - uses: actions/setup-java@v3
       with:

--- a/.github/workflows/build-firmware.yaml
+++ b/.github/workflows/build-firmware.yaml
@@ -299,8 +299,8 @@ jobs:
 
     - name: Checkout Submodules
       run: |
-        git checkout --init firmware/ChibiOS
-        git checkout --init firmware/ChibiOS-Contrib
+        git submodule update --init --depth=1 firmware/ChibiOS
+        git submodule update --init --depth=1 firmware/ChibiOS-Contrib
 
     - uses: actions/setup-java@v3
       if: ${{ env.skip != 'true' }}
@@ -458,8 +458,8 @@ jobs:
 
     - name: Checkout Submodules
       run: |
-        git checkout --init firmware/ChibiOS
-        git checkout --init firmware/ChibiOS-Contrib
+        git submodule update --init --depth=1 firmware/ChibiOS
+        git submodule update --init --depth=1 firmware/ChibiOS-Contrib
 
     - uses: actions/setup-java@v3
       with:

--- a/.github/workflows/build-firmware.yaml
+++ b/.github/workflows/build-firmware.yaml
@@ -304,6 +304,7 @@ jobs:
         git submodule update --init --depth=1 firmware/ChibiOS-Contrib
         git submodule update --init --depth=1 firmware/libfirmware
         git submodule update --init --depth=1 firmware/ext/lua
+        git submodule update --init --depth=1 firmware/ext/uzlib
 
     - uses: actions/setup-java@v3
       if: ${{ env.skip != 'true' }}
@@ -465,6 +466,7 @@ jobs:
         git submodule update --init --depth=1 firmware/ChibiOS-Contrib
         git submodule update --init --depth=1 firmware/libfirmware
         git submodule update --init --depth=1 firmware/ext/lua
+        git submodule update --init --depth=1 firmware/ext/uzlib
 
     - uses: actions/setup-java@v3
       with:

--- a/.github/workflows/build-firmware.yaml
+++ b/.github/workflows/build-firmware.yaml
@@ -303,6 +303,7 @@ jobs:
         git submodule update --init --depth=1 firmware/ChibiOS
         git submodule update --init --depth=1 firmware/ChibiOS-Contrib
         git submodule update --init --depth=1 firmware/libfirmware
+        git submodule update --init --depth=1 firmware/ext/lua
 
     - uses: actions/setup-java@v3
       if: ${{ env.skip != 'true' }}
@@ -463,6 +464,7 @@ jobs:
         git submodule update --init --depth=1 firmware/ChibiOS
         git submodule update --init --depth=1 firmware/ChibiOS-Contrib
         git submodule update --init --depth=1 firmware/libfirmware
+        git submodule update --init --depth=1 firmware/ext/lua
 
     - uses: actions/setup-java@v3
       with:

--- a/.github/workflows/build-firmware.yaml
+++ b/.github/workflows/build-firmware.yaml
@@ -298,9 +298,11 @@ jobs:
       if: ${{ env.skip != 'true' }}
 
     - name: Checkout Submodules
+      if: ${{ env.skip != 'true' }}
       run: |
         git submodule update --init --depth=1 firmware/ChibiOS
         git submodule update --init --depth=1 firmware/ChibiOS-Contrib
+        git submodule update --init --depth=1 firmware/libfirmware
 
     - uses: actions/setup-java@v3
       if: ${{ env.skip != 'true' }}
@@ -460,6 +462,7 @@ jobs:
       run: |
         git submodule update --init --depth=1 firmware/ChibiOS
         git submodule update --init --depth=1 firmware/ChibiOS-Contrib
+        git submodule update --init --depth=1 firmware/libfirmware
 
     - uses: actions/setup-java@v3
       with:

--- a/.github/workflows/build-firmware.yaml
+++ b/.github/workflows/build-firmware.yaml
@@ -305,6 +305,7 @@ jobs:
         git submodule update --init --depth=1 firmware/libfirmware
         git submodule update --init --depth=1 firmware/ext/lua
         git submodule update --init --depth=1 firmware/ext/uzlib
+        git submodule update --init --depth=1 firmware/ext/openblt
         git submodule update --init --depth=1 firmware/controllers/lua/luaaa
         git submodule update --init --depth=1 firmware/controllers/can/wideband_firmware
 
@@ -469,8 +470,10 @@ jobs:
         git submodule update --init --depth=1 firmware/libfirmware
         git submodule update --init --depth=1 firmware/ext/lua
         git submodule update --init --depth=1 firmware/ext/uzlib
+        git submodule update --init --depth=1 firmware/ext/openblt
         git submodule update --init --depth=1 firmware/controllers/lua/luaaa
         git submodule update --init --depth=1 firmware/controllers/can/wideband_firmware
+        git submodule update --init --depth=1 java_console/luaformatter
 
     - uses: actions/setup-java@v3
       with:

--- a/.github/workflows/build-firmware.yaml
+++ b/.github/workflows/build-firmware.yaml
@@ -308,6 +308,7 @@ jobs:
         git submodule update --init --depth=1 firmware/ext/openblt
         git submodule update --init --depth=1 firmware/controllers/lua/luaaa
         git submodule update --init --depth=1 firmware/controllers/can/wideband_firmware
+        git submodule update --init --depth=1 java_console/luaformatter
 
     - uses: actions/setup-java@v3
       if: ${{ env.skip != 'true' }}

--- a/.github/workflows/build-rusEFI-console.yaml
+++ b/.github/workflows/build-rusEFI-console.yaml
@@ -12,6 +12,7 @@ jobs:
       - name: Checkout Submodules
         run: |
           git submodule update --init --depth=1 unit_tests/googletest
+          git submodule update --init --depth=1 firmware/libfirmware
 
       - uses: actions/setup-java@v3
         with:

--- a/.github/workflows/build-rusEFI-console.yaml
+++ b/.github/workflows/build-rusEFI-console.yaml
@@ -16,6 +16,7 @@ jobs:
           git submodule update --init --depth=1 firmware/ext/lua
           git submodule update --init --depth=1 firmware/controllers/lua/luaaa
           git submodule update --init --depth=1 firmware/controllers/can/wideband_firmware
+          git submodule update --init --depth=1 java_console/luaformatter
 
       - uses: actions/setup-java@v3
         with:

--- a/.github/workflows/build-rusEFI-console.yaml
+++ b/.github/workflows/build-rusEFI-console.yaml
@@ -8,8 +8,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-        with:
-          submodules: recursive
 
       - uses: actions/setup-java@v3
         with:

--- a/.github/workflows/build-rusEFI-console.yaml
+++ b/.github/workflows/build-rusEFI-console.yaml
@@ -13,6 +13,9 @@ jobs:
         run: |
           git submodule update --init --depth=1 unit_tests/googletest
           git submodule update --init --depth=1 firmware/libfirmware
+          git submodule update --init --depth=1 firmware/ext/lua
+          git submodule update --init --depth=1 firmware/controllers/lua/luaaa
+          git submodule update --init --depth=1 firmware/controllers/can/wideband_firmware
 
       - uses: actions/setup-java@v3
         with:

--- a/.github/workflows/build-rusEFI-console.yaml
+++ b/.github/workflows/build-rusEFI-console.yaml
@@ -9,6 +9,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Checkout Submodules
+        run: |
+          git submodule update --init --depth=1 unit_tests/googletest
+
       - uses: actions/setup-java@v3
         with:
           distribution: 'zulu'

--- a/.github/workflows/build-simulator.yaml
+++ b/.github/workflows/build-simulator.yaml
@@ -10,6 +10,11 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
+    - name: Checkout Submodules
+      run: |
+        git submodule update --init --depth=1 firmware/ChibiOS
+        git submodule update --init --depth=1 firmware/ChibiOS-Contrib
+
     - uses: actions/setup-java@v3
       with:
         distribution: 'zulu'

--- a/.github/workflows/build-simulator.yaml
+++ b/.github/workflows/build-simulator.yaml
@@ -9,8 +9,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-      with:
-        submodules: recursive
+
     - uses: actions/setup-java@v3
       with:
         distribution: 'zulu'

--- a/.github/workflows/build-simulator.yaml
+++ b/.github/workflows/build-simulator.yaml
@@ -14,6 +14,7 @@ jobs:
       run: |
         git submodule update --init --depth=1 firmware/ChibiOS
         git submodule update --init --depth=1 firmware/ChibiOS-Contrib
+        git submodule update --init --depth=1 firmware/libfirmware
 
     - uses: actions/setup-java@v3
       with:

--- a/.github/workflows/build-simulator.yaml
+++ b/.github/workflows/build-simulator.yaml
@@ -15,6 +15,8 @@ jobs:
         git submodule update --init --depth=1 firmware/ChibiOS
         git submodule update --init --depth=1 firmware/ChibiOS-Contrib
         git submodule update --init --depth=1 firmware/libfirmware
+        git submodule update --init --depth=1 firmware/ext/lua
+        git submodule update --init --depth=1 firmware/controllers/lua/luaaa
 
     - uses: actions/setup-java@v3
       with:

--- a/.github/workflows/build-simulator.yaml
+++ b/.github/workflows/build-simulator.yaml
@@ -17,6 +17,7 @@ jobs:
         git submodule update --init --depth=1 firmware/libfirmware
         git submodule update --init --depth=1 firmware/ext/lua
         git submodule update --init --depth=1 firmware/controllers/lua/luaaa
+        git submodule update --init --depth=1 firmware/controllers/can/wideband_firmware
 
     - uses: actions/setup-java@v3
       with:

--- a/.github/workflows/build-tsplugin-body.yaml
+++ b/.github/workflows/build-tsplugin-body.yaml
@@ -8,8 +8,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-        with:
-          submodules: recursive
+
       - uses: actions/setup-java@v3
         with:
           distribution: 'zulu'

--- a/.github/workflows/build-unit-tests.yaml
+++ b/.github/workflows/build-unit-tests.yaml
@@ -12,9 +12,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-      with:
-        submodules: recursive
-        fetch-depth: 0
 
     - name: Discover cores
       if: ${{ matrix.os != 'macos-latest' }}

--- a/.github/workflows/build-unit-tests.yaml
+++ b/.github/workflows/build-unit-tests.yaml
@@ -18,6 +18,7 @@ jobs:
       run: |
         git submodule update --init --depth=1 unit_tests/googletest
         git submodule update --init --depth=1 firmware/libfirmware
+        git submodule update --init --depth=1 firmware/ext/lua
 
     - name: Discover cores
       if: ${{ matrix.os != 'macos-latest' }}

--- a/.github/workflows/build-unit-tests.yaml
+++ b/.github/workflows/build-unit-tests.yaml
@@ -19,6 +19,7 @@ jobs:
         git submodule update --init --depth=1 unit_tests/googletest
         git submodule update --init --depth=1 firmware/libfirmware
         git submodule update --init --depth=1 firmware/ext/lua
+        git submodule update --init --depth=1 firmware/controllers/lua/luaaa
 
     - name: Discover cores
       if: ${{ matrix.os != 'macos-latest' }}

--- a/.github/workflows/build-unit-tests.yaml
+++ b/.github/workflows/build-unit-tests.yaml
@@ -13,6 +13,11 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
+    - name: Checkout Submodules
+      if: ${{ env.skip != 'true' }}
+      run: |
+        git submodule update --init --depth=1 unit_tests/googletest
+
     - name: Discover cores
       if: ${{ matrix.os != 'macos-latest' }}
       run: lscpu | egrep 'Model name|Socket|Thread|NUMA|CPU\(s\)'

--- a/.github/workflows/build-unit-tests.yaml
+++ b/.github/workflows/build-unit-tests.yaml
@@ -17,6 +17,7 @@ jobs:
       if: ${{ env.skip != 'true' }}
       run: |
         git submodule update --init --depth=1 unit_tests/googletest
+        git submodule update --init --depth=1 firmware/libfirmware
 
     - name: Discover cores
       if: ${{ matrix.os != 'macos-latest' }}

--- a/.github/workflows/build-unit-tests.yaml
+++ b/.github/workflows/build-unit-tests.yaml
@@ -14,7 +14,6 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Checkout Submodules
-      if: ${{ env.skip != 'true' }}
       run: |
         git submodule update --init --depth=1 unit_tests/googletest
         git submodule update --init --depth=1 firmware/libfirmware

--- a/.github/workflows/build-unit-tests.yaml
+++ b/.github/workflows/build-unit-tests.yaml
@@ -20,6 +20,7 @@ jobs:
         git submodule update --init --depth=1 firmware/libfirmware
         git submodule update --init --depth=1 firmware/ext/lua
         git submodule update --init --depth=1 firmware/controllers/lua/luaaa
+        git submodule update --init --depth=1 firmware/controllers/can/wideband_firmware
 
     - name: Discover cores
       if: ${{ matrix.os != 'macos-latest' }}

--- a/.github/workflows/gen-configs.yaml
+++ b/.github/workflows/gen-configs.yaml
@@ -12,6 +12,14 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
+    - name: Checkout Submodules
+      run: |
+        git submodule update --init --depth=1 unit_tests/googletest
+        git submodule update --init --depth=1 firmware/libfirmware
+        git submodule update --init --depth=1 firmware/ext/lua
+        git submodule update --init --depth=1 firmware/controllers/lua/luaaa
+        git submodule update --init --depth=1 firmware/controllers/can/wideband_firmware
+
     - name: Install Tools
       run: |
         sudo gem install apt-spy2 && sudo time apt-spy2 fix --commit

--- a/.github/workflows/gen-configs.yaml
+++ b/.github/workflows/gen-configs.yaml
@@ -11,9 +11,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-      with:
-        submodules: recursive
-        fetch-depth: 0
 
     - name: Install Tools
       run: |

--- a/.github/workflows/gen-diffs.yaml
+++ b/.github/workflows/gen-diffs.yaml
@@ -12,6 +12,10 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
+    - name: Checkout Submodules
+      run: |
+        git submodule update --init --depth=1 hardware/rusefi_lib
+
     - name: Install sshpass, kicad, and tk bindings
       run: |
         sudo gem install apt-spy2 && sudo time apt-spy2 fix --commit

--- a/.github/workflows/gen-diffs.yaml
+++ b/.github/workflows/gen-diffs.yaml
@@ -11,9 +11,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-      with:
-        submodules: recursive
-        fetch-depth: 0
 
     - name: Install sshpass, kicad, and tk bindings
       run: |

--- a/.github/workflows/gen-diffs.yaml
+++ b/.github/workflows/gen-diffs.yaml
@@ -11,6 +11,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+      with:
+        fetch-depth: 2
 
     - name: Checkout Submodules
       run: |

--- a/.github/workflows/gen-docs.yaml
+++ b/.github/workflows/gen-docs.yaml
@@ -10,8 +10,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
 
     - name: Install prerequisite software
       run: |

--- a/.github/workflows/gen-ibom.yaml
+++ b/.github/workflows/gen-ibom.yaml
@@ -10,9 +10,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-      with:
-        submodules: recursive
-        fetch-depth: 0
+
+    - name: Checkout Submodules
+      run: |
+        git submodule update --init --depth=1 hardware/InteractiveHtmlBom
 
     - name: Install prerequisite software
       run: |

--- a/.github/workflows/gen-pinouts.yaml
+++ b/.github/workflows/gen-pinouts.yaml
@@ -15,8 +15,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
 
     - name: Install prerequisite software
       env:

--- a/.github/workflows/hardware-ci.yaml
+++ b/.github/workflows/hardware-ci.yaml
@@ -35,8 +35,16 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-      with:
-        submodules: recursive
+
+    - name: Checkout Submodules
+      run: |
+        git submodule update --init --depth=1 firmware/ChibiOS
+        git submodule update --init --depth=1 firmware/ChibiOS-Contrib
+        git submodule update --init --depth=1 firmware/libfirmware
+        git submodule update --init --depth=1 firmware/ext/lua
+        git submodule update --init --depth=1 firmware/ext/uzlib
+        git submodule update --init --depth=1 firmware/controllers/lua/luaaa
+        git submodule update --init --depth=1 firmware/controllers/can/wideband_firmware
 
     - name: Identify Agent
       run: uname -a

--- a/.github/workflows/set-date.yaml
+++ b/.github/workflows/set-date.yaml
@@ -18,8 +18,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
 
     - name: Install Tools
       run: |


### PR DESCRIPTION
I haven't tested HW-CI, so we for sure need to wait for that.

This will fix #3494. I removed all `submodules: recursive` statements and figured out, largely by trial and error, which submodules were required for which workflows.

I also removed some `fetch-depth: 0` statements. Somewhat counterintuitively, this means that the whole history is checked. The default is to only fetch HEAD.

I also haven't tested:
- gen-ibom (currently broken green)
- gen-docs (only removed fetch-depth)
- set-date (only removed fetch-depth)