### PR TITLE
Import board-specific meta-info

### DIFF
--- a/.github/workflows/build-firmware.yaml
+++ b/.github/workflows/build-firmware.yaml
@@ -532,18 +532,11 @@ jobs:
       if: ${{ env.skip != 'true' }}
       working-directory: ./firmware/
       run: |
-        META_INFO=${{matrix.folder}}/meta-info-${{matrix.build-target}}.env
-        if [ -f "$META_INFO" ]; then
-          echo "[$META_INFO] found!"
-          echo META_INFO=$META_INFO >> $GITHUB_ENV
-        else
-          echo "Using default meta-info.env."
-          echo META_INFO="${{matrix.folder}}/meta-info.env" >> $GITHUB_ENV
-        fi
         echo LTS=${{toJSON(inputs.lts)}} >> $GITHUB_ENV
         echo REF=${{github.ref_name}} >> $GITHUB_ENV
         echo BUNDLE_NAME=${{matrix.build-target}} >> $GITHUB_ENV
         echo BOARD_DIR=${{matrix.folder}} >> $GITHUB_ENV
+        echo BOARD_META_PATH=$(bash bin/find_meta_info.sh ${{matrix.folder}} ${{matrix.build-target}}) >> $GITHUB_ENV
 
     - name: Git Status
       if: ${{ env.skip != 'true' }}
@@ -596,16 +589,19 @@ jobs:
       # Build the firmware!
     - name: Build Firmware
       if: ${{ env.skip != 'true' }}
-      run: bash misc/jenkins/compile_other_versions/compile.sh ${{matrix.folder}} ${{matrix.build-target}}
+      run: |
+        bash misc/jenkins/compile_other_versions/compile.sh
 
     - name: Package Bundle
       if: ${{ env.full == 'true' }}
-      run: bash misc/jenkins/compile_other_versions/prepare_bundle.sh ${{matrix.build-target}} "firmware/tunerstudio/generated/rusefi_${{matrix.short-board-name}}.ini" ${{ github.ref_name }}
+      run: |
+        source firmware/config/boards/common_script_read_meta_env.inc firmware/${{ env.BOARD_META_PATH }}
+        bash misc/jenkins/build_working_folder.sh
 
     - name: Upload Bundle
       if: ${{ env.full == 'true' }}
       working-directory: ./artifacts
-      run: bash ../firmware/bin/upload_bundle.sh ${{matrix.build-target}} ${{ toJSON(inputs.lts) }}
+      run: bash ../firmware/bin/upload_bundle.sh
 
     - name: Add Bundles to Release
       if: ${{ env.full == 'true' && env.upload == 'release' }}
@@ -621,8 +617,11 @@ jobs:
 
     - name: Upload .ini files to server
       if: ${{ env.full == 'true' }}
-      working-directory: ./firmware/tunerstudio/generated
-      run: ../upload_ini.sh "rusefi_${{matrix.short-board-name}}.ini" ${{ secrets.RUSEFI_ONLINE_FTP_USER }} ${{ secrets.RUSEFI_ONLINE_FTP_PASS }} ${{ secrets.RUSEFI_FTP_SERVER }}
+      working-directory: ./firmware
+      run: |
+        source config/boards/common_script_read_meta_env.inc ${{ env.BOARD_META_PATH }}
+        cd tunerstudio/generated
+        ../upload_ini.sh ${{ secrets.RUSEFI_ONLINE_FTP_USER }} ${{ secrets.RUSEFI_ONLINE_FTP_PASS }} ${{ secrets.RUSEFI_FTP_SERVER }}
 
     - name: Upload build elf artifact
       if: ${{ env.partial == 'true' }}

--- a/.github/workflows/hw-ci/build_for_hw_ci.sh
+++ b/.github/workflows/hw-ci/build_for_hw_ci.sh
@@ -13,6 +13,8 @@ echo "HW CI build [$HW_FOLDER][$HW_TARGET]"
 
 cd firmware
 
+export BOARD_META_PATH=$(bash bin/find_meta_info.sh ${HW_FOLDER} ${HW_TARGET})
+
 ./gen_live_documentation.sh
 ./gen_config_board.sh $HW_FOLDER $HW_TARGET
 
@@ -23,4 +25,4 @@ cd ..
 export EXTRA_2_PARAMS=-DHARDWARE_CI
 
 echo Build Firmware
-misc/jenkins/compile_other_versions/compile.sh $HW_FOLDER $HW_TARGET
+misc/jenkins/compile_other_versions/compile.sh

--- a/firmware/bin/find_meta_info.sh
+++ b/firmware/bin/find_meta_info.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+BOARD_DIR=${1:-$BOARD_DIR}
+BUNDLE_NAME=${2:-$BUNDLE_NAME}
+
+META_INFO="${BOARD_DIR}/meta-info-${BUNDLE_NAME}.env"
+if [ -f "$META_INFO" ]; then
+  echo "[$META_INFO] found!" >&2
+  echo "$META_INFO"
+else
+  echo "Using default meta-info.env." >&2
+  echo "${BOARD_DIR}/meta-info.env"
+fi

