### PR TITLE
Add BOARDINC to the bootloader's Makefile

### DIFF
--- a/firmware/bootloader/Makefile
+++ b/firmware/bootloader/Makefile
@@ -230,6 +230,7 @@ ASMXSRC = $(STARTUPASM) $(PORTASM) $(OSALASM) \
 INCDIR = $(ALLINC) \
 	$(PCH_DIR) \
 	.. \
+	$(BOARDINC) \
 	$(CHIBIOS)/os/various \
 	$(CHIBIOS)/os/ex/ST \
 	$(CONFIG)/engines \


### PR DESCRIPTION
Make it closer to the main Makefile which uses $(BOARDINC)