### PR TITLE
Fix nightly again

### DIFF
--- a/.github/workflows/build-firmware.yaml
+++ b/.github/workflows/build-firmware.yaml
@@ -36,6 +36,7 @@ jobs:
       with:
         github_token: ${{ secrets.ACCESS_TOKEN }}
         custom_tag: ${{ env.date }}
+        tag_prefix: ''
 
     - name: Create Release
       if: ${{ env.full == 'true' && env.upload == 'release' }}

--- a/.github/workflows/build-firmware.yaml
+++ b/.github/workflows/build-firmware.yaml
@@ -24,16 +24,13 @@ jobs:
           echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
         fi
 
-    - name: Fetch tags
-      if: ${{ env.full == 'true' && env.upload == 'release' }}
-      run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
-
-    - name: Check if tag exists
-      if: ${{ env.full == 'true' && env.upload == 'release' }}
-      run: git show-ref --tags --verify --quiet -- "refs/tags/${{ env.date }}" && echo "tagged=true" >> $GITHUB_ENV || echo "tagged=false" >> $GITHUB_ENV
+    - uses: mukunku/tag-exists-action@v1.2.0
+      id: checkTag
+      with:
+        tag: ${{ env.date }}
 
     - name: Create Release Tag
-      if: ${{ env.full == 'true' && env.upload == 'release' && env.tagged == 'false' }}
+      if: ${{ env.full == 'true' && env.upload == 'release' && steps.checkTag.outputs.exists == 'false' }}
       id: tag
       uses: mathieudutour/github-tag-action@v6.1
       with:


### PR DESCRIPTION
It didn't fail on my fork because it was running on a self-hosted runner that already had the repo checked out, d'oh.
The tag-exists-action doesn't need the repo to be checked out.

(I shut down my self hosted runner to test this)