### PR TITLE
Build only one bundle

### DIFF
--- a/.github/workflows/build-firmware.yaml
+++ b/.github/workflows/build-firmware.yaml
@@ -298,8 +298,12 @@ jobs:
       run: echo '::error::Branch names must not contain ".", this breaks firmware autoupdates.' && exit 1
     - name: Execution throttle early exit
       # Don't skip any jobs if this workflow was run manually.
-      if: ${{ matrix.skip-rate && github.event_name != 'workflow_dispatch' }}
-      run: if (($(($RANDOM % 100)) < ${{ matrix.skip-rate }})); then echo "skip=true" >> $GITHUB_ENV; fi
+      if: ${{ matrix.skip-rate && github.event_name != 'workflow_dispatch' || contains(github.event.head_commit.message, 'only:') }}
+      run: |
+        if [ "$(echo ${{ github.event.head_commit.message }} | grep -Po '(?<=only:)[^\s]*')" = "${{ matrix.build-target }}" ]; then
+          exit 0
+        fi
+        if (($(($RANDOM % 100)) < ${{ matrix.skip-rate }})); then echo "skip=true" >> $GITHUB_ENV; fi
 
     - uses: actions/checkout@v3
       if: ${{ env.skip != 'true' }}

--- a/.github/workflows/build-firmware.yaml
+++ b/.github/workflows/build-firmware.yaml
@@ -296,14 +296,18 @@ jobs:
     - name: Check branch name
       if: ${{ contains(github.ref_name, '.') }}
       run: echo '::error::Branch names must not contain ".", this breaks firmware autoupdates.' && exit 1
+
     - name: Execution throttle early exit
-      # Don't skip any jobs if this workflow was run manually.
+      # Don't skip any jobs if this workflow was run manually,
+      # or if the commit contains `only:`, signifying that only one bundle should be built.
       if: ${{ matrix.skip-rate && github.event_name != 'workflow_dispatch' || contains(github.event.head_commit.message, 'only:') }}
       run: |
+        # if the commit message contains `only:`, get the part after the semicolon and check if it matches the build target.
         if echo ${{ github.event.head_commit.message }} | grep "only:"; then
           if [ "$(echo ${{ github.event.head_commit.message }} | grep -Po '(?<=only:)[^\s]*')" = "${{ matrix.build-target }}" ]; then
             exit 0
           else
+            # if it doesn't match, skip this job.
             echo "skip=true" >> $GITHUB_ENV
             exit 0
           fi

--- a/.github/workflows/build-firmware.yaml
+++ b/.github/workflows/build-firmware.yaml
@@ -300,8 +300,13 @@ jobs:
       # Don't skip any jobs if this workflow was run manually.
       if: ${{ matrix.skip-rate && github.event_name != 'workflow_dispatch' || contains(github.event.head_commit.message, 'only:') }}
       run: |
-        if [ "$(echo ${{ github.event.head_commit.message }} | grep -Po '(?<=only:)[^\s]*')" = "${{ matrix.build-target }}" ]; then
-          exit 0
+        if echo ${{ github.event.head_commit.message }} | grep "only:"; then
+          if [ "$(echo ${{ github.event.head_commit.message }} | grep -Po '(?<=only:)[^\s]*')" = "${{ matrix.build-target }}" ]; then
+            exit 0
+          else
+            echo "skip=true" >> $GITHUB_ENV
+            exit 0
+          fi
         fi
         if (($(($RANDOM % 100)) < ${{ matrix.skip-rate }})); then echo "skip=true" >> $GITHUB_ENV; fi
 


### PR DESCRIPTION
To use this mode, put `only:<bundle name>` in your commit message.
There must not be a space between `only:` and the name, and the name is case-sensitive.
Fix #5104