### PR TITLE
Vss fixes, efiExtiEnablePin() fixes

### DIFF
--- a/firmware/controllers/core/error_handling.h
+++ b/firmware/controllers/core/error_handling.h
@@ -54,6 +54,7 @@ int getRusEfiVersion(void);
   #define efiAssertVoid(code, condition, message) { UNUSED(condition);}
 #endif /* EFI_ENABLE_ASSERTS */
 
+#define criticalAssert(condition, message, result) efiAssert(ObdCode::OBD_PCM_Processor_Fault, condition, message, result)
 #define criticalAssertVoid(condition, message) efiAssertVoid(ObdCode::OBD_PCM_Processor_Fault, condition, message)
 
 #ifdef __cplusplus

--- a/firmware/controllers/sensors/frequency_sensor.cpp
+++ b/firmware/controllers/sensors/frequency_sensor.cpp
@@ -28,14 +28,15 @@ void FrequencySensor::initIfValid(brain_pin_e pin, SensorConverter &converter, f
 
 	setFunction(converter);
 
-	m_pin = pin;
-
 #if EFI_PROD_CODE
 	// todo: refactor https://github.com/rusefi/rusefi/issues/2123
-	efiExtiEnablePin(getSensorName(), pin, 
-		PAL_EVENT_MODE_FALLING_EDGE,
-		freqSensorExtiCallback, reinterpret_cast<void*>(this));
+	if (efiExtiEnablePin(getSensorName(), pin, PAL_EVENT_MODE_FALLING_EDGE,
+			freqSensorExtiCallback, reinterpret_cast<void*>(this)) < 0) {
+		return;
+	}
 #endif // EFI_PROD_CODE
+
+	m_pin = pin;
 
 	Register();
 }

