### PR TITLE
firmware workflow schedule only for rusefi/rusefi

### DIFF
--- a/.github/workflows/build-firmware.yaml
+++ b/.github/workflows/build-firmware.yaml
@@ -18,7 +18,7 @@ jobs:
 
     - name: Set run condition variables
       run: |
-        if [ "${{github.event_name}}" = "schedule" ]; then
+        if [ "${{github.event_name}}" = "schedule" ] && [ "${{github.repository}}" = "rusefi/rusefi" ]; then
           echo "full=true" >> $GITHUB_ENV
           echo "upload=release" >> $GITHUB_ENV
           echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
@@ -360,7 +360,7 @@ jobs:
 
     - name: Set run condition variables
       run: |
-        if [ "${{github.event_name}}" = "schedule" ]; then
+        if [ "${{github.event_name}}" = "schedule" ] && [ "${{github.repository}}" = "rusefi/rusefi" ]; then
           echo "full=true" >> $GITHUB_ENV
           echo "upload=release" >> $GITHUB_ENV
           echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_ENV


### PR DESCRIPTION
for https://github.com/rusefi/rusefi/issues/5117#issuecomment-1454313413

avoids failing release scheduled runs for non-golden repos, allowing to keep the workflow and associated notifications and avoid spam about unconcerning failures: https://github.com/nmschulte/rusefi/actions/runs/4443042591/jobs/7799915165#step:4:15

please double check my work:
- condition is correct? https://docs.github.com/en/actions/learn-github-actions/contexts#github-context
- concern in all the correct places?