### PR TITLE
VSSGauge: why red zone from 4 KMh?

### DIFF
--- a/firmware/tunerstudio/rusefi.input
+++ b/firmware/tunerstudio/rusefi.input
@@ -1465,7 +1465,7 @@ gaugeCategory = Sensors - Basic
 
        ;Name               Var            Title                 Units     Lo     Hi     LoD    LoW   HiW   HiD vd ld
 gaugeCategory = Sensors - Extra 1
-	VSSGauge			= vehicleSpeedKph,		@@GAUGE_NAME_VVS@@,			"kmh",		0,	200,		0,		1,		3,	4,	1,	1
+	VSSGauge			= vehicleSpeedKph,		@@GAUGE_NAME_VVS@@,			"kmh",		0,	200,		0,		5,		110,	130,	1,	1
 	wheelSlipRatioGauge			= wheelSlipRatio,		"Wheel Slip Ratio",			"",		0,	200,		0,		1,		3,	4,	3,	3
 	turboSpeedGauge	= turboSpeed,			@@GAUGE_NAME_TURBO_SPEED@@, "hz",			0,	200,		0,		1,		3,	4,	1,	1
 	baroPressureGauge	= baroPressure,			@@GAUGE_NAME_BARO_PRESSURE@@,		"kPa",		0,	1024,		0,		0,		0,	0,	0,	0


### PR DESCRIPTION
Why?
![Screenshot from 2024-03-06 00-16-21](https://github.com/rusefi/rusefi/assets/28624689/22049d91-555d-4d3c-af7c-55b30f358f62)
Set warning to 110 KMh, red zone from 130.