### PR TITLE
ASE and CL Ignition fixes confirmed on the real car

### DIFF
--- a/firmware/config/engines/honda_k_dbc.cpp
+++ b/firmware/config/engines/honda_k_dbc.cpp
@@ -44,7 +44,7 @@ void setHondaK() {
 
 	engineConfiguration->crankingIACposition = 70;
 	static const uint16_t defaultPostCrankinDurationBins[] = {
-		0, 35, 65, 100, 125, 150, 200, 250
+		0, 65, 100, 125, 150, 250
 	};
 	copyArray(engineConfiguration->postCrankingDurationBins, defaultPostCrankinDurationBins);
 	setTable(engineConfiguration->postCrankingFactor, 1.25f);

--- a/firmware/controllers/actuators/idle_thread.cpp
+++ b/firmware/controllers/actuators/idle_thread.cpp
@@ -76,6 +76,12 @@ IIdleController::Phase IdleController::determinePhase(int rpm, int targetRpm, Se
 	}
 #endif // EFI_SHAFT_POSITION_INPUT
 
+	// If we are entering idle, and the PID settings are aggressive, it's good to make a soft entry upon entering closed loop
+	if (m_crankTaperEndTime == 0.0f) {
+		m_crankTaperEndTime = engine->fuelComputer.running.timeSinceCrankingInSecs;
+		m_idleTimingSoftEntryEndTime = m_crankTaperEndTime + engineConfiguration->idleTimingSoftEntryTime;
+	}
+
 	// No other conditions met, we are idling!
 	return Phase::Idling;
 }
