### PR TITLE
Include rusefi_config.mk for unit tests

### DIFF
--- a/.github/workflows/build-rusEFI-console.yaml
+++ b/.github/workflows/build-rusEFI-console.yaml
@@ -32,9 +32,9 @@ jobs:
           sudo bash misc/actions/add-ubuntu-latest-apt-mirrors.sh
           sudo apt-get install sshpass mtools
 
-      - name: Generate Configs, Enums & Live Documentation
+      - name: Generate Enums & Live Documentation
         working-directory: ./firmware/
-        run: ./gen_default_everything.sh
+        run: ./gen_live_documentation.sh
 
       - name: Print GCC version
         working-directory: .

--- a/.github/workflows/build-unit-tests.yaml
+++ b/.github/workflows/build-unit-tests.yaml
@@ -44,9 +44,9 @@ jobs:
     - name: Test Java Compiler
       run: javac -version
 
-    - name: Generate Configs, Enums & Live Documentation
+    - name: Generate Enums & Live Documentation
       working-directory: ./firmware/
-      run: bash gen_default_everything.sh
+      run: bash gen_live_documentation.sh
 
     - name: Print Compiler version
       # NOTE: on mac, this is actually symlink'd to clang, not gcc, but that's ok - we want to build on both

--- a/unit_tests/unit_test_rules.mk
+++ b/unit_tests/unit_test_rules.mk
@@ -244,5 +244,22 @@ $(info Invoked "git submodule update --init")
 $(error Please run 'make' again. Please make sure you have 'git' command in PATH)
 endif
 
+ifeq ($(PROJECT_BOARD),)
+ifneq ($(SHORT_BOARD_NAME),)
+  PROJECT_BOARD = $(SHORT_BOARD_NAME)
+else
+  PROJECT_BOARD = f407-discovery
+endif
+endif
+
+BOARDS_DIR = $(PROJECT_DIR)/config/boards
+
+# allow passing a custom board dir, otherwise generate it based on the board name
+ifeq ($(BOARD_DIR),)
+	BOARD_DIR = $(BOARDS_DIR)/$(PROJECT_BOARD)
+	-include $(BOARD_DIR)/meta-info.env
+endif
+
 include $(UNIT_TESTS_DIR)/rules.mk
+include $(PROJECT_DIR)/rusefi_config.mk
 include $(PROJECT_DIR)/rusefi_pch.mk


### PR DESCRIPTION
This prepares unit tests for regenerating configs if they need to be.
Because generating configs requires board meta info, I copied the code that sets the default from firmware/rusefi.mk.

Green custom: https://github.com/chuckwagoncomputing/fw-custom-example/actions/runs/8043683225