### PR TITLE
very interesting

### DIFF
--- a/.github/workflows/hardware-ci.yaml
+++ b/.github/workflows/hardware-ci.yaml
@@ -8,7 +8,7 @@ jobs:
       # Let all builds finish even if one fails early
       fail-fast: false
       matrix:
-        build-target: [f407-discovery, proteus_f7]
+        build-target: [f407-discovery, proteus_f4, proteus_f7]
 
         include:
           - build-target: f407-discovery
@@ -18,13 +18,12 @@ jobs:
             openocd-script: ../.github/workflows/openocd_ci_f4_discovery.cfg
             serial-device: /dev/serial/by-id/usb-rusEFI_LLC_rusEFI_Engine_Management_ECU_2B003B000A51343033393930-if01
 
-#   https://github.com/rusefi/rusefi/issues/5981
-#          - build-target: proteus_f4
-#            runs-on: hw-ci-proteus
-#            test-suite: com.rusefi.HwCiProteus
-#            folder: config/boards/proteus
-#            openocd-script: ../.github/workflows/openocd_ci_proteus_f4.cfg
-#            serial-device: /dev/serial/by-id/usb-rusEFI_LLC_rusEFI_Engine_Management_ECU_41003D000451383037343335-if01
+          - build-target: proteus_f4
+            runs-on: hw-ci-proteus
+            test-suite: com.rusefi.HwCiProteus
+            folder: config/boards/proteus
+            openocd-script: ../.github/workflows/openocd_ci_proteus_f4.cfg
+            serial-device: /dev/serial/by-id/usb-rusEFI_LLC_rusEFI_Engine_Management_ECU_41003D000451383037343335-if01
 
           - build-target: proteus_f7
             runs-on: hw-ci-proteus-f7

--- a/.github/workflows/hardware-ci.yaml
+++ b/.github/workflows/hardware-ci.yaml
@@ -8,7 +8,7 @@ jobs:
       # Let all builds finish even if one fails early
       fail-fast: false
       matrix:
-        build-target: [f407-discovery, proteus_f4]
+        build-target: [f407-discovery, proteus_f7]
 
         include:
           - build-target: f407-discovery
@@ -18,20 +18,20 @@ jobs:
             openocd-script: ../.github/workflows/openocd_ci_f4_discovery.cfg
             serial-device: /dev/serial/by-id/usb-rusEFI_LLC_rusEFI_Engine_Management_ECU_2B003B000A51343033393930-if01
 
-          - build-target: proteus_f4
-            runs-on: hw-ci-proteus
-            test-suite: com.rusefi.HwCiProteus
-            folder: config/boards/proteus
-            openocd-script: ../.github/workflows/openocd_ci_proteus_f4.cfg
-            serial-device: /dev/serial/by-id/usb-rusEFI_LLC_rusEFI_Engine_Management_ECU_41003D000451383037343335-if01
-
-# it's not 100% reliable, looks like something around OpenOCD :(
-#          - build-target: proteus_f7
-#            runs-on: andrey
+#   https://github.com/rusefi/rusefi/issues/5981
+#          - build-target: proteus_f4
+#            runs-on: hw-ci-proteus
 #            test-suite: com.rusefi.HwCiProteus
 #            folder: config/boards/proteus
-#            openocd-script: ../.github/workflows/openocd_ci_proteus_f7.cfg
-#            serial-device: /dev/serial/by-id/usb-rusEFI_LLC_rusEFI_Engine_Management_ECU_38002B0005504B4634303120-if01
+#            openocd-script: ../.github/workflows/openocd_ci_proteus_f4.cfg
+#            serial-device: /dev/serial/by-id/usb-rusEFI_LLC_rusEFI_Engine_Management_ECU_41003D000451383037343335-if01
+
+          - build-target: proteus_f7
+            runs-on: hw-ci-proteus-f7
+            test-suite: com.rusefi.HwCiProteus
+            folder: config/boards/proteus
+            openocd-script: ../.github/workflows/openocd_ci_proteus_f7.cfg
+            serial-device: /dev/serial/by-id/usb-rusEFI_LLC_rusEFI_Engine_Management_ECU_38002D0005504B4634303120-if01
 
     runs-on: ${{matrix.runs-on}}
 


### PR DESCRIPTION
very interesting different failure now that we have HW CI for F7 as well

related to https://github.com/rusefi/rusefi/issues/5997