--- a/firmware/bin/upload_bundle.sh
+++ b/firmware/bin/upload_bundle.sh
@@ -1,17 +1,16 @@
 #!/usr/bin/env bash
 
 SCRIPT_NAME=$(basename "$0")
-FULL_BUNDLE_FILE="rusefi_bundle_$1.zip"
-UPDATE_BUNDLE_FILE="rusefi_bundle_$1_autoupdate.zip"
-LTS="$2"
+FULL_BUNDLE_FILE="rusefi_bundle_${BUNDLE_NAME}.zip"
+UPDATE_BUNDLE_FILE="rusefi_bundle_${BUNDLE_NAME}_autoupdate.zip"
 
 if [ -n "$RUSEFI_SSH_USER" ]; then
  echo "$SCRIPT_NAME: Uploading full bundle"
  RET=0
  if [ "${LTS}" = "true" ]; then
-   tar -czf - $FULL_BUNDLE_FILE  | sshpass -p $RUSEFI_SSH_PASS ssh -o StrictHostKeyChecking=no $RUSEFI_SSH_USER@$RUSEFI_SSH_SERVER "mkdir -p build_server/lts/$1; tar -xzf - -C build_server/lts/$1"
+   tar -czf - $FULL_BUNDLE_FILE  | sshpass -p $RUSEFI_SSH_PASS ssh -o StrictHostKeyChecking=no $RUSEFI_SSH_USER@$RUSEFI_SSH_SERVER "mkdir -p build_server/lts/${BUNDLE_NAME}; tar -xzf - -C build_server/lts/${BUNDLE_NAME}"
 	 RET=$((RET+$?))
-   tar -czf - $UPDATE_BUNDLE_FILE  | sshpass -p $RUSEFI_SSH_PASS ssh -o StrictHostKeyChecking=no $RUSEFI_SSH_USER@$RUSEFI_SSH_SERVER "mkdir -p build_server/lts/$1/autoupdate; tar -xzf - -C build_server/lts/$1/autoupdate"
+   tar -czf - $UPDATE_BUNDLE_FILE  | sshpass -p $RUSEFI_SSH_PASS ssh -o StrictHostKeyChecking=no $RUSEFI_SSH_USER@$RUSEFI_SSH_SERVER "mkdir -p build_server/lts/${BUNDLE_NAME}/autoupdate; tar -xzf - -C build_server/lts/${BUNDLE_NAME}/autoupdate"
 	 RET=$((RET+$?))
  else
    tar -czf - $FULL_BUNDLE_FILE  | sshpass -p $RUSEFI_SSH_PASS ssh -o StrictHostKeyChecking=no $RUSEFI_SSH_USER@$RUSEFI_SSH_SERVER "tar -xzf - -C build_server"

--- a/firmware/bootloader/Makefile
+++ b/firmware/bootloader/Makefile
@@ -158,6 +158,7 @@ include $(CHIBIOS)/os/various/cpp_wrappers/chcpp.mk
 include $(CHIBIOS)/os/hal/lib/streams/streams.mk
 
 BOARD_DIR := ../$(BOARD_DIR)
+BOARD_META_PATH := ../$(BOARD_META_PATH)
 BOARDINC = $(BOARD_DIR)
 include $(BOARD_DIR)/board.mk
 

--- a/firmware/config/boards/common_script.sh
+++ b/firmware/config/boards/common_script.sh
@@ -2,7 +2,7 @@
 
 # this script is supposed to be executed from within 'firmware' folder
 
-BOARD_META_PATH=$1
+export BOARD_META_PATH=${1:-$BOARD_META_PATH}
 . config/boards/common_script_read_meta_env.inc $BOARD_META_PATH
 
 # fail on error
@@ -21,6 +21,7 @@ echo "Entering $SCRIPT_NAME with board [$PROJECT_BOARD] and CPU [$PROJECT_CPU] a
 mkdir -p .dep
 # todo: start using env variable for number of threads or for '-r'
 make -j$(nproc) -r
+
 [ -e build/rusefi.hex ] || { echo "FAILED to compile by $SCRIPT_NAME with $PROJECT_BOARD $DEBUG_LEVEL_OPT and $EXTRA_PARAMS"; exit 1; }
 
 if [ ! -z $POST_BUILD_SCRIPT ]; then

--- a/firmware/tunerstudio/upload_ini.sh
+++ b/firmware/tunerstudio/upload_ini.sh
@@ -1,16 +1,16 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-fileName=$1
-# user=$2
-# pass=$3
-# host=$4
+fileName="rusefi_$SHORT_BOARD_NAME.ini"
+# user=$1
+# pass=$2
+# host=$3
 
