### PR TITLE
fix mixed up CLT & IAT in the bench_test_raw_analog CAN packet

### DIFF
--- a/firmware/controllers/can/can_bench_test.cpp
+++ b/firmware/controllers/can/can_bench_test.cpp
@@ -61,8 +61,8 @@ void sendRawAnalogValues() {
 		Sensor::getRaw(SensorType::AcceleratorPedalPrimary),
 		Sensor::getRaw(SensorType::AcceleratorPedalSecondary),
 		Sensor::getRaw(SensorType::MapSlow),
-		Sensor::getRaw(SensorType::Iat),
 		Sensor::getRaw(SensorType::Clt),
+		Sensor::getRaw(SensorType::Iat),
 		Sensor::getRaw(SensorType::BatteryVoltage),
 	};
 


### PR DESCRIPTION
https://github.com/rusefi/rusefi-hardware/issues/228