### PR TITLE
remove leading ./

### DIFF
--- a/.github/workflows/gen-pinouts.yaml
+++ b/.github/workflows/gen-pinouts.yaml
@@ -17,9 +17,9 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Generate Pinouts
-      uses: chuckwagoncomputing/interactive-pinout@2.7
+      uses: chuckwagoncomputing/interactive-pinout@2.8
       with:
-        mapping-path: ./firmware/config/boards/*/connectors/*.yaml
+        mapping-path: firmware/config/boards/*/connectors/*.yaml
         warnings: "false"
         warning-dupe: "error"
         columns: |


### PR DESCRIPTION
I broke this without realizing it. Before, a leading ./ was required, now it must not be present.