### PR TITLE
Call gen_config_board with make

### DIFF
--- a/.github/workflows/build-firmware-windows.yaml
+++ b/.github/workflows/build-firmware-windows.yaml
@@ -41,9 +41,9 @@ jobs:
       - name: Test Java Compiler
         run: javac -version
 
-      - name: Generate Configs, Enums & Live Documentation
+      - name: Generate Enums & Live Documentation
         working-directory: ./firmware/
-        run: bash gen_default_everything.sh
+        run: bash gen_live_documentation.sh
 
       - name: Print arm GCC version
         working-directory: .

--- a/.github/workflows/build-firmware.yaml
+++ b/.github/workflows/build-firmware.yaml
@@ -513,30 +513,6 @@ jobs:
       working-directory: ./firmware/
       run: ./gen_live_documentation.sh
 
-    - name: Generate Configs for build-target
-      if: ${{ env.skip != 'true' }}
-      working-directory: ./firmware/
-      # todo: we have code duplication with gen_config.sh here :(
-      run: |
-        if [ "${{ matrix.build-target }}" = "kinetis" ]; then
-          config/boards/kinetis/config/gen_kinetis_config.sh
-          [ $? -eq 0 ] || { echo "ERROR generating board kinetis kin"; exit 1; }
-        elif [ "${{ matrix.build-target }}" = "cypress" ]; then
-          config/boards/cypress/config/gen_cypress_config.sh
-          [ $? -eq 0 ] || { echo "ERROR generating board cypress cypress"; exit 1; }
-        elif [ "${{ matrix.build-target }}" = "subaru_eg33_f7" ]; then
-          bash config/boards/subaru_eg33/config/gen_subaru_config.sh
-          [ $? -eq 0 ] || { echo "ERROR generating board subaru_eg33 subaru_eg33_f7"; exit 1; }
-        elif [ "${{ matrix.build-target }}" = "subaru_eg33_f7_no_bl" ]; then
-          bash config/boards/subaru_eg33/config/gen_subaru_config.sh
-          [ $? -eq 0 ] || { echo "ERROR generating board subaru_eg33 subaru_eg33_f7_no_bl"; exit 1; }
-        elif [ "${{ matrix.short-board-name }}" = "" ]; then
-          echo "ERROR: ${{ matrix.build-target }} is missing short-board-name attribute"
-          exit -1
-        else
-          bash gen_config_board.sh ${{matrix.folder}} ${{matrix.short-board-name}}
-        fi
-
     - name: Set Build Env Variables
       if: ${{ env.skip != 'true' }}
       working-directory: ./firmware/

--- a/.github/workflows/build-unit-tests-windows.yaml
+++ b/.github/workflows/build-unit-tests-windows.yaml
@@ -33,9 +33,9 @@ jobs:
     - name: Test Java Compiler
       run: javac -version
 
-    - name: Generate Configs, Enums & Live Documentation
+    - name: Generate Enums & Live Documentation
       working-directory: ./firmware/
-      run: bash gen_default_everything.sh
+      run: bash gen_live_documentation.sh
 
     - name: Print GCC version
       working-directory: .

--- a/.github/workflows/build-unit-tests.yaml
+++ b/.github/workflows/build-unit-tests.yaml
@@ -35,7 +35,7 @@ jobs:
     - name: Install required software (macos)
       if: ${{ matrix.os == 'macos-latest' }}
       run: |
-        brew install mtools zip dosfstools
+        brew install mtools zip dosfstools flock
 
     - name: Print bash version
       working-directory: .

--- a/.github/workflows/custom-board-build.yaml
+++ b/.github/workflows/custom-board-build.yaml
@@ -116,10 +116,6 @@ jobs:
           sudo bash ${{inputs.rusefi_dir}}/misc/actions/add-ubuntu-latest-apt-mirrors.sh
           sudo apt-get install sshpass sshpass mtools
 
-      - name: Gen Config
-        working-directory: ${{inputs.rusefi_dir}}/firmware
-        run: bash gen_config_board.sh
-
       - name: Repo Status
         run: |
           git status
@@ -132,6 +128,23 @@ jobs:
           else
             echo Not a repository
           fi
+
+      - name: Configs build_server upload SSH variables
+        env:
+          ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
+        run: |
+          if [ "${{github.event_name}}" = "push" ] && [ "${{github.ref}}" = "refs/heads/master" ]; then
+            echo "Setting credentials..."
+            echo "RUSEFI_SSH_SERVER=${{secrets.RUSEFI_SSH_SERVER}}" >> $GITHUB_ENV
+            echo "RUSEFI_SSH_USER=${{secrets.RUSEFI_SSH_USER}}" >> $GITHUB_ENV
+            echo "RUSEFI_SSH_PASS=${{secrets.RUSEFI_SSH_PASS}}" >> $GITHUB_ENV
+          else
+            echo "NOT setting credentials: ${{github.event_name}} ${{github.ref}}"
+          fi
+
+      - name: Build Firmware
+        working-directory: ${{inputs.rusefi_dir}}/firmware
+        run: bash bin/compile.sh -b ${{ env.BOARD_META_PATH }} deliver/rusefi.bin
 
       - name: Push Config
         run: |