-if [ ! "$fileName" ]; then
- echo "No $fileName"
+if [ ! "$SHORT_BOARD_NAME" ]; then
+ echo "No SHORT_BOARD_NAME"
  exit 1
 fi
 
-if [ ! "$2" ] || [ ! "$3" ] || [ ! "$4" ]; then
+if [ ! "$1" ] || [ ! "$2" ] || [ ! "$3" ]; then
  echo "upload_ini.sh says No Secrets, exiting"
  exit 0
 fi
@@ -39,7 +39,7 @@ if [ ! -z "$sig" -a "$sig" != " " ]; then
     echo "* found path: $path"
     # we do not have ssh for this user
     # sftp does not support -p flag on mkdir :(
-    sshpass -p $3 sftp -o StrictHostKeyChecking=no $2@$4 <<SSHCMD
+    sshpass -p $2 sftp -o StrictHostKeyChecking=no $1@$3 <<SSHCMD
 cd rusefi
 mkdir $branch
 mkdir $branch/$year

--- a/misc/jenkins/build_working_folder.sh
+++ b/misc/jenkins/build_working_folder.sh
@@ -5,25 +5,24 @@
 #
 # LTS: at some we had a dream of Long-term support branches. As of Jan 2024 this is not being used
 #
-# export FOLDER="temp/rusefi.999.hello" ; export BUNDLE_FULL_NAME=rusefi_test ; export INI_FILE_OVERRIDE=firmware/tunerstudio/generated/rusefi_uaefi.ini ; bash misc/jenkins/build_working_folder.sh
+# BUNDLE_NAME="uaefi" LTS="true" REF="ltsbranch"  bash misc/jenkins/build_working_folder.sh
 #
 
 set -e
 
-if [[ -z "$FOLDER" ]]; then
-    echo "FOLDER variable not defined"
+if [ -z "$BUNDLE_NAME" ]; then
+    echo "BUNDLE_NAME variable not defined"
     exit -1
 fi
 
-if [[ -z "BUNDLE_FULL_NAME" ]]; then
-    echo "BUNDLE_FULL_NAME variable not defined"
-    exit -1
+if [ "$LTS" = "true" -a -n "$REF" ]; then
+  FOLDER="temp/rusefi.${REF}.${BUNDLE_NAME}"
+else
+  FOLDER="temp/rusefi.snapshot.${BUNDLE_NAME}"
 fi
 
-if [ -z $INI_FILE_OVERRIDE ]; then
-    echo "$SCRIPT_NAME: No ini_file specified!"
-    exit -1
-fi
+INI_FILE_OVERRIDE="firmware/tunerstudio/generated/rusefi_$SHORT_BOARD_NAME.ini"
+BUNDLE_FULL_NAME="rusefi_bundle_${BUNDLE_NAME}"
 
 echo "$SCRIPT_NAME: Will use $INI_FILE_OVERRIDE"
 

--- a/misc/jenkins/compile_other_versions/compile.sh
+++ b/misc/jenkins/compile_other_versions/compile.sh
@@ -3,37 +3,7 @@
 # fail on error!
 set -e
 
-# for example 'config/boards/proteus'
-BOARD_DIR="$1"
-
-# for example 'proteus_f4'
-export BUNDLE_NAME="$2"
-
-SCRIPT_NAME=compile.sh
-echo "Entering $SCRIPT_NAME with folder $BOARD_DIR and bundle name $BUNDLE_NAME"
-
-[ -n $BOARD_DIR ] || { echo "BOARD_DIR parameter expected"; exit 1; }
-
-[ -n $BUNDLE_NAME ] || { echo "BUNDLE_NAME parameter expected"; exit 1; }
-
 cd firmware
 bash clean.sh
-cd ..
 
-cd firmware/$BOARD_DIR
-pwd
-
-COMPILE_SCRIPT="compile_$BUNDLE_NAME.sh"
-if [ -f $COMPILE_SCRIPT ]; then
-  # detailed compile script is useful for instance when same board has multiple MCU targets
-  echo "[$COMPILE_SCRIPT] found!"
-else
-  echo "Using default script name..."
-  COMPILE_SCRIPT="compile_firmware.sh"
-fi
-
-echo "Invoking $COMPILE_SCRIPT"
-
-bash $COMPILE_SCRIPT
-
-echo "Success for $SCRIPT_NAME!"
+bash config/boards/common_script.sh "${BOARD_META_PATH}"


### PR DESCRIPTION
Don't call the compile script any more, we can just call common_script.sh directly. This gets rid of most of compile.sh.

Arguments can be removed from calls to scripts in build-firmware.yaml, as they can get those values from the environment variables. Also included are changes in upload_bundle.sh to use the environtment variables instead of the passed arguments.
There's no reason this has to be done in this commit, but I'm out of Github Actions minutes for today and am depending on my own self-hosted runners, which makes splitting up commits take way longer, so I left them in this commit.