### PR TITLE
GitHub workflows: more ubuntu-latest mirrors

### DIFF
--- a/.github/workflows/build-android.yaml
+++ b/.github/workflows/build-android.yaml
@@ -24,6 +24,10 @@ jobs:
 
       - name: Install Tools
         run: |
+          sudo cp /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu-latest-mirrors.list
+          sudo sed 's#http://azure.archive.ubuntu.com/ubuntu/#http://ubuntu.osuosl.org/ubuntu/#' -i /etc/apt/sources.list.d/ubuntu-latest-mirrors.list
+          cat /etc/apt/sources.list | sudo tee -a /etc/apt/sources.list.d/ubuntu-latest-mirrors.list > /dev/null
+          sudo sed 's#http://azure.archive.ubuntu.com/ubuntu/#http://mirrors.ocf.berkeley.edu/ubuntu/#' -i /etc/apt/sources.list.d/ubuntu-latest-mirrors.list
           sudo apt-get -o Acquire::Retries=3 update
           sudo apt-get install mtools
 

--- a/.github/workflows/build-firmware.yaml
+++ b/.github/workflows/build-firmware.yaml
@@ -318,6 +318,10 @@ jobs:
     - name: Install multilib, mingw, sshpass and mtools
       if: ${{ env.skip != 'true' }}
       run: |
+        sudo cp /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu-latest-mirrors.list
+        sudo sed 's#http://azure.archive.ubuntu.com/ubuntu/#http://ubuntu.osuosl.org/ubuntu/#' -i /etc/apt/sources.list.d/ubuntu-latest-mirrors.list
+        cat /etc/apt/sources.list | sudo tee -a /etc/apt/sources.list.d/ubuntu-latest-mirrors.list > /dev/null
+        sudo sed 's#http://azure.archive.ubuntu.com/ubuntu/#http://mirrors.ocf.berkeley.edu/ubuntu/#' -i /etc/apt/sources.list.d/ubuntu-latest-mirrors.list
         sudo apt-get -o Acquire::Retries=3 update
         sudo apt-get install gcc-multilib g++-multilib g++-mingw-w64 gcc-mingw-w64 sshpass mtools
         sudo apt-get install zip

--- a/.github/workflows/build-rusEFI-console.yaml
+++ b/.github/workflows/build-rusEFI-console.yaml
@@ -28,6 +28,10 @@ jobs:
 
       - name: Install Tools
         run: |
+          sudo cp /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu-latest-mirrors.list
+          sudo sed 's#http://azure.archive.ubuntu.com/ubuntu/#http://ubuntu.osuosl.org/ubuntu/#' -i /etc/apt/sources.list.d/ubuntu-latest-mirrors.list
+          cat /etc/apt/sources.list | sudo tee -a /etc/apt/sources.list.d/ubuntu-latest-mirrors.list > /dev/null
+          sudo sed 's#http://azure.archive.ubuntu.com/ubuntu/#http://mirrors.ocf.berkeley.edu/ubuntu/#' -i /etc/apt/sources.list.d/ubuntu-latest-mirrors.list
           sudo apt-get -o Acquire::Retries=3 update
           sudo apt-get install sshpass mtools
 

--- a/.github/workflows/build-simulator.yaml
+++ b/.github/workflows/build-simulator.yaml
@@ -30,6 +30,10 @@ jobs:
 
     - name: Install multilib
       run: |
+        sudo cp /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu-latest-mirrors.list
+        sudo sed 's#http://azure.archive.ubuntu.com/ubuntu/#http://ubuntu.osuosl.org/ubuntu/#' -i /etc/apt/sources.list.d/ubuntu-latest-mirrors.list
+        cat /etc/apt/sources.list | sudo tee -a /etc/apt/sources.list.d/ubuntu-latest-mirrors.list > /dev/null
+        sudo sed 's#http://azure.archive.ubuntu.com/ubuntu/#http://mirrors.ocf.berkeley.edu/ubuntu/#' -i /etc/apt/sources.list.d/ubuntu-latest-mirrors.list
         sudo apt-get -o Acquire::Retries=3 update
         sudo apt-get install gcc-multilib g++-multilib mtools dosfstools zip
 