@@ -169,23 +182,6 @@ jobs:
       - name: Upload .ini files to rusEFI Online server
         working-directory: generated/tunerstudio/generated
         run: ../../../${{inputs.rusefi_dir}}/firmware/tunerstudio/upload_ini.sh ${{ secrets.RUSEFI_ONLINE_FTP_USER }} ${{ secrets.RUSEFI_ONLINE_FTP_PASS }} ${{ secrets.RUSEFI_FTP_SERVER }}
-
-      - name: Configs build_server upload SSH variables
-        env:
-          ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
-        run: |
-          if [ "${{github.event_name}}" = "push" ] && [ "${{github.ref}}" = "refs/heads/master" ]; then
-            echo "Setting credentials..."
-            echo "RUSEFI_SSH_SERVER=${{secrets.RUSEFI_SSH_SERVER}}" >> $GITHUB_ENV
-            echo "RUSEFI_SSH_USER=${{secrets.RUSEFI_SSH_USER}}" >> $GITHUB_ENV
-            echo "RUSEFI_SSH_PASS=${{secrets.RUSEFI_SSH_PASS}}" >> $GITHUB_ENV
-          else
-            echo "NOT setting credentials: ${{github.event_name}} ${{github.ref}}"
-          fi
-
-      - name: Build Firmware
-        working-directory: ${{inputs.rusefi_dir}}/firmware
-        run: bash bin/compile.sh -b ${{ env.BOARD_META_PATH }} deliver/rusefi.bin
 
       - name: Upload github action bin artifact
         uses: actions/upload-artifact@v4

--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -382,6 +382,8 @@ ULIBS = -lm --specs=nano.specs -Wl,--sort-section=alignment
 
 include $(RULESFILE)
 
+include rusefi_config.mk
+
 # Enable precompiled header
 include rusefi_pch.mk
 

--- a/firmware/bundle.mk
+++ b/firmware/bundle.mk
@@ -22,8 +22,6 @@ else
   FOLDER = rusefi.snapshot.$(BUNDLE_NAME)
 endif
 
-INI_FILE = $(META_OUTPUT_ROOT_FOLDER)tunerstudio/generated/rusefi_$(SHORT_BOARD_NAME).ini
-
 DELIVER = deliver
 ARTIFACTS = ../artifacts
 

--- a/firmware/config/boards/cypress/meta-info.env
+++ b/firmware/config/boards/cypress/meta-info.env
@@ -1,2 +1,3 @@
 SHORT_BOARD_NAME=cypress
 PROJECT_CPU=custom_platform
+CUSTOM_GEN_CONFIG=config/gen_cypress_config.sh

--- a/firmware/config/boards/kinetis/meta-info.env
+++ b/firmware/config/boards/kinetis/meta-info.env
@@ -1,2 +1,3 @@
 SHORT_BOARD_NAME=kin
 PROJECT_CPU=custom_platform
+CUSTOM_GEN_CONFIG=config/gen_kinetis_config.sh

--- a/firmware/config/boards/subaru_eg33/meta-info-subaru_eg33_f7.env
+++ b/firmware/config/boards/subaru_eg33/meta-info-subaru_eg33_f7.env
@@ -1,3 +1,4 @@
 SHORT_BOARD_NAME=subaru_eg33_f7
 PROJECT_CPU=ARCH_STM32F7
 USE_OPENBLT=yes
+CUSTOM_GEN_CONFIG=config/gen_subaru_config.sh

--- a/firmware/config/boards/subaru_eg33/meta-info-subaru_eg33_f7_no_bl.env
+++ b/firmware/config/boards/subaru_eg33/meta-info-subaru_eg33_f7_no_bl.env
@@ -1,2 +1,3 @@
 SHORT_BOARD_NAME=subaru_eg33_f7
 PROJECT_CPU=ARCH_STM32F7
+CUSTOM_GEN_CONFIG=config/gen_subaru_config.sh

--- a/firmware/gen_config_board.sh
+++ b/firmware/gen_config_board.sh
@@ -13,7 +13,7 @@
 set -e
 
 cd ../java_tools
-./gradlew :config_definition:shadowJar
+flock /tmp/java.lock ./gradlew :config_definition:shadowJar
 cd ../firmware
 
 echo "This script reads rusefi_config.txt and produces firmware persistent configuration headers"

