### PR TITLE
picking mildly fresh Chibios branch 20 version - our commits replayed over same tag of ChibiOS as before

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "firmware/ChibiOS"]
 	path = firmware/ChibiOS
 	url = https://github.com/rusefi/ChibiOS.git
-	branch = stable_20.3.x.rusefi
+	branch = stable_20.3.x.rusefi_clean_history
 [submodule "firmware/ChibiOS-Contrib"]
 	path = firmware/ChibiOS-Contrib
 	url = https://github.com/rusefi/ChibiOS-Contrib.git


### PR DESCRIPTION
All our commits replayed on top of all original commits, same tag as https://github.com/rusefi/ChibiOS/tree/stable_21.11.x.rusefi - no new ChibiOS commits

Since our commits are now on top of all chibios merges there were some minor merge conflicts in cases where ChibiOS has fixed same stuff we have fixed

https://github.com/rusefi/ChibiOS/tree/stable_21.11.x.rusefi
https://github.com/rusefi/ChibiOS/tree/stable_20.3.x.rusefi_clean_history