@@ -187,18 +193,12 @@ float IdleController::getIdleTimingAdjustment(int rpm, int targetRpm, Phase phas
 	if (phase != Phase::Idling) {
 		m_timingPid.reset();
 		return 0;
-	} else {
-		// If we are entering idle, and the PID settings are aggressive, it's good to make a soft entry upon entering closed loop
-		if (m_lastPhase == Phase::CrankToIdleTaper) {
-			m_crankTaperEndTime = engine->fuelComputer.running.timeSinceCrankingInSecs;
-			m_idleTimingSoftEntryEndTime = m_crankTaperEndTime + engineConfiguration->idleTimingSoftEntryTime;
-		}
-		if (engineConfiguration->idleTimingSoftEntryTime > 0.0f) {
-			// Use interpolation for correction taper
-			m_timingPid.setErrorAmplification(interpolateClamped(m_crankTaperEndTime, 0.0f, m_idleTimingSoftEntryEndTime, 1.0f, engine->fuelComputer.running.timeSinceCrankingInSecs));
-		}
 	}
-
+	
+	if (engineConfiguration->idleTimingSoftEntryTime > 0.0f) {
+		// Use interpolation for correction taper
+		m_timingPid.setErrorAmplification(interpolateClamped(m_crankTaperEndTime, 0.0f, m_idleTimingSoftEntryEndTime, 1.0f, engine->fuelComputer.running.timeSinceCrankingInSecs));
+	}
 
 	// We're now in the idle mode, and RPM is inside the Timing-PID regulator work zone!
 	return m_timingPid.getOutput(targetRpm, rpm, FAST_CALLBACK_PERIOD_MS / 1000.0f);

--- a/firmware/controllers/algo/defaults/default_cranking.cpp
+++ b/firmware/controllers/algo/defaults/default_cranking.cpp
@@ -24,10 +24,10 @@ void setDefaultCranking() {
 #if !EFI_UNIT_TEST
 	// don't set this for unit tests, as it makes things more complicated to test
 	static const float defaultPostCrankingCLTBins[] = {
-		-20.0f, 0.0f, 30.0f, 60.0f
+		-20.0f, 0.0f, 20.0f, 40.0f, 60.0f, 80.0f
 	};
 	static const uint16_t defaultPostCrankinDurationBins[] = {
-		0, 15, 35, 50, 65, 100, 125, 150
+		0, 15, 35, 65, 100, 150
 	};
 	copyArray(engineConfiguration->postCrankingCLTBins, defaultPostCrankingCLTBins);
 	copyArray(engineConfiguration->postCrankingDurationBins, defaultPostCrankinDurationBins);

--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -177,6 +177,8 @@ struct_no_prefix engine_configuration_s
 
 #define CRANKING_CURVE_SIZE 8
 
+#define CRANKING_ENRICH_COUNT 6
+
 #define IGN_LOAD_COUNT 16
 #define IGN_RPM_COUNT 16
 
@@ -1247,9 +1249,9 @@ tle8888_mode_e tle8888mode;
 	pin_output_mode_e fan2PinMode;
 	float fuelReferencePressure;This is the pressure at which your injector flow is known.\nFor example if your injectors flow 400cc/min at 3.5 bar, enter 350kpa here.;"kPa", 1, 0, 50, 700000, 0
 
-	float[CRANKING_ADVANCE_CURVE_SIZE x DWELL_CURVE_SIZE] postCrankingFactor;;"mult", 1, 0, 1, 3, 2
-	float[CRANKING_ADVANCE_CURVE_SIZE] postCrankingCLTBins;;"C", 1, 0, -100, 100, 0
-	float[DWELL_CURVE_SIZE] postCrankingDurationBins;;"count", 1, 0, 0, 1000, 0
+	float[CRANKING_ENRICH_COUNT x CRANKING_ENRICH_COUNT] postCrankingFactor;;"mult", 1, 0, 1, 3, 2
+	float[CRANKING_ENRICH_COUNT] postCrankingDurationBins;;"count", 1, 0, 0, 1000, 0
+	float[CRANKING_ENRICH_COUNT] postCrankingCLTBins;;"C", 1, 0, -100, 100, 0
 
 	ThermistorConf auxTempSensor1
 	ThermistorConf auxTempSensor2
@@ -1355,7 +1357,7 @@ tChargeMode_e tChargeMode;
 	int16_t etb_iTermMax;iTerm max value;"", 1, 0, -30000, 30000, 0
 
 	pid_s idleTimingPid;See useIdleTimingPidControl
-	float idleTimingSoftEntryTime
+	float idleTimingSoftEntryTime;When entering idle, and the PID settings are aggressive, it's good to make a soft entry upon entering closed loop;"", 1, 0, 0, 100, 1
 
 	int16_t etbRocExpAverageLength;By the way ETB PID runs at 500hz, length in 1/500 of second here.
 

--- a/firmware/tunerstudio/rusefi.input
+++ b/firmware/tunerstudio/rusefi.input
@@ -1305,7 +1305,7 @@ curve = rangeMatrix, "Range Switch Input Matrix"
 		zBins	= hpfpCompensation
 
 	table = postCrankingEnrichmentTbl, postCrankingEnrichmentMap, "After start enrichment", 1
-		xBins	= postCrankingDurationBins, engineCycles
+		xBins	= postCrankingDurationBins, seconds ; TODO "engineCycles" should be there
 		yBins	= postCrankingCLTBins, coolant
 		zBins	= postCrankingFactor
 


### PR DESCRIPTION
Thanks to the last tip, I was able to get it to build myself to test on my Lexus
Idle advance is entering slowly now upon starting the car. That can be changed to work always when entering idle by setting m_crankTaperEndTime to 0 below m_timingPid.reset();
For me I did not see reason to do it.

![obraz](https://github.com/rusefi/rusefi/assets/79016748/c46ac744-3cd3-4180-8303-b6d42caf73bc)

I have fixed both previous feature commits, unfortunately I had to break the TunerStudio again.
Also, it looks to me like the interpolate3d function, or TunerStudio generation swaps X an Y axis, if the axes are of not equal lengths like it was 4x8 instead of 6x6, then the axes are swapped.