--- a/firmware/rusefi_config.mk
+++ b/firmware/rusefi_config.mk
@@ -1,0 +1,25 @@
+INI_FILE = $(META_OUTPUT_ROOT_FOLDER)tunerstudio/generated/rusefi_$(SHORT_BOARD_NAME).ini
+
+CONFIG_FILES = \
+  $(PROJECT_DIR)/$(INI_FILE) \
+  $(PROJECT_DIR)/controllers/generated/$(PROJECT)_generated_$(SHORT_BOARD_NAME).h \
+  $(PROJECT_DIR)/controllers/generated/signature_$(SHORT_BOARD_NAME).h \
+  $(PROJECT_DIR)/hw_layer/mass_storage/ramdisk_image.h \
+  $(PROJECT_DIR)/hw_layer/mass_storage/ramdisk_image_compressed.h \
+  $(PROJECT_DIR)/../java_console/models/src/main/java/com/rusefi/config/generated/Fields.java \
+  $(PROJECT_DIR)/$(BOARD_DIR)/connectors/generated_outputs.h \
+  $(PROJECT_DIR)/$(BOARD_DIR)/connectors/generated_ts_name_by_pin.cpp
+
+.FORCE:
+
+$(ACOBJS): $(CONFIG_FILES)
+
+$(CONFIG_FILES): .config-sentinel ;
+
+.config-sentinel: .FORCE
+ifneq (,$(CUSTOM_GEN_CONFIG))
+	bash $(PROJECT_DIR)/$(BOARD_DIR)/$(CUSTOM_GEN_CONFIG)
+else
+	bash $(PROJECT_DIR)/gen_config_board.sh $(BOARD_DIR) $(SHORT_BOARD_NAME)
+endif
+	@touch $@

--- a/firmware/rusefi_pch.mk
+++ b/firmware/rusefi_pch.mk
@@ -1,12 +1,10 @@
-
-
 # Add the PCH dir to source path
 SRCPATHS += $(PCH_DIR)
 
 PCHOBJ = $(addprefix $(PCH_DIR)/, $(notdir $(PCHSRC:.h=.h.gch)))/$(PCHSUB)
 
 # Compile precompiled header file(s) as a cpp file, but output to .h.gch file
-$(PCHOBJ) : $(PCH_DIR)/%.h.gch/$(PCHSUB) : %.h Makefile
+$(PCHOBJ) : $(PCH_DIR)/%.h.gch/$(PCHSUB) : %.h Makefile $(CONFIG_FILES)
 	@mkdir -p $<.gch
 ifeq ($(USE_VERBOSE_COMPILE),yes)
 	@echo


### PR DESCRIPTION
Instead of having hard-coded checks for calling custom gen_config scripts, I have added a variable to the meta-info of those boards that require it.

As of this PR, configs are generated every time make is run. This is not optimal, it's a small-PR stepping stone.

I had to add flock to the call to Gradle in gen_config_board.sh. Eventually, this call will be removed from this file, but it has to stay for now.
Because of this, unit tests on macOS require installing flock.  Flock is a BSD standard system call which Linux has also adopted, but macOS doesn't ship with a command line utility for using it. In linux, the command line tool is a part of the util-linux package. Util-linux is shipped with every linux distro and cygwin.

All the config-related stuff is in a new file, rusefi_config.mk. This allows us to claim the configs as prerequisites in different makefiles, e.g. the unit tests makefile.

There's one thing I don't really like here.

`$(ACOBJS): $(CONFIG_FILES)`

This is kinda following the example of rusefi_pch.mk

https://github.com/rusefi/rusefi/blob/44ebfc633f5c5d29b583b38a130f25ce64031cd6/firmware/rusefi_pch.mk#L20-L21

This is required because of the way the ChibiOS makefile is set up. The automatic prerequisite generation is done in the same step as the compilation. Therefore, if the .dep folder isn't already in the correct state, Make doesn't know which .o files require the config headers until it has already tried and failed to compile them. So to work around this, we just tell Make that all C .o files require the config headers. The downside of this is that if a config header changes, all C .o files will be rebuilt, not jut those that require the config headers. The lines in rusefi_pch.mk take care of most things that require the config headers, but there's an exception I ran into: init.c includes lwip/opts.h which includes console/lwipopts.h, which includes generated_lookup_meta.h. It would also work to make CONFIG_FILES a prerequisite of just init.o, and not ACOBJS, but who know what other edge cases are lurking.

Example of lwipopts failure: https://github.com/chuckwagoncomputing/rusefi/actions/runs/7942940928/job/21687118848

Green custom: https://github.com/chuckwagoncomputing/fw-custom-example/actions/runs/8035615243