### PR TITLE
Call make bootloader from make

### DIFF
--- a/firmware/bootloader/Makefile
+++ b/firmware/bootloader/Makefile
@@ -46,7 +46,7 @@ endif
 # C++ specific options here (added to USE_OPT).
 ifeq ($(USE_CPPOPT),)
   # constexpr float expf_taylor_impl probably needs just c++14 but why not go with 17?
-  USE_CPPOPT = -std=c++20 -Wno-register -fno-rtti -fno-exceptions -fno-use-cxa-atexit -Werror=write-strings -Werror=type-limits -Winvalid-pch
+  USE_CPPOPT = -std=c++20 -Wno-register -fno-rtti -fno-exceptions -fno-use-cxa-atexit -Werror=write-strings -Werror=type-limits
   # gcc-10 c++ 20 depricated uses of volatile errors
   USE_CPPOPT += -Wno-deprecated
 endif

--- a/firmware/bundle.mk
+++ b/firmware/bundle.mk
@@ -12,6 +12,7 @@ BUNDLEFILES = \
   $(BOUTS)
 
 ifeq ($(USE_OPENBLT),yes)
+  BOOTLOADER_BIN = bootloader/blbuild/openblt_$(PROJECT_BOARD).bin
   BOOTLOADER_HEX = bootloader/blbuild/openblt_$(PROJECT_BOARD).hex
   BOUTS = deliver/openblt.bin
 else
@@ -20,6 +21,9 @@ ifeq ($(INCLUDE_ELF),yes)
   OUTS += deliver/$(PROJECT).elf deliver/$(PROJECT).map deliver/$(PROJECT).list
 endif
 endif
+
+$(BOOTLOADER_HEX) $(BOOTLOADER_BIN) &:
+	$(MAKE) -C bootloader -r
 
 $(BUILDDIR)/$(PROJECT).map: $(BUILDDIR)/$(PROJECT).elf
 

--- a/firmware/config/boards/common_script.sh
+++ b/firmware/config/boards/common_script.sh
@@ -20,16 +20,6 @@ echo "Entering $SCRIPT_NAME with board [$PROJECT_BOARD] and CPU [$PROJECT_CPU] a
 
 mkdir -p .dep
 
-if [ "$USE_OPENBLT" = "yes" ]; then
-  # TODO: why is this rm necessary?
-  # TODO: probably make/gcc do not like two separate projects (primary firmware and bootloader) co-existing in same folder structure?
-  cd bootloader
-  make -j$(nproc)
-  cd ..
-  [ -e bootloader/blbuild/openblt_$PROJECT_BOARD.hex ] || { echo "FAILED to compile OpenBLT by $SCRIPT_NAME with $PROJECT_BOARD"; exit 1; }
-fi
-
-rm -f pch/pch.h.gch/*
 # todo: start using env variable for number of threads or for '-r'
 make bundle -j$(nproc) -r
 


### PR DESCRIPTION
Ignore invalid PCH warnings in the bootloader Makefile as @racer-coder did in the firmware Makefile in https://github.com/rusefi/rusefi/commit/37da55c9206328bfba2a3bc24ef26d0ad419d1ab

Make coordinates with sub-instances of make to maintain the total number of parallel build threads; we don't even need to use the `-j` option.