### PR TITLE
test branch showing that simulator does not compile with O2

### DIFF
--- a/simulator/Makefile
+++ b/simulator/Makefile
@@ -49,10 +49,7 @@ else
   SANITIZE = no
 endif
 
-ifeq ($(SIMULATOR_DEBUG_LEVEL_OPT),)
-# If you would like to debug the simulator, swap which of these lines is commented. It's commented because debug info causes a 10-15x increase in binary size.
-  SIMULATOR_DEBUG_LEVEL_OPT = -O0 -g
-endif
+  SIMULATOR_DEBUG_LEVEL_OPT = -O2
 
 # Compiler options here.
 ifeq ($(USE_OPT),)


### PR DESCRIPTION
static_vector.h:29:17: error: writing 10 bytes into a region of size ……0 [-Werror=stringop-overflow=] #6270