### PR TITLE
Fix invoking virtual functions from constructors

### DIFF
--- a/firmware/controllers/trigger/trigger_decoder.cpp
+++ b/firmware/controllers/trigger/trigger_decoder.cpp
@@ -54,7 +54,7 @@
 TriggerDecoderBase::TriggerDecoderBase(const char* name)
 	: name(name)
 {
-	resetState();
+	TriggerDecoderBase::resetState();
 }
 
 bool TriggerDecoderBase::getShaftSynchronized() {

--- a/firmware/util/math/efi_pid.cpp
+++ b/firmware/util/math/efi_pid.cpp
@@ -25,7 +25,7 @@ void Pid::initPidClass(pid_s *parameters) {
 	this->parameters = parameters;
 	resetCounter = 0;
 
-	reset();
+	Pid::reset();
 }
 
 bool Pid::isSame(const pid_s *parameters) const {
@@ -190,12 +190,12 @@ void Pid::updateITerm(float value) {
 
 PidCic::PidCic() {
 	// call our derived reset()
-	reset();
+	PidCic::reset();
 }
 
 PidCic::PidCic(pid_s *parameters) : Pid(parameters) {
 	// call our derived reset()
-	reset();
+	PidCic::reset();
 }
 
 void PidCic::reset(void) {


### PR DESCRIPTION
Virtual functions should not be invoked from a constructor or destructor of the same class. Confusingly, virtual functions are resolved statically (not dynamically) in constructors and destructors for the same class. The call should be made explicitly static by qualifying it using the scope resolution operator.