### PR TITLE
# some compilers seem to have this off by default?

### DIFF
--- a/firmware/rusefi_rules.mk
+++ b/firmware/rusefi_rules.mk
@@ -1,5 +1,7 @@
 # Warnings-as-errors...
 RUSEFI_OPT = -Werror
+# some compilers seem to have this off by default?
+RUSEFI_OPT += -Werror=stringop-truncation
 
 ifneq ($(ALLOW_SHADOW),yes)
 #     RUSEFI_OPT += -Werror=shadow


### PR DESCRIPTION
RUSEFI_OPT += -Werror=stringop-truncation