### PR TITLE
Try enabling globstar

### DIFF
--- a/.github/workflows/build-simulator.yaml
+++ b/.github/workflows/build-simulator.yaml
@@ -78,6 +78,7 @@ jobs:
       env:
         ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
       run: |
+        shopt -s globstar
         git config --local user.email "action@github.com"
         git config --local user.name "GitHub gen-default-tune Action"
         echo See https://github.com/rusefi/rusefi/issues/2446


### PR DESCRIPTION
`**/*.h` etc. seem to not be working. On bash this is disabled by default. We will try enabling it with `shopt -s globstar`
This issue has probably always existed, but files other than the .xml files are not always created. It may be happening more often because more things are being rebuilt because one of their prerequisites were updated, I'm not sure.