### PR TITLE
reducing code duplication - internal flash order of operations

### DIFF
--- a/firmware/controllers/flash_main.cpp
+++ b/firmware/controllers/flash_main.cpp
@@ -220,7 +220,16 @@ enum class FlashState {
 };
 
 static FlashState validatePersistentState() {
-    if (persistentState.version != FLASH_DATA_VERSION || persistentState.size != sizeof(persistentState)) {
+	auto flashCrc = flashStateCrc(persistentState);
+
+	if (flashCrc != persistentState.crc) {
+		// If the stored crc is all 1s, that probably means the flash is actually blank, not that the crc failed.
+		if (persistentState.crc == ((decltype(persistentState.crc))-1)) {
+			return FlashState::BlankChip;
+		} else {
+			return FlashState::CrcFailed;
+		}
+	} else if (persistentState.version != FLASH_DATA_VERSION || persistentState.size != sizeof(persistentState)) {
 		return FlashState::IncompatibleVersion;
 	} else {
         return FlashState::Ok;
@@ -240,18 +249,7 @@ static FlashState readOneConfigurationCopy(flashaddr_t address) {
 
 	intFlashRead(address, (char *) &persistentState, sizeof(persistentState));
 
-	auto flashCrc = flashStateCrc(persistentState);
-
-	if (flashCrc != persistentState.crc) {
-		// If the stored crc is all 1s, that probably means the flash is actually blank, not that the crc failed.
-		if (persistentState.crc == ((decltype(persistentState.crc))-1)) {
-			return FlashState::BlankChip;
-		} else {
-			return FlashState::CrcFailed;
-		}
-	} else {
-		return validatePersistentState();
-	}
+	return validatePersistentState();
 }
 
 /**
@@ -270,22 +268,7 @@ static FlashState readConfiguration() {
 		// readed size is not exactly the same
 		if (settings_size != sizeof(persistentState))
 			return FlashState::IncompatibleVersion;
-		// claimed size or version is not the same
-		if (persistentState.version != FLASH_DATA_VERSION || persistentState.size != sizeof(persistentState))
-			return FlashState::IncompatibleVersion;
-
-		// now crc
-		auto flashCrc = flashStateCrc(persistentState);
-
-		if (flashCrc != persistentState.crc) {
-			// If the stored crc is all 1s, that probably means the flash is actually blank, not that the crc failed.
-			if (persistentState.crc == ((decltype(persistentState.crc))-1)) {
-				return FlashState::BlankChip;
-			} else {
-				return FlashState::CrcFailed;
-			}
-		}
-		return FlashState::Ok;
+		return validatePersistentState();
 	} else {
 		return FlashState::BlankChip;
 	}

--- a/firmware/controllers/flash_main.cpp
+++ b/firmware/controllers/flash_main.cpp
@@ -219,6 +219,14 @@ enum class FlashState {
 	BlankChip,
 };
 
+static FlashState validatePersistentState() {
+    if (persistentState.version != FLASH_DATA_VERSION || persistentState.size != sizeof(persistentState)) {
+		return FlashState::IncompatibleVersion;
+	} else {
+        return FlashState::Ok;
+    }
+}
+
 /**
  * Read single copy of rusEFI configuration from flash
  */
@@ -241,10 +249,8 @@ static FlashState readOneConfigurationCopy(flashaddr_t address) {
 		} else {
 			return FlashState::CrcFailed;
 		}
-	} else if (persistentState.version != FLASH_DATA_VERSION || persistentState.size != sizeof(persistentState)) {
-		return FlashState::IncompatibleVersion;
 	} else {
-		return FlashState::Ok;
+		return validatePersistentState();
 	}
 }
 


### PR DESCRIPTION
@dron0gus see also https://github.com/rusefi/rusefi/pull/5671

this PR here and https://github.com/rusefi/rusefi/pull/5671 are different in order of operations in the duplicated code.