--- a/.github/workflows/build-tsplugin-body.yaml
+++ b/.github/workflows/build-tsplugin-body.yaml
@@ -19,6 +19,10 @@ jobs:
 
       - name: Install Tools
         run: |
+          sudo cp /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu-latest-mirrors.list
+          sudo sed 's#http://azure.archive.ubuntu.com/ubuntu/#http://ubuntu.osuosl.org/ubuntu/#' -i /etc/apt/sources.list.d/ubuntu-latest-mirrors.list
+          cat /etc/apt/sources.list | sudo tee -a /etc/apt/sources.list.d/ubuntu-latest-mirrors.list > /dev/null
+          sudo sed 's#http://azure.archive.ubuntu.com/ubuntu/#http://mirrors.ocf.berkeley.edu/ubuntu/#' -i /etc/apt/sources.list.d/ubuntu-latest-mirrors.list
           sudo apt-get -o Acquire::Retries=3 update
           sudo apt-get install sshpass
 

--- a/.github/workflows/build-unit-tests.yaml
+++ b/.github/workflows/build-unit-tests.yaml
@@ -28,6 +28,10 @@ jobs:
     - name: Install required software (ubuntu)
       if: ${{ matrix.os != 'macos-latest' }}
       run: |
+        sudo cp /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu-latest-mirrors.list
+        sudo sed 's#http://azure.archive.ubuntu.com/ubuntu/#http://ubuntu.osuosl.org/ubuntu/#' -i /etc/apt/sources.list.d/ubuntu-latest-mirrors.list
+        cat /etc/apt/sources.list | sudo tee -a /etc/apt/sources.list.d/ubuntu-latest-mirrors.list > /dev/null
+        sudo sed 's#http://azure.archive.ubuntu.com/ubuntu/#http://mirrors.ocf.berkeley.edu/ubuntu/#' -i /etc/apt/sources.list.d/ubuntu-latest-mirrors.list
         sudo apt-get -o Acquire::Retries=3 update
         sudo apt-get install mtools zip dosfstools sshpass lcov valgrind
 

--- a/.github/workflows/gen-configs.yaml
+++ b/.github/workflows/gen-configs.yaml
@@ -22,6 +22,10 @@ jobs:
 
     - name: Install Tools
       run: |
+        sudo cp /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu-latest-mirrors.list
+        sudo sed 's#http://azure.archive.ubuntu.com/ubuntu/#http://ubuntu.osuosl.org/ubuntu/#' -i /etc/apt/sources.list.d/ubuntu-latest-mirrors.list
+        cat /etc/apt/sources.list | sudo tee -a /etc/apt/sources.list.d/ubuntu-latest-mirrors.list > /dev/null
+        sudo sed 's#http://azure.archive.ubuntu.com/ubuntu/#http://mirrors.ocf.berkeley.edu/ubuntu/#' -i /etc/apt/sources.list.d/ubuntu-latest-mirrors.list
         sudo apt-get -o Acquire::Retries=3 update
         sudo apt-get install sshpass sshpass mtools
 

--- a/.github/workflows/gen-diffs.yaml
+++ b/.github/workflows/gen-diffs.yaml
@@ -20,6 +20,10 @@ jobs:
 
     - name: Install sshpass, kicad, and tk bindings
       run: |
