### PR TITLE
Fix flock issues on Windows

### DIFF
--- a/java_tools/java_tools.mk
+++ b/java_tools/java_tools.mk
@@ -7,7 +7,7 @@ JAVA_TOOLS = $(PROJECT_DIR)/../java_tools
 # Once it isn't locked, it locks it, runs the command, then unlocks it once the command is finished.
 # Note that flock doesn't ship on macOS. You can install it with `brew install flock`
 # On Windows, flock comes with Cygwin.
-FLOCK = flock /tmp/java.lock
+FLOCK = flock -o /tmp/java.lock
 
 FIELDS =   $(PROJECT_DIR)/../java_console/models/src/main/java/com/rusefi/config/generated/Fields.java
 


### PR DESCRIPTION
Something acts up with flock on windows, I think it has to with Gradle starting a background process. I don't know why this isn't affecting current workflows, it just showed up when I started generating docs and enums from Make as well.
The -o option for flock closes the file descriptor so the child process doesn't hold the lock, only flock does.