### PR TITLE
Add obfuscated bundle target

### DIFF
--- a/.github/workflows/custom-board-build/action.yaml
+++ b/.github/workflows/custom-board-build/action.yaml
@@ -200,6 +200,7 @@ runs:
         if ac 'srec'; then TARGETS+=("build/rusefi.srec"); fi
         if ac 'bundles' || ac 'bundle'; then TARGETS+=("../artifacts/rusefi_bundle_${SHORT_BOARD_NAME}.zip"); fi
         if ac 'bundles' || ac 'autoupdate'; then TARGETS+=("../artifacts/rusefi_bundle_${SHORT_BOARD_NAME}_autoupdate.zip"); fi
+        if ac 'obfuscated'; then TARGETS+=("../artifacts/rusefi_bundle_${SHORT_BOARD_NAME}_obfuscated.zip"); fi
         bash bin/compile.sh $BOARD_META_PATH ${TARGETS[@]}
 
     - name: Upload Bundle


### PR DESCRIPTION
I have royally clogged my GHA pipeline so IDK if this is all good, but it _should_ be.

call `make obfuscated-bundle` to build the obfuscated bundle
expects a POST_BUILD_SCRIPT environment variable
POST_BUILD_SCRIPT is expected to be a shell script which uses `$1` as input bin to construct `$2` output bin.