### PR TITLE
use new interactive-pinouts release, error on duplicates

### DIFF
--- a/.github/workflows/gen-pinouts.yaml
+++ b/.github/workflows/gen-pinouts.yaml
@@ -17,10 +17,11 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Generate Pinouts
-      uses: chuckwagoncomputing/interactive-pinout@2.0
+      uses: chuckwagoncomputing/interactive-pinout@2.1
       with:
         mapping-path: ./firmware/config/boards/*/connectors/*.yaml
         warnings: "false"
+        warning-dupe: "error"
         columns: |
           {
           "pin":"Pin Number",


### PR DESCRIPTION
Please note that in the current state, the workflow will fail.