### PR TITLE
make simulator depend on config files

### DIFF
--- a/firmware/bundle.mk
+++ b/firmware/bundle.mk
@@ -116,11 +116,11 @@ BUNDLE_FILES = \
   $(FOLDER_TARGETS) \
   $(CONSOLE_FOLDER_TARGETS)
 
-$(SIMULATOR_OUT):
-	$(MAKE) -C ../simulator -r SIMULATOR_DEBUG_LEVEL_OPT="-O2" OS="Windows_NT"
+$(SIMULATOR_OUT): $(CONFIG_FILES)
+	$(MAKE) -C ../simulator -r SIMULATOR_DEBUG_LEVEL_OPT="-O2" OS="Windows_NT" SUBMAKE=yes
 
-../simulator/build/rusefi_simulator:
-	$(MAKE) -C ../simulator -r SIMULATOR_DEBUG_LEVEL_OPT="-O2" OS="Linux"
+../simulator/build/rusefi_simulator: $(CONFIG_FILES)
+	$(MAKE) -C ../simulator -r SIMULATOR_DEBUG_LEVEL_OPT="-O2" OS="Linux" SUBMAKE=yes
 
 $(BOOTLOADER_HEX) $(BOOTLOADER_BIN): .bootloader-sentinel ;
 

--- a/firmware/rusefi_config.mk
+++ b/firmware/rusefi_config.mk
@@ -27,6 +27,7 @@ CONFIG_FILES = \
   $(INI_FILE) \
   $(PROJECT_DIR)/controllers/generated/rusefi_generated_$(SHORT_BOARD_NAME).h \
   $(PROJECT_DIR)/controllers/generated/signature_$(SHORT_BOARD_NAME).h \
+  $(PROJECT_DIR)/controllers/generated/engine_configuration_generated_structures_$(SHORT_BOARD_NAME).h \
   $(FIELDS) \
   $(PIN_FILES)
 

--- a/simulator/Makefile
+++ b/simulator/Makefile
@@ -288,6 +288,10 @@ endif
 
 include $(RULESPATH)/rules.mk
 
+ifneq (yes,$(SUBMAKE))
+  include $(PROJECT_DIR)/rusefi_config.mk
+endif
+
 # Enable precompiled header
 include $(PROJECT_DIR)/rusefi_pch.mk
 


### PR DESCRIPTION
This is trying to fix #6206
Also missed a generated file - `engine_configuration_generated_structures_<board>.h`