### PR TITLE
one-based indexing enums is not cool

### DIFF
--- a/firmware/hw_layer/hardware.cpp
+++ b/firmware/hw_layer/hardware.cpp
@@ -75,7 +75,8 @@
 #endif
 
 #if HAL_USE_SPI
-extern bool isSpiInitialized[SPI_TOTAL_COUNT];
+/* zero index is SPI_NONE */
+extern bool isSpiInitialized[SPI_TOTAL_COUNT + 1];
 
 /**
  * Only one consumer can use SPI bus at a given time

--- a/firmware/hw_layer/ports/at32/at32_spi.cpp
+++ b/firmware/hw_layer/ports/at32/at32_spi.cpp
@@ -9,7 +9,8 @@
 #include "pch.h"
 
 #if HAL_USE_SPI
-bool isSpiInitialized[SPI_TOTAL_COUNT] = { false, false, false, false, false, false };
+/* zero index is SPI_NONE */
+bool isSpiInitialized[SPI_TOTAL_COUNT + 1] = { true, false, false, false, false, false, false };
 
 struct af_pairs {
 	brain_pin_e pin;

--- a/firmware/hw_layer/ports/cypress/mpu_util.cpp
+++ b/firmware/hw_layer/ports/cypress/mpu_util.cpp
@@ -65,7 +65,8 @@ void HardFaultVector(void) {
 }
 
 #if HAL_USE_SPI || defined(__DOXYGEN__)
-bool isSpiInitialized[SPI_TOTAL_COUNT] = { false, false, false, false, false, false };
+/* zero index is SPI_NONE */
+bool isSpiInitialized[SPI_TOTAL_COUNT + 1] = { true, false, false, false, false, false, false };
 
 static int getSpiAf(SPIDriver *driver) {
 #if STM32_SPI_USE_SPI1

--- a/firmware/hw_layer/ports/kinetis/mpu_util.cpp
+++ b/firmware/hw_layer/ports/kinetis/mpu_util.cpp
@@ -58,7 +58,8 @@ void HardFaultVector(void) {
 }
 
 #if HAL_USE_SPI || defined(__DOXYGEN__)
-bool isSpiInitialized[SPI_TOTAL_COUNT] = { false, false, false, false, false, false };
+/* zero index is SPI_NONE */
+bool isSpiInitialized[SPI_TOTAL_COUNT + 1] = { true, false, false, false, false, false, false };
 
 static int getSpiAf(SPIDriver *driver) {
 #if STM32_SPI_USE_SPI1

--- a/firmware/hw_layer/ports/stm32/stm32_spi.cpp
+++ b/firmware/hw_layer/ports/stm32/stm32_spi.cpp
@@ -9,7 +9,8 @@
 #include "pch.h"
 
 #if HAL_USE_SPI
-bool isSpiInitialized[SPI_TOTAL_COUNT] = { false, false, false, false, false, false };
+/* zero index is SPI_NONE */
+bool isSpiInitialized[SPI_TOTAL_COUNT + 1] = { true, false, false, false, false, false, false };
 
 static int getSpiAf(SPIDriver *driver) {
 #if STM32_SPI_USE_SPI1


### PR DESCRIPTION
Fixes possible out of array bounds introduced in 5af710ff73a0d9cd51e21478b3c665b803613b27