### PR TITLE
Allow for compiling both Windows and Linux simulators in a single Make run

### DIFF
--- a/firmware/bundle.mk
+++ b/firmware/bundle.mk
@@ -119,7 +119,8 @@ BUNDLE_FILES = \
 $(SIMULATOR_OUT): $(CONFIG_FILES)
 	$(MAKE) -C ../simulator -r OS="Windows_NT" SUBMAKE=yes
 
-../simulator/build/rusefi_simulator: $(CONFIG_FILES)
+# make Windows simulator a prerequisite so that we don't try compiling them concurrently
+../simulator/build/rusefi_simulator: $(CONFIG_FILES) | $(SIMULATOR_OUT)
 	$(MAKE) -C ../simulator -r OS="Linux" SUBMAKE=yes
 
 $(BOOTLOADER_HEX) $(BOOTLOADER_BIN): .bootloader-sentinel ;

--- a/simulator/Makefile
+++ b/simulator/Makefile
@@ -304,6 +304,14 @@ endif
 # Enable precompiled header
 include $(PROJECT_DIR)/rusefi_pch.mk
 
+$(OBJS): .os-sentinel
+
+.os-sentinel: .FORCE
+	if [ "$$(cat $@ 2>/dev/null)" != $(OS) ]; then \
+	echo $(OS) >$@; fi
+
+.FORCE:
+
 .PHONY: CLEAN_RULE_HOOK CLEAN_PCH_HOOK
 
 CLEAN_RULE_HOOK: CLEAN_PCH_HOOK


### PR DESCRIPTION
It is currently possible to request both simulators with the custom board action. Prior to this PR, this fails because make doesn't know that the .o files need to be rebuilt for whichever version runs second. Even worse, they could run concurrently. This PR fixes both of these issues.