### PR TITLE
deduplicate $(BOARD_DIR) in makefiles

### DIFF
--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -164,6 +164,7 @@ MAKEFLAGS += ${NUMJOBS}
 # Project, sources and paths
 #
 
+BOARDINC = $(BOARD_DIR)
 include $(BOARD_DIR)/board.mk
 
 # Include various ChibiOS mk files

--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -164,9 +164,7 @@ MAKEFLAGS += ${NUMJOBS}
 # Project, sources and paths
 #
 
-BOARDS_DIR = $(PROJECT_DIR)/config/boards
-
-include $(PROJECT_DIR)/config/boards/$(PROJECT_BOARD)/board.mk
+include $(BOARD_DIR)/board.mk
 
 # Include various ChibiOS mk files
 # Licensing files.
@@ -222,6 +220,7 @@ ifeq ($(USE_OPENBLT),yes)
 endif
 
 $(info PROJECT_BOARD: $(PROJECT_BOARD))
+$(info BOARD_DIR:     $(BOARD_DIR))
 $(info PROJECT_CPU:   $(PROJECT_CPU))
 $(info CPU_HWLAYER:   $(CPU_HWLAYER))
 $(info CONFDIR:       $(CONFDIR))

--- a/firmware/bootloader/src/Makefile
+++ b/firmware/bootloader/src/Makefile
@@ -160,7 +160,8 @@ include $(CHIBIOS)/os/various/cpp_wrappers/chcpp.mk
 # EX files (optional).
 include $(CHIBIOS)/os/hal/lib/streams/streams.mk
 
-include $(CONFIG)/boards/$(PROJECT_BOARD)/board.mk
+BOARDINC = $(BOARD_DIR)
+include $(BOARD_DIR)/board.mk
 include $(PROJECT_DIR)/init/init.mk
 include $(PROJECT_DIR)/util/util.mk
 

--- a/firmware/common.mk
+++ b/firmware/common.mk
@@ -33,7 +33,7 @@ ALLINC += \
 	$(CONSOLE_INC) \
  	$(DEVELOPMENT_DIR) \
 	$(PROJECT_DIR)/config/engines \
-	$(PROJECT_DIR)/config/boards/ \
+	$(BOARDS_DIR) \
 	$(PROJECT_DIR)/hw_layer/algo \
     $(PROJECT_DIR)/init \
     $(PROJECT_DIR)/ext_algo \

--- a/firmware/config/boards/48way/board.mk
+++ b/firmware/config/boards/48way/board.mk
@@ -1,7 +1,5 @@
 # List of all the board related files.
-BOARDCPPSRC =  $(PROJECT_DIR)/config/boards/48way/board_configuration.cpp
-
-BOARDINC = $(PROJECT_DIR)/config/boards/48way
+BOARDCPPSRC =  $(BOARD_DIR)/board_configuration.cpp
 
 # Override DEFAULT_ENGINE_TYPE
 DDEFS += -DSHORT_BOARD_NAME=48way

--- a/firmware/config/boards/BB_V2/board.mk
+++ b/firmware/config/boards/BB_V2/board.mk
@@ -1,8 +1,6 @@
 # List of all the board related files.
-BOARDCPPSRC =  $(PROJECT_DIR)/config/boards/BB_V2/board_configuration.cpp \
-				$(PROJECT_DIR)/config/boards/proteus/adc_hack.cpp
-
-BOARDINC = $(PROJECT_DIR)/config/boards/BB_V2
+BOARDCPPSRC =  $(BOARD_DIR)/board_configuration.cpp \
+				$(BOARDS_DIR)/proteus/adc_hack.cpp
 
 # Override DEFAULT_ENGINE_TYPE
 DDEFS += -DSTM32F407xx

--- a/firmware/config/boards/BB_V3/board.mk
+++ b/firmware/config/boards/BB_V3/board.mk
@@ -1,8 +1,6 @@
 # List of all the board related files.
-BOARDCPPSRC =  $(PROJECT_DIR)/config/boards/BB_V3/board_configuration.cpp \
-				$(PROJECT_DIR)/config/boards/proteus/adc_hack.cpp
-
-BOARDINC = $(PROJECT_DIR)/config/boards/BB_V3
+BOARDCPPSRC =  $(BOARD_DIR)/board_configuration.cpp \
+				$(BOARDS_DIR)/proteus/adc_hack.cpp
 
 # Override DEFAULT_ENGINE_TYPE
 DDEFS += -DSTM32F407xx

