### PR TITLE
picking fresh Chibios branch 20 via stable_20.3.x_rusefi_2023.07.06

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "firmware/ChibiOS"]
 	path = firmware/ChibiOS
 	url = https://github.com/rusefi/ChibiOS.git
-	branch = stable_20.3.x.rusefi_clean_history
+	branch = stable_20.3.x_rusefi_2023.07.06
 [submodule "firmware/ChibiOS-Contrib"]
 	path = firmware/ChibiOS-Contrib
 	url = https://github.com/rusefi/ChibiOS-Contrib.git


### PR DESCRIPTION
A few different things are happening here
* as is https://github.com/ChibiOS/ChibiOS/tree/stable_20.3.x simply does not compile potentially for at least two different reasons

* https://github.com/rusefi/ChibiOS/tree/stable_21.11.x.rusefi is great but merge commits are making history hard to read
* well that reminds me that we kind of should contribute to https://github.com/ChibiOS/ChibiOS see some tickets at https://github.com/rusefi/ChibiOS/issues
* https://github.com/rusefi/ChibiOS/tree/stable_20.3.x.rusefi_clean_history is linear version of stable_21.11.x.rusefi actually let me create a separate migration ticket

https://github.com/rusefi/ChibiOS/tree/stable_20.3.x_rusefi_2023.07.06 is today ChibiOS with https://github.com/rusefi/ChibiOS/tree/stable_20.3.x.rusefi_clean_history commits added on top of it