+        sudo cp /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu-latest-mirrors.list
+        sudo sed 's#http://azure.archive.ubuntu.com/ubuntu/#http://ubuntu.osuosl.org/ubuntu/#' -i /etc/apt/sources.list.d/ubuntu-latest-mirrors.list
+        cat /etc/apt/sources.list | sudo tee -a /etc/apt/sources.list.d/ubuntu-latest-mirrors.list > /dev/null
+        sudo sed 's#http://azure.archive.ubuntu.com/ubuntu/#http://mirrors.ocf.berkeley.edu/ubuntu/#' -i /etc/apt/sources.list.d/ubuntu-latest-mirrors.list
         sudo add-apt-repository --yes ppa:kicad/kicad-6.0-releases
         sudo apt-get -o Acquire::Retries=3 update
         sudo apt-get install sshpass kicad python3-pip python3-tk scour librsvg2-bin

--- a/.github/workflows/gen-docs.yaml
+++ b/.github/workflows/gen-docs.yaml
@@ -13,6 +13,10 @@ jobs:
 
     - name: Install prerequisite software
       run: |
+        sudo cp /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu-latest-mirrors.list
+        sudo sed 's#http://azure.archive.ubuntu.com/ubuntu/#http://ubuntu.osuosl.org/ubuntu/#' -i /etc/apt/sources.list.d/ubuntu-latest-mirrors.list
+        cat /etc/apt/sources.list | sudo tee -a /etc/apt/sources.list.d/ubuntu-latest-mirrors.list > /dev/null
+        sudo sed 's#http://azure.archive.ubuntu.com/ubuntu/#http://mirrors.ocf.berkeley.edu/ubuntu/#' -i /etc/apt/sources.list.d/ubuntu-latest-mirrors.list
         sudo apt-get -o Acquire::Retries=3 update
         sudo apt-get install doxygen graphviz sshpass
 

--- a/.github/workflows/gen-ibom.yaml
+++ b/.github/workflows/gen-ibom.yaml
@@ -17,6 +17,10 @@ jobs:
 
     - name: Install prerequisite software
       run: |
+        sudo cp /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu-latest-mirrors.list
+        sudo sed 's#http://azure.archive.ubuntu.com/ubuntu/#http://ubuntu.osuosl.org/ubuntu/#' -i /etc/apt/sources.list.d/ubuntu-latest-mirrors.list
+        cat /etc/apt/sources.list | sudo tee -a /etc/apt/sources.list.d/ubuntu-latest-mirrors.list > /dev/null
+        sudo sed 's#http://azure.archive.ubuntu.com/ubuntu/#http://mirrors.ocf.berkeley.edu/ubuntu/#' -i /etc/apt/sources.list.d/ubuntu-latest-mirrors.list
         sudo add-apt-repository ppa:kicad/kicad-5.1-releases
         sudo apt-get -o Acquire::Retries=3 update
         sudo apt-get install kicad sshpass

--- a/.github/workflows/set-date.yaml
+++ b/.github/workflows/set-date.yaml
@@ -21,6 +21,10 @@ jobs:
 
     - name: Install Tools
       run: |
+        sudo cp /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu-latest-mirrors.list
+        sudo sed 's#http://azure.archive.ubuntu.com/ubuntu/#http://ubuntu.osuosl.org/ubuntu/#' -i /etc/apt/sources.list.d/ubuntu-latest-mirrors.list
+        cat /etc/apt/sources.list | sudo tee -a /etc/apt/sources.list.d/ubuntu-latest-mirrors.list > /dev/null
+        sudo sed 's#http://azure.archive.ubuntu.com/ubuntu/#http://mirrors.ocf.berkeley.edu/ubuntu/#' -i /etc/apt/sources.list.d/ubuntu-latest-mirrors.list
         sudo apt-get -o Acquire::Retries=3 update
         sudo apt-get install subversion
 


### PR DESCRIPTION
re: https://github.com/rusefi/rusefi/pull/5037#issuecomment-1419135471, #4967.

Attempts to resolve issues with `archive.ubuntu.com` mirrors failing, without `apt-spy2`, by adding more mirrors to the `apt` configuration, which sources say will allow apt to use these additional mirrors in the case of failure.