--- a/firmware/config/boards/atlas/board.mk
+++ b/firmware/config/boards/atlas/board.mk
@@ -1,7 +1,5 @@
 # List of all the board related files.
-BOARDCPPSRC =  $(PROJECT_DIR)/config/boards/atlas/board_configuration.cpp
-
-BOARDINC = $(PROJECT_DIR)/config/boards/atlas
+BOARDCPPSRC =  $(BOARD_DIR)/board_configuration.cpp
 
 #DDEFS += -DLED_CRITICAL_ERROR_BRAIN_PIN=Gpio::E3
 DDEFS += -DFIRMWARE_ID=\"atlas\"

--- a/firmware/config/boards/core8/board.mk
+++ b/firmware/config/boards/core8/board.mk
@@ -1,7 +1,5 @@
 # List of all the board related files.
-BOARDCPPSRC =  $(PROJECT_DIR)/config/boards/core8/board_configuration.cpp
-
-BOARDINC = $(PROJECT_DIR)/config/boards/core8
+BOARDCPPSRC =  $(BOARD_DIR)/board_configuration.cpp
 
 # Override DEFAULT_ENGINE_TYPE
 DDEFS += -DSHORT_BOARD_NAME=core8

--- a/firmware/config/boards/coreECU/board.mk
+++ b/firmware/config/boards/coreECU/board.mk
@@ -1,8 +1,6 @@
 # List of all the board related files.
-BOARDCPPSRC =  $(PROJECT_DIR)/config/boards/coreECU/board_configuration.cpp \
-				$(PROJECT_DIR)/config/boards/proteus/adc_hack.cpp
-
-BOARDINC = $(PROJECT_DIR)/config/boards/coreECU
+BOARDCPPSRC =  $(BOARD_DIR)/board_configuration.cpp \
+				$(BOARDS_DIR)/proteus/adc_hack.cpp
 
 # Override DEFAULT_ENGINE_TYPE
 DDEFS += -DSTM32F407xx

--- a/firmware/config/boards/cypress/board.mk
+++ b/firmware/config/boards/cypress/board.mk
@@ -1,7 +1,5 @@
 # List of all the board related files.
 
-BOARD_DIR = $(PROJECT_DIR)/config/boards/$(PROJECT_BOARD)
-
 # we have:
 # 	PDL_DEVICE_TYPE=PDL_TYPE3
 # 	PDL_MCU_INT_TYPE=PDL_FM4_INT_TYPE_B
@@ -12,7 +10,6 @@ BOARDSRC = $(BOARD_DIR)/board.c
 BOARDCPPSRC = $(BOARD_DIR)/board_configuration.cpp
 
 # Required include directories
-BOARDINC = $(BOARD_DIR)
 BOARDINC += $(BOARD_DIR)/config/controllers/algo
 
 BOARDINC += $(PDL_DIR)/driver $(PDL_DIR)/driver/gpio $(PDL_DIR)/driver/usb $(PDL_DIR)/driver/mfs $(PDL_DIR)/midware/usb/device

--- a/firmware/config/boards/cypress/config.mk
+++ b/firmware/config/boards/cypress/config.mk
@@ -5,7 +5,7 @@ USE_FATFS = no
 USE_BOOTLOADER = no
 DEBUG_LEVEL_OPT= -O2
 
-CYPRESS_CONTRIB = $(PROJECT_DIR)/config/boards/$(PROJECT_BOARD)/OS
+CYPRESS_CONTRIB = $(BOARD_DIR)/OS
 
 GENERATED_ENUMS_DIR = $(BOARD_DIR)/config/controllers/algo
 
@@ -13,4 +13,4 @@ EXTRA_PARAMS += -DFIRMWARE_ID=\"cypress\" -DSHORT_BOARD_NAME=cypress
 # -nodefaultlibs -lc -lgcc -ltinyc
 
 # used by USE_SMART_BUILD
-CONFDIR = $(PROJECT_DIR)/config/boards/$(PROJECT_BOARD)
+CONFDIR = $(BOARD_DIR)

--- a/firmware/config/boards/f407-discovery/board.mk
+++ b/firmware/config/boards/f407-discovery/board.mk
@@ -1,5 +1,5 @@
 # List of all the board related files.
-BOARDCPPSRC = $(PROJECT_DIR)/config/boards/f407-discovery/board_extra.cpp
+BOARDCPPSRC = $(BOARD_DIR)/board_extra.cpp
 
 # MCU defines
 DDEFS += -DSTM32F407xx

