### PR TITLE
Reduce missing hex errors

### DIFF
--- a/firmware/config/boards/common_make.sh
+++ b/firmware/config/boards/common_make.sh
@@ -45,6 +45,7 @@ else
   # standalone images (for use with no bootloader)
   cp build/rusefi.bin  deliver/
   cp build/rusefi.dfu  deliver/
+  cp build/rusefi.hex  deliver/
 fi
 
 # bootloader and composite image


### PR DESCRIPTION
I'm not sure if hex is needed?
There will still be an error for boards that use an OpenBLT composite image. The comments in common_make.sh say not to deliver any format that can confuse users, so I didn't copy the .hex for those boards.
Before:
![image](https://user-images.githubusercontent.com/1531127/221383551-ffc8b1db-a5dd-4ce6-ba53-00b5a7fd8dab.png)
After:
![image](https://user-images.githubusercontent.com/1531127/221383562-ac20943d-b3fe-4b31-896a-c1e0df15e3de.png)
