### PR TITLE
Include board.mk in Simulator build if BOARD_DIR is set

### DIFF
--- a/simulator/Makefile
+++ b/simulator/Makefile
@@ -23,7 +23,6 @@ PROJECT_CPU=simulator
 ifeq (,$(filter clean,$(MAKECMDGOALS)))
 ifneq ($(BOARD_DIR),)
   include ../firmware/$(BOARD_DIR)/board.mk
-  BOARDCPPSRC += $(BOARDS_DIR)/board_id.cpp
 endif
 endif
 

--- a/simulator/Makefile
+++ b/simulator/Makefile
@@ -19,6 +19,14 @@ RULESPATH = $(CHIBIOS)/os/common/startup/SIMIA32/compilers/GCC
 
 PROJECT_CPU=simulator
 
+# Board-specific configuration
+ifeq (,$(filter clean,$(MAKECMDGOALS)))
+ifneq ($(BOARD_DIR),)
+  include ../firmware/$(BOARD_DIR)/board.mk
+  BOARDCPPSRC += $(BOARDS_DIR)/board_id.cpp
+endif
+endif
+
 include ../firmware/rusefi.mk
 RULESFILE = ../firmware/rusefi_rules.mk
 
@@ -172,6 +180,7 @@ CSRC =  $(ALLCSRC) \
 # C++ sources that can be compiled in ARM or THUMB mode depending on the global
 # setting.
 CPPSRC = $(ALLCPPSRC) \
+  $(BOARDCPPSRC) \
   $(CHIBIOS)/os/various/cpp_wrappers/ch.cpp \
   $(HW_LAYER_DRIVERS_CPP) \
   $(HW_LAYER_DRIVERS_CORE_CPP) \


### PR DESCRIPTION
Fix #6195
Green custom: https://github.com/chuckwagoncomputing/fw-custom-paralela/actions/runs/8289357534
Result: https://github.com/chuckwagoncomputing/fw-custom-paralela/commit/4aff60dc17f0982c33b50aff5956b874a1949f85