### PR TITLE
sensors: support AEM X series EGT CAN gauge 

### DIFF
--- a/firmware/controllers/sensors/impl/AemXSeriesEgt.cpp
+++ b/firmware/controllers/sensors/impl/AemXSeriesEgt.cpp
@@ -1,0 +1,27 @@
+#include "pch.h"
+
+#if EFI_CAN_SUPPORT || EFI_UNIT_TEST
+#include "AemXSeriesEgt.h"
+
+static constexpr uint32_t aem_egt_base = 0x000A0305;
+#define AEM_EGT_DEFAULT_PERIOD_MS 100	/* 10 Hz */
+
+AemXSeriesEgt::AemXSeriesEgt(uint8_t sensorIndex, SensorType type)
+	: CanSensorBase(
+		aem_egt_base + sensorIndex,
+		type,
+		MS2NT(3 * AEM_EGT_DEFAULT_PERIOD_MS)	// sensor transmits at 10hz, allow a frame to be missed
+	)
+	, m_sensorIndex(sensorIndex)
+{
+	// nope
+}
+
+void AemXSeriesEgt::decodeFrame(const CANRxFrame& frame, efitick_t nowNt) {
+	// No status flags, just a value
+	uint16_t egt = SWAP_UINT16(frame.data16[0]);
+
+	setValidValue((float)egt, nowNt);
+}
+
+#endif

--- a/firmware/controllers/sensors/impl/AemXSeriesEgt.cpp
+++ b/firmware/controllers/sensors/impl/AemXSeriesEgt.cpp
@@ -12,7 +12,6 @@ AemXSeriesEgt::AemXSeriesEgt(uint8_t sensorIndex, SensorType type)
 		type,
 		MS2NT(3 * AEM_EGT_DEFAULT_PERIOD_MS)	// sensor transmits at 10hz, allow a frame to be missed
 	)
-	, m_sensorIndex(sensorIndex)
 {
 	// nope
 }

--- a/firmware/controllers/sensors/impl/AemXSeriesEgt.h
+++ b/firmware/controllers/sensors/impl/AemXSeriesEgt.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "can_sensor.h"
+
+class AemXSeriesEgt final : public CanSensorBase {
+public:
+	AemXSeriesEgt(uint8_t sensorIndex, SensorType type);
+
+protected:
+	void decodeFrame(const CANRxFrame& frame, efitick_t nowNt) override;
+
+private:
+	const uint8_t m_sensorIndex;
+};

--- a/firmware/controllers/sensors/impl/AemXSeriesEgt.h
+++ b/firmware/controllers/sensors/impl/AemXSeriesEgt.h
@@ -8,7 +8,4 @@ public:
 
 protected:
 	void decodeFrame(const CANRxFrame& frame, efitick_t nowNt) override;
-
-private:
-	const uint8_t m_sensorIndex;
 };

--- a/firmware/controllers/sensors/sensors.mk
+++ b/firmware/controllers/sensors/sensors.mk
@@ -6,6 +6,7 @@ CONTROLLERS_SENSORS_SRC_CPP = \
 	$(PROJECT_DIR)/controllers/sensors/allsensors.cpp \
 	$(PROJECT_DIR)/controllers/sensors/auto_generated_sensor.cpp \
 	$(PROJECT_DIR)/controllers/sensors/impl/AemXSeriesLambda.cpp \
+	$(PROJECT_DIR)/controllers/sensors/impl/AemXSeriesEgt.cpp \
 	$(PROJECT_DIR)/controllers/sensors/impl/map.cpp \
 	$(PROJECT_DIR)/controllers/sensors/impl/maf.cpp \
 	$(PROJECT_DIR)/controllers/sensors/impl/Lps25Sensor.cpp \

--- a/firmware/init/init.h
+++ b/firmware/init/init.h
@@ -26,6 +26,7 @@ void initFluidPressure();
 void initThermistors();
 void initCanSensors();
 void initLambda();
+void initEgt();
 void initFlexSensor(bool isFirstTime);
 void initFuelLevel();
 void initBaro();
@@ -46,5 +47,9 @@ void deinitTurbochargerSpeedSensor();
 void deinitMap();
 void deinitAuxSpeedSensors();
 void deinitInputShaftSpeedSensor();
+
+void stopEgt(void);
+void startEgt(void);
+
 
 void pokeAuxDigital();

