### PR TITLE
Use cygwin instead of minGW

### DIFF
--- a/.github/workflows/build-firmware-windows.yaml
+++ b/.github/workflows/build-firmware-windows.yaml
@@ -6,10 +6,6 @@ jobs:
   build:
     runs-on: windows-2019
 
-
-
-
-
     steps:
       - uses: actions/setup-java@v4
         with:
@@ -35,15 +31,8 @@ jobs:
           git submodule update --init --depth=1 java_console/luaformatter
           git submodule update --init --depth=1 java_console/peak-can-basic
 
-      - name: Set up MinGW
-        uses: egor-tensin/setup-mingw@v2
-        # 12 has pch https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105858
-        # 13 has x86 issue https://github.com/egor-tensin/setup-mingw/issues/14
-        with:
-          version: 8.1.0
-
-
-
+      - name: Set up Cygwin
+        uses: cygwin/cygwin-install-action@master
 
       - name: Print bash version
         working-directory: .

--- a/.github/workflows/build-unit-tests-windows.yaml
+++ b/.github/workflows/build-unit-tests-windows.yaml
@@ -6,10 +6,6 @@ jobs:
   build:
     runs-on: windows-2019
 
-
-
-
-
     steps:
     - uses: actions/setup-java@v4
       with:
@@ -27,18 +23,8 @@ jobs:
         git submodule update --init --depth=1 firmware/controllers/can/wideband_firmware
         git submodule update --init --depth=1 java_console/peak-can-basic
 
-    - name: Set up MinGW
-      uses: egor-tensin/setup-mingw@v2
-      # 8.1.0 from 2018 works!
-      # available options see https://community.chocolatey.org/packages/mingw#versionhistory
-      # 10.3.0 internal error in mingw32_gt_pch_use_address
-      # 12 has pch https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105858
-      # 13 has x86 issue https://github.com/egor-tensin/setup-mingw/issues/14
-      with:
-        version: 8.1.0
-
-
-
+    - name: Set up Cygwin
+      uses: cygwin/cygwin-install-action@master
 
     - name: Print bash version
       working-directory: .


### PR DESCRIPTION
[setup-mingw](https://github.com/egor-tensin/setup-mingw) has not been maintained in over a year and is currently pretty broken.

This PR switches to the official Cygwin install action. Cygwin bundles more packages and has a large repository for installing more if needed. I expected the extra weight to slow down the workflow, but it looks like it's actually faster because setup-mingw used Chocolatey for installing minGW, which added some overhead.