--- a/firmware/config/boards/f429-208/board.mk
+++ b/firmware/config/boards/f429-208/board.mk
@@ -1,13 +1,9 @@
-BOARD_DIR = $(PROJECT_DIR)/config/boards/$(PROJECT_BOARD)
-
 HALCONFDIR = $(BOARD_DIR)
 
 # List of all the board related files.
 BOARDCPPSRC = $(BOARD_DIR)/board_configuration.cpp
 
 # Required include directories
-BOARDINC = $(BOARD_DIR)
-
 # STM32F429 has FSMC with SDRAM support
 DDEFS += -DFIRMWARE_ID=\"stm32f429\"
 IS_STM32F429 = yes

--- a/firmware/config/boards/f429-discovery/board.mk
+++ b/firmware/config/boards/f429-discovery/board.mk
@@ -1,13 +1,9 @@
-BOARD_DIR = $(PROJECT_DIR)/config/boards/$(PROJECT_BOARD)
-
 HALCONFDIR = $(BOARD_DIR)
 
 # List of all the board related files.
 BOARDCPPSRC = $(BOARD_DIR)/board_configuration.cpp
 
 # Required include directories
-BOARDINC = $(BOARD_DIR)
-
 # STM32F429 has FSMC with SDRAM support
 DDEFS += -DFIRMWARE_ID=\"stm32f429\"
 IS_STM32F429 = yes

--- a/firmware/config/boards/hellen/alphax-2chan/board.mk
+++ b/firmware/config/boards/hellen/alphax-2chan/board.mk
@@ -1,9 +1,7 @@
 # Combine the related files for a specific platform and MCU.
 
 # Target ECU board design
-BOARDCPPSRC = $(BOARDS_DIR)/hellen/alphax-2chan/board_configuration.cpp
-BOARDINC = $(BOARDS_DIR)/hellen/alphax-2chan
-
+BOARDCPPSRC = $(BOARD_DIR)/board_configuration.cpp
 DDEFS += -DEFI_MAIN_RELAY_CONTROL=TRUE
 
 # This board has trigger scope hardware!

--- a/firmware/config/boards/hellen/alphax-4chan/board.mk
+++ b/firmware/config/boards/hellen/alphax-4chan/board.mk
@@ -1,9 +1,7 @@
 # Combine the related files for a specific platform and MCU.
 
 # Target ECU board design
-BOARDCPPSRC = $(BOARDS_DIR)/hellen/alphax-4chan/board_configuration.cpp
-BOARDINC = $(BOARDS_DIR)/hellen/alphax-4chan
-
+BOARDCPPSRC = $(BOARD_DIR)/board_configuration.cpp
 DDEFS += -DEFI_MAIN_RELAY_CONTROL=TRUE
 
 # This board has trigger scope hardware!

--- a/firmware/config/boards/hellen/alphax-8chan/board.mk
+++ b/firmware/config/boards/hellen/alphax-8chan/board.mk
@@ -1,9 +1,7 @@
 # Combine the related files for a specific platform and MCU.
 
 # Target ECU board design
-BOARDCPPSRC = $(BOARDS_DIR)/hellen/alphax-8chan/board_configuration.cpp
-BOARDINC = $(BOARDS_DIR)/hellen/alphax-8chan
-
+BOARDCPPSRC = $(BOARD_DIR)/board_configuration.cpp
 DDEFS += -DEFI_MAIN_RELAY_CONTROL=TRUE
 
 # This board has trigger scope hardware!

--- a/firmware/config/boards/hellen/harley81/board.mk
+++ b/firmware/config/boards/hellen/harley81/board.mk
@@ -1,9 +1,7 @@
 # Combine the related files for a specific platform and MCU.
 
 # Target ECU board design
-BOARDCPPSRC = $(BOARDS_DIR)/hellen/harley81/board_configuration.cpp
-BOARDINC = $(BOARDS_DIR)/hellen/harley81
-
+BOARDCPPSRC = $(BOARD_DIR)/board_configuration.cpp
 DDEFS += -DEFI_MAIN_RELAY_CONTROL=TRUE
 
 

--- a/firmware/config/boards/hellen/hellen-gm-e67/board.mk
+++ b/firmware/config/boards/hellen/hellen-gm-e67/board.mk
@@ -1,9 +1,7 @@
 # Combine the related files for a specific platform and MCU.
 
 # Target ECU board design