--- a/firmware/controllers/sensors/frequency_sensor.cpp
+++ b/firmware/controllers/sensors/frequency_sensor.cpp
@@ -29,7 +29,6 @@ void FrequencySensor::initIfValid(brain_pin_e pin, SensorConverter &converter, f
 	setFunction(converter);
 
 #if EFI_PROD_CODE
-	// todo: refactor https://github.com/rusefi/rusefi/issues/2123
 	if (efiExtiEnablePin(getSensorName(), pin, PAL_EVENT_MODE_FALLING_EDGE,
 			freqSensorExtiCallback, reinterpret_cast<void*>(this)) < 0) {
 		return;

--- a/firmware/controllers/sensors/hella_oil_level.cpp
+++ b/firmware/controllers/sensors/hella_oil_level.cpp
@@ -15,15 +15,28 @@ void HellaOilLevelSensor::init(brain_pin_e pin) {
 		return;
 	}
 
-	m_pin = pin;
-
 #if EFI_PROD_CODE
-	efiExtiEnablePin(getSensorName(), pin, 
-		PAL_EVENT_MODE_BOTH_EDGES,
-		hellaSensorExtiCallback, reinterpret_cast<void*>(this));
+	if (efiExtiEnablePin(getSensorName(), pin, PAL_EVENT_MODE_BOTH_EDGES,
+		hellaSensorExtiCallback, reinterpret_cast<void*>(this)) < 0) {
+		return;
+	}
 #endif // EFI_PROD_CODE
 
+	m_pin = pin;
+
 	Register();
+}
+
+void HellaOilLevelSensor::deInit() {
+	if (!isBrainPinValid(m_pin)) {
+		return;
+	}
+
+#if EFI_PROD_CODE
+	efiExtiDisablePin(m_pin);
+#endif
+
+	m_pin = Gpio::Unassigned;
 }
 
 void HellaOilLevelSensor::onEdge(efitick_t nowNt) {

--- a/firmware/controllers/sensors/hella_oil_level.h
+++ b/firmware/controllers/sensors/hella_oil_level.h
@@ -7,6 +7,7 @@ public:
 	HellaOilLevelSensor(SensorType type) : StoredValueSensor(type, MS2NT(2000)) {}
 
 	void init(brain_pin_e pin);
+	void deInit();
 
 	void onEdge(efitick_t nowNt);
 

--- a/firmware/hw_layer/digital_input/digital_input_exti.h
+++ b/firmware/hw_layer/digital_input/digital_input_exti.h
@@ -12,7 +12,7 @@
 using ExtiCallback = void(*)(void*, efitick_t);
 
 void efiExtiInit();
-void efiExtiEnablePin(const char *msg, brain_pin_e pin, uint32_t mode, ExtiCallback cb, void *cb_data);
+int efiExtiEnablePin(const char *msg, brain_pin_e pin, uint32_t mode, ExtiCallback cb, void *cb_data);
 void efiExtiDisablePin(brain_pin_e brainPin);
 uint8_t getExtiOverflowCounter();
 #endif /* HAL_USE_PAL */

--- a/firmware/hw_layer/digital_input/trigger/trigger_input_adc.cpp
+++ b/firmware/hw_layer/digital_input/trigger/trigger_input_adc.cpp
@@ -110,9 +110,6 @@ int adcTriggerTurnOnInputPin(const char *msg, int index, bool isTriggerShaft) {
 	brain_pin_e brainPin = isTriggerShaft ?
 		engineConfiguration->triggerInputPins[index] : engineConfiguration->camInputs[index];
 
-	if (!isBrainPinValid(brainPin))
-		return 0;
-
 	trigAdcState.init();
 
 	triggerInputPort = getHwPort("trg", brainPin);

--- a/firmware/hw_layer/digital_input/trigger/trigger_input_adc.cpp
+++ b/firmware/hw_layer/digital_input/trigger/trigger_input_adc.cpp
@@ -121,7 +121,10 @@ int adcTriggerTurnOnInputPin(const char *msg, int index, bool isTriggerShaft) {
 	ioline_t pal_line = PAL_LINE(triggerInputPort, triggerInputPin);
 	efiPrintf("turnOnTriggerInputPin %s l=%d", hwPortname(brainPin), pal_line);
 
-	efiExtiEnablePin(msg, brainPin, PAL_EVENT_MODE_BOTH_EDGES, isTriggerShaft ? shaft_callback : cam_callback, (void *)pal_line);
+	if (efiExtiEnablePin(msg, brainPin, PAL_EVENT_MODE_BOTH_EDGES,
+		isTriggerShaft ? shaft_callback : cam_callback, (void *)pal_line) < 0) {
+		return -1;
+	}
 
 	// ADC mode is default, because we don't know if the wheel is already spinning
 	setTriggerAdcMode(TRIGGER_ADC_ADC);

--- a/firmware/hw_layer/digital_input/trigger/trigger_input_exti.cpp
+++ b/firmware/hw_layer/digital_input/trigger/trigger_input_exti.cpp
@@ -58,13 +58,14 @@ int extiTriggerTurnOnInputPin(const char *msg, int index, bool isTriggerShaft) {
 
 	efiPrintf("extiTriggerTurnOnInputPin %s %s", msg, hwPortname(brainPin));
 
+	/* TODO:
+	 * * do not set to both edges if we need only one
+	 * * simplify callback in case of one edge */
 	if (efiExtiEnablePin(msg, brainPin, PAL_EVENT_MODE_BOTH_EDGES,
 		isTriggerShaft ? shaft_callback : cam_callback, (void *)index) < 0) {
 		return -1;
 	}
-	/* TODO:
-	 * * do not set to both edges if we need only one
-	 * * simplify callback in case of one edge */
+
 	ioline_t pal_line = PAL_LINE(getHwPort("trg", brainPin), getHwPin("trg", brainPin));
 	if (isTriggerShaft) {
 		shaftLines[index] = pal_line;

--- a/firmware/hw_layer/digital_input/trigger/trigger_input_exti.cpp
+++ b/firmware/hw_layer/digital_input/trigger/trigger_input_exti.cpp
@@ -58,6 +58,10 @@ int extiTriggerTurnOnInputPin(const char *msg, int index, bool isTriggerShaft) {
 
 	efiPrintf("extiTriggerTurnOnInputPin %s %s", msg, hwPortname(brainPin));
 
+	if (efiExtiEnablePin(msg, brainPin, PAL_EVENT_MODE_BOTH_EDGES,
+		isTriggerShaft ? shaft_callback : cam_callback, (void *)index) < 0) {
+		return -1;
+	}
 	/* TODO:
 	 * * do not set to both edges if we need only one
 	 * * simplify callback in case of one edge */
@@ -67,7 +71,6 @@ int extiTriggerTurnOnInputPin(const char *msg, int index, bool isTriggerShaft) {
 	} else {
 		camLines[index] = pal_line;
 	}
-	efiExtiEnablePin(msg, brainPin, PAL_EVENT_MODE_BOTH_EDGES, isTriggerShaft ? shaft_callback : cam_callback, (void *)index);
 
 	return 0;
 }

--- a/firmware/init/sensor/init_flex.cpp
+++ b/firmware/init/sensor/init_flex.cpp
@@ -61,20 +61,19 @@ static void flexExtiCallback(void*, efitick_t nowNt) {
 // https://rusefi.com/forum/viewtopic.php?p=37452#p37452
 
 void initFlexSensor(bool isFirstTime) {
-	flexPin = engineConfiguration->flexSensorPin;
-	if (!isBrainPinValid(flexPin)) {
+#if EFI_PROD_CODE
+	if (efiExtiEnablePin("flex", engineConfiguration->flexSensorPin,
+		PAL_EVENT_MODE_BOTH_EDGES, flexExtiCallback, nullptr) < 0) {
 		return;
 	}
+#endif
+	flexPin = engineConfiguration->flexSensorPin;
 
 	// 0.01 means filter bandwidth of ~1hz with ~100hz sensor
 	flexTempFilter.configureLowpass(1, 0.01f);
 	flexSensor.setFunction(converter);
 
 #if EFI_PROD_CODE
-	efiExtiEnablePin("flex", flexPin,
-		PAL_EVENT_MODE_BOTH_EDGES,
-		flexExtiCallback, nullptr);
-
     if (isFirstTime) {
 	    addConsoleAction("flexinfo", []() {
 	        efiPrintf("flex counter %d", flexCallbackCounter);


### PR DESCRIPTION
Set one of trigger inputs to PD6
Set VSS input to PD6
Get firmware error
![Screenshot from 2024-03-05 23-36-06](https://github.com/rusefi/rusefi/assets/28624689/8e714ee4-56ec-405e-b4de-a83cb51181ad)
Try to fix: set VSS to PD7. Things get even worse - ChibiOS dies on internal assert:
```
#0  chDbgPanic3 (msg=0x8075d64 <__func__.0.lto_priv.14> "_pal_lld_disablepadevent", file=0x8075adc "ChibiOS/os/rt/src/chsys.c", line=201) at ./controllers/core/error_handling.cpp:108
#1  0x08002c6c in chSysHalt (reason=reason@entry=0x8075d64 <__func__.0.lto_priv.14> "_pal_lld_disablepadevent") at ChibiOS/os/rt/src/chsys.c:201
#2  0x08003456 in _pal_lld_disablepadevent (port=<optimized out>, pad=<optimized out>) at ChibiOS/os/hal/ports/STM32/LLD/GPIOv2/hal_pal_lld.c:23
```
This is becase Vss sensor will try to disable exti on pin that it fails to obtain on init.