### PR TITLE
Get default tune and include meta output folder

### DIFF
--- a/firmware/rusefi.mk
+++ b/firmware/rusefi.mk
@@ -27,6 +27,12 @@ endif
 
 BOARDS_DIR = $(PROJECT_DIR)/config/boards
 
+ifneq ($(META_OUTPUT_ROOT_FOLDER),)
+ifeq ($(BOARD_DIR),)
+  BOARDINC += $(META_OUTPUT_ROOT_FOLDER)
+endif
+endif
+
 # allow passing a custom board dir, otherwise generate it based on the board name
 ifeq ($(BOARD_DIR),)
 	BOARD_DIR = $(BOARDS_DIR)/$(PROJECT_BOARD)

--- a/simulator/Makefile
+++ b/simulator/Makefile
@@ -12,15 +12,17 @@
 #
 
 
-
 CHIBIOS = ../firmware/ChibiOS
-CHIBIOS_CONTRIB= ../firmware/ChibiOS-Contrib
+CHIBIOS_CONTRIB = ../firmware/ChibiOS-Contrib
 RULESPATH = $(CHIBIOS)/os/common/startup/SIMIA32/compilers/GCC
 
 PROJECT_CPU=simulator
 
+ifneq ($(BOARD_DIR),)
+  BOARDCPPSRC += $(BOARD_DIR)/default_tune.cpp
+endif
+
 include ../firmware/rusefi.mk
-RULESFILE = ../firmware/rusefi_rules.mk
 
 # Configure precompiled header
 PCH_DIR = $(PROJECT_DIR)/pch


### PR DESCRIPTION
Draft because I have a red custom board with an error I haven't seen before.
https://github.com/chuckwagoncomputing/fw-custom-paralela/actions/runs/8312666260/job/22747852617