-BOARDCPPSRC = $(BOARDS_DIR)/hellen/hellen-gm-e67/board_configuration.cpp
-BOARDINC = $(BOARDS_DIR)/hellen/hellen-gm-e67
-
+BOARDCPPSRC = $(BOARD_DIR)/board_configuration.cpp
 
 DDEFS += -DEFI_MAIN_RELAY_CONTROL=TRUE
 

--- a/firmware/config/boards/hellen/hellen-honda-k/board.mk
+++ b/firmware/config/boards/hellen/hellen-honda-k/board.mk
@@ -1,9 +1,7 @@
 # Combine the related files for a specific platform and MCU.
 
 # Target ECU board design
-BOARDCPPSRC = $(BOARDS_DIR)/hellen/hellen-honda-k/board_configuration.cpp
-BOARDINC = $(BOARDS_DIR)/hellen/hellen-honda-k
-
+BOARDCPPSRC = $(BOARD_DIR)/board_configuration.cpp
 # Set this if you want a default engine type other than normal
 ifeq ($(VAR_DEF_ENGINE_TYPE),)
   VAR_DEF_ENGINE_TYPE = -DDEFAULT_ENGINE_TYPE=HELLEN_154_HYUNDAI_COUPE_BK2

--- a/firmware/config/boards/hellen/hellen-nb1/board.mk
+++ b/firmware/config/boards/hellen/hellen-nb1/board.mk
@@ -1,9 +1,7 @@
 # Combine the related files for a specific platform and MCU.
 
 # Target ECU board design
-BOARDCPPSRC = $(BOARDS_DIR)/hellen/hellen-nb1/board_configuration.cpp
-BOARDINC = $(BOARDS_DIR)/hellen/hellen-nb1
-
+BOARDCPPSRC = $(BOARD_DIR)/board_configuration.cpp
 # Set this if you want a default engine type other than normal hellen-nb1
 ifeq ($(VAR_DEF_ENGINE_TYPE),)
   VAR_DEF_ENGINE_TYPE = -DDEFAULT_ENGINE_TYPE=HELLEN_NB1

--- a/firmware/config/boards/hellen/hellen121nissan/board.mk
+++ b/firmware/config/boards/hellen/hellen121nissan/board.mk
@@ -1,9 +1,7 @@
 # Combine the related files for a specific platform and MCU.
 
 # Target ECU board design
-BOARDCPPSRC = $(BOARDS_DIR)/hellen/hellen121nissan/board_configuration.cpp
-BOARDINC = $(BOARDS_DIR)/hellen/hellen121nissan
-
+BOARDCPPSRC = $(BOARD_DIR)/board_configuration.cpp
 # Set this if you want a default engine type other than normal hellen121nissan
 ifeq ($(VAR_DEF_ENGINE_TYPE),)
   VAR_DEF_ENGINE_TYPE = -DDEFAULT_ENGINE_TYPE=HELLEN_121_NISSAN_6_CYL

--- a/firmware/config/boards/hellen/hellen121vag/board.mk
+++ b/firmware/config/boards/hellen/hellen121vag/board.mk
@@ -1,9 +1,7 @@
 # Combine the related files for a specific platform and MCU.
 
 # Target ECU board design
-BOARDCPPSRC = $(BOARDS_DIR)/hellen/hellen121vag/board_configuration.cpp
-BOARDINC = $(BOARDS_DIR)/hellen/hellen121vag
-
+BOARDCPPSRC = $(BOARD_DIR)/board_configuration.cpp
 # Set this if you want a default engine type other than normal hellen121vag
 ifeq ($(VAR_DEF_ENGINE_TYPE),)
   VAR_DEF_ENGINE_TYPE = -DDEFAULT_ENGINE_TYPE=HELLEN_121_VAG_4_CYL

--- a/firmware/config/boards/hellen/hellen128/board.mk
+++ b/firmware/config/boards/hellen/hellen128/board.mk
@@ -1,9 +1,7 @@
 # Combine the related files for a specific platform and MCU.
 
 # Target ECU board design
-BOARDCPPSRC = $(BOARDS_DIR)/hellen/hellen128/board_configuration.cpp
-
-BOARDINC = $(BOARDS_DIR)/hellen/hellen128
+BOARDCPPSRC = $(BOARD_DIR)/board_configuration.cpp
 
 # Set this if you want a default engine type other than normal hellen128
 ifeq ($(VAR_DEF_ENGINE_TYPE),)

