### PR TITLE
Don't skip firmware build on re-run

### DIFF
--- a/.github/workflows/build-firmware.yaml
+++ b/.github/workflows/build-firmware.yaml
@@ -451,7 +451,7 @@ jobs:
     - name: Execution throttle early exit
       # Don't skip any jobs if this workflow was run manually,
       # or if the commit contains `only:`, signifying that only one bundle should be built.
-      if: ${{ matrix.skip-rate && github.event_name != 'workflow_dispatch' && github.event_name != 'schedule' && github.event_name != 'pull_request' || contains(github.event.head_commit.message, 'only:') }}
+      if: ${{ matrix.skip-rate && github.event_name != 'workflow_dispatch' && github.event_name != 'schedule' && github.event_name != 'pull_request' && github.run_attempt == 1 || contains(github.event.head_commit.message, 'only:') }}
       run: |
         # if the commit message contains `only:`, get the part after the semicolon and check if it matches the build target.
         read -d '' MSG << EOM || true


### PR DESCRIPTION
With this change, re-running a firmware build workflow run will prevent skip-rate and only: from having any effect. This is a little QOL improvement for me. If it will negatively affect your workflow, don't merge it; it's not a big deal at all.