### PR TITLE
Use make output-sync option

### DIFF
--- a/.github/workflows/build-firmware.yaml
+++ b/.github/workflows/build-firmware.yaml
@@ -237,25 +237,11 @@ jobs:
 #        name: libopenblt-macos
 #        path: ./firmware/ext/openblt/Host/
 
-    - name: Clean (Just in Case)
-      working-directory: ./firmware/
-      run: |
-        make clean
-
-    - name: Handle configs separately just to make github logs more readable
-      working-directory: ./firmware/
-      run: |
-        bash bin/compile.sh ${{env.BOARD_META_PATH}} config
-
-    - name: Building simulator separately just to make github logs more readable
-      working-directory: ./firmware/
-      run: |
-        bash bin/compile.sh ${{env.BOARD_META_PATH}} ../simulator/build/rusefi_simulator.exe
-
-      # Build the firmware! We have the technology to build _everything_ in one 'make' invocation but choose to do separately for sake of more readable GHA logs
+      # Build the firmware!
     - name: Build Firmware
       working-directory: ./firmware/
       run: |
+        make clean
         if [ "$full" == "true" ]; then
           bash bin/compile.sh ${{env.BOARD_META_PATH}} bundles --output-sync=recurse
         else

--- a/.github/workflows/custom-board-build/action.yaml
+++ b/.github/workflows/custom-board-build/action.yaml
@@ -19,7 +19,7 @@ inputs:
     default: ./generated/
   sim_output:
     required: false
-    default: ./generated/
+    default: ./generated/  
   lts:
     description: 'LTS Build'
     required: false
@@ -164,7 +164,7 @@ runs:
         fi
         sudo bash ${{inputs.rusefi_dir}}/misc/actions/add-ubuntu-latest-apt-mirrors.sh
         sudo apt-get install sshpass mtools $SIM_REQS
-
+ 
     - name: Repo Status
       shell: bash
       run: |
@@ -178,20 +178,6 @@ runs:
           git status
         else
           echo "Not a repository"
-        fi
-
-    - name: Handle configs separately just to make github logs more readable
-      working-directory: ${{inputs.rusefi_dir}}/firmware
-      shell: bash
-      run: |
-        bash bin/compile.sh $BOARD_META_PATH config
-
-    - name: Building simulator separately just to make github logs more readable
-      working-directory: ${{inputs.rusefi_dir}}/firmware
-      shell: bash
-      run: |
-        if [ "$RUN_SIMULATOR" == "true" ]; then
-          bash bin/compile.sh $BOARD_META_PATH ../simulator/build/rusefi_simulator
         fi
 
     - name: Build Firmware


### PR DESCRIPTION
This keeps log output together on a per-recipe basis, and all the output of a submake (e.g. bootloader) together.
There is still some stuff that seems like output is mixing but isn't actuallly, in particular, output from other recipes can happen between compilation of .c files and compilation of .cpp files.
This is my preferred way to fix #6259, though it doesn't address the concern of "simulator build failing under Build Firmware banner".