--- a/firmware/config/boards/hellen/hellen154hyundai/board.mk
+++ b/firmware/config/boards/hellen/hellen154hyundai/board.mk
@@ -1,9 +1,7 @@
 # Combine the related files for a specific platform and MCU.
 
 # Target ECU board design
-BOARDCPPSRC = $(BOARDS_DIR)/hellen/hellen154hyundai/board_configuration.cpp
-BOARDINC = $(BOARDS_DIR)/hellen/hellen154hyundai
-
+BOARDCPPSRC = $(BOARD_DIR)/board_configuration.cpp
 # Set this if you want a default engine type other than normal
 ifeq ($(VAR_DEF_ENGINE_TYPE),)
   VAR_DEF_ENGINE_TYPE = -DDEFAULT_ENGINE_TYPE=HELLEN_154_HYUNDAI_COUPE_BK2

--- a/firmware/config/boards/hellen/hellen64_miataNA6_94/board.mk
+++ b/firmware/config/boards/hellen/hellen64_miataNA6_94/board.mk
@@ -1,9 +1,7 @@
 # Combine the related files for a specific platform and MCU.
 
 # Target ECU board design
-BOARDCPPSRC = $(BOARDS_DIR)/hellen/hellen64_miataNA6_94/board_configuration.cpp
-BOARDINC = $(BOARDS_DIR)/hellen/hellen64_miataNA6_94
-
+BOARDCPPSRC = $(BOARD_DIR)/board_configuration.cpp
 # Set this if you want a default engine type other than normal hellen64_miataNA6_94
 ifeq ($(VAR_DEF_ENGINE_TYPE),)
   VAR_DEF_ENGINE_TYPE = -DDEFAULT_ENGINE_TYPE=HELLEN_NA6

--- a/firmware/config/boards/hellen/hellen72/board.mk
+++ b/firmware/config/boards/hellen/hellen72/board.mk
@@ -1,9 +1,7 @@
 # Combine the related files for a specific platform and MCU.
 
 # Target ECU board design
-BOARDCPPSRC = $(BOARDS_DIR)/hellen/hellen72/board_configuration.cpp
-
-BOARDINC = $(BOARDS_DIR)/hellen/hellen72
+BOARDCPPSRC = $(BOARD_DIR)/board_configuration.cpp
 
 # Set this if you want a default engine type other than normal Hellen72
 ifeq ($(VAR_DEF_ENGINE_TYPE),)

--- a/firmware/config/boards/hellen/hellen81/board.mk
+++ b/firmware/config/boards/hellen/hellen81/board.mk
@@ -1,9 +1,7 @@
 # Combine the related files for a specific platform and MCU.
 
 # Target ECU board design
-BOARDCPPSRC = $(BOARDS_DIR)/hellen/hellen81/board_configuration.cpp
-BOARDINC = $(BOARDS_DIR)/hellen/hellen81
-
+BOARDCPPSRC = $(BOARD_DIR)/board_configuration.cpp
 DDEFS += -DEFI_MAIN_RELAY_CONTROL=TRUE
 
 # Add them all together

--- a/firmware/config/boards/hellen/hellen88bmw/board.mk
+++ b/firmware/config/boards/hellen/hellen88bmw/board.mk
@@ -1,9 +1,7 @@
 # Combine the related files for a specific platform and MCU.
 
 # Target ECU board design
-BOARDCPPSRC = $(BOARDS_DIR)/hellen/hellen88bmw/board_configuration.cpp
-BOARDINC = $(BOARDS_DIR)/hellen/hellen88bmw
-
+BOARDCPPSRC = $(BOARD_DIR)/board_configuration.cpp
 # Set this if you want a default engine type other than normal hellen88bmw
 ifeq ($(VAR_DEF_ENGINE_TYPE),)
   VAR_DEF_ENGINE_TYPE = -DDEFAULT_ENGINE_TYPE=HELLEN_88_BMW

--- a/firmware/config/boards/hellen/hellenNA8_96/board.mk
+++ b/firmware/config/boards/hellen/hellenNA8_96/board.mk
@@ -1,9 +1,7 @@
 # Combine the related files for a specific platform and MCU.
 
 # Target ECU board design
-BOARDCPPSRC = $(BOARDS_DIR)/hellen/hellenNA8_96/board_configuration.cpp
-BOARDINC = $(BOARDS_DIR)/hellen/hellenNA8_96
-
+BOARDCPPSRC = $(BOARD_DIR)/board_configuration.cpp
 # Set this if you want a default engine type other than normal hellen-nb1
 ifeq ($(VAR_DEF_ENGINE_TYPE),)
   VAR_DEF_ENGINE_TYPE = -DDEFAULT_ENGINE_TYPE=HELLEN_NA8_96

