### PR TITLE
Call gen_live_documentation.sh from make

### DIFF
--- a/.github/workflows/build-firmware-proteus-f7-mac.yaml
+++ b/.github/workflows/build-firmware-proteus-f7-mac.yaml
@@ -44,11 +44,6 @@ jobs:
       - name: Test Java Compiler
         run: javac -version
 
-      - name: Generate Live Documentation
-        if: ${{ env.skip != 'true' }}
-        working-directory: ./firmware/
-        run: ./gen_live_documentation.sh
-
       - name: Build Firmware
         if: ${{ env.skip != 'true' }}
         working-directory: ./firmware/config/boards/proteus

--- a/.github/workflows/build-firmware-windows.yaml
+++ b/.github/workflows/build-firmware-windows.yaml
@@ -40,10 +40,6 @@ jobs:
       - name: Test Java Compiler
         run: javac -version
 
-      - name: Generate Enums & Live Documentation
-        working-directory: ./firmware/
-        run: bash gen_live_documentation.sh
-
       - name: Print arm GCC version
         run: arm-none-eabi-gcc -v
 

--- a/.github/workflows/build-firmware.yaml
+++ b/.github/workflows/build-firmware.yaml
@@ -454,11 +454,6 @@ jobs:
         sudo bash misc/actions/add-ubuntu-latest-apt-mirrors.sh
         sudo apt-get install gcc-multilib g++-multilib g++-mingw-w64 gcc-mingw-w64 sshpass mtools zip dosfstools
 
-    - name: Generate Live Documentation
-      if: ${{ env.skip != 'true' }}
-      working-directory: ./firmware/
-      run: ./gen_live_documentation.sh
-
     - name: Set Build Env Variables
       if: ${{ env.skip != 'true' }}
       working-directory: ./firmware/

--- a/.github/workflows/build-rusEFI-console.yaml
+++ b/.github/workflows/build-rusEFI-console.yaml
@@ -32,6 +32,12 @@ jobs:
           sudo bash misc/actions/add-ubuntu-latest-apt-mirrors.sh
           sudo apt-get install sshpass mtools
 
+      - name: Build Config Definition Base and Enum to String
+        working-directory: ./java_tools/
+        run: |
+          ./gradlew :config_definition_base:shadowJar
+          ./gradlew :enum_to_string:shadowJar
+
       - name: Generate Enums & Live Documentation
         working-directory: ./firmware/
         run: ./gen_live_documentation.sh

--- a/.github/workflows/build-unit-tests-windows.yaml
+++ b/.github/workflows/build-unit-tests-windows.yaml
@@ -32,10 +32,6 @@ jobs:
     - name: Test Java Compiler
       run: javac -version
 
-    - name: Generate Enums & Live Documentation
-      working-directory: ./firmware/
-      run: bash gen_live_documentation.sh
-
     - name: Print GCC version
       run: gcc -v
 

--- a/.github/workflows/build-unit-tests.yaml
+++ b/.github/workflows/build-unit-tests.yaml
@@ -43,10 +43,6 @@ jobs:
     - name: Test Java Compiler
       run: javac -version
 
-    - name: Generate Enums & Live Documentation
-      working-directory: ./firmware/
-      run: bash gen_live_documentation.sh
-
     - name: Print Compiler version
       # NOTE: on mac, this is actually symlink'd to clang, not gcc, but that's ok - we want to build on both
       run: gcc -v

--- a/.github/workflows/gen-configs.yaml
+++ b/.github/workflows/gen-configs.yaml
@@ -34,9 +34,12 @@ jobs:
         sudo bash misc/actions/add-ubuntu-latest-apt-mirrors.sh
         sudo apt-get install sshpass sshpass mtools
 
-    - name: Configuration Definition CI, without pushing new .jar
+    - name: Configuration Definition and Enum to String CI, without pushing new .jar
       working-directory: ./java_tools
-      run: ./gradlew :config_definition:shadowJar
+      run: |
+        ./gradlew :config_definition:shadowJar
+        ./gradlew :config_definition_base:shadowJar
+        ./gradlew :enum_to_string:shadowJar
 
     - name: Generate Live Documentation
       working-directory: ./firmware/

--- a/.github/workflows/hw-ci/build_for_hw_ci.sh
+++ b/.github/workflows/hw-ci/build_for_hw_ci.sh
@@ -16,11 +16,6 @@ cd firmware
 export BOARD_META_PATH=$(bash bin/find_meta_info.sh ${HW_FOLDER} ${HW_TARGET})
 source config/boards/common_script_read_meta_env.inc "${BOARD_META_PATH}"
 
-bash gen_live_documentation.sh
-bash gen_signature.sh $HW_TARGET
-bash gen_config_board.sh $HW_FOLDER $HW_TARGET
-bash bin/gen_image_board.sh $HW_FOLDER $HW_TARGET
-
 echo "[build_for_hw_ci.sh] We aren't guaranteed a clean machine every time, so manually clean the output."
 make clean
 

