### PR TITLE
Move ramdisk creation to its own script and make target

### DIFF
--- a/.github/workflows/hw-ci/build_for_hw_ci.sh
+++ b/.github/workflows/hw-ci/build_for_hw_ci.sh
@@ -16,8 +16,10 @@ cd firmware
 export BOARD_META_PATH=$(bash bin/find_meta_info.sh ${HW_FOLDER} ${HW_TARGET})
 source config/boards/common_script_read_meta_env.inc "${BOARD_META_PATH}"
 
-./gen_live_documentation.sh
-./gen_config_board.sh $HW_FOLDER $HW_TARGET
+bash gen_live_documentation.sh
+bash gen_signature.sh $HW_TARGET
+bash gen_config_board.sh $HW_FOLDER $HW_TARGET
+bash bin/gen_image_board.sh $HW_FOLDER $HW_TARGET
 
 echo "[build_for_hw_ci.sh] We aren't guaranteed a clean machine every time, so manually clean the output."
 make clean

--- a/firmware/bin/gen_image_board.sh
+++ b/firmware/bin/gen_image_board.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+BOARD_DIR=${1:-$BOARD_DIR}
+SHORT_BOARD_NAME=${2:-$SHORT_BOARD_NAME}
+INI=${3:-"rusefi_$SHORT_BOARD_NAME.ini"}
+
+which realpath >/dev/null 2>&1 || (which grealpath >/dev/null 2>&1 && alias realpath='grealpath')
+FDIR=$(realpath $(dirname "$0")/..)
+BOARD_DIR=$(realpath --relative-to "$FDIR" "$BOARD_DIR")
+
+cd "$FDIR"
+
+PREPEND_FILE=${BOARD_DIR}/prepend.txt
+
+BOARD_SPECIFIC_URL=$(cat $PREPEND_FILE | grep MAIN_HELP_URL | cut -d " " -f 3 | sed -e 's/^"//' -e 's/"$//')
+
+echo "BOARD_SPECIFIC_URL=[$BOARD_SPECIFIC_URL] for [$SHORT_BOARD_NAME] from [$BOARD_DIR]"
+if [ "" = "$BOARD_SPECIFIC_URL" ]; then
+  BOARD_SPECIFIC_URL=https://rusefi.com/s/wiki
+fi
+echo "BOARD_SPECIFIC_URL=[$BOARD_SPECIFIC_URL]"
+
+# we generate both versions of the header but only one would be actually included due to conditional compilation see EFI_USE_COMPRESSED_INI_MSD
+# todo: make things consistent by
+# 0) having generated content not in the same folder with the tool generating content?
+# 1) using unique file name for each configuration?
+# 2) leverage consistent caching mechanism so that image is generated only in case of fresh .ini. Laziest approach would be to return exit code from java process above
+#
+hw_layer/mass_storage/create_ini_image.sh            ${META_OUTPUT_ROOT_FOLDER}tunerstudio/generated/${INI} ./hw_layer/mass_storage/ramdisk_image.h             128 ${SHORT_BOARD_NAME} ${BOARD_SPECIFIC_URL}
+hw_layer/mass_storage/create_ini_image_compressed.sh ${META_OUTPUT_ROOT_FOLDER}tunerstudio/generated/${INI} ./hw_layer/mass_storage/ramdisk_image_compressed.h 1088 ${SHORT_BOARD_NAME} ${BOARD_SPECIFIC_URL}

--- a/firmware/gen_config.sh
+++ b/firmware/gen_config.sh
@@ -73,7 +73,9 @@ for BOARD in \
    ; do
  BOARD_DIR=$(echo "$BOARD" | cut -d " " -f 1)
  BOARD_SHORT_NAME=$(echo "$BOARD" | cut -d " " -f 2)
- ./gen_config_board.sh $BOARD_DIR $BOARD_SHORT_NAME
+ bash gen_signature.sh ${SHORT_BOARD_NAME}
+ bash gen_config_board.sh $BOARD_DIR $BOARD_SHORT_NAME
+ bash bin/gen_image_board.sh $BOARD_DIR $BOARD_SHORT_NAME
  [ $? -eq 0 ] || { echo "ERROR generating board dir=[$BOARD_DIR] short=[$BOARD_SHORT_NAME]"; exit 1; }
 done
 

--- a/firmware/gen_config_board.sh
+++ b/firmware/gen_config_board.sh
@@ -37,18 +37,6 @@ BOARD_DIR=$(realpath --relative-to "$FDIR" "$BOARD_DIR")
 
 cd "$FDIR"
 