--- a/firmware/init/init.mk
+++ b/firmware/init/init.mk
@@ -5,6 +5,7 @@ INIT_SRC_CPP =	$(PROJECT_DIR)/init/sensor/init_sensors.cpp \
 				$(PROJECT_DIR)/init/sensor/init_can_sensors.cpp \
 				$(PROJECT_DIR)/init/sensor/init_thermistors.cpp \
 				$(PROJECT_DIR)/init/sensor/init_lambda.cpp \
+				$(PROJECT_DIR)/init/sensor/init_egt.cpp \
 				$(PROJECT_DIR)/init/sensor/init_maf.cpp \
 				$(PROJECT_DIR)/init/sensor/init_map.cpp \
 				$(PROJECT_DIR)/init/sensor/init_flex.cpp \
@@ -15,4 +16,4 @@ INIT_SRC_CPP =	$(PROJECT_DIR)/init/sensor/init_sensors.cpp \
 				$(PROJECT_DIR)/init/sensor/init_vehicle_speed_sensor.cpp \
 				$(PROJECT_DIR)/init/sensor/init_aux_speed_sensor.cpp \
 				$(PROJECT_DIR)/init/sensor/init_turbocharger_speed_sensor.cpp \
-				$(PROJECT_DIR)/init/sensor/init_input_shaft_speed_sensor.cpp \
+				$(PROJECT_DIR)/init/sensor/init_input_shaft_speed_sensor.cpp

--- a/firmware/init/sensor/init_egt.cpp
+++ b/firmware/init/sensor/init_egt.cpp
@@ -1,0 +1,46 @@
+#include "pch.h"
+
+#include "init.h"
+#include "AemXSeriesEgt.h"
+#include "max3185x.h"
+
+#if EFI_CAN_SUPPORT
+static AemXSeriesEgt aemEgt1(0, SensorType::EGT1);
+static AemXSeriesEgt aemEgt2(1, SensorType::EGT2);
+#endif
+
+void initEgt() {
+#if EFI_CAN_SUPPORT
+	if (engineConfiguration->enableAemXSeriesEgt) {
+		if (!engineConfiguration->canWriteEnabled || !engineConfiguration->canReadEnabled) {
+			criticalError("CAN read and write are required to use CAN EGT.");
+			return;
+		}
+
+		registerCanSensor(aemEgt1);
+		registerCanSensor(aemEgt2);
+
+		return;
+	}
+#endif
+
+#if EFI_MAX_31855
+	initMax3185x(engineConfiguration->max31855spiDevice, engineConfiguration->max31855_cs);
+#endif /* EFI_MAX_31855 */
+}
+
+void stopEgt(void)
+{
+	/* TODO: also stop CAN sensors */
+#if EFI_MAX_31855
+	stopMax3185x();
+#endif /* EFI_MAX_31855 */
+}
+
+void startEgt(void)
+{
+	/* TODO: also start CAN sensors */
+#if EFI_MAX_31855
+	startMax3185x(engineConfiguration->max31855spiDevice, engineConfiguration->max31855_cs);
+#endif /* EFI_MAX_31855 */
+}

