### PR TITLE
[TODO should be part of automated coverage] Using smart chip without having smart chip should produce nice critical error not hang ECU

### DIFF
--- a/firmware/config/boards/f407-discovery/board_configuration.cpp
+++ b/firmware/config/boards/f407-discovery/board_configuration.cpp
@@ -88,6 +88,12 @@ void setBoardDefaultConfiguration() {
 
 	engineConfiguration->communityCommsLedPid = Gpio::D15;  // blue LED on discovery
 
+	engineConfiguration->injectionPins[0] = Gpio::MC33810_0_OUT_0;
+	engineConfiguration->injectionPins[1] = Gpio::MC33810_0_OUT_1;
+
+	engineConfiguration->ignitionPins[0] = Gpio::MC33810_0_GD_0;
+	engineConfiguration->ignitionPins[1] = Gpio::MC33810_0_GD_1;
+
 #if EFI_HIP_9011
 	setHip9011FrankensoPinout();
 #endif /* EFI_HIP_9011 */


### PR DESCRIPTION
problem statement: this https://github.com/rusefi/rusefi/pull/5911/commits/c7e88ccf26c127e3658969d0a67dab6ee9451cae here causes full hard fault/ECU hanging

expected: should be explicit fatal "please do not use smart pins if you do not have smart chips"

@dron0gus FYI