-bash gen_signature.sh ${SHORT_BOARD_NAME}
-
-PREPEND_FILE=${BOARD_DIR}/prepend.txt
-
-BOARD_SPECIFIC_URL=$(cat $PREPEND_FILE | grep MAIN_HELP_URL | cut -d " " -f 3 | sed -e 's/^"//' -e 's/"$//')
-
-echo "BOARD_SPECIFIC_URL=[$BOARD_SPECIFIC_URL] for [$SHORT_BOARD_NAME] from [$BOARD_DIR]"
-if [ "" = "$BOARD_SPECIFIC_URL" ]; then
-  BOARD_SPECIFIC_URL=https://rusefi.com/s/wiki
-fi
-echo "BOARD_SPECIFIC_URL=[$BOARD_SPECIFIC_URL]"
-
 source gen_config_common.sh
 echo "Using COMMON_GEN_CONFIG [$COMMON_GEN_CONFIG]"
 
@@ -67,15 +55,6 @@ java \
 if [ -z "META_OUTPUT_ROOT_FOLDER" ]; then
 	META_OUTPUT_ROOT_FOLDER=""
 fi
-
-# we generate both versions of the header but only one would be actually included due to conditional compilation see EFI_USE_COMPRESSED_INI_MSD
-# todo: make things consistent by
-# 0) having generated content not in the same folder with the tool generating content?
-# 1) using unique file name for each configuration?
-# 2) leverage consistent caching mechanism so that image is generated only in case of fresh .ini. Laziest approach would be to return exit code from java process above
-#
-hw_layer/mass_storage/create_ini_image.sh            ${META_OUTPUT_ROOT_FOLDER}tunerstudio/generated/${INI} ./hw_layer/mass_storage/ramdisk_image.h             128 ${SHORT_BOARD_NAME} ${BOARD_SPECIFIC_URL}
-hw_layer/mass_storage/create_ini_image_compressed.sh ${META_OUTPUT_ROOT_FOLDER}tunerstudio/generated/${INI} ./hw_layer/mass_storage/ramdisk_image_compressed.h 1088 ${SHORT_BOARD_NAME} ${BOARD_SPECIFIC_URL}
 
 echo "Happy ${SHORT_BOARD_NAME}!"
 exit 0

--- a/firmware/rusefi_config.mk
+++ b/firmware/rusefi_config.mk
@@ -3,12 +3,14 @@ include $(PROJECT_DIR)/../java_tools/java_tools.mk
 INI_FILE = $(META_OUTPUT_ROOT_FOLDER)tunerstudio/generated/rusefi_$(SHORT_BOARD_NAME).ini
 SIG_FILE = $(PROJECT_DIR)/tunerstudio/generated/signature_$(SHORT_BOARD_NAME).txt
 
+RAMDISK = \
+  $(PROJECT_DIR)/hw_layer/mass_storage/ramdisk_image.h \
+  $(PROJECT_DIR)/hw_layer/mass_storage/ramdisk_image_compressed.h
+
 CONFIG_FILES = \
   $(PROJECT_DIR)/$(INI_FILE) \
   $(PROJECT_DIR)/controllers/generated/rusefi_generated_$(SHORT_BOARD_NAME).h \
   $(PROJECT_DIR)/controllers/generated/signature_$(SHORT_BOARD_NAME).h \
-  $(PROJECT_DIR)/hw_layer/mass_storage/ramdisk_image.h \
-  $(PROJECT_DIR)/hw_layer/mass_storage/ramdisk_image_compressed.h \
   $(PROJECT_DIR)/$(BOARD_DIR)/connectors/generated_outputs.h \
   $(PROJECT_DIR)/$(BOARD_DIR)/connectors/generated_ts_name_by_pin.cpp \
   $(FIELDS)
@@ -16,9 +18,15 @@ CONFIG_FILES = \
 .FORCE:
 
 $(TCOBJS): $(CONFIG_FILES)
+mass_storage_init.o: $(RAMDISK)
 
 $(SIG_FILE): .FORCE
 	bash $(PROJECT_DIR)/gen_signature.sh $(SHORT_BOARD_NAME)
+
+$(RAMDISK): .ramdisk-sentinel ;
+
+.ramdisk-sentinel: $(INI_FILE)
+	bash $(PROJECT_DIR)/bin/gen_image_board.sh $(BOARD_DIR) $(SHORT_BOARD_NAME)
 
 $(CONFIG_FILES): .config-sentinel ;
 


### PR DESCRIPTION
Previous to this PR, ramdisk headers are always touched, even when no other config files are. Now the ramdisk headers will only be built if the .ini file was touched.
Currently the configs are always re-generated, which prior to this PR also caused most of the firmware to be rebuilt.
A future PR (hopefully next one) will only re-generate configs if one of their input files changed, but we still want to avoid rebuilding the firmware if one of those input files changed in a way that doesn't actually effect the output of config generation.

Green custom: https://github.com/chuckwagoncomputing/fw-custom-example/actions/runs/8087460266
