### PR TITLE
only:better placement for shared line

### DIFF
--- a/firmware/config/boards/nucleo_f767/readme.md
+++ b/firmware/config/boards/nucleo_f767/readme.md
@@ -1,0 +1,1 @@
+NUCLEO-F767ZI features STM32F767ZI with 2MB Flash.

--- a/firmware/rusefi.mk
+++ b/firmware/rusefi.mk
@@ -25,8 +25,6 @@ else
 endif
 endif
 
-BOARDS_DIR = $(PROJECT_DIR)/config/boards
-
 # allow passing a custom board dir, otherwise generate it based on the board name
 ifeq ($(BOARD_DIR),)
 	BOARD_DIR = $(BOARDS_DIR)/$(PROJECT_BOARD)

--- a/firmware/rusefi_rules.mk
+++ b/firmware/rusefi_rules.mk
@@ -11,3 +11,5 @@ endif
 RUSEFI_OPT += -Wno-error=sign-compare
 RUSEFI_OPT += -Wno-error=overloaded-virtual
 RUSEFI_OPT += -Wno-error=unused-parameter
+
+BOARDS_DIR = $(PROJECT_DIR)/config/boards

--- a/simulator/Makefile
+++ b/simulator/Makefile
@@ -19,6 +19,10 @@ RULESPATH = $(CHIBIOS)/os/common/startup/SIMIA32/compilers/GCC
 
 PROJECT_CPU=simulator
 
+include ../firmware/rusefi_rules.mk
+
+BOARDS_DIR = $(PROJECT_DIR)/config/boards
+
 # Board-specific configuration
 ifeq (,$(filter clean,$(MAKECMDGOALS)))
 ifneq ($(BOARD_DIR),)
@@ -27,14 +31,11 @@ endif
 endif
 
 include ../firmware/rusefi.mk
-include ../firmware/rusefi_rules.mk
 
 # Configure precompiled header
 PCH_DIR = $(PROJECT_DIR)/pch
 PCHSRC = $(PCH_DIR)/pch.h
 PCHSUB = simulator
-
-BOARDS_DIR = $(PROJECT_DIR)/config/boards
 
 # used by USE_SMART_BUILD
 CONFDIR = .

--- a/simulator/Makefile
+++ b/simulator/Makefile
@@ -27,6 +27,8 @@ PCH_DIR = $(PROJECT_DIR)/pch
 PCHSRC = $(PCH_DIR)/pch.h
 PCHSUB = simulator
 
+BOARDS_DIR = $(PROJECT_DIR)/config/boards
+
 # used by USE_SMART_BUILD
 CONFDIR = .
 

--- a/simulator/Makefile
+++ b/simulator/Makefile
@@ -20,7 +20,7 @@ RULESPATH = $(CHIBIOS)/os/common/startup/SIMIA32/compilers/GCC
 PROJECT_CPU=simulator
 
 include ../firmware/rusefi.mk
-RULESFILE = ../firmware/rusefi_rules.mk
+include ../firmware/rusefi_rules.mk
 
 # Configure precompiled header
 PCH_DIR = $(PROJECT_DIR)/pch

--- a/simulator/Makefile
+++ b/simulator/Makefile
@@ -21,8 +21,6 @@ PROJECT_CPU=simulator
 
 include ../firmware/rusefi_rules.mk
 
-BOARDS_DIR = $(PROJECT_DIR)/config/boards
-
 # Board-specific configuration
 ifeq (,$(filter clean,$(MAKECMDGOALS)))
 ifneq ($(BOARD_DIR),)

--- a/simulator/Makefile
+++ b/simulator/Makefile
@@ -19,6 +19,13 @@ RULESPATH = $(CHIBIOS)/os/common/startup/SIMIA32/compilers/GCC
 
 PROJECT_CPU=simulator
 
+# Board-specific configuration
+ifeq (,$(filter clean,$(MAKECMDGOALS)))
+ifneq ($(BOARD_DIR),)
+  include ../firmware/$(BOARD_DIR)/board.mk
+endif
+endif
+
 include ../firmware/rusefi.mk
 include ../firmware/rusefi_rules.mk
 
@@ -174,6 +181,7 @@ CSRC =  $(ALLCSRC) \
 # C++ sources that can be compiled in ARM or THUMB mode depending on the global
 # setting.
 CPPSRC = $(ALLCPPSRC) \
+  $(BOARDCPPSRC) \
   $(CHIBIOS)/os/various/cpp_wrappers/ch.cpp \
   $(HW_LAYER_DRIVERS_CPP) \
   $(HW_LAYER_DRIVERS_CORE_CPP) \

--- a/unit_tests/unit_test_rules.mk
+++ b/unit_tests/unit_test_rules.mk
@@ -14,8 +14,6 @@ PCHSUB = unit_tests
 
 include $(PROJECT_DIR)/rusefi_rules.mk
 
-BOARDS_DIR = $(PROJECT_DIR)/config/boards
-
 # User may want to pass in a forced value for SANITIZE
 ifeq ($(SANITIZE),)
 	ifneq ($(OS),Windows_NT)

--- a/unit_tests/unit_test_rules.mk
+++ b/unit_tests/unit_test_rules.mk
@@ -230,8 +230,6 @@ else
 endif
 endif
 
-BOARDS_DIR = $(PROJECT_DIR)/config/boards
-
 # allow passing a custom board dir, otherwise generate it based on the board name
 ifeq ($(BOARD_DIR),)
 	BOARD_DIR = $(BOARDS_DIR)/$(PROJECT_BOARD)


### PR DESCRIPTION
we have firmware and unit_tests duplicate a setting which simulator does not seem to have

simulator would need it for board.mk from https://github.com/rusefi/rusefi/commit/f45d4c768de2c75f13cf73ceed73b564c1c8ce77 to be compileable by simulator