### PR TITLE
HW CI multihost

### DIFF
--- a/.github/workflows/hardware-ci.yaml
+++ b/.github/workflows/hardware-ci.yaml
@@ -7,7 +7,7 @@ name: HW CI
 on: [push, pull_request]
 
 jobs:
-  build-firmware:
+  hardware-ci:
     strategy:
       # Let all builds finish even if one fails early
       fail-fast: false

--- a/.github/workflows/hardware-ci.yaml
+++ b/.github/workflows/hardware-ci.yaml
@@ -91,7 +91,7 @@ jobs:
         lsusb -vvv
 
     - name: Check for STLINK
-      run: lsusb | grep 'ST-LINK\|STLINK'
+      run: lsusb | grep -i "st-\?link"
 
 #    - name: Install tools
 #      run: |

--- a/.github/workflows/hardware-ci.yaml
+++ b/.github/workflows/hardware-ci.yaml
@@ -22,18 +22,20 @@ jobs:
             # see HwCiF4Discovery.java or https://github.com/rusefi/rusefi/wiki/Dev-Quality-Control#stm32f407g-disc1 for wiring documentation
             test-suite: com.rusefi.HwCiF4Discovery
             folder: config/boards/f407-discovery
-            openocd-script: ../.github/workflows/openocd_ci_f4_discovery.cfg
+            openocd-script: .github/workflows/openocd_ci_f4_discovery.cfg
             serial-device: /dev/serial/by-id/usb-rusEFI_LLC_rusEFI_Engine_Management_ECU_2B003B000A51343033393930-if01
             vbatt_supply: 12
+            stlink-serial: H?u\x06geVQ2S\x08g
 
           - build-target: proteus_f4
             runs-on: hw-ci-proteus
             # see HwCiProteus which would point you at ProteusAnalogTest.java for wiring documentation
             test-suite: com.rusefi.HwCiProteus
             folder: config/boards/proteus
-            openocd-script: ../.github/workflows/openocd_ci_proteus_f4.cfg
+            openocd-script: .github/workflows/openocd_ci_proteus_f4.cfg
             serial-device: /dev/serial/by-id/usb-rusEFI_LLC_rusEFI_Engine_Management_ECU_41003D000451383037343335-if01
             vbatt_supply: 12
+            stlink-serial: 004D00323137511133333639
 
 #          - build-target: proteus_f7
 #            runs-on: hw-ci-proteus-f7
@@ -103,27 +105,33 @@ jobs:
 #      working-directory: .github/workflows/hw-ci/gethla
 #      run: ./gethla
 
-    - name: OpenOCD wipe & flash STM32
-      run: .github/workflows/hw-ci/openocd_wipe_and_flash.sh ${{matrix.openocd-script}}
-
-    - name: Show USB status
+    # ls -l /dev/serial/by-id/
+    # we specify power supply voltage to share power supply between NUC and ECU under test
+    # java automated test suite picks ECU based on specified serial
+    - name: Set EXTRA env
       run: |
-        lsusb -vvv
-        ls -l /dev/serial/by-id/
+        if [ "$(hostname)" == "rusefi-hw-ci-2" -o "$(hostname)" == "mck1117-github-actions-nuc" ]; then
+          echo "HARDWARE_CI_SERIAL_DEVICE=${{matrix.serial-device}}" >> $GITHUB_ENV
+          echo "HARDWARE_CI_VBATT=${{matrix.vbatt_supply}}" >> $GITHUB_ENV
+        else
+          cat $GITHUB_WORKSPACE/../../../rusefi-env >> $GITHUB_ENV
+        fi
+
+    - name: OpenOCD wipe & flash STM32
+      run: |
+        if [ "$(hostname)" == "rusefi-hw-ci-2" -o "$(hostname)" == "mck1117-github-actions-nuc" ]; then
+          (cat ${{matrix.openocd-script}}; echo "hla_serial ${{matrix.stlink-serial}}") \
+          | .github/workflows/hw-ci/openocd_wipe_and_flash.sh
+        else
+          (cat ${{matrix.openocd-script}}; echo "hla_serial $HARDWARE_CI_STLINK_SERIAL") \
+          | .github/workflows/hw-ci/openocd_wipe_and_flash.sh
+        fi
 
     - name: Upload build bin artifact
       uses: actions/upload-artifact@v4
       with:
         name: rusefi_hw-ci-${{matrix.build-target}}.bin
         path: ./firmware/build/rusefi*.bin