--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -22,8 +22,9 @@
 #
 # If you wish to call make directly, here are the available commands:
 #
-# make					Generate configs and build firmware
-# make bundle		Generate configs, built bootloader, build firmware, and package both full and autoupdate bundles
+# make docs-enums	Generate docs and enums
+# make						Generate docs, enums, configs, and build firmware
+# make bundle			Generate docs, enums, configs, built bootloader, build firmware, and package both full and autoupdate bundles
 #
 # You can make a single bundle by passing the target bundle path, for example:
 # make ../artifacts/rusefi_bundle_f407-discovery.zip
@@ -419,6 +420,8 @@ include $(RULESFILE)
 include target_sentinel.mk
 
 include rusefi_config.mk
+
+include docs_enums.mk
 
 # Enable precompiled header
 include rusefi_pch.mk

--- a/firmware/docs_enums.mk
+++ b/firmware/docs_enums.mk
@@ -1,0 +1,32 @@
+DOCS_ENUMS_INPUTS = \
+  $(PROJECT_DIR)/integration/rusefi_config.txt \
+  $(PROJECT_DIR)/integration/LiveData.yaml \
+  $(PROJECT_DIR)/console/binary/generated/live_data_ids.h \
+  $(PROJECT_DIR)/controllers/sensors/sensor_type.h \
+  $(PROJECT_DIR)/controllers/trigger/decoders/sync_edge.h \
+  $(PROJECT_DIR)/controllers/algo/engine_types.h \
+  $(PROJECT_DIR)/libfirmware/can/can_common.h \
+  $(PROJECT_DIR)/controllers/algo/rusefi_enums.h \
+  $(PROJECT_DIR)/hw_layer/drivers/can/can_category.h \
+  $(PROJECT_DIR)/controllers/trigger/decoders/sync_edge.h \
+  $(PROJECT_DIR)/controllers/algo/rusefi_hw_enums.h \
+  $(PROJECT_DIR)/controllers/sensors/sensor_type.h \
+  $(PROJECT_DIR)/config/boards/cypress/rusefi_hw_enums.h \
+  $(PROJECT_DIR)/config/boards/kinetis/rusefi_hw_enums.h \
+  $(PROJECT_DIR)/config/boards/subaru_eg33/rusefi_hw_enums.h
+
+.docsenums-sentinel: $(DOCS_ENUMS_INPUTS) $(CONFIG_DEFINITION_BASE) $(ENUM_TO_STRING)
+	bash $(PROJECT_DIR)/gen_live_documentation.sh
+	@touch $@
+
+.PHONY: docs-enums
+
+docs-enums: .docsenums-sentinel
+
+$(CONFIG_FILES): .docsenums-sentinel
+
+# This is necessary because the ChibiOS makefile builds a .o file and generates
+#  the deps for that .o file in the same GCC call, so if the .deps aren't already
+#  in the correct state, things can fail to build because Make doesn't know it needs
+#  to build the prerequisites (in this case the generated live docs and enums) for those files ahead of time.
+$(OBJS): .docsenums-sentinel

--- a/firmware/gen_enum_to_string.sh
+++ b/firmware/gen_enum_to_string.sh
@@ -2,11 +2,6 @@
 
 echo "This batch files reads rusefi_enums.h and produces auto_generated_enums.* files"
 
-cd ../java_tools
-./gradlew :config_definition:shadowJar
-./gradlew :enum_to_string:shadowJar
-cd ../firmware
-
 rm gen_enum_to_string.log
 
 ENUM_JAR=../java_tools/enum_to_string/build/libs/enum_to_string-all.jar

--- a/firmware/gen_live_documentation.sh
+++ b/firmware/gen_live_documentation.sh
@@ -1,11 +1,8 @@
 #!/bin/bash
 
-rm gen_live_documentation.log
+cd $(dirname "$0")
 
-cd ../java_tools
-./gradlew :config_definition_base:shadowJar
-./gradlew :enum_to_string:shadowJar
-cd ../firmware
+rm gen_live_documentation.log
 
 java -DSystemOut.name=logs/gen_live_documentation \
  -cp ../java_tools/configuration_definition_base/build/libs/config_definition_base-all.jar \

--- a/unit_tests/unit_test_rules.mk
+++ b/unit_tests/unit_test_rules.mk
@@ -262,4 +262,5 @@ endif
 
 include $(UNIT_TESTS_DIR)/rules.mk
 include $(PROJECT_DIR)/rusefi_config.mk
+include $(PROJECT_DIR)/docs_enums.mk
 include $(PROJECT_DIR)/rusefi_pch.mk


### PR DESCRIPTION
- call gen_live_documentation if any input files or the jars were updated
- don't build config_definition_base or enum_to_string in gen_live_documentation or gen_enum_to_string because make will do that if needed
- build config_definition_base and enum_to_string in places that are calling gen_live_documentation directly