### PR TITLE
Add Transmission range input

### DIFF
--- a/firmware/controllers/algo/engine.h
+++ b/firmware/controllers/algo/engine.h
@@ -48,6 +48,7 @@
 #include "fuel_schedule.h"
 #include "prime_injection.h"
 #include "throttle_model.h"
+#include "gc_generic.h"
 
 #ifndef EFI_UNIT_TEST
 #error EFI_UNIT_TEST must be defined!

--- a/firmware/controllers/controllers.mk
+++ b/firmware/controllers/controllers.mk
@@ -61,6 +61,7 @@ CONTROLLERS_SRC_CPP = \
 	$(CONTROLLERS_DIR)/tcu/buttonshift.cpp \
 	$(CONTROLLERS_DIR)/tcu/tcu.cpp \
 	$(CONTROLLERS_DIR)/tcu/gear_controller.cpp \
+	$(CONTROLLERS_DIR)/tcu/gc_generic.cpp \
 	$(CONTROLLERS_DIR)/tcu/simple_tcu.cpp \
 	$(CONTROLLERS_DIR)/tcu/tc_4l6x.cpp \
 	$(CONTROLLERS_DIR)/shutdown_controller.cpp \

--- a/firmware/controllers/engine_controller.cpp
+++ b/firmware/controllers/engine_controller.cpp
@@ -60,6 +60,7 @@
 #include "dynoview.h"
 #include "vr_pwm.h"
 #include "adc_subscription.h"
+#include "gc_generic.h"
 
 #if EFI_SENSOR_CHART
 #include "sensor_chart.h"

