### PR TITLE
only:simulator has rules

### DIFF
--- a/simulator/Makefile
+++ b/simulator/Makefile
@@ -25,6 +25,7 @@ endif
 endif
 
 include ../firmware/rusefi.mk
+include ../firmware/rusefi_rules.mk
 
 # Configure precompiled header
 PCH_DIR = $(PROJECT_DIR)/pch


### PR DESCRIPTION
regardless of boards let's force simulator to be clean?