### PR TITLE
replace correct digit in assert

### DIFF
--- a/simulator/simulator/rusEfiFunctionalTest.cpp
+++ b/simulator/simulator/rusEfiFunctionalTest.cpp
@@ -87,8 +87,8 @@ static void runChprintfTest() {
 		LoggingWithStorage testLogging("test");
 		testLogging.appendPrintf( "a%.2fb%fc", -1.2, -3.4);
 		// different compilers produce different 8th digit
-		testLogging.buffer[strlen(testLogging.buffer) - 1] = 'X';
-		assertString(testLogging.buffer, "a-1.20b-3.400000095X");
+		testLogging.buffer[strlen(testLogging.buffer) - 2] = 'X';
+		assertString(testLogging.buffer, "a-1.20b-3.40000009Xc");
 	}
 
 }


### PR DESCRIPTION
Simulator run was failing on my laptop with GCC 13.
I found this change trying to fix this error for a different compiler:
https://github.com/rusefi/rusefi/commit/61909b2f4ec1cbd831916624940b41fee1d341f4
I think the wrong digit was replaced by mistake - it was replacing the `c`.
```
assertString FAILED
>>>>>>>>>> firmwareError [chprintf test: got a-1.20b-3.400000096X while a-1.20b-3.400000095X]
```