### PR TITLE
Update to interactive-pinout@2.0

### DIFF
--- a/.github/workflows/gen-pinouts.yaml
+++ b/.github/workflows/gen-pinouts.yaml
@@ -17,7 +17,7 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Generate Pinouts
-      uses: chuckwagoncomputing/interactive-pinout@1.2
+      uses: chuckwagoncomputing/interactive-pinout@2.0
       with:
         mapping-path: ./firmware/config/boards/*/connectors/*.yaml
         warnings: "false"

--- a/firmware/config/boards/48way/connectors/main.yaml
+++ b/firmware/config/boards/48way/connectors/main.yaml
@@ -107,3 +107,6 @@ pins:
     - id: B14
       class: outputs
       ts_name: Ignition 4 Output (B14)
+
+info:
+  directory: 48way

--- a/firmware/config/boards/BB_V2/connectors/main.yaml
+++ b/firmware/config/boards/BB_V2/connectors/main.yaml
@@ -284,9 +284,6 @@ pins:
     type: hall
     ts_name: Digital input 2
 
-
-
-
-    
- 
+info:
+  directory: BB_V2
 

--- a/firmware/config/boards/BB_V3/connectors/main.yaml
+++ b/firmware/config/boards/BB_V3/connectors/main.yaml
@@ -297,9 +297,6 @@ pins:
     type: hall
     ts_name: Digital input 2
 
-
-
-
-    
- 
+info:
+  directory: BB_V3
 

--- a/firmware/config/boards/Benelli_Walbro/connectors/Benelli_Walbro.yaml
+++ b/firmware/config/boards/Benelli_Walbro/connectors/Benelli_Walbro.yaml
@@ -278,7 +278,8 @@ pins:
 
 info:
 # todo:  trigger build after PR
-  title: Benelli_Walbro 
+  title: Benelli_Walbro
+  directory: Benelli_Walbro
   name: 'Benelli_Walbro  !! NOTE: status is DRAFT !! - there a unknown and potential wrong pin assignments, these are flagged with "??" and "ToDo:"!!'
   board_url: https://rusefi.com/s/Benelli_Walbro
   image:

--- a/firmware/config/boards/GDI4/connectors/gdi4.yaml
+++ b/firmware/config/boards/GDI4/connectors/gdi4.yaml
@@ -108,6 +108,7 @@ info:
   title: GDI4
   name: GDI4
   board_url: https://rusefi.com/s/gdi4
+  directory: GDI4
   image:
     file: 121pin.jpg
 #copy-paste of firmware/config/boards/hellen/hellen121vag/connectors/ yaml file

--- a/firmware/config/boards/core8/connectors/main.yaml
+++ b/firmware/config/boards/core8/connectors/main.yaml
@@ -289,5 +289,6 @@ pins:
 
 info:
   title: Core8
+  directory: core8
   name: Core8
   board_url: https://rusefi.com/s/core8

--- a/firmware/config/boards/coreECU/connectors/main.yaml
+++ b/firmware/config/boards/coreECU/connectors/main.yaml
@@ -324,8 +324,5 @@ pins:
     type: hall
     ts_name: Digital Input 4
 
-
-
-    
- 
-
+info:
+  directory: coreECU

--- a/firmware/config/boards/frankenso/connectors/main.yaml
+++ b/firmware/config/boards/frankenso/connectors/main.yaml
@@ -224,4 +224,5 @@ pins:
     function: Injector #4
 
 info:
-  id: Frankenso
+  cid: Frankenso
+  directory: frankenso

--- a/firmware/config/boards/hellen/alphax-2chan/connectors/main.yaml
+++ b/firmware/config/boards/hellen/alphax-2chan/connectors/main.yaml
@@ -207,6 +207,7 @@ info:
   title: AlphaX 2chan
   name: AlphaX 2chan
   board_url: https://rusefi.com/s/2chan
+  directory: hellen/alphax-2chan
   image:
     file: alphax-2chan.jpg
   pins:

--- a/firmware/config/boards/hellen/alphax-4chan/connectors/main.yaml
+++ b/firmware/config/boards/hellen/alphax-4chan/connectors/main.yaml
@@ -406,6 +406,7 @@ info:
   title: AlphaX 4chan
   name: AlphaX 4chan
   board_url: https://rusefi.com/s/4chan
+  directory: hellen/alphax-4chan
   image:
     file: alphax-4chan.jpg
   pins:

--- a/firmware/config/boards/hellen/alphax-8chan/connectors/8chan-D.yaml
+++ b/firmware/config/boards/hellen/alphax-8chan/connectors/8chan-D.yaml
@@ -58,6 +58,7 @@ pins:
 
 info:
   title: AlphaX 8chan
+  directory: hellen/alphax-8chan
   name: AlphaX 8chan
   image:
     file: 8chan-D.jpg

--- a/firmware/config/boards/hellen/harley81/connectors/harley81.yaml
+++ b/firmware/config/boards/hellen/harley81/connectors/harley81.yaml
@@ -260,6 +260,7 @@ info:
   title: Hellen Harley 81
   name: Hellen Harley 81
   board_url: https://rusefi.com/s/harley81
+  directory: hellen/harley81
   image:
     file: harley81.jpg
   pins:

--- a/firmware/config/boards/hellen/hellen-112-17/connectors/main.yaml
+++ b/firmware/config/boards/hellen/hellen-112-17/connectors/main.yaml
@@ -163,8 +163,9 @@ pins:
 
 
 info:
-  id: H-112
+  cid: H-112
   title: H-112
+  directory: hellen/hellen-112-17
   name: H-112
   image:
     file: main.jpg

--- a/firmware/config/boards/hellen/hellen-gm-e67/connectors/main.yaml
+++ b/firmware/config/boards/hellen/hellen-gm-e67/connectors/main.yaml
@@ -491,10 +491,11 @@ pins:
 #
 
 info:
-  id: GM-E67
+  cid: GM-E67
   title: Hellen GM E67
   name: Hellen GM E67
   board_url: https://rusefi.com/s/gm-e67
+  directory: hellen/hellen-gm-e67
   image:
     file: main.jpg
   pins:

--- a/firmware/config/boards/hellen/hellen-honda-k/connectors/main.yaml
+++ b/firmware/config/boards/hellen/hellen-honda-k/connectors/main.yaml
@@ -323,10 +323,11 @@ pins:
     function: Check Engine
 
 info:
-  id: Honda-K
+  cid: Honda-K
   title: Hellen Honda K
   name: Hellen Honda K
   board_url: https://rusefi.com/s/honda-k
+  directory: hellen/hellen-honda-k
   image:
     file: hellen-k.jpg
   pins:

--- a/firmware/config/boards/hellen/hellen-nb1/connectors/main.yaml
+++ b/firmware/config/boards/hellen/hellen-nb1/connectors/main.yaml
@@ -363,6 +363,7 @@ pins:
 
 info:
   title: Hellen Miata NB1
+  directory: hellen/hellen-nb1
   image:
     file: main.jpg
   pins:

--- a/firmware/config/boards/hellen/hellen121nissan/connectors/main.yaml
+++ b/firmware/config/boards/hellen/hellen121nissan/connectors/main.yaml
@@ -374,6 +374,7 @@ info:
   title: Hellen 121 Nissan
   name: Hellen 121 Nissan
   board_url: https://github.com/rusefi/rusefi/wiki/Hellen-121-Nissan
+  directory: hellen/hellen121nissan
   image:
     file: 121pin.jpg
   pins:

--- a/firmware/config/boards/hellen/hellen121vag/connectors/main.yaml
+++ b/firmware/config/boards/hellen/hellen121vag/connectors/main.yaml
@@ -414,6 +414,7 @@ info:
   title: Hellen 121 VAG
   name: Hellen 121 VAG
   board_url: https://github.com/rusefi/rusefi/wiki/Hellen121VAG
+  directory: hellen/hellen121vag
   image:
     file: 121pin.jpg
   pins:

--- a/firmware/config/boards/hellen/hellen128/connectors/main.yaml
+++ b/firmware/config/boards/hellen/hellen128/connectors/main.yaml
@@ -670,10 +670,11 @@ pins:
     type: ign
 
 info:
-  id: Hellen-128
+  cid: Hellen-128
   title: Hellen 128 Mercedes
   name: Hellen 128 Mercedes
   board_url: https://rusefi.com/s/hellen128merc
+  directory: hellen/hellen128
   image:
     file: main.jpg
   pins:

--- a/firmware/config/boards/hellen/hellen154_9.7/connectors/main.yaml
+++ b/firmware/config/boards/hellen/hellen154_9.7/connectors/main.yaml
@@ -67,6 +67,7 @@ pins:
 
 info:
   title: Hellen 154 VAG GDI
+  directory: hellen/hellen154_9.7
   image:
     file: main.jpg
   pins:

--- a/firmware/config/boards/hellen/hellen154hyundai/connectors/main.yaml
+++ b/firmware/config/boards/hellen/hellen154hyundai/connectors/main.yaml
@@ -411,6 +411,7 @@ pins:
 
 info:
   board_url: https://github.com/rusefi/rusefi/wiki/Hellen-154-Hyundai
+  directory: hellen/hellen154hyundai
   title: Hellen 154 Hyundai
   image:
     file: main.jpg

--- a/firmware/config/boards/hellen/hellen64_miataNA6_94/connectors/main.yaml
+++ b/firmware/config/boards/hellen/hellen64_miataNA6_94/connectors/main.yaml
@@ -372,6 +372,7 @@ pins:
 
 info:
   title: Hellen Miata NA6
+  directory: hellen/hellen64_miataNA6_94
   image:
     file: main.jpg
   pins:

--- a/firmware/config/boards/hellen/hellen72/connectors/main.yaml
+++ b/firmware/config/boards/hellen/hellen72/connectors/main.yaml
@@ -604,6 +604,7 @@ pins:
 
 info:
   title: Hellen Miata NB2
+  directory: hellen/hellen72
   image:
     file: main.jpg
   pins:

--- a/firmware/config/boards/hellen/hellen81/connectors/main.yaml
+++ b/firmware/config/boards/hellen/hellen81/connectors/main.yaml
@@ -513,6 +513,7 @@ pins:
 
 info:
   title: Hellen 81
+  directory: hellen/hellen81
   image:
     file: main.jpg
   pins:

--- a/firmware/config/boards/hellen/hellen88bmw/connectors/main.yaml
+++ b/firmware/config/boards/hellen/hellen88bmw/connectors/main.yaml
@@ -225,4 +225,4 @@ pins:
 
 info:
   title: Hellen 88 BMW
-  pins:
+  directory: hellen/hellen88bmw

--- a/firmware/config/boards/hellen/hellenNA8_96/connectors/main.yaml
+++ b/firmware/config/boards/hellen/hellenNA8_96/connectors/main.yaml
@@ -321,6 +321,7 @@ pins:
 
 info:
   title: Hellen Miata NB1
+  directory: hellen/hellenNA8_96
   image:
     file: main.jpg
   pins:

--- a/firmware/config/boards/lambda-x2/connectors/main.yaml
+++ b/firmware/config/boards/lambda-x2/connectors/main.yaml
@@ -93,6 +93,7 @@ info:
   title: lambda-x2
   name: lambda-x2
   board_url: https://github.com/rusefi/rusefi-hardware/tree/main/lambda-x2
+  directory: lambda-x2
   image:
     file: alphax-2chan.jpg
   pins:

--- a/firmware/config/boards/microrusefi/connectors/main.yaml
+++ b/firmware/config/boards/microrusefi/connectors/main.yaml
@@ -363,7 +363,8 @@ info:
   title: microRusEFI
   name: Main Connector
   board_url: https://rusefi.com/s/microrusefi
-  id: main
+  directory: microrusefi
+  cid: main
   order: 0
   image:
     file: main.jpg

--- a/firmware/config/boards/proteus/connectors/black23.yaml
+++ b/firmware/config/boards/proteus/connectors/black23.yaml
@@ -152,7 +152,8 @@ info:
   title: Proteus
   name: Black23
   board_url: "https://wiki.rusefi.com/Hardware/Proteus/Proteus/"
-  id: black23
+  directory: proteus
+  cid: black23
   image:
     file: black23.jpg
   pins:

--- a/firmware/config/boards/proteus/connectors/black35.yaml
+++ b/firmware/config/boards/proteus/connectors/black35.yaml
@@ -238,7 +238,7 @@ pins:
 info:
   title: Proteus
   name: Black35
-  id: black23
+  cid: black23
   image:
     file: black35.jpg
   pins:

--- a/firmware/config/boards/proteus/connectors/white35.yaml
+++ b/firmware/config/boards/proteus/connectors/white35.yaml
@@ -185,7 +185,7 @@ pins:
 info:
   title: Proteus
   name: White35
-  id: white35
+  cid: white35
   image:
     file: white35.jpg
   pins:

--- a/firmware/config/boards/s105/connectors/s105.yaml
+++ b/firmware/config/boards/s105/connectors/s105.yaml
@@ -352,6 +352,7 @@ pins:
 
 info:
   title: S105
+  directory: s105
   name: S105
   image:
     file: 121pin.jpg

--- a/firmware/config/boards/skeleton/connectors/main.yaml
+++ b/firmware/config/boards/skeleton/connectors/main.yaml
@@ -268,3 +268,6 @@ pins:
     function: Crank VR+/hall
     ts_name: 45 - VR/Hall Crank
     type: vr hall
+
+info:
+  directory: skeleton

--- a/firmware/config/boards/subaru_eg33/connectors/C-B61.yaml
+++ b/firmware/config/boards/subaru_eg33/connectors/C-B61.yaml
@@ -84,3 +84,6 @@ pins:
     function: Tacho out
     ts_name: C16 - Tacho out
     type: gp_low
+
+info:
+  directory: subaru_eg33

--- a/firmware/config/boards/tdg-pdm8/connectors/main.yaml
+++ b/firmware/config/boards/tdg-pdm8/connectors/main.yaml
@@ -128,8 +128,9 @@ pins:
     ts_name: Sense 1
 
 info:
-  id: tdg-pdm8
+  cid: tdg-pdm8
   title: tdg-pdm8
+  directory: tdg-pdm8
   name: tdg-pdm8
   image:
     file: tdg-pdm8.jpg

--- a/firmware/config/boards/tdg-pdm8/connectors/x3.yaml
+++ b/firmware/config/boards/tdg-pdm8/connectors/x3.yaml
@@ -12,7 +12,7 @@ pins:
     function: SWDIO
 
 info:
-  id: tdg-pdm8-x3
+  cid: tdg-pdm8-x3
   title: tdg-pdm8-x3
   name: tdg-pdm8-x3
   image:


### PR DESCRIPTION
# TL;DR

Small breaking changes to yaml schema
I have update all YAMLs to reflect this
I'll consider myself responsible for updating the Connector-Mapping wiki page

# YAML Change 1

Older versions of interactive pinouts assumed that the pinouts were at `firmware/config/boards/<something>/connectors/<whatever>.yaml`, and made the `<something>` the directory the generated pinout was placed in within the pinouts directory.
e.g. `firmware/config/boards/microrusefi/connectors/main.yaml` -> `pinouts/microrusefi`

Now a field has been added to the `info` section of the yaml to specify the directory.
If it doesn't exist, the `title` field will be used as backup, and if that doesn't exist, the full path will be used, e.g. `pinouts/firmware/config/boards/microrusefi/connectors`

I have switched all yamls over, so the final directory structure hasn't changed. This required adding the info section to some boards.

# YAML Change 2

The `id` field in the `info` section has been changed to `cid`. I have updated all yamls to reflect this.
I think this will satisfy one of @mi-hol's complaints in https://github.com/rusefi/rusefi_documentation/issues/388