### PR TITLE
get rid of compile and clean scripts

### DIFF
--- a/.github/workflows/build-firmware.yaml
+++ b/.github/workflows/build-firmware.yaml
@@ -589,8 +589,10 @@ jobs:
       # Build the firmware!
     - name: Build Firmware
       if: ${{ env.skip != 'true' }}
+      working-directory: ./firmware/
       run: |
-        bash misc/jenkins/compile_other_versions/compile.sh
+        make clean
+        bash config/boards/common_script.sh ${{ env.BOARD_META_PATH }}
 
     - name: Package Bundle
       if: ${{ env.full == 'true' }}

--- a/.github/workflows/hw-ci/build_for_hw_ci.sh
+++ b/.github/workflows/hw-ci/build_for_hw_ci.sh
@@ -20,9 +20,8 @@ export BOARD_META_PATH=$(bash bin/find_meta_info.sh ${HW_FOLDER} ${HW_TARGET})
 
 echo "We aren't guaranteed a clean machine every time, so manually clean the output."
 make clean
-cd ..
 
 export EXTRA_2_PARAMS=-DHARDWARE_CI
 
 echo Build Firmware
-misc/jenkins/compile_other_versions/compile.sh
+bash config/boards/common_script.sh "${BOARD_META_PATH}"

--- a/firmware/clean.bat
+++ b/firmware/clean.bat
@@ -1,2 +1,0 @@
-@echo off
-bash.exe clean.sh

--- a/firmware/clean.sh
+++ b/firmware/clean.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-echo "Entering firmware/clean.sh"
-rm -rf .dep
-rm -rf build
-rm -rf pch/pch.h.gch

--- a/misc/jenkins/compile_other_versions/compile.sh
+++ b/misc/jenkins/compile_other_versions/compile.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-# fail on error!
-set -e
-
-cd firmware
-bash clean.sh
-
-bash config/boards/common_script.sh "${BOARD_META_PATH}"

--- a/misc/jenkins/compile_other_versions/compile_and_upload.bat
+++ b/misc/jenkins/compile_other_versions/compile_and_upload.bat
@@ -1,3 +1,0 @@
-@echo off
-bash.exe misc\jenkins\compile_other_versions\compile.sh %1 %2 %3 %4
-bash.exe misc\jenkins\compile_other_versions\prepare_bundle.sh %1 %2 %3 %4


### PR DESCRIPTION
let Make take care of cleaning, and call common_script directly