--- a/firmware/config/boards/kinetis/board.mk
+++ b/firmware/config/boards/kinetis/board.mk
@@ -1,7 +1,5 @@
 # List of all the board related files.
 
-BOARD_DIR = $(PROJECT_DIR)/config/boards/$(PROJECT_BOARD)
-
 BOARDSRC = $(BOARD_DIR)/board.c
 BOARDCPPSRC = $(BOARD_DIR)/board_configuration.cpp
 

--- a/firmware/config/boards/kinetis/config.mk
+++ b/firmware/config/boards/kinetis/config.mk
@@ -7,8 +7,8 @@ USE_FATFS = no
 USE_BOOTLOADER = no
 DEBUG_LEVEL_OPT = -O2
 
-KINETIS_CONTRIB = $(PROJECT_DIR)/config/boards/$(PROJECT_BOARD)/OS
+KINETIS_CONTRIB = $(BOARD_DIR)/OS
 
 GENERATED_ENUMS_DIR = $(BOARD_DIR)/config/controllers/algo
 
-EXTRA_PARAMS += -DFIRMWARE_ID=\"kinetis\" -L$(PROJECT_DIR)/config/boards/$(PROJECT_BOARD)/libc -lgcc -ltinyc
+EXTRA_PARAMS += -DFIRMWARE_ID=\"kinetis\" -L$(BOARD_DIR)/libc -lgcc -ltinyc

--- a/firmware/config/boards/m74_9/board.mk
+++ b/firmware/config/boards/m74_9/board.mk
@@ -1,7 +1,5 @@
 # List of all the board related files.
-BOARDCPPSRC = $(PROJECT_DIR)/config/boards/m74_9/board_configuration.cpp
-BOARDINC = $(PROJECT_DIR)/config/boards/m74_9
-
+BOARDCPPSRC = $(BOARD_DIR)/board_configuration.cpp
 DDEFS += -DLED_CRITICAL_ERROR_BRAIN_PIN=Gpio::G14
 
 # This is an F429!

--- a/firmware/config/boards/microrusefi/board.mk
+++ b/firmware/config/boards/microrusefi/board.mk
@@ -1,16 +1,9 @@
 # Combine the related files for a specific platform and MCU.
 
 # Target ECU board design
-BOARDCPPSRC = $(BOARDS_DIR)/microrusefi/board_configuration.cpp
+BOARDCPPSRC = $(BOARD_DIR)/board_configuration.cpp
 
-# Target processor details
-ifeq ($(PROJECT_CPU),ARCH_STM32F4)
-  BOARDINC  = $(BOARDS_DIR)/microrusefi
-  BOARDINC += $(PROJECT_DIR)/config/stm32f4ems	# For board.h
-  BOARDINC += $(BOARDS_DIR)/microrusefi # For knock_config.h
-else
-  BOARDINC += $(BOARDS_DIR)/microrusefi # For knock_config.h
-endif
+BOARDINC  = $(BOARD_DIR)
 
 # see also openblt/board.mk STATUS_LED
 DDEFS += -DLED_CRITICAL_ERROR_BRAIN_PIN=Gpio::E3

--- a/firmware/config/boards/nucleo_f429/board.mk
+++ b/firmware/config/boards/nucleo_f429/board.mk
@@ -1,7 +1,5 @@
 # List of all the board related files.
-BOARDCPPSRC = $(PROJECT_DIR)/config/boards/nucleo_f429/board_configuration.cpp
-BOARDINC = $(PROJECT_DIR)/config/boards/nucleo_f429
-
+BOARDCPPSRC = $(BOARD_DIR)/board_configuration.cpp
 DDEFS += -DLED_CRITICAL_ERROR_BRAIN_PIN=Gpio::B14
 
 # Enable ethernet

--- a/firmware/config/boards/nucleo_f767/board.mk
+++ b/firmware/config/boards/nucleo_f767/board.mk
@@ -1,7 +1,7 @@
 # List of all the board related files.
 
 # F429 and F767 Nucleo are indeed the same board with a different chip fitted - so recycle the F429 config
