### PR TITLE
Fix cypress enum gen

### DIFF
--- a/firmware/config/boards/cypress/config/hellen_cypress_gen_enum_to_string.sh
+++ b/firmware/config/boards/cypress/config/hellen_cypress_gen_enum_to_string.sh
@@ -2,7 +2,7 @@
 
 # This batch files reads rusefi_hw_enums.h and produces auto_generated_enums.* files
 
-cd ../../../../..
+cd ../../../..
 
 java -DSystemOut.name=logs/gen_enum_to_string_hellen_cypress \
  -jar ../java_tools/enum_to_string/build/libs/enum_to_string-all.jar \


### PR DESCRIPTION
How was this ever working?