### PR TITLE
Set env variables in firmware workflow

### DIFF
--- a/.github/workflows/build-firmware.yaml
+++ b/.github/workflows/build-firmware.yaml
@@ -528,6 +528,23 @@ jobs:
           bash gen_config_board.sh ${{matrix.folder}} ${{matrix.short-board-name}}
         fi
 
+    - name: Set Build Env Variables
+      if: ${{ env.skip != 'true' }}
+      working-directory: ./firmware/
+      run: |
+        META_INFO=${{matrix.folder}}/meta-info-${{matrix.build-target}}.env
+        if [ -f "$META_INFO" ]; then
+          echo "[$META_INFO] found!"
+          echo META_INFO=$META_INFO >> $GITHUB_ENV
+        else
+          echo "Using default meta-info.env."
+          echo META_INFO="${{matrix.folder}}/meta-info.env" >> $GITHUB_ENV
+        fi
+        echo LTS=${{toJSON(inputs.lts)}} >> $GITHUB_ENV
+        echo REF=${{github.ref_name}} >> $GITHUB_ENV
+        echo BUNDLE_NAME=${{matrix.build-target}} >> $GITHUB_ENV
+        echo BOARD_DIR=${{matrix.folder}} >> $GITHUB_ENV
+
     - name: Git Status
       if: ${{ env.skip != 'true' }}
       run: |

--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -159,6 +159,7 @@ MAKEFLAGS += ${NUMJOBS}
 # Project, sources and paths
 #
 
+BOARD_DIR := ./$(BOARD_DIR)
 BOARDINC = $(BOARD_DIR)
 include $(BOARD_DIR)/board.mk
 BOARDCPPSRC += $(BOARDS_DIR)/board_id.cpp

--- a/firmware/bootloader/Makefile
+++ b/firmware/bootloader/Makefile
@@ -157,6 +157,7 @@ include $(CHIBIOS)/os/various/cpp_wrappers/chcpp.mk
 # EX files (optional).
 include $(CHIBIOS)/os/hal/lib/streams/streams.mk
 
+BOARD_DIR := ../$(BOARD_DIR)
 BOARDINC = $(BOARD_DIR)
 include $(BOARD_DIR)/board.mk
 

--- a/firmware/config/boards/common_script.sh
+++ b/firmware/config/boards/common_script.sh
@@ -10,12 +10,17 @@ set -e
 
 SCRIPT_NAME="common_script.sh"
 
+# temporary
+if [ -z "$PROJECT_BOARD" ]; then
+  export PROJECT_BOARD="$SHORT_BOARD_NAME"
+fi
+
 # check if board dir is set
 echo "Entering $SCRIPT_NAME with board [$PROJECT_BOARD] and CPU [$PROJECT_CPU] at [$BOARD_DIR]"
 
 mkdir -p .dep
 # todo: start using env variable for number of threads or for '-r'
-make -j$(nproc) -r PROJECT_BOARD=$PROJECT_BOARD PROJECT_CPU=$PROJECT_CPU BOARD_DIR=$BOARD_DIR BOARD_META_PATH=$BOARD_META_PATH
+make -j$(nproc) -r
 [ -e build/rusefi.hex ] || { echo "FAILED to compile by $SCRIPT_NAME with $PROJECT_BOARD $DEBUG_LEVEL_OPT and $EXTRA_PARAMS"; exit 1; }
 
 if [ ! -z $POST_BUILD_SCRIPT ]; then
@@ -28,7 +33,7 @@ if [ "$USE_OPENBLT" = "yes" ]; then
   # TODO: probably make/gcc do not like two separate projects (primary firmware and bootloader) co-existing in same folder structure?
   rm -f pch/pch.h.gch/*
   cd bootloader
-  make PROJECT_BOARD=$PROJECT_BOARD PROJECT_CPU=$PROJECT_CPU BOARD_DIR=../$BOARD_DIR BOARD_META_PATH=../$BOARD_META_PATH -j12
+  make -j12
   cd ..
   [ -e bootloader/blbuild/openblt_$PROJECT_BOARD.hex ] || { echo "FAILED to compile OpenBLT by $SCRIPT_NAME with $PROJECT_BOARD"; exit 1; }
 fi


### PR DESCRIPTION
Find the meta-info.env file so we can use it in future commits

Set PROJECT_BOARD to SHORT_BOARD_NAME if it is empty

Add `./` and `../` to BOARD_DIR for firmware and bootloader builds respectively - the path in the workflow matrix doesn't have them. We could do this somewhere else, like common_script.sh, but it's going to end up in the Makefile anyhow, so we might as well put it there now.

Don't pass the variables to make, because when you do that, it overrides any setting of that variable within the makefile, in our case:
- Adding `./` or `../` to BOARD_DIR
- In the future, setting PROJECT_BOARD to SHORT_BOARD_NAME will happen in the makefile