### PR TITLE
gppwm Y axis doesn't work

### DIFF
--- a/firmware/controllers/actuators/gppwm/gppwm.cpp
+++ b/firmware/controllers/actuators/gppwm/gppwm.cpp
@@ -62,6 +62,6 @@ void updateGppwm() {
 
 		engine->outputChannels.gppwmOutput[i] = result.Result;
 		engine->outputChannels.gppwmXAxis[i] = result.X;
-		engine->outputChannels.gppwmYAxis[i] = result.X;
+		engine->outputChannels.gppwmYAxis[i] = result.Y;
 	}
 }


### PR DESCRIPTION
Fix the GPPWM Y axis display in TS/logs.