### PR TITLE
set aim dash CAN gear frame to current gear

### DIFF
--- a/firmware/controllers/can/can_dash.cpp
+++ b/firmware/controllers/can/can_dash.cpp
@@ -1228,7 +1228,7 @@ struct Aim5f4 {
 	scaled_channel<uint16_t, 10000> Boost;
 	scaled_channel<uint16_t, 3200> Vbat;
 	scaled_channel<uint16_t, 10> FuelUse;
-	scaled_channel<uint16_t, 10> Gear;
+	scaled_channel<int16_t, 1> Gear;
 };
 
 static void populateFrame(Aim5f4& msg) {

--- a/firmware/controllers/can/can_dash.cpp
+++ b/firmware/controllers/can/can_dash.cpp
@@ -1239,7 +1239,7 @@ static void populateFrame(Aim5f4& msg) {
 	msg.Boost = boostBar;
 	msg.Vbat = Sensor::getOrZero(SensorType::BatteryVoltage);
 	msg.FuelUse = 0;
-	msg.Gear = 0;
+	msg.Gear = Sensor::getOrZero(SensorType::CurrentGear);
 }
 
 struct Aim5f5 {


### PR DESCRIPTION
Small edit sending gear over CAN with AIM dashboards, I want it to update with rpm/vss gear calculations. 
From the AIM documentation, it seems like it's supposed to be a signed 16 bit int:
![image](https://user-images.githubusercontent.com/25947228/230588853-01ee311b-0a67-4a1e-8f10-fb4d39be5b0a.png)

Currently the frame struct is using `scaled_channel<uint16_t, 10>`, so I imagine it should be changed to `scaled_channel<int16_t, 1>`?