--- a/firmware/controllers/tcu/buttonshift.h
+++ b/firmware/controllers/tcu/buttonshift.h
@@ -15,8 +15,8 @@ class ButtonShiftController: public GearControllerBase {
 public:
 	ButtonShiftController();
 
-	void update() override;
-  void init() override;
+	void update();
+  void init();
 	GearControllerMode getMode() const {
 		return GearControllerMode::ButtonShift;
 	}

--- a/firmware/controllers/tcu/gc_generic.cpp
+++ b/firmware/controllers/tcu/gc_generic.cpp
@@ -1,0 +1,107 @@
+#include "pch.h"
+
+#include "gc_generic.h"
+
+#if EFI_TCU
+GenericGearController genericGearController;
+
+GenericGearController::GenericGearController() {
+}
+
+void GenericGearController::init() {
+	for (int i = 0; i < efi::size(engineConfiguration->tcu_rangeInput); i++) {
+		if (isBrainPinValid(engineConfiguration->tcu_rangeInput[i])) {
+			efiSetPadMode("Range Input", engineConfiguration->tcu_rangeInput[i], getInputMode(engineConfiguration->tcu_rangeInputMode[i]));
+		}
+	}
+
+	GearControllerBase::init();
+}
+
+void GenericGearController::update() {
+	SelectedGear gear = SelectedGear::Invalid;
+	// 1-9 because 0 is SelectedGear::Invalid
+	for (int i = 1; i <= 9; i++) {
+		uint8_t *rangeStates = getRangeStateArray(i);
+		for (int p = 0; p < efi::size(engineConfiguration->tcu_rangeInput); p++) {
+			int cellState = rangeStates[p];
+			if (!isBrainPinValid(engineConfiguration->tcu_rangeInput[p]) || cellState == 3) {
+				gear = SelectedGear::Invalid;
+				break;
+			}
+			bool pinState = efiReadPin(engineConfiguration->tcu_rangeInput[p]);
+			if (cellState == 2 || (pinState && cellState == 1) || (!pinState && cellState == 0)) {
+				gear = static_cast<SelectedGear>(i);
+				continue;
+			}
+		}
+		if (gear == SelectedGear::Invalid) {
+			continue;
+		} else {
+			break;
+		}
+	}
+	if (gear != SelectedGear::Invalid) {
+		switch (gear) {
+		case SelectedGear::Manual3 :
+			setDesiredGear(GEAR_3);
+			break;
+		case SelectedGear::Manual2 :
+			setDesiredGear(GEAR_2);
+			break;
+		case SelectedGear::Manual1 :
+			setDesiredGear(GEAR_1);
+			break;
+		case SelectedGear::Reverse :
+			setDesiredGear(REVERSE);
+			break;
+		case SelectedGear::Park :
+		case SelectedGear::Neutral :
+			setDesiredGear(NEUTRAL);
+			break;
+		case SelectedGear::ManualPlus :
+			switch (getDesiredGear()) {
+			case GEAR_1 :
+				setDesiredGear(GEAR_2);
+				break;
+			case GEAR_2 :
+				setDesiredGear(GEAR_3);
+				break;
+			case GEAR_3 :
+				setDesiredGear(GEAR_4);
+				break;
+			default:
+				break;
+			}
+			break;
+		case SelectedGear::ManualMinus :
+			switch (getDesiredGear()) {
+			case GEAR_2 :
+				setDesiredGear(GEAR_1);
+				break;
+			case GEAR_3 :
+				setDesiredGear(GEAR_2);
+				break;
+			case GEAR_4 :
+				setDesiredGear(GEAR_3);
+				break;
+			default:
+				break;
+			}
+			break;
+		case SelectedGear::Drive :
+			// TODO
+			//  for Drive, need shift tables etc.
+			break;
+		default:
+			break;
+		}
+	}
+
+	GearControllerBase::update();
+}
+
+GenericGearController* getGenericGearController() {
+	return &genericGearController;
+}
+#endif // EFI_TCU

--- a/firmware/controllers/tcu/gc_generic.cpp
+++ b/firmware/controllers/tcu/gc_generic.cpp
@@ -20,23 +20,32 @@ void GenericGearController::init() {
 
 void GenericGearController::update() {
 	SelectedGear gear = SelectedGear::Invalid;
+	// Loop through possible range states
 	// 1-9 because 0 is SelectedGear::Invalid
 	for (int i = 1; i <= 9; i++) {
 		uint8_t *rangeStates = getRangeStateArray(i);
+		// Loop through inputs
 		for (int p = 0; p < efi::size(engineConfiguration->tcu_rangeInput); p++) {
 			int cellState = rangeStates[p];
-			if (!isBrainPinValid(engineConfiguration->tcu_rangeInput[p]) || cellState == 3) {
+			// If the pin isn't configured and it matters, or if we've locked out this range with 3 in a cell
+			if ((!isBrainPinValid(engineConfiguration->tcu_rangeInput[p]) && cellState != 2) || cellState == 3) {
 				gear = SelectedGear::Invalid;
 				break;
 			}
 			bool pinState = efiReadPin(engineConfiguration->tcu_rangeInput[p]);
+			// If the pin doesn't matter, and it matches the cellState
 			if (cellState == 2 || (pinState && cellState == 1) || (!pinState && cellState == 0)) {
+			        // Set the gear to the one we're checking, and continue to the next pin
 				gear = static_cast<SelectedGear>(i);
-				continue;
+			} else {
+				// This possibility doesn't match, set to invalid
+				gear = SelectedGear::Invalid;
 			}
 		}
+		// If we didn't find it, try the next range
 		if (gear == SelectedGear::Invalid) {
 			continue;
+		// We found a match
 		} else {
 			break;
 		}

--- a/firmware/controllers/tcu/gc_generic.h
+++ b/firmware/controllers/tcu/gc_generic.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "gear_controller.h"
+
+#if EFI_TCU
+class GenericGearController: public GearControllerBase {
+public:
+  GenericGearController();
+
+	void update();
+  void init();
+	GearControllerMode getMode() const {
+		return GearControllerMode::Generic;
+	}
+};
+
+GenericGearController* getGenericGearController();
+#endif // EFI_TCU

--- a/firmware/controllers/tcu/gear_controller.cpp
+++ b/firmware/controllers/tcu/gear_controller.cpp
@@ -55,10 +55,53 @@ void initGearController() {
 	case GearControllerMode::ButtonShift :
 		engine->gearController = getButtonShiftController();
 		break;
+	case GearControllerMode::Generic :
+		engine->gearController = getGenericGearController();
+		break;
 	default :
 		engine->gearController = NULL;
 		return;
 	}
 	engine->gearController->init();
+}
+
+uint8_t* GearControllerBase::getRangeStateArray(int i) {
+	switch (i) {
+	case 1 :
+		return config->tcu_rangePlus;
+		break;
+	case 2 :
+		return config->tcu_rangeMinus;
+		break;
+	case 3 :
+		return config->tcu_rangeP;
+		break;
+	case 4 :
+		return config->tcu_rangeR;
+		break;
+	case 5 :
+		return config->tcu_rangeN;
+		break;
+	case 6 :
+		return config->tcu_rangeD;
+		break;
+	case 7 :
+		return config->tcu_rangeM;
+		break;
+	case 8 :
+		return config->tcu_rangeM3;
+		break;
+	case 9 :
+		return config->tcu_rangeM2;
+		break;
+	case 10 :
+		return config->tcu_rangeM1;
+		break;
+	case 11 :
+		return config->tcu_rangeLow;
+		break;
+	default:
+		return NULL;
+	}
 }
 #endif // EFI_TCU

--- a/firmware/controllers/tcu/gear_controller.h
+++ b/firmware/controllers/tcu/gear_controller.h
@@ -20,6 +20,7 @@ protected:
 	virtual gear_e setDesiredGear(gear_e);
 	void initTransmissionController();
 	TransmissionControllerBase *transmissionController;
+	uint8_t* getRangeStateArray(int);
 private:
 	gear_e desiredGear = NEUTRAL;
 	void postState();

--- a/firmware/controllers/tcu/tcu.cpp
+++ b/firmware/controllers/tcu/tcu.cpp
@@ -30,7 +30,12 @@ gear_e TransmissionControllerBase::getCurrentGear() const {
 
 void TransmissionControllerBase::postState() {
 #if EFI_TUNER_STUDIO
-    engine->outputChannels.tcuCurrentGear = getCurrentGear();
+	auto iss = Sensor::get(SensorType::InputShaftSpeed);
+	auto rpm = Sensor::get(SensorType::Rpm);
+	if (iss.Valid && rpm.Valid) {
+		engine->outputChannels.tcRatio = rpm.Value / iss.Value;
+	}
+	engine->outputChannels.tcuCurrentGear = getCurrentGear();
 #endif
 }
 

--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -160,6 +160,8 @@ struct_no_prefix engine_configuration_s
 #define TCU_SOLENOID_COUNT 6
 #define TCU_GEAR_COUNT 10
 
+#define RANGE_INPUT_COUNT 6
+
 ! Matt says: The problem is the driver chip. Tle9201 can't do 20k. The drivers are too slow. On purpose to reduce EMI
 ! https://rusefi.com/forum/viewtopic.php?p=47307#p47307
 #define ETB_HW_MAX_FREQUENCY 3000
@@ -1532,10 +1534,13 @@ pin_input_mode_e[LUA_DIGITAL_INPUT_COUNT iterate] luaDigitalInputPinModes;
 	uint32_t benchTestCount;How many test bench pulses do you want;"", 1, 0, 0, 10000000, 0
 	uint8_t autoscale iacByTpsHoldTime;How long initial IAC adder is held before starting to decay.;"seconds", 0.1, 0, 0, 25, 1
 	uint8_t autoscale iacByTpsDecayTime;How long it takes to remove initial IAC adder to return to normal idle.;"seconds", 0.1, 0, 0, 25, 1
+
+	switch_input_pin_e[RANGE_INPUT_COUNT iterate] tcu_rangeInput;
+	pin_input_mode_e[RANGE_INPUT_COUNT iterate] tcu_rangeInputMode;
 !
 ! Just a shortcut to facilitate compatible configuration changes, i.e. a change which does not touch FLASH_DATA_VERSION and thus does not require manual tune migration
 !
-uint8_t[214] mainUnusedEnd;;"units", 1, 0, 0, 1, 0
+uint8_t[194] mainUnusedEnd;;"units", 1, 0, 0, 1, 0
 
 ! end of engine_configuration_s
 end_struct
@@ -1779,6 +1784,18 @@ uint16_t[12] autoscale throttleEstimateEffectiveAreaValues;In units of g/s norma
 
 blend_table_s[BOOST_BLEND_COUNT iterate] boostOpenLoopBlends
 blend_table_s[BOOST_BLEND_COUNT iterate] boostClosedLoopBlends
+
+uint8_t[6] tcu_rangeP;;"level", 1, 0, 0, 3, 0
+uint8_t[6] tcu_rangeR;;"level", 1, 0, 0, 3, 0
+uint8_t[6] tcu_rangeN;;"level", 1, 0, 0, 3, 0
+uint8_t[6] tcu_rangeD;;"level", 1, 0, 0, 3, 0
+uint8_t[6] tcu_rangeM;;"level", 1, 0, 0, 3, 0
+uint8_t[6] tcu_rangeM3;;"level", 1, 0, 0, 3, 0
+uint8_t[6] tcu_rangeM2;;"level", 1, 0, 0, 3, 0
+uint8_t[6] tcu_rangeM1;;"level", 1, 0, 0, 3, 0
+uint8_t[6] tcu_rangePlus;;"level", 1, 0, 0, 3, 0
+uint8_t[6] tcu_rangeMinus;;"level", 1, 0, 0, 3, 0
+uint8_t[6] tcu_rangeLow;;"level", 1, 0, 0, 3, 0
 
 end_struct
 

--- a/firmware/tunerstudio/rusefi.input
+++ b/firmware/tunerstudio/rusefi.input
@@ -1894,17 +1894,16 @@ menuDialog = main
 		groupChildMenu = scriptCurve5Settings,				"Script Curve #5"
 		groupChildMenu = scriptCurve6Settings,				"Script Curve #6"
 
-# users are confused by TCU dialogs. open question how to repackage as pre-alpha
-#		subMenu = std_separator
-#		subMenu = tcuControls,			"Transmission Settings"
-#		subMenu = gearControls,			"Gear Selection Settings"
-#		subMenu = inputSpeedSensor, "Input Speed Sensor"
-#		subMenu = tcuSolenoidTableTbl,		"Shift Solenoids"
-#		subMenu = tccCurves, "TCC Lock/Unlock Speed"
-#		subMenu = pcPerGearDialog, "Line Pressure Per Gear"
-#		subMenu = pcPerShiftDialog, "Line Pressure Per Shift"
-#		subMenu = 32Dialog, "3-2 Shift Solenoid Percent by Speed"
-#		subMenu = rangeMatrixDialog, "Range Selector Input Matrix"
+		subMenu = std_separator
+		subMenu = tcuControls,			"Transmission Settings (alpha)"
+		subMenu = gearControls,			"Gear Selection Settings (alpha)"
+		subMenu = inputSpeedSensor,		"Input Speed Sensor (alpha)"
+		subMenu = tcuSolenoidTableTbl,		"Shift Solenoids (alpha)"
+		subMenu = tccCurves,			"TCC Lock/Unlock Speed (alpha)"
+		subMenu = pcPerGearDialog,		"Line Pressure Per Gear (alpha)"
+		subMenu = pcPerShiftDialog,		"Line Pressure Per Shift (alpha)"
+		subMenu = 32Dialog,			"3-2 Shift Solenoid Percent by Speed (alpha)"
+		subMenu = rangeMatrixDialog,		"Range Selector Input Matrix (alpha)"
 
 	menu = "&Sensors"
 		# Base analog input settings

--- a/firmware/tunerstudio/rusefi.input
+++ b/firmware/tunerstudio/rusefi.input
@@ -205,6 +205,9 @@ enable2ndByteCanID = false
 	gearCountArray = array, S08, [@@TCU_GEAR_COUNT@@], "Gear", 1, 0, -1, { @@TCU_GEAR_COUNT@@ - 2 }, 0, noMsqSave
 	solenoidCountArray = array, U08, [@@TCU_SOLENOID_COUNT@@], "Solenoid", 1, 0, 1, @@TCU_SOLENOID_COUNT@@, 0, noMsqSave
 
+	rangeInputArray = array, U08, [6], "Input", 1, 0, 0, 6, 0, noMsqSave
+	rangeStateArray = array, U08, [9], "State", 1, 0, 0, 9, 0, noMsqSave
+
 ; wall of debug mode :)
 ; https://rusefi.com/wiki/index.php?title=Manual:Debug_fields
 ;											Alternator					TPS Acceleration						Idle										Engine Load Acc		Trigger Counters									VVT1 PID													Cranking						Ignition Timing		Fu Corr  VSS			SD Card	Knock								Wall Wetting			ETB PID						Executor																				InstantRpm											CJ125				CAN			MAP													TLE8888			Analog inputs 2												Start									ETB Autotune																												DYNO_VIEW	LOGIC_ANALYZER	Wideband				TCU					Lua					VVT2 PID						VVT3 PID						VVT4 PID
@@ -314,6 +317,10 @@ enable2ndByteCanID = false
 	defaultValue = solenoidCountArray, 1 2 3 4 5 6 7 8
 	readOnly = solenoidCountArray
 
+	defaultValue = rangeStateArray, 0 1 2 3 4 5 6 7 8
+	readOnly = rangeStateArray
+	defaultValue = rangeInputArray, 0 1 2 3 4 5
+	readOnly = solenoidCountArray
 
 [CurveEditor]
 ;	xAxis		=  leftValue, rightValue, step
@@ -719,6 +726,34 @@ curve = 32Curve, "3-2 Shift Solenoid Percent by Speed"
 		yAxis = 0, 100, 10
 		xBins = tcu_32SpeedBins, vehicleSpeedKph
 		yBins = tcu_32Vals
+
+curve = rangeMatrix, "Range Switch Input Matrix"
+    columnLabel = "Pin", ""
+    xAxis = 0, 6, 6
+    yAxis = 0, 3, 3
+    xBins = rangeInputArray
+		yBins = tcu_rangeP
+		yBins = tcu_rangeR
+		yBins = tcu_rangeN
+		yBins = tcu_rangeD
+		yBins = tcu_rangeM
+		yBins = tcu_rangeM3
+		yBins = tcu_rangeM2
+		yBins = tcu_rangeM1
+		yBins = tcu_rangePlus
+		yBins = tcu_rangeMinus
+		yBins = tcu_rangeLow
+		lineLabel = "Park"
+		lineLabel = "Reverse"
+		lineLabel = "Neutral"
+		lineLabel = "Drive"
+		lineLabel = "Manual"
+		lineLabel = "Manual 3rd"
+		lineLabel = "Manual 2nd"
+		lineLabel = "Manual 1st"
+		lineLabel = "Manual +"
+		lineLabel = "Manual -"
+		lineLabel = "Low"
 
 	curve = ignAdder1Bias, "Ignition adder 1 bias"
 		columnLabel = "param", "bias"
@@ -1869,6 +1904,7 @@ menuDialog = main
 #		subMenu = pcPerGearDialog, "Line Pressure Per Gear"
 #		subMenu = pcPerShiftDialog, "Line Pressure Per Shift"
 #		subMenu = 32Dialog, "3-2 Shift Solenoid Percent by Speed"
+#		subMenu = rangeMatrixDialog, "Range Selector Input Matrix"
 
 	menu = "&Sensors"
 		# Base analog input settings
@@ -3945,6 +3981,16 @@ cmd_set_engine_type_default					= "@@TS_IO_TEST_COMMAND_char@@@@ts_command_e_TS_
 		field = "Filter parameter",		issFilterReciprocal, { tcuInputSpeedSensorPin != @@ADC_CHANNEL_NONE@@ }
 		field = "Tooth Count", tcuInputSpeedSensorTeeth
 
+dialog = rangeMatrixInputPanel, "Range Selector Inputs"
+		field = "Input 1 Pin", tcu_rangeInput1, { tcuEnabled }
+		field = "Input 1 Pin Mode", tcu_rangeInputMode1, { tcuEnabled }
+		field = "Input 2 Pin", tcu_rangeInput2, { tcuEnabled }
+		field = "Input 2 Pin Mode", tcu_rangeInputMode2, { tcuEnabled }
+		field = "Input 3 Pin", tcu_rangeInput3, { tcuEnabled }
+		field = "Input 3 Pin Mode", tcu_rangeInputMode3, { tcuEnabled }
+		field = "Input 4 Pin", tcu_rangeInput4, { tcuEnabled }
+		field = "Input 4 Pin Mode", tcu_rangeInputMode4, { tcuEnabled }
+
 dialog = tcuControls, "Transmission Settings"
 		panel = transmissionPanel
 		panel = shiftSolenoidPanel
@@ -3952,6 +3998,7 @@ dialog = tcuControls, "Transmission Settings"
 
 	dialog = gearControls, "Gear Selection Settings"
 		panel = buttonShiftInputPanel
+		panel = rangeMatrixInputPanel
 
 	dialog = inputSpeedSensor, "Input Speed Sensor"
 		panel = inputSpeedSensorPanel
@@ -3967,6 +4014,9 @@ dialog = tcuControls, "Transmission Settings"
 
 	dialog = 32Dialog, "3-2 Shift Solenoid Percent by Speed"
 		panel = 32Curve
+
+	dialog = rangeMatrixDialog, "Range Selector Input Matrix"
+		panel = rangeMatrix
 
 ;Boost Open Loop
 

--- a/firmware/tunerstudio/rusefi.input
+++ b/firmware/tunerstudio/rusefi.input
@@ -4014,8 +4014,15 @@ dialog = tcuControls, "Transmission Settings"
 	dialog = 32Dialog, "3-2 Shift Solenoid Percent by Speed"
 		panel = 32Curve
 
-	dialog = rangeMatrixDialog, "Range Selector Input Matrix"
-		panel = rangeMatrix
+	dialog = rangeMatrixDocumentation, "Cell Values"
+		field = "0 = this pin must be low to reach this state"
+		field = "1 = this pin must be high to reach this state"
+		field = "2 = this pin is ignored for reaching this state"
+		field = "3 = this state is unreachable"
+
+	dialog = rangeMatrixDialog, "Range Selector Input Matrix", border
+		panel = rangeMatrix, Center
+		panel = rangeMatrixDocumentation, South
 
 ;Boost Open Loop
 


### PR DESCRIPTION
I haven't PR'd this until now because I'm not terribly pleased with how I ended up doing the TS UI, but I can't think of a better way.

![image](https://github.com/rusefi/rusefi/assets/1531127/c639cae7-f669-4c5e-a006-df946039bb14)

Being able to hide the graph by default would be an improvement, but I don't think it's possible.

I also put the transmission settings back in the menu with an "(alpha)" label. If this isn't acceptable, I'm open to suggestions.