### PR TITLE
apt-spy is doing more harm than good

### DIFF
--- a/.github/workflows/build-android.yaml
+++ b/.github/workflows/build-android.yaml
@@ -24,7 +24,6 @@ jobs:
 
       - name: Install Tools
         run: |
-          sudo gem install apt-spy2 && sudo time apt-spy2 fix --commit
           sudo apt-get -o Acquire::Retries=3 update
           sudo apt-get install mtools
 

--- a/.github/workflows/build-firmware.yaml
+++ b/.github/workflows/build-firmware.yaml
@@ -319,7 +319,6 @@ jobs:
     - name: Install multilib, mingw, sshpass and mtools
       if: ${{ env.skip != 'true' }}
       run: |
-        sudo gem install apt-spy2 && sudo time apt-spy2 fix --commit
         sudo apt-get -o Acquire::Retries=3 update
         sudo apt-get install gcc-multilib g++-multilib g++-mingw-w64 gcc-mingw-w64 sshpass mtools
         sudo apt-get install zip
@@ -483,7 +482,6 @@ jobs:
 
     - name: Install multilib, mingw, and sshpass
       run: |
-        sudo gem install apt-spy2 && sudo time apt-spy2 fix --commit
         sudo apt-get -o Acquire:Retries=3 update
         sudo apt-get install gcc-multilib g++-multilib g++-mingw-w64 gcc-mingw-w64 sshpass mtools zip dosfstools
 

--- a/.github/workflows/build-rusEFI-console.yaml
+++ b/.github/workflows/build-rusEFI-console.yaml
@@ -28,7 +28,6 @@ jobs:
 
       - name: Install Tools
         run: |
-          sudo gem install apt-spy2 && sudo time apt-spy2 fix --commit
           sudo apt-get -o Acquire::Retries=3 update
           sudo apt-get install sshpass mtools
 

--- a/.github/workflows/build-simulator.yaml
+++ b/.github/workflows/build-simulator.yaml
@@ -30,7 +30,6 @@ jobs:
 
     - name: Install multilib
       run: |
-        sudo gem install apt-spy2 && sudo time apt-spy2 fix --commit
         sudo apt-get -o Acquire::Retries=3 update
         sudo apt-get install gcc-multilib g++-multilib mtools dosfstools zip
 

--- a/.github/workflows/build-tsplugin-body.yaml
+++ b/.github/workflows/build-tsplugin-body.yaml
@@ -19,7 +19,6 @@ jobs:
 
       - name: Install Tools
         run: |
-          sudo gem install apt-spy2 && sudo time apt-spy2 fix --commit
           sudo apt-get -o Acquire::Retries=3 update
           sudo apt-get install sshpass
 

--- a/.github/workflows/build-unit-tests.yaml
+++ b/.github/workflows/build-unit-tests.yaml
@@ -28,7 +28,6 @@ jobs:
     - name: Install required software (ubuntu)
       if: ${{ matrix.os != 'macos-latest' }}
       run: |
-        sudo gem install apt-spy2 && sudo time apt-spy2 fix --commit
         sudo apt-get -o Acquire::Retries=3 update
         sudo apt-get install mtools zip dosfstools sshpass lcov valgrind
 

--- a/.github/workflows/gen-configs.yaml
+++ b/.github/workflows/gen-configs.yaml
@@ -22,7 +22,6 @@ jobs:
 
     - name: Install Tools
       run: |
-        sudo gem install apt-spy2 && sudo time apt-spy2 fix --commit
         sudo apt-get -o Acquire::Retries=3 update
         sudo apt-get install sshpass sshpass mtools
 

--- a/.github/workflows/gen-diffs.yaml
+++ b/.github/workflows/gen-diffs.yaml
@@ -20,7 +20,6 @@ jobs:
 
     - name: Install sshpass, kicad, and tk bindings
       run: |
-        sudo gem install apt-spy2 && sudo time apt-spy2 fix --commit
         sudo add-apt-repository --yes ppa:kicad/kicad-6.0-releases
         sudo apt-get -o Acquire::Retries=3 update
         sudo apt-get install sshpass kicad python3-pip python3-tk scour librsvg2-bin

--- a/.github/workflows/gen-docs.yaml
+++ b/.github/workflows/gen-docs.yaml
@@ -13,7 +13,6 @@ jobs:
 
     - name: Install prerequisite software
       run: |
-        sudo gem install apt-spy2 && sudo time apt-spy2 fix --commit
         sudo apt-get -o Acquire::Retries=3 update
         sudo apt-get install doxygen graphviz sshpass
 

--- a/.github/workflows/gen-ibom.yaml
+++ b/.github/workflows/gen-ibom.yaml
@@ -17,7 +17,6 @@ jobs:
 
     - name: Install prerequisite software
       run: |
-        sudo gem install apt-spy2 && sudo time apt-spy2 fix --commit
         sudo add-apt-repository ppa:kicad/kicad-5.1-releases
         sudo apt-get -o Acquire::Retries=3 update
         sudo apt-get install kicad sshpass

--- a/.github/workflows/set-date.yaml
+++ b/.github/workflows/set-date.yaml
@@ -21,7 +21,6 @@ jobs:
 
     - name: Install Tools
       run: |
-        sudo gem install apt-spy2 && sudo time apt-spy2 fix --commit
         sudo apt-get -o Acquire::Retries=3 update
         sudo apt-get install subversion
 


### PR DESCRIPTION
apt-spy keeps picking repo mirrors that aren't reliable, causing workflows to fail.