-BOARDCPPSRC = $(PROJECT_DIR)/config/boards/nucleo_f429/board_configuration.cpp
+BOARDCPPSRC = $(BOARD_DIR)/board_configuration.cpp
 
 # reducing flash consumption for EFI_ETHERNET to fit
 DDEFS += -DEFI_FILE_LOGGING=FALSE -DEFI_ALTERNATOR_CONTROL=FALSE -DEFI_LOGIC_ANALYZER=FALSE -DEFI_ENABLE_ASSERTS=FALSE

--- a/firmware/config/boards/nucleo_h743/board.mk
+++ b/firmware/config/boards/nucleo_h743/board.mk
@@ -1,6 +1,6 @@
 # List of all the board related files.
 
-BOARDCPPSRC = $(PROJECT_DIR)/config/boards/nucleo_h743/board_configuration.cpp
+BOARDCPPSRC = $(BOARD_DIR)/board_configuration.cpp
 
 DDEFS += -DLED_CRITICAL_ERROR_BRAIN_PIN=Gpio::B14
 

--- a/firmware/config/boards/prometheus/f405/board.mk
+++ b/firmware/config/boards/prometheus/f405/board.mk
@@ -1,3 +1,3 @@
 PROMETHEUS_BOARD = 405
 
-include $(PROJECT_DIR)/config/boards/prometheus/prometheus-common-board.mk
+include $(BOARD_DIR)/prometheus-common-board.mk

--- a/firmware/config/boards/prometheus/f469/board.mk
+++ b/firmware/config/boards/prometheus/f469/board.mk
@@ -1,3 +1,3 @@
 PROMETHEUS_BOARD = 469
 
-include $(PROJECT_DIR)/config/boards/prometheus/prometheus-common-board.mk
+include $(BOARD_DIR)/prometheus-common-board.mk

--- a/firmware/config/boards/prometheus/prometheus-common-board.mk
+++ b/firmware/config/boards/prometheus/prometheus-common-board.mk
@@ -1,11 +1,9 @@
 # List of all the board related files.
-BOARDSRC = $(PROJECT_DIR)/config/boards/prometheus/board_extra.c
+BOARDSRC = $(BOARD_DIR)/board_extra.c
 
-BOARDCPPSRC = $(PROJECT_DIR)/config/boards/Prometheus/board_configuration.cpp
+BOARDCPPSRC = $(BOARD_DIR)/board_configuration.cpp
 
 # Required include directories
-BOARDINC = $(PROJECT_DIR)/config/boards/prometheus
-
 # Default to a release build - clear EXTRA_PARAMS from cmdline to build debug
 ifeq ($(EXTRA_PARAMS),)
 	EXTRA_PARAMS = -DEFI_ENABLE_ASSERTS=FALSE -DCH_DBG_ENABLE_ASSERTS=FALSE -DCH_DBG_ENABLE_STACK_CHECK=FALSE -DCH_DBG_FILL_THREADS=FALSE -DCH_DBG_THREADS_PROFILING=FALSE

--- a/firmware/config/boards/proteus/board.mk
+++ b/firmware/config/boards/proteus/board.mk
@@ -1,8 +1,6 @@
 # List of all the board related files.
-BOARDCPPSRC =  $(PROJECT_DIR)/config/boards/proteus/board_configuration.cpp \
-				$(PROJECT_DIR)/config/boards/proteus/adc_hack.cpp
-
-BOARDINC = $(PROJECT_DIR)/config/boards/proteus
+BOARDCPPSRC =  $(BOARD_DIR)/board_configuration.cpp \
+				$(BOARD_DIR)/adc_hack.cpp
 
 ifeq ($(PROJECT_CPU),ARCH_STM32F4)
   IS_STM32F429 = yes

--- a/firmware/config/boards/s105/board.mk
+++ b/firmware/config/boards/s105/board.mk
@@ -1,5 +1,3 @@
-BOARD_DIR = $(PROJECT_DIR)/config/boards/$(PROJECT_BOARD)
-
 HALCONFDIR = $(BOARD_DIR)
 
 # List of all the board related files.
@@ -35,8 +33,6 @@ DDEFS += -DFIRMWARE_ID=\"s105\"
 DDEFS += -DDEFAULT_ENGINE_TYPE=MINIMAL_PINS
 
 # Required include directories
-BOARDINC = $(BOARD_DIR)
-
 # Shared variables
 # Add board's directory first in include dir list so files in board directory will be included instead of default
 ALLINC += $(BOARDINC)

--- a/firmware/config/boards/skeleton/board.mk
+++ b/firmware/config/boards/skeleton/board.mk
@@ -1,12 +1,9 @@
 # Combine the related files for a specific platform and MCU.
 
 # Target ECU board design