```
Compiling pch.h
mkdir -p deliver
Compiling crt0_v7m.S
Compiling vectors.S
make[1]: Entering directory '/home/Andrey/actions-runner/_work/rusefi/rusefi/firmware/bootloader'
Compiler Options
arm-none-eabi-gcc -c -mcpu=cortex-m4 -mthumb -Os -ggdb -g -Wno-error=implicit-fallthrough -Wno-error=bool-operation -fomit-frame-pointer -falign-functions=16 -Werror -Wno-error=pointer-sign -Wno-error=unused-function -Wno-error=unused-variable -Wno-error=sign-compare -Wno-error=unused-parameter -Wno-error=missing-field-initializers -Werror=type-limits -Wno-error=strict-aliasing -Wno-error=attributes -Wl,--defsym=IS_BOOTLOADER=1 -falign-functions=16 -ffunction-sections -fdata-sections -fno-common -flto -mfloat-abi=hard -mfpu=fpv4-sp-d16 -fgnu89-inline -std=gnu99 -Werror-implicit-function-declaration -Wall -Wextra -Wstrict-prototypes -Wa,-alms=blbuild/lst/ -DENABLE_AUTO_DETECT_HSE=TRUE -DSTM32_HSECLK=25000000 -DEFI_BOOTLOADER -DHAL_USE_EXT=FALSE -DHAL_USE_ICU=FALSE -DHAL_USE_PWM=FALSE -DHAL_USE_RTC=FALSE -DEF_LUA=FALSE -DHAL_USE_FLASH=FALSE -DEFI_USE_UART_DMA=FALSE -DEFI_USB_SERIAL=TRUE -DHAL_USE_USB_MSD=FALSE -DEFI_CAN_SUPPORT=FALSE -DSTM32_SRAM2_NOCACHE=FALSE -DSTM32_NOCACHE_SRAM1_SRAM2=FALSE -DSTM32_NOCACHE_SRAM3=FALSE -DEFI_UNIT_TEST=0 -DEFI_PROD_CODE=1 -DEFI_SIMULATOR=0 -DLED_CRITICAL_ERROR_BRAIN_PIN=Gpio::E3 -DFIRMWARE_ID="proteus" -DEFI_MAIN_RELAY_CONTROL=TRUE -DEFI_HD_ACR=TRUE -DVR_SUPPLY_VOLTAGE=5 -DSTM32_ADC_USE_ADC3=TRUE -DEFI_SOFTWARE_KNOCK=TRUE -DHW_PROTEUS=1 -DSTATIC_BOARD_ID=STATIC_BOARD_ID_PROTEUS_F7 -DEFI_LUA_LOOKUP=FALSE -DSHORT_BOARD_NAME=proteus_f7 -DSTM32F767xx -DCORTEX_USE_FPU=TRUE -MD -MP -MF .dep/blbuild.d -I. -I../ChibiOS/os/license -I../ChibiOS/os/common/portability/GCC -I../ChibiOS/os/common/startup/ARMCMx/compilers/GCC -I../ChibiOS/os/common/startup/ARMCMx/devices/STM32F7xx -I../ChibiOS/os/common/ext/ARM/CMSIS/Core/Include -I../ChibiOS/os/common/ext/ST/STM32F7xx -I../ChibiOS/os/hal/include -I../ChibiOS/../ChibiOS-Contrib/os/hal/include -I../ChibiOS/os/hal/ports/common/ARMCMx -I../ChibiOS/os/hal/ports/STM32/STM32F7xx -I../ChibiOS/os/hal/ports/STM32/LLD/ADCv2 -I../ChibiOS/os/hal/ports/STM32/LLD/CANv1 -I../ChibiOS/os/hal/ports/STM32/LLD/CRYPv1 -I../ChibiOS/os/hal/ports/STM32/LLD/DACv1 -I../ChibiOS/os/hal/ports/STM32/LLD/DMAv2 -I../ChibiOS/os/hal/ports/STM32/LLD/EXTIv1 -I../ChibiOS/os/hal/ports/STM32/LLD/GPIOv2 -I../ChibiOS/os/hal/ports/STM32/LLD/I2Cv2 -I../ChibiOS/os/hal/ports/STM32/LLD/MACv1 -I../ChibiOS/os/hal/ports/STM32/LLD/OTGv1 -I../ChibiOS/os/hal/ports/STM32/LLD/QUADSPIv1 -I../ChibiOS/os/hal/ports/STM32/LLD/RNGv1 -I../ChibiOS/os/hal/ports/STM32/LLD/RTCv2 -I../ChibiOS/os/hal/ports/STM32/LLD/SPIv2 -I../ChibiOS/os/hal/ports/STM32/LLD/SDMMCv1 -I../ChibiOS/os/hal/ports/STM32/LLD/TIMv1 -I../ChibiOS/os/hal/ports/STM32/LLD/USARTv2 -I../ChibiOS/os/hal/ports/STM32/LLD/xWDGv1 -I../ChibiOS/../ChibiOS-Contrib/os/hal/ports/STM32/LLD/CRCv1 -I../ChibiOS/../ChibiOS-Contrib/os/hal/ports/STM32/LLD/DMA2Dv1 -I../ChibiOS/../ChibiOS-Contrib/os/hal/ports/STM32/LLD/FSMCv1 -I../ChibiOS/../ChibiOS-Contrib/os/hal/ports/STM32/LLD/TIMv1 -I../ChibiOS/../ChibiOS-Contrib/os/hal/ports/STM32/LLD/LTDCv1 -I../ChibiOS/../ChibiOS-Contrib/os/hal/ports/STM32/LLD/USBHv1 -I../ChibiOS/os/hal/osal/rt-nil -I../ChibiOS/os/rt/include -I../ChibiOS/os/oslib/include -I../ChibiOS/os/common/ports/ARMCMx -I../ChibiOS/os/common/ports/ARMCMx/compilers/GCC -I../ChibiOS/os/various/cpp_wrappers -I../ChibiOS/os/hal/lib/streams -I../config/stm32f7ems -I../pch -I.. -I../././config/boards/proteus -I../ChibiOS/os/various -I../ChibiOS/os/ex/ST -I../config/engines -I../config -I../hw_layer/ports/stm32/stm32f7/cfg -I../ext -I../ext_algo -I../util -I../util/containers -I../util/math -I../console_util -I../console -I../console/binary -I../console/binary_log -I../console/fl_binary -I../hw_layer -I../hw_layer/adc -I../hw_layer/mass_storage -I../hw_layer/algo -I../hw_layer/sensors -I../controllers/sensors/impl -I../controllers/sensors/core -I../hw_layer/mass_storage -I../hw_layer/ports -I../console/binary/generated -I../hw_layer/ports/stm32/stm32f7 -I../hw_layer/ports/stm32 -I../hw_layer/ports/stm32/serial_over_usb -I../hw_layer/drivers -I../hw_layer/drivers/gpio -I../hw_layer/drivers/can -I../hw_layer/drivers/sent -I../hw_layer/drivers/serial -I../hw_layer/drivers/i2c -I../hw_layer/drivers/led -I../development -I../development/hw_layer -I../development/test -I../controllers -I../controllers/system -I../controllers/system/timer -I../controllers/algo -I../controllers/algo/airmass -I../controllers/algo/defaults -I../controllers/algo/fuel -I../controllers/engine_cycle -I../controllers/trigger/decoders -I../controllers/tcu -I../controllers/trigger -I../controllers/can -I../controllers/core -I../controllers/gauges -I../controllers/math -I../controllers/generated -I../controllers/actuators -I../controllers/actuators/gppwm -I../controllers/serial -I../controllers/sensors -I../init -I../libfirmware/util/include -I../libfirmware/util/include/rusefi/containers -I../libfirmware/can -I../libfirmware/board_id -I../libfirmware/pt2001/include -I../libfirmware/pt2001/project/rusefi/sample_code -I../config/boards -I../hw_layer/openblt -I../ext/openblt/Target/Source -I../bootloader/openblt_chibios -Iconfig main.c -o main.o
Compiling chcoreasm_v7m.S

Compiling rusEfiStartup.S
make[1]: *** No rule to make target 'backdoor.c', needed by 'blbuild/obj/backdoor.o'.  Stop.
make[1]: *** Waiting for unfinished jobs....
make[1]: Leaving directory '/home/Andrey/actions-runner/_work/rusefi/rusefi/firmware/bootloader'
make: *** [bundle.mk:26: bootloader/blbuild/openblt_proteus_f7.hex] Error 2
make: *** Waiting for unfinished jobs....
```