### PR TITLE
Make simulator build use PCH

### DIFF
--- a/firmware/rusefi_pch.mk
+++ b/firmware/rusefi_pch.mk
@@ -19,8 +19,9 @@ endif
 #  the deps for that .o file in the same GCC call, so if the .deps aren't already
 #  in the correct state, things can fail to build because Make doesn't know it needs
 #  to build the prerequisites (in this case PCHOBJ) for those files ahead of time.
-$(TCPPOBJS) : $(PCHOBJ)
-$(ACPPOBJS) : $(PCHOBJ)
+$(TCPPOBJS): $(PCHOBJ)
+$(ACPPOBJS): $(PCHOBJ)
+$(CPPOBJS): $(PCHOBJ)
 
 # Delete PCH output on clean
 CLEAN_PCH_HOOK:

--- a/simulator/Makefile
+++ b/simulator/Makefile
@@ -289,7 +289,10 @@ endif
 include $(RULESPATH)/rules.mk
 
 ifneq (yes,$(SUBMAKE))
-  include $(PROJECT_DIR)/rusefi_config.mk
+ifeq ($(SHORT_BOARD_NAME),)
+  SHORT_BOARD_NAME = f407-discovery
+endif
+include $(PROJECT_DIR)/rusefi_config.mk
 endif
 
 # Enable precompiled header

--- a/simulator/Makefile
+++ b/simulator/Makefile
@@ -298,7 +298,9 @@ endif
 # Enable precompiled header
 include $(PROJECT_DIR)/rusefi_pch.mk
 
-CLEAN_RULE_HOOK:
+.PHONY: CLEAN_RULE_HOOK CLEAN_PCH_HOOK
+
+CLEAN_RULE_HOOK: CLEAN_PCH_HOOK
 	@echo Cleaning Simulator
 	rm -rf build
 	rm -rf .dep


### PR DESCRIPTION
I tested build times on my laptop:
before: 1:45.05
after: 0:38.71
That after time even includes config generation, which didn't happen before, because the simulator uses a different rules.mk in which ACPPOBJS and TCPPOBJS don't exist, so nothing had CONFIG_FILES as a prerequisite.
Now CPPOBJS has PCHOBJ as a prerequisite, which in turn has CONFIG_FILES as a prerequisite, so configs get generated.