-BOARDCPPSRC = $(BOARDS_DIR)/skeleton/board_configuration.cpp
+BOARDCPPSRC = $(BOARD_DIR)/board_configuration.cpp
 
-# Target processor details
-ifeq ($(PROJECT_CPU),ARCH_STM32F4)
-  BOARDINC  = $(BOARDS_DIR)/skeleton
-endif
+BOARDINC  = $(BOARD_DIR)
 
 DDEFS += -DDEFAULT_ENGINE_TYPE=DEFAULT_FRANKENSO
 # Add them all together

--- a/firmware/config/boards/subaru_eg33/board.mk
+++ b/firmware/config/boards/subaru_eg33/board.mk
@@ -1,10 +1,7 @@
-BOARD_DIR = $(PROJECT_DIR)/config/boards/$(PROJECT_BOARD)
-
 # List of all the board related files.
 BOARDCPPSRC = $(BOARD_DIR)/board_configuration.cpp
 
 # Required include directories
-BOARDINC = $(BOARD_DIR)
 BOARDINC += $(BOARD_DIR)/config/controllers/algo
 
 # Override LD script

--- a/firmware/config/boards/subaru_eg33/config.mk
+++ b/firmware/config/boards/subaru_eg33/config.mk
@@ -1,2 +1,2 @@
 #We have our own enums
-GENERATED_ENUMS_DIR = $(PROJECT_DIR)/config/boards/$(PROJECT_BOARD)/config/controllers/algo
+GENERATED_ENUMS_DIR = $(BOARD_DIR)/config/controllers/algo

--- a/firmware/config/boards/tdg-pdm8/board.mk
+++ b/firmware/config/boards/tdg-pdm8/board.mk
@@ -1,5 +1,5 @@
 
-BOARDCPPSRC = $(PROJECT_DIR)/config/boards/tdg-pdm8/board_configuration.cpp
+BOARDCPPSRC = $(BOARD_DIR)/board_configuration.cpp
 
 PROJECT_CPU = ARCH_STM32F4
 

--- a/firmware/hw_layer/openblt/openblt.mk
+++ b/firmware/hw_layer/openblt/openblt.mk
@@ -46,7 +46,7 @@ TOOL_PATH=$(TRGT)
 #|--------------------------------------------------------------------------------------|
 PROJECT_DIR=.
 OPENBLT_TRGT_DIR=$(PROJECT_DIR)/ext/openblt/Target
-OPENBLT_BOARD_DIR=$(PROJECT_DIR)/config/boards/$(PROJECT_BOARD)/openblt
+OPENBLT_BOARD_DIR=$(BOARD_DIR)/openblt
 ifeq ($(PROJECT_CPU),ARCH_STM32F4)
 	OPENBLT_PORT_DIR=$(PROJECT_DIR)/hw_layer/ports/stm32/stm32f4/openblt
 else ifeq ($(PROJECT_CPU),ARCH_STM32F7)

--- a/firmware/rusefi.mk
+++ b/firmware/rusefi.mk
@@ -20,14 +20,21 @@ ifeq ($(PROJECT_BOARD),)
   PROJECT_BOARD = f407-discovery
 endif
 
+BOARDS_DIR = $(PROJECT_DIR)/config/boards
+
+# allow passing a custom board dir, otherwise generate it based on the board name
+ifeq ($(BOARD_DIR),)
+	BOARD_DIR = $(BOARDS_DIR)/$(PROJECT_BOARD)
+endif
+
 ifeq ($(PROJECT_CPU),)
   # many boards all the way to Proteus use this F4 default
   PROJECT_CPU = ARCH_STM32F4
 endif
 
--include $(PROJECT_DIR)/config/boards/$(PROJECT_BOARD)/config.mk
+-include $(BOARD_DIR)/config.mk
 
-PIN_NAMES_FILE=$(PROJECT_DIR)/config/boards/$(PROJECT_BOARD)/connectors/generated_ts_name_by_pin.cpp
+PIN_NAMES_FILE=$(BOARD_DIR)/connectors/generated_ts_name_by_pin.cpp
 
 ifneq ("$(wildcard $(PIN_NAMES_FILE))","")
 $(info found $(PIN_NAMES_FILE) )


### PR DESCRIPTION
calculate $(BOARDS_DIR) and $(BOARD_DIR) exactly once, instead of many times, or repeating a board's name over and over again in its board.mk.