### PR TITLE
Do not insert aem can listeners to list on each flash write

### DIFF
--- a/firmware/init/sensor/init_sensors.cpp
+++ b/firmware/init/sensor/init_sensors.cpp
@@ -145,7 +145,6 @@ void reconfigureSensors() {
 	initFluidPressure();
 	initVbatt();
 	initThermistors();
-	initLambda();
 	initFlexSensor(false);
 	initVehicleSpeedSensor();
 	initTurbochargerSpeedSensor();


### PR DESCRIPTION
reconfigureSensors()->initLambda()->registerCanSensor() ...

This cause linked list loop.

Proper solution is to remove AEM sensors from can listener list before inserting them again.

Revert "missing initLambda in reconfigureSensors"

This reverts commit ee20cbd33b114dd05782faf02728f1966216ae9b.