### PR TITLE
Use absolute path for generated outputs dir

### DIFF
--- a/.github/workflows/custom-board-build.yaml
+++ b/.github/workflows/custom-board-build.yaml
@@ -90,7 +90,7 @@ jobs:
           echo "SHORT_BOARD_NAME=$SHORT_BOARD_NAME" >> $GITHUB_ENV
           echo "BUNDLE_NAME=$SHORT_BOARD_NAME" >> $GITHUB_ENV
           cd ..
-          echo "META_OUTPUT_ROOT_FOLDER=$(realpath --relative-to=. firmware/$BOARD_DIR/generated)/" >> $GITHUB_ENV
+          echo "META_OUTPUT_ROOT_FOLDER=$(realpath firmware/$BOARD_DIR/generated)/" >> $GITHUB_ENV
           echo "${{ secrets.ADDITIONAL_ENV }}" >> $GITHUB_ENV
 
       # Build machines don't have arm-none-eabi gcc, so let's download it and put it on the path


### PR DESCRIPTION
build_working_folder.sh expects META_OUTPUT_ROOT_FOLDER to be relative to the repo root, but gen_config_board.sh expects it to be relative to the firmware directory. So let's just use an absolute path.
Green run: https://github.com/chuckwagoncomputing/fw-custom-example/actions/runs/7949685960/job/21701131321