-
-    # ls -l /dev/serial/by-id/
-    # we specify power supply voltage to share power supply between NUC and ECU under test
-    # java automated test suite picks ECU based on specified serial
-    - name: Set EXTRA env
-      run: |
-        echo "HARDWARE_CI_VBATT=${{matrix.vbatt_supply}}" >> $GITHUB_ENV
-        echo "HARDWARE_CI_SERIAL_DEVICE=${{matrix.serial-device}}" >> $GITHUB_ENV
 
     # This both compiles and runs HW CI tests
     - name: Run Hardware CI

--- a/.github/workflows/hw-ci/openocd_wipe_and_flash.sh
+++ b/.github/workflows/hw-ci/openocd_wipe_and_flash.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 
-HW_SCRIPT=$1
+HW_SCRIPT=${1:-/tmp/openocd.tmp}
+
+if [ -z "$1" ]; then
+# Write whatever is piped to this script to temp file
+	cat >$HW_SCRIPT
+fi
 
 set -e
 
@@ -14,3 +19,7 @@ cd firmware
 
 # works on F4 with ST-LINK/V3 does not seem to work using V2 :(
 openocd -f "$HW_SCRIPT" -c init -c targets -c "reset halt" -c "flash erase_sector 0 0 last" -c "flash write_image "deliver/rusefi.bin" 0x08000000" -c "reset run" -c "shutdown"
+
+if [ -z "$1" ]; then
+	rm $HW_SCRIPT
+fi

--- a/.github/workflows/hw-ci/run_hw_ci.sh
+++ b/.github/workflows/hw-ci/run_hw_ci.sh
@@ -11,4 +11,13 @@ cd java_tools
 ./gradlew :autotest:shadowJar
 cd ..
 
+if [ -n "$HARDWARE_CI_SERIAL" ]; then
+	for t in /sys/class/tty/tty*/device/../serial; do
+	  if [ "$(cat $t)" == "$HARDWARE_CI_SERIAL" ]; then
+	    export HARDWARE_CI_SERIAL_DEVICE=/dev/$(echo $t | cut -d '/' -f 5)
+			break
+		fi
+	done
+fi
+
 java -cp java_console/autotest/build/libs/autotest-all.jar $HW_SUITE

--- a/.github/workflows/openocd_ci_f4_discovery.cfg
+++ b/.github/workflows/openocd_ci_f4_discovery.cfg
@@ -1,6 +1,5 @@
 # Openocd script for STM32F4 Discovery Hardware CI
 source [find interface/stlink.cfg]
-hla_serial H?u\x06geVQ2S\x08g
 
 transport select hla_swd
 

--- a/.github/workflows/openocd_ci_proteus_f4.cfg
+++ b/.github/workflows/openocd_ci_proteus_f4.cfg
@@ -1,6 +1,5 @@
 # Openocd script for Proteus hardware CI
 source [find interface/stlink.cfg]
-hla_serial 004D00323137511133333639
 
 transport select hla_swd
 

--- a/.github/workflows/openocd_ci_proteus_f7.cfg
+++ b/.github/workflows/openocd_ci_proteus_f7.cfg
@@ -1,7 +1,6 @@
 # Openocd script for Proteus hardware CI
 source [find interface/stlink.cfg]
 
-
 transport select hla_swd
 
 # increase working area to 128KB


### PR DESCRIPTION
An approach at #6103

expects environment variables:
```
HARDWARE_CI_SERIAL
HARDWARE_CI_STLINK_SERIAL
HARDWARE_CI_VBATT
```

`HARDWARE_CI_SERIAL` is just the serial, not the full path, and will be turned into a full path. This is to avoid needing to install systemd (which creates /dev/serial/by-id symlinks) on the self-hosted docker image. We can get the path manually from the serial in run_hw_ci.sh.

Making this draft PR to test on Matthew's hardware