### PR TITLE
always try to rebuild ramdisk, but check and save SHORT_BOARD_NAME

### DIFF
--- a/firmware/rusefi_config.mk
+++ b/firmware/rusefi_config.mk
@@ -39,9 +39,11 @@ $(SIG_FILE): .FORCE
 
 $(RAMDISK): .ramdisk-sentinel ;
 
-.ramdisk-sentinel: $(INI_FILE)
-	bash $(PROJECT_DIR)/bin/gen_image_board.sh $(BOARD_DIR) $(SHORT_BOARD_NAME)
-	@touch $@
+.ramdisk-sentinel: $(INI_FILE) .FORCE
+	test $$(cat $@ 2>/dev/null) == $(SHORT_BOARD_NAME) -a \
+	! $$(echo "$?" | cut -d ' ' -f 1) -ef $(INI_FILE) \
+	|| (bash $(PROJECT_DIR)/bin/gen_image_board.sh $(BOARD_DIR) $(SHORT_BOARD_NAME) \
+	&& echo $(SHORT_BOARD_NAME) >$@)
 
 $(CONFIG_FILES): .config-sentinel ;
 


### PR DESCRIPTION
Fix #6088

Don't worry, comments are coming. I'm waiting until files are no longer in a state of flux so I don't have to waste so much time rebasing comments.

Basically we check if the .ini file was what triggered this rule, or if the contents of .ramdisk-sentinel don't match SHORT_BOARD_NAME, and if either of those things are true, rebuild the ramdisk images and write the SHORT_BOARD_NAME to .ramdisk-sentinel.