### PR TITLE
update pinouts, use new warning option

### DIFF
--- a/.github/workflows/gen-pinouts.yaml
+++ b/.github/workflows/gen-pinouts.yaml
@@ -17,10 +17,11 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Generate Pinouts
-      uses: chuckwagoncomputing/interactive-pinout@2.11
+      uses: chuckwagoncomputing/interactive-pinout@2.12
       with:
         mapping-path: firmware/config/boards/*/connectors/*.yaml
         warnings: "false"
+        warning-no-pins: "skip"
         warning-dupe: "error"
         columns: |
           {


### PR DESCRIPTION
Note that the gen-pinouts workflow will never delete old files in the pinouts directory, so you will have to manually delete the empty index.html.