--- a/firmware/init/sensor/init_egt.cpp
+++ b/firmware/init/sensor/init_egt.cpp
@@ -12,8 +12,8 @@ static AemXSeriesEgt aemEgt2(1, SensorType::EGT2);
 void initEgt() {
 #if EFI_CAN_SUPPORT
 	if (engineConfiguration->enableAemXSeriesEgt) {
-		if (!engineConfiguration->canWriteEnabled || !engineConfiguration->canReadEnabled) {
-			criticalError("CAN read and write are required to use CAN EGT.");
+		if (!engineConfiguration->canReadEnabled) {
+			criticalError("CAN read is required to use CAN EGT.");
 			return;
 		}
 

--- a/firmware/init/sensor/init_sensors.cpp
+++ b/firmware/init/sensor/init_sensors.cpp
@@ -8,7 +8,6 @@
 #include "cli_registry.h"
 #include "io_pins.h"
 #include "lua_hooks.h"
-#include "max3185x.h"
 
 static void initSensorCli();
 
@@ -90,6 +89,7 @@ void initNewSensors() {
 	initFluidPressure();
 	initThermistors();
 	initLambda();
+	initEgt();
 	initFlexSensor(true);
 	initBaro();
 	initAuxSensors();
@@ -105,10 +105,6 @@ void initNewSensors() {
 
 	initOldAnalogInputs();
 	initAuxDigital();
-
-#if EFI_MAX_31855
-	initMax3185x(engineConfiguration->max31855spiDevice, engineConfiguration->max31855_cs);
-#endif /* EFI_MAX_31855 */
 
 	// Init CLI functionality for sensors (mocking)
 	initSensorCli();
@@ -142,9 +138,7 @@ void stopSensors() {
 	deinitAuxSpeedSensors();
 	deinitMap();
 	deinitInputShaftSpeedSensor();
-#if EFI_MAX_31855
-	stopMax3185x();
-#endif /* EFI_MAX_31855 */
+	stopEgt();
 }
 
 void reconfigureSensors() {
@@ -158,11 +152,9 @@ void reconfigureSensors() {
 	initTurbochargerSpeedSensor();
 	initAuxSpeedSensors();
 	initInputShaftSpeedSensor();
+	startEgt();
 
 	initOldAnalogInputs();
-#if EFI_MAX_31855
-	startMax3185x(engineConfiguration->max31855spiDevice, engineConfiguration->max31855_cs);
-#endif /* EFI_MAX_31855 */
 }
 
 // Mocking/testing helpers

--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -1172,7 +1172,7 @@ int16_t tps2Max;Full throttle#2. tpsMax value as 10 bit ADC value. Not Voltage!\
 	bit useVssAsSecondWheelSpeed;VSS and auxSpeed1 or auxSpeed1 with auxSpeed2?
 	bit is_enabled_spi_5
 	bit is_enabled_spi_6
-	bit unusedBit_503_15
+	bit enableAemXSeriesEgt;AEM X-Series EGT gauge kit or rusEFI EGT sensor from Wideband controller
 	bit unusedBit_503_16
 	bit unusedBit_503_17
 	int16_t afterCrankingIACtaperDuration;This is the duration in cycles that the IAC will take to reach its normal idle position, it can be used to hold the idle higher for a few seconds after cranking to improve startup.\Should be 100 once tune is better;"cycles", 1, 0, 0, 5000, 0

--- a/firmware/tunerstudio/rusefi.input
+++ b/firmware/tunerstudio/rusefi.input
@@ -308,6 +308,7 @@ enable2ndByteCanID = false
 	requiresPowerCycle = startStopButtonMode
 
 	requiresPowerCycle = enableAemXSeries
+	requiresPowerCycle = enableAemXSeriesEgt
 
 	requiresPowerCycle = etb_use_two_wires
 	requiresPowerCycle = etbSplit
@@ -3432,15 +3433,18 @@ cmd_set_engine_type_default					= "@@TS_IO_TEST_COMMAND_char@@@@ts_command_e_TS_
 
 ;			Engine->EGT inputs
 	dialog = egtInputs, "EGT inputs"
-		field = "SPI",									max31855spiDevice
-		field = "CS #1",								max31855_cs1
-		field = "CS #2",								max31855_cs2
-		field = "CS #3",								max31855_cs3
-		field = "CS #4",								max31855_cs4
-		field = "CS #5",								max31855_cs5
-		field = "CS #6",								max31855_cs6
-		field = "CS #7",								max31855_cs7
-		field = "CS #8",								max31855_cs8
+		field = "CAN support only EGT1 and EGT2"
+		field = "CAN EGT (AEM X series of RusEFI)"		enableAemXSeriesEgt, { canReadEnabled }
+		field = "If both CAN and SPI EGT sensors are used, please leave two first for CAN"
+		field = "MAX31855/MAX31856 SPI",				max31855spiDevice
+		field = "CS for EGT1",							max31855_cs1
+		field = "CS for EGT2",							max31855_cs2
+		field = "CS for EGT3",							max31855_cs3
+		field = "CS for EGT4",							max31855_cs4
+		field = "CS for EGT5",							max31855_cs5
+		field = "CS for EGT6",							max31855_cs6
+		field = "CS for EGT7",							max31855_cs7
+		field = "CS for EGT8",							max31855_cs8
 
 ;			Engine->idle Settings
 	dialog = idleSolenoid, "Solenoid"


### PR DESCRIPTION
Same protocol is implemented on RusEFI WBOx2

Currently only 0x000A0305 and 0x000A0306 IDs are supported
These two will be mapped to EGT1 and EGT2