### PR TITLE
Proteus HW CI test branch

### DIFF
--- a/.github/workflows/hardware-ci.yaml
+++ b/.github/workflows/hardware-ci.yaml
@@ -75,6 +75,9 @@ jobs:
     - name: OpenOCD wipe & flash STM32
       run: .github/workflows/hw-ci/openocd_wipe_and_flash.sh ${{matrix.openocd-script}}
 
+    - name: Show USB status
+      run: lsusb
+
     - name: Upload build bin artifact
       uses: actions/upload-artifact@v4
       with:

--- a/INFO.md
+++ b/INFO.md
@@ -1,0 +1,1 @@
+test branch


### PR DESCRIPTION
one real commit ago https://github.com/rusefi/rusefi/commit/17f508e158971115ab450a6f389cffa2eead6692 HW CI proteus is a success

with just a text file to reduce change of breakage Proteus HW CI is red. is that a platform glitch of some sort?