### PR TITLE
Only commit msq and canned-tunes md files in simulator commit

### DIFF
--- a/.github/workflows/build-simulator.yaml
+++ b/.github/workflows/build-simulator.yaml
@@ -36,15 +36,7 @@ jobs:
         distribution: 'zulu'
         java-version: '11'
 
-    - name: Code generation tools
-      working-directory: ./java_tools
-      run: ./gradlew :config_definition:shadowJar
-
-    - name: Generate Configs, Enums & Live Documentation
-      working-directory: ./firmware/
-      run: ./gen_default_everything.sh
-
-    - name: enerate docs and enums
+    - name: Generate docs and enums
       working-directory: ./firmware/
       run: make docs-enums
 

--- a/.github/workflows/build-simulator.yaml
+++ b/.github/workflows/build-simulator.yaml
@@ -76,20 +76,9 @@ jobs:
       run: |
         git config --local user.email "action@github.com"
         git config --local user.name "GitHub gen-default-tune Action"
-        echo See https://github.com/rusefi/rusefi/issues/2446
-        echo "Status 1/3"
-        git status
-        # not our place to update live data etc
-        FILES=$(git status --porcelain | grep -e "\.java" -e "\.ini" -e "\.h"| cut -d' ' -f3)
-        [ -n "$FILES" ] && git restore $FILES
-        echo "Status 2/3"
-        git status
-        git pull https://github.com/rusefi/rusefi master
-        git add 'simulator/generated/*msq'
-        git add 'simulator/generated/canned-tunes/*md'
-        echo "Status 3/3"
-        git status
-        OUT=$(git commit -am "Auto-generated default tune" 2>&1) || echo "commit failed, finding out why"
+        git add "simulator/generated/*msq"
+        git add "simulator/generated/canned-tunes/*md"
+        OUT=$(git commit -m "Auto-generated default tune" 2>&1) || echo "commit failed, finding out why"
         if echo "$OUT" | grep 'nothing to commit'; then
           echo "default tune: looks like nothing to commit"
           echo "NOCOMMIT=true" >> $GITHUB_ENV


### PR DESCRIPTION
Attempt at fixing #5984
Also remove redundant config generation.