### PR TITLE
can msg tx: do not ignore bus argument

### DIFF
--- a/firmware/hw_layer/drivers/can/can_msg_tx.cpp
+++ b/firmware/hw_layer/drivers/can/can_msg_tx.cpp
@@ -43,7 +43,7 @@ CanTxMessage::CanTxMessage(CanCategory category, uint32_t eid, uint8_t dlc, size
 
 	setDlc(dlc);
 
-	setBus(0);
+	setBus(bus);
 
 	memset(m_frame.data8, 0, sizeof(m_frame.data8));
 #endif // HAL_USE_CAN || EFI_UNIT_TEST


### PR DESCRIPTION
bus argument was introduces in 12c899ddcab89ff79a40782bc82d473f90ae6bfc but was ignored.

@mck1117 ping