### PR TITLE
After-start enrichment handling more similar to OEM

### DIFF
--- a/firmware/CHANGELOG.md
+++ b/firmware/CHANGELOG.md
@@ -30,6 +30,7 @@ Release template (copy/paste this for new release):
 
 ### Breaking Changes
  - "acIdleRpmBump" renamed to "acIdleRpmTarget", and changed the way of RPM rise needed for proper A/C operation from added to absolute target #5628
+ - After Cranking Enrichment changed from fixed value to table, it can help with some engines that want lots of fuel on cold, but don't run too well with big enrichment on hot
 
 ### Added
  - DAC with Lua #5601

--- a/firmware/config/boards/hellen/hellen121nissan/board_configuration.cpp
+++ b/firmware/config/boards/hellen/hellen121nissan/board_configuration.cpp
@@ -139,16 +139,6 @@ void setBoardDefaultConfiguration() {
 	setPPSCalibration(0.75, 4.45, 0.43, 2.20);
 
 	engineConfiguration->startUpFuelPumpDuration = 4;
-	
-	static const float defaultPostCrankingCLTBins[] = {
-		-20.0f, 0.0f, 30.0f, 60.0f
-	};
-	static const uint16_t defaultPostCrankinDurationBins[] = {
-		0, 2, 4, 6, 8, 10, 12, 15
-	};
-	copyArray(engineConfiguration->postCrankingCLTBins, defaultPostCrankingCLTBins);
-	copyArray(engineConfiguration->postCrankingDurationBins, defaultPostCrankinDurationBins);
-	setTable(engineConfiguration->postCrankingFactor, 1.0f);
 
     setEtbPID(6.1350, 87.7182, 0.0702);
 

--- a/firmware/config/boards/hellen/hellen121nissan/board_configuration.cpp
+++ b/firmware/config/boards/hellen/hellen121nissan/board_configuration.cpp
@@ -139,7 +139,16 @@ void setBoardDefaultConfiguration() {
 	setPPSCalibration(0.75, 4.45, 0.43, 2.20);
 
 	engineConfiguration->startUpFuelPumpDuration = 4;
-	engineConfiguration->postCrankingFactor = 1.05;
+	
+	static const float defaultPostCrankingCLTBins[] = {
+		-20.0f, 0.0f, 30.0f, 60.0f
+	};
+	static const uint16_t defaultPostCrankinDurationBins[] = {
+		0, 2, 4, 6, 8, 10, 12, 15
+	};
+	copyArray(engineConfiguration->postCrankingCLTBins, defaultPostCrankingCLTBins);
+	copyArray(engineConfiguration->postCrankingDurationBins, defaultPostCrankinDurationBins);
+	setTable(engineConfiguration->postCrankingFactor, 1.0f);
 
     setEtbPID(6.1350, 87.7182, 0.0702);
 

--- a/firmware/config/engines/custom_engine.cpp
+++ b/firmware/config/engines/custom_engine.cpp
@@ -889,17 +889,6 @@ void detectBoardType() {
 void fuelBenchMode() {
     engineConfiguration->cranking.rpm = 12000;
     setFlatInjectorLag(0);
-
-	static const float defaultPostCrankingCLTBins[] = {
-		-20.0f, 0.0f, 30.0f, 60.0f
-	};
-	static const uint16_t defaultPostCrankinDurationBins[] = {
-		0, 2, 4, 6, 8, 10, 12, 15
-	};
-	copyArray(engineConfiguration->postCrankingCLTBins, defaultPostCrankingCLTBins);
-	copyArray(engineConfiguration->postCrankingDurationBins, defaultPostCrankinDurationBins);
-	setTable(engineConfiguration->postCrankingFactor, 1.0f);
-
 	setArrayValues(config->crankingFuelCoef, 1.0f);
 	setArrayValues(config->crankingCycleCoef, 1.0f);
     setBodyControlUnit();

--- a/firmware/config/engines/custom_engine.cpp
+++ b/firmware/config/engines/custom_engine.cpp
@@ -889,7 +889,17 @@ void detectBoardType() {
 void fuelBenchMode() {
     engineConfiguration->cranking.rpm = 12000;
     setFlatInjectorLag(0);
-    engineConfiguration->postCrankingFactor = 1;
+
+	static const float defaultPostCrankingCLTBins[] = {
+		-20.0f, 0.0f, 30.0f, 60.0f
+	};
+	static const uint16_t defaultPostCrankinDurationBins[] = {
+		0, 2, 4, 6, 8, 10, 12, 15
+	};
+	copyArray(engineConfiguration->postCrankingCLTBins, defaultPostCrankingCLTBins);
+	copyArray(engineConfiguration->postCrankingDurationBins, defaultPostCrankinDurationBins);
+	setTable(engineConfiguration->postCrankingFactor, 1.0f);
+
 	setArrayValues(config->crankingFuelCoef, 1.0f);
 	setArrayValues(config->crankingCycleCoef, 1.0f);
     setBodyControlUnit();

--- a/firmware/config/engines/custom_engine.cpp
+++ b/firmware/config/engines/custom_engine.cpp
@@ -889,6 +889,7 @@ void detectBoardType() {
 void fuelBenchMode() {
     engineConfiguration->cranking.rpm = 12000;
     setFlatInjectorLag(0);
+	setTable(engineConfiguration->postCrankingFactor, 1.0f);
 	setArrayValues(config->crankingFuelCoef, 1.0f);
 	setArrayValues(config->crankingCycleCoef, 1.0f);
     setBodyControlUnit();

--- a/firmware/config/engines/honda_k_dbc.cpp
+++ b/firmware/config/engines/honda_k_dbc.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "honda_k_dbc.h"
+#include "table_helper.h"
 
 #if HW_PROTEUS & EFI_PROD_CODE
 #include "proteus_meta.h"
@@ -42,7 +43,11 @@ void setHondaK() {
 	engineConfiguration->injectionMode = IM_SEQUENTIAL;
 
 	engineConfiguration->crankingIACposition = 70;
-    
+	static const uint16_t defaultPostCrankinDurationBins[] = {
+		0, 2, 4, 6, 8, 10, 12, 15
+	};
+	copyArray(engineConfiguration->postCrankingDurationBins, defaultPostCrankinDurationBins);
+	setTable(engineConfiguration->postCrankingFactor, 1.25f);
     engineConfiguration->useRunningMathForCranking = true;
 
 	strcpy(engineConfiguration->engineMake, ENGINE_MAKE_HONDA);

--- a/firmware/config/engines/honda_k_dbc.cpp
+++ b/firmware/config/engines/honda_k_dbc.cpp
@@ -6,7 +6,6 @@
  */
 
 #include "honda_k_dbc.h"
-#include "table_helper.h"
 
 #if HW_PROTEUS & EFI_PROD_CODE
 #include "proteus_meta.h"
@@ -44,16 +43,6 @@ void setHondaK() {
 
 	engineConfiguration->crankingIACposition = 70;
     
-	static const float defaultPostCrankingCLTBins[] = {
-		-20.0f, 0.0f, 30.0f, 60.0f
-	};
-	static const uint16_t defaultPostCrankingDurationBins[] = {
-		0, 2, 4, 6, 8, 10, 12, 15
-	};
-	copyArray(engineConfiguration->postCrankingCLTBins, defaultPostCrankingCLTBins);
-	copyArray(engineConfiguration->postCrankingDurationBins, defaultPostCrankingDurationBins);
-	setTable(engineConfiguration->postCrankingFactor, 1.0f);
-
     engineConfiguration->useRunningMathForCranking = true;
 
 	strcpy(engineConfiguration->engineMake, ENGINE_MAKE_HONDA);

--- a/firmware/config/engines/honda_k_dbc.cpp
+++ b/firmware/config/engines/honda_k_dbc.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "honda_k_dbc.h"
+#include "table_helper.h"
 
 #if HW_PROTEUS & EFI_PROD_CODE
 #include "proteus_meta.h"
@@ -42,8 +43,17 @@ void setHondaK() {
 	engineConfiguration->injectionMode = IM_SEQUENTIAL;
 
 	engineConfiguration->crankingIACposition = 70;
-    engineConfiguration->postCrankingFactor = 1.25;
-    engineConfiguration->postCrankingDurationSec = 15;
+    
+	static const float defaultPostCrankingCLTBins[] = {
+		-20.0f, 0.0f, 30.0f, 60.0f
+	};
+	static const uint16_t defaultPostCrankingDurationBins[] = {
+		0, 2, 4, 6, 8, 10, 12, 15
+	};
+	copyArray(engineConfiguration->postCrankingCLTBins, defaultPostCrankingCLTBins);
+	copyArray(engineConfiguration->postCrankingDurationBins, defaultPostCrankingDurationBins);
+	setTable(engineConfiguration->postCrankingFactor, 1.0f);
+
     engineConfiguration->useRunningMathForCranking = true;
 
 	strcpy(engineConfiguration->engineMake, ENGINE_MAKE_HONDA);

--- a/firmware/controllers/algo/defaults/default_cranking.cpp
+++ b/firmware/controllers/algo/defaults/default_cranking.cpp
@@ -23,10 +23,16 @@ void setDefaultCranking() {
 	// After start enrichment
 #if !EFI_UNIT_TEST
 	// don't set this for unit tests, as it makes things more complicated to test
-	engineConfiguration->postCrankingFactor = 1.2;
+	static const float defaultPostCrankingCLTBins[] = {
+		-20.0f, 0.0f, 30.0f, 60.0f
+	};
+	static const uint16_t defaultPostCrankinDurationBins[] = {
+		0, 2, 4, 6, 8, 10, 12, 15
+	};
+	copyArray(engineConfiguration->postCrankingCLTBins, defaultPostCrankingCLTBins);
+	copyArray(engineConfiguration->postCrankingDurationBins, defaultPostCrankinDurationBins);
+	setTable(engineConfiguration->postCrankingFactor, 1.0f);
 #endif
-
-	engineConfiguration->postCrankingDurationSec = 10;
 
 	setLinearCurve(config->crankingTpsCoef, /*from*/1, /*to*/1, 1);
 	setLinearCurve(config->crankingTpsBins, 0, 100, 1);

--- a/firmware/controllers/algo/defaults/default_cranking.cpp
+++ b/firmware/controllers/algo/defaults/default_cranking.cpp
@@ -27,11 +27,11 @@ void setDefaultCranking() {
 		-20.0f, 0.0f, 30.0f, 60.0f
 	};
 	static const uint16_t defaultPostCrankinDurationBins[] = {
-		0, 2, 4, 6, 8, 10, 12, 15
+		0, 1, 2, 3, 4, 6, 8, 10
 	};
 	copyArray(engineConfiguration->postCrankingCLTBins, defaultPostCrankingCLTBins);
 	copyArray(engineConfiguration->postCrankingDurationBins, defaultPostCrankinDurationBins);
-	setTable(engineConfiguration->postCrankingFactor, 1.0f);
+	setTable(engineConfiguration->postCrankingFactor, 1.2f);
 #endif
 
 	setLinearCurve(config->crankingTpsCoef, /*from*/1, /*to*/1, 1);

--- a/firmware/controllers/algo/engine2.cpp
+++ b/firmware/controllers/algo/engine2.cpp
@@ -125,7 +125,8 @@ void EngineState::periodicFastCallback() {
 		engineConfiguration->postCrankingDurationBins, engine->fuelComputer.running.timeSinceCrankingInSecs
 	);
 	// for compatibility reasons, apply only if the factor is greater than unity (only allow adding fuel)
-	if (m_postCrankingFactor < 1.0f) {
+	// if the engine run time is past the last duration bin, disable ASE in case the table is filled with values more than 1.0, helps with compatibility with older solutioin
+	if ((m_postCrankingFactor < 1.0f) || (engine->fuelComputer.running.timeSinceCrankingInSecs > engineConfiguration->postCrankingDurationBins[(sizeof(engineConfiguration->postCrankingDurationBins)/sizeof(engineConfiguration->postCrankingDurationBins[0]))-1])) {
 		m_postCrankingFactor = 1.0f;
 	}
 	engine->fuelComputer.running.postCrankingFuelCorrection = m_postCrankingFactor;

--- a/firmware/controllers/algo/engine2.cpp
+++ b/firmware/controllers/algo/engine2.cpp
@@ -125,8 +125,8 @@ void EngineState::periodicFastCallback() {
 		engineConfiguration->postCrankingDurationBins, engine->fuelComputer.running.timeSinceCrankingInSecs
 	);
 	// for compatibility reasons, apply only if the factor is greater than unity (only allow adding fuel)
-	// if the engine run time is past the last duration bin, disable ASE in case the table is filled with values more than 1.0, helps with compatibility with older solutioin
-	if ((m_postCrankingFactor < 1.0f) || (engine->fuelComputer.running.timeSinceCrankingInSecs > engineConfiguration->postCrankingDurationBins[(sizeof(engineConfiguration->postCrankingDurationBins)/sizeof(engineConfiguration->postCrankingDurationBins[0]))-1])) {
+	// if the engine run time is past the last bin, disable ASE in case the table is filled with values more than 1.0, helps with compatibility
+	if ((m_postCrankingFactor < 1.0f) || (engine->fuelComputer.running.timeSinceCrankingInSecs > engineConfiguration->postCrankingDurationBins[efi::size(engineConfiguration->postCrankingDurationBins)-1])) {
 		m_postCrankingFactor = 1.0f;
 	}
 	engine->fuelComputer.running.postCrankingFuelCorrection = m_postCrankingFactor;

--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -1246,8 +1246,11 @@ tle8888_mode_e tle8888mode;
 
 	pin_output_mode_e fan2PinMode;
 	float fuelReferencePressure;This is the pressure at which your injector flow is known.\nFor example if your injectors flow 400cc/min at 3.5 bar, enter 350kpa here.;"kPa", 1, 0, 50, 700000, 0
-	float postCrankingFactor;Fuel multiplier (enrichment) immediately after engine start;"mult", 1, 0, 1, 3, 2
-	float postCrankingDurationSec;Time over which to taper out after start enrichment;"seconds", 1, 0, 0, 30, 0
+
+	float[CRANKING_ADVANCE_CURVE_SIZE x DWELL_CURVE_SIZE] postCrankingFactor;;"mult", 1, 0, 1, 3, 2
+	float[CRANKING_ADVANCE_CURVE_SIZE] postCrankingCLTBins;;"C", 1, 0, -100, 100, 0
+	float[DWELL_CURVE_SIZE] postCrankingDurationBins;;"sec", 1, 0, 0, 1000, 0
+
 	ThermistorConf auxTempSensor1
 	ThermistorConf auxTempSensor2
 	int16_t knockSamplingDuration;;"Deg", 1, 0, 0, 720, 0

--- a/firmware/tunerstudio/rusefi.input
+++ b/firmware/tunerstudio/rusefi.input
@@ -1304,6 +1304,11 @@ curve = rangeMatrix, "Range Switch Input Matrix"
 		yBins	= hpfpCompensationLoadBins, running_fuel
 		zBins	= hpfpCompensation
 
+	table = postCrankingEnrichmentTbl, postCrankingEnrichmentMap, "After start enrichment", 1
+		xBins	= postCrankingCLTBins, coolant
+		yBins	= postCrankingDurationBins, seconds
+		zBins	= postCrankingFactor
+
 
 [GaugeConfigurations]
 @@LIVE_DATA_GAUGES_FROM_FILE@@
@@ -3964,10 +3969,6 @@ cmd_set_engine_type_default					= "@@TS_IO_TEST_COMMAND_char@@@@ts_command_e_TS_
 		field = "Timing Advance mode",	useSeparateAdvanceForCranking
 		field = "Fixed cranking advance",	crankingTimingAngle, {useSeparateAdvanceForCranking == 0}
 		field = "Fixed Cranking Dwell",						ignitionDwellForCrankingMs
-
-	dialog = postCrankingEnrichment, "After start enrichment"
-		field = "Post-Cranking factor",				postCrankingFactor
-		field = "Duration",				postCrankingDurationSec
 
 	dialog = primingFuelPulsePanel, "Priming fuel pulse"
 		field = "Priming delay",	primingDelay

--- a/firmware/tunerstudio/rusefi.input
+++ b/firmware/tunerstudio/rusefi.input
@@ -1839,7 +1839,7 @@ menuDialog = main
 
 	menu = "&Cranking"
 		subMenu = crankingDialog,			"Cranking settings"
-		subMenu = postCrankingEnrichment,	"After-start enrichment"
+		subMenu = postCrankingEnrichmentTbl,"After-start enrichment"
 		subMenu = primingFuelPulsePanel,	"Priming pulse"
 		subMenu = std_separator
 


### PR DESCRIPTION
My LPG-converted engine was not happy with fixed ASE for all temperatures.
That is because while cold it needs lots of fuel after start, but when the LPG evaporator is hot, and I'm using the hot-start feature it's giving too rich mixture.
LPG doesn't get along too well with overly rich mixtures (and cylinder head really hates this!) like petrol does.
I have implemented this as 3D table like in OEM and other Standalone EFI systems do.
Ideally the axis for duration should not be in seconds, but engine cycles... I'm still getting to know how rusEFI works...