### PR TITLE
AT32: chip detection, flash detection, sayHello()

### DIFF
--- a/firmware/console/eficonsole.cpp
+++ b/firmware/console/eficonsole.cpp
@@ -58,11 +58,11 @@ static void sayHello() {
 	uint32_t *uid = ((uint32_t *)UID_BASE);
 	efiPrintf("UID=%x %x %x", uid[0], uid[1], uid[2]);
 
+#if defined(STM32F4) && !defined(AT32F4XX)
 	efiPrintf("can read 0x20000010 %d", ramReadProbe((const char *)0x20000010));
 	efiPrintf("can read 0x20020010 %d", ramReadProbe((const char *)0x20020010));
 	efiPrintf("can read 0x20070010 %d", ramReadProbe((const char *)0x20070010));
 
-#if defined(STM32F4)
 	efiPrintf("isStm32F42x %s", boolToString(isStm32F42x()));
 #endif // STM32F4
 

--- a/firmware/console/eficonsole.cpp
+++ b/firmware/console/eficonsole.cpp
@@ -93,7 +93,7 @@ static void sayHello() {
 	efiPrintf("MCU SER_ID %s rev %c",
 		(mcuSerId == 0x0d) ? "AT32F435" : ((mcuSerId == 0x0e) ? "AT32F437" : "UNKNOWN"),
 		'A' + mcuRevision);
-	efiPrintf("MCU F_SEZE %d KB", flashSize);
+	efiPrintf("MCU F_SIZE %d KB", flashSize);
 #else
 #define MCU_REVISION_MASK  0xfff
 	int mcuRevision = DBGMCU->IDCODE & MCU_REVISION_MASK;

--- a/firmware/console/eficonsole.cpp
+++ b/firmware/console/eficonsole.cpp
@@ -84,9 +84,8 @@ static void sayHello() {
 	efiPrintf("MCU rev=%x flashSize=%d", mcuRevision, flashSize);
 #endif
 
-
-#ifdef CH_FREQUENCY
-	efiPrintf("CH_FREQUENCY=%d", CH_FREQUENCY);
+#ifdef CH_CFG_ST_FREQUENCY
+	efiPrintf("CH_CFG_ST_FREQUENCY=%d", CH_CFG_ST_FREQUENCY);
 #endif
 
 #ifdef CORTEX_MAX_KERNEL_PRIORITY

--- a/firmware/hw_layer/ports/at32/at32_common.cpp
+++ b/firmware/hw_layer/ports/at32/at32_common.cpp
@@ -1,0 +1,67 @@
+/**
+ * @file	at32_common.cpp
+ * @brief	Low level common Artery AT32 code
+ *
+ * @date Oct 29, 2023
+ * @author Andrey Gusakov, (c) 2023
+ */
+
+#include "pch.h"
+
+int at32GetMcuType(uint32_t id, const char **pn, const char **package, uint32_t *flashSize)
+{
+    const struct {
+        uint32_t uid;
+        const char *pn;
+        uint32_t flashSize;
+        const char *package;
+    } at32f43x_types[] = {
+        { 0x70084540, "AT32F435ZMT7", 4032, "LQFP144" },
+        { 0x70083341, "AT32F435ZGT7", 1024, "LQFP144" },
+        { 0x70084598, "AT32F435ZDT7",  448, "LQFP144" },
+        { 0x70083242, "AT32F435ZCT7",  256, "LQFP144" },
+        { 0x70084543, "AT32F435VMT7", 4032, "LQFP100" },
+        { 0x70083344, "AT32F435VGT7", 1024, "LQFP100" },
+        { 0x70084599, "AT32F435VDT7",  448, "LQFP100" },
+        { 0x70083245, "AT32F435VCT7",  256, "LQFP100" },
+        { 0x70084546, "AT32F435RMT7", 4032,  "LQFP64" },
+        { 0x70083347, "AT32F435RGT7", 1024,  "LQFP64" },
+        { 0x7008459A, "AT32F435RDT7",  448,  "LQFP64" },
+        { 0x70083248, "AT32F435RCT7",  256,  "LQFP64" },
+        { 0x70084549, "AT32F435CMT7", 4032,  "LQFP48" },
+        { 0x7008334A, "AT32F435CGT7", 1024,  "LQFP48" },
+        { 0x7008459B, "AT32F435CDT7",  448,  "LQFP48" },
+        { 0x7008324B, "AT32F435CCT7",  256,  "LQFP48" },
+        { 0x7008454C, "AT32F435CMU7", 4032,   "QFN48" },
+        { 0x7008334D, "AT32F435CGU7", 1024,   "QFN48" },
+        { 0x7008459C, "AT32F435CDU7",  448,   "QFN48" },
+        { 0x7008324E, "AT32F435CCU7",  256,   "QFN48" },
+        { 0x7008454F, "AT32F437ZMT7", 4032, "LQFP144" },
+        { 0x70083350, "AT32F437ZGT7", 1024, "LQFP144" },
+        { 0x7008459D, "AT32F437ZDT7",  448, "LQFP144" },
+        { 0x70083251, "AT32F437ZCT7",  256, "LQFP144" },
+        { 0x70084552, "AT32F437VMT7", 4032, "LQFP100" },
+        { 0x70083353, "AT32F437VGT7", 1024, "LQFP100" },
+        { 0x7008459E, "AT32F437VDT7",  448, "LQFP100" },
+        { 0x70083254, "AT32F437VCT7",  256, "LQFP100" },
+        { 0x70084555, "AT32F437RMT7", 4032,  "LQFP64" },
+        { 0x70083356, "AT32F437RGT7", 1024,  "LQFP64" },
+        { 0x7008459F, "AT32F437RDT7",  448,  "LQFP64" },
+        { 0x70083257, "AT32F437RCT7",  256,  "LQFP64" },
+    };
+
+    for (int i = 0; i < efi::size(at32f43x_types); i++) {
+        if (id == at32f43x_types[i].uid) {
+            if (pn)
+                *pn = at32f43x_types[i].pn;
+            if (package)
+                *package = at32f43x_types[i].package;
+            if (flashSize)
+                *flashSize = at32f43x_types[i].flashSize;
+            return 0;
+        }
+    }
+
+    /* unknown */
+    return -1;
+}

--- a/firmware/hw_layer/ports/at32/at32_common.mk
+++ b/firmware/hw_layer/ports/at32/at32_common.mk
@@ -1,0 +1,4 @@
+HW_AT32_PORT_DIR = $(PROJECT_DIR)/hw_layer/ports/at32
+
+HW_LAYER_PORT_CPP += \
+	$(HW_AT32_PORT_DIR)/at32_common.cpp

--- a/firmware/hw_layer/ports/mpu_util.h
+++ b/firmware/hw_layer/ports/mpu_util.h
@@ -76,6 +76,10 @@ typedef enum {
 BOR_Level_t BOR_Get(void);
 BOR_Result_t BOR_Set(BOR_Level_t BORValue);
 
+#ifdef AT32F4XX
+int at32GetMcuType(uint32_t id, const char **pn, const char **package, uint32_t *flashSize);
+#endif
+
 extern "C"
 {
 #endif /* __cplusplus */

--- a/firmware/hw_layer/ports/stm32/stm32f4/hw_ports.mk
+++ b/firmware/hw_layer/ports/stm32/stm32f4/hw_ports.mk
@@ -37,5 +37,10 @@ endif
 # Now add common stm32 stuff
 include $(PROJECT_DIR)/hw_layer/ports/stm32/stm32_common.mk
 
+# Add Artery AT32 common stuff
+ifeq ($(IS_AT32F435),yes)
+	include $(PROJECT_DIR)/hw_layer/ports/at32/at32_common.mk
+endif
+
 # TODO: remove, for efifeatures.h
 ALLINC += $(PROJECT_DIR)/config/stm32f4ems


### PR DESCRIPTION
Now sayHello() knows something about AT32:
```
2023-10-30_12_36_02_598: EngineState: *** rusEFI LLC (c) 2012-2023. All rights reserved.
2023-10-30_12_36_02_598: EngineState: *** rusEFI v20231029@65034
2023-10-30_12_36_02_598: EngineState: *** Chibios Kernel:       6.1.4
2023-10-30_12_36_02_598: EngineState: *** Compiled:     Oct 30 2023 - 12:34:37
2023-10-30_12_36_02_599: EngineState: *** COMPILER=12.2.1 20221205
2023-10-30_12_36_02_599: EngineState: hellenBoardId=0
2023-10-30_12_36_02_599: EngineState: UID=A075EE 3C754000 E808722
2023-10-30_12_36_02_600: EngineState: MCU IDCODE AT32F437ZMT7 in LQFP144 with 4032 KB flash
2023-10-30_12_36_02_600: EngineState: MCU SER_ID AT32F437 rev A
2023-10-30_12_36_02_600: EngineState: MCU F_SEZE 4032 KB
2023-10-30_12_36_02_600: EngineState: CH_CFG_ST_FREQUENCY=1000
2023-10-30_12_36_02_601: EngineState: CORTEX_MAX_KERNEL_PRIORITY=2

```