### PR TITLE
Use file with short board name to trigger rebuild on target change

### DIFF
--- a/firmware/rusefi_config.mk
+++ b/firmware/rusefi_config.mk
@@ -37,15 +37,19 @@ $(TCPPOBJS): $(RAMDISK)
 $(SIG_FILE): .FORCE
 	bash $(PROJECT_DIR)/gen_signature.sh $(SHORT_BOARD_NAME)
 
+.target-sentinel: .FORCE
+	if [ "$$(cat $@ 2>/dev/null)" != $(SHORT_BOARD_NAME) ]; then \
+	echo $(SHORT_BOARD_NAME) >$@; fi
+
 $(RAMDISK): .ramdisk-sentinel ;
 
-.ramdisk-sentinel: $(INI_FILE)
+.ramdisk-sentinel: $(INI_FILE) .target-sentinel
 	bash $(PROJECT_DIR)/bin/gen_image_board.sh $(BOARD_DIR) $(SHORT_BOARD_NAME)
 	@touch $@
 
 $(CONFIG_FILES): .config-sentinel ;
 
-.config-sentinel: $(CONFIG_INPUTS) $(CONFIG_DEFINITION)
+.config-sentinel: $(CONFIG_INPUTS) $(CONFIG_DEFINITION) .target-sentinel
 ifneq (,$(CUSTOM_GEN_CONFIG))
 	bash $(BOARD_DIR)/$(CUSTOM_GEN_CONFIG)
 else


### PR DESCRIPTION
Caveat: SHORT_BOARD_NAME doesn't cover all possible changes. For example, if I build Proteus F7, then build Proteus F7 Debug, it won't actually rebuild. BUNDLE_NAME would be a better specifier, but it's currently only available from the build_firmware GHA workflow. Another option would be to use BOARD_META_PATH, and export it in config.sh.
@rusefillc Let me know what you think.

Fix #6088
Green custom: https://github.com/chuckwagoncomputing/fw-custom-example/actions/runs/8102640677