### PR TITLE
Use sentinel for bootloader

### DIFF
--- a/firmware/bundle.mk
+++ b/firmware/bundle.mk
@@ -108,8 +108,11 @@ BUNDLE_FILES = \
 $(SIMULATOR):
 	$(MAKE) -C ../simulator -r SIMULATOR_DEBUG_LEVEL_OPT="-O2" OS="Windows_NT"
 
-bootloader/blbuild/openblt_$(PROJECT_BOARD).%:
+$(BOOTLOADER_HEX) $(BOOTLOADER_BIN): .bootloader-sentinel ;
+
+.bootloader-sentinel:
 	BOARD_DIR=../$(BOARD_DIR) BOARD_META_PATH=../$(BOARD_META_PATH) $(MAKE) -C bootloader -r
+	@touch $@
 
 $(BUILDDIR)/$(PROJECT).map: $(BUILDDIR)/$(PROJECT).elf
 


### PR DESCRIPTION
I thought the patter rule would work from reading this answer:
https://stackoverflow.com/questions/63928066/what-is-the-canonical-way-to-simulate-grouped-targets-in-older-versions-of-make
I think the kind of pattern rule that would have worked is one that listed both BOOTLOADER_HEX and BOOTLOADER_BIN, but both with a % in them, like `bootloader/blbuild/openblt_%.bin bootloader/blbuild/openblt_%.hex`

I decided to go with another sentinel file instead. It's clearer (to me at least) that it was done that way for a reason. If I see a pattern rule with no prerequisites, I'm likely to think "that's stupid" and change it.