### PR TITLE
Generate .deps before compiling

### DIFF
--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -396,6 +396,10 @@ include rusefi_pch.mk
 
 include bundle.mk
 
+ifeq (,$(filter clean,$(MAKECMDGOALS)))
+include deps.mk
+endif
+
 .PHONY: CLEAN_RULE_HOOK CLEAN_PCH_HOOK CLEAN_BUNDLE_HOOK
 
 CLEAN_RULE_HOOK: CLEAN_PCH_HOOK CLEAN_BUNDLE_HOOK

--- a/firmware/bootloader/Makefile
+++ b/firmware/bootloader/Makefile
@@ -365,6 +365,10 @@ endif
 
 include $(PROJECT_DIR)/rusefi_pch.mk
 
+ifeq (,$(filter clean,$(MAKECMDGOALS)))
+include $(PROJECT_DIR)/deps.mk
+endif
+
 .PHONY: CLEAN_RULE_HOOK CLEAN_PCH_HOOK
 
 CLEAN_RULE_HOOK: CLEAN_PCH_HOOK

--- a/firmware/deps.mk
+++ b/firmware/deps.mk
@@ -1,0 +1,44 @@
+# The ChibiOS rules makefile at ChibiOS/os/common/startup/ARMCMx/compilers/GCC/mk/rules.mk
+#  builds a .o file and generates the deps for that .o file in the same GCC call,
+#  so if the .deps aren't already in the correct state,
+#  things can fail to build because Make doesn't know it needs
+#  to generate the prerequisites for those files ahead of time.
+# This makefile is the answer to that problem.
+# In this file, we do the following:
+# - try to include a .d file for every .o file
+# - define recipes to build a .d file if it doesn't exist
+# - declare that every .o file has its .d file as a prerequisite, so that if the .d file changes,
+#   the .o file will be rebuilt.
+# - declare TGT_SENTINEL (see rusefi_config.mk) as a prerequisite of all .d files, so that if we switch
+#   to building a different board, all .d files (and consequently all .o files) will be rebuilt.
+#   There are a few .d and .o files that wouldn't necessarily need to be rebuilt, but there's no good
+#   way to selectively not rebuild them without checking if they need to be rebuilt every time make is run.
+
+TCDEP = $(addprefix $(DEPDIR)/, $(notdir $(TCSRC:.c=.o.d)))
+TCPPDEP = $(addprefix $(DEPDIR)/, $(notdir $(patsubst %.cpp, %.o.d, $(filter %.cpp, $(TCPPSRC)))))
+TCCDEP = $(addprefix $(DEPDIR)/, $(notdir $(patsubst %.cc, %.o.d, $(filter %.cc, $(TCPPSRC)))))
+
+# Override CFLAGS and CPPFLAGS with their original values before the .dep creation variables were appended.
+# This is to prevent to compilation rule in ChibiOS/os/common/startup/ARMCMx/compilers/GCC/mk/rules.mk from
+#  also generating .deps
+CFLAGS = $(MCFLAGS) $(OPT) $(COPT) $(CWARN) -Wa,-alms=$(LSTDIR)/$(notdir $(<:.c=.lst)) $(DEFS)
+CPPFLAGS = $(MCFLAGS) $(OPT) $(CPPOPT) $(CPPWARN) -Wa,-alms=$(LSTDIR)/$(notdir $(<:.cpp=.lst)) $(DEFS)
+
+$(TCDEP): $(DEPDIR)/%.o.d: %.c $(TGT_SENTINEL) | $(CONFIG_FILES) $(DEPDIR)
+	@echo Gen deps for $(<F)
+	@$(CC) -M -MP -MF $@ $(CFLAGS) -I. $(IINCDIR) $<
+
+$(TCPPDEP): $(DEPDIR)/%.o.d: %.cpp $(TGT_SENTINEL) | $(CONFIG_FILES) $(DEPDIR)
+	@echo Gen deps for $(<F)
+	@$(CPPC) -M -MP -MF $@ $(CPPFLAGS) -I. $(IINCDIR) $<
+
+$(TCCDEP): $(DEPDIR)/%.o.d: %.cc $(TGT_SENTINEL) | $(CONFIG_FILES) $(DEPDIR)
+	@echo Gen deps for $(<F)
+	@$(CPPC) -M -MP -MF $@ $(CPPFLAGS) -I. $(IINCDIR) $<
+
+# Make each .o object depend on its .dep file
+$(TCOBJS) $(TCPPOBJS) $(TCCOBJS): $(OBJDIR)/%.o: $(DEPDIR)/%.o.d
+
+include $(TCDEP)
+include $(TCPPDEP)
+include $(TCCDEP)

--- a/firmware/rusefi_config.mk
+++ b/firmware/rusefi_config.mk
@@ -32,13 +32,6 @@ CONFIG_FILES = \
 
 .FORCE:
 
-# This is necessary because the ChibiOS makefile builds a .o file and generates
-#  the deps for that .o file in the same GCC call, so if the .deps aren't already
-#  in the correct state, things can fail to build because Make doesn't know it needs
-#  to build the prerequisites (in this case CONFIG_FILES and RAMDISK) for those files ahead of time.
-$(TCOBJS): $(CONFIG_FILES)
-$(TCPPOBJS): $(RAMDISK)
-
 # Always try to rebuild the signature file.
 # The script won't actually update the file if the signature hasn't changed, so it won't trigger a config file generation.
 $(SIG_FILE): .FORCE

--- a/firmware/rusefi_pch.mk
+++ b/firmware/rusefi_pch.mk
@@ -14,14 +14,6 @@ else
 	@$(CPPC) -c $(CPPFLAGS) $(AOPT) -I. $(IINCDIR) $< -o $@
 endif
 
-# Make all cpp objects explicitly depend on the PCH
-# This is necessary because the ChibiOS makefile builds a .o file and generates
-#  the deps for that .o file in the same GCC call, so if the .deps aren't already
-#  in the correct state, things can fail to build because Make doesn't know it needs
-#  to build the prerequisites (in this case PCHOBJ) for those files ahead of time.
-$(TCPPOBJS) : $(PCHOBJ)
-$(ACPPOBJS) : $(PCHOBJ)
-
 # Delete PCH output on clean
 CLEAN_PCH_HOOK:
 	@echo Cleaning PCH


### PR DESCRIPTION
Explained in deps.mk

In theory this should take care of #5990, but I think it's likely there are edge cases. Also, .target-sentinel is still using SHORT_BOARD_NAME, so it will really only work when switching between boards, not board variants.

I think this change is more likely than some to cause issues, so I'm making this a draft until I have the time to deal with any ensuing problems. Feel free to check it out and play around.

Note that live docs and enums aren't auto generated yet.