### PR TITLE
Stop microsecond TIM clock when CPU is halted by debuger

### DIFF
--- a/firmware/hw_layer/ports/stm32/microsecond_timer_stm32.cpp
+++ b/firmware/hw_layer/ports/stm32/microsecond_timer_stm32.cpp
@@ -65,7 +65,10 @@ void portInitMicrosecondTimer() {
 	/* TODO: implement for all possible TIMs */
 	if (SCHEDULER_TIMER_DEVICE == TIM5) {
 		/* stop timers clock when core is halted */
+	#if defined(STM32F4XX) || defined (STM32F7XX)
 		DBGMCU->APB1FZ |= DBGMCU_APB1_FZ_DBG_TIM5_STOP;
+	#endif
+		/* TODO: stm32h7? */
 	}
 }
 

--- a/firmware/hw_layer/ports/stm32/microsecond_timer_stm32.cpp
+++ b/firmware/hw_layer/ports/stm32/microsecond_timer_stm32.cpp
@@ -61,6 +61,12 @@ void portInitMicrosecondTimer() {
 	// (which would take 358 seconds at 12mhz timer speed), so we have to use normal upcounting
 	// output compare mode instead.
 	SCHEDULER_TIMER_DEVICE->CCMR1 = STM32_TIM_CCMR1_OC1M(1);
+
+	/* TODO: implement for all possible TIMs */
+	if (SCHEDULER_TIMER_DEVICE == TIM5) {
+		/* stop timers clock when core is halted */
+		DBGMCU->APB1FZ |= DBGMCU_APB1_FZ_DBG_TIM5_STOP;
+	}
 }
 
 uint32_t getTimeNowLowerNt() {


### PR DESCRIPTION
To avoid "gap in time" error during debug