### PR TITLE
Make matrix generation more resilient to funny commit messages

### DIFF
--- a/.github/workflows/build-firmware.yaml
+++ b/.github/workflows/build-firmware.yaml
@@ -125,7 +125,10 @@ jobs:
       run: |
         export EVENT_NAME="${{github.event_name}}"
         export RUN_ATTEMPT="${{github.run_attempt}}"
-        export COMMIT_MESSAGE="${{github.event.head_commit.message}}"
+        read -d '' COMMIT_MESSAGE << EOM || true
+        ${{ github.event.head_commit.message }}
+        EOM
+        export COMMIT_MESSAGE
         echo "matrix=$(bash firmware/bin/generate_matrix.sh)" >> $GITHUB_OUTPUT
 
   build-firmware:


### PR DESCRIPTION
Fixes this: https://github.com/rusefi/rusefi/actions/runs/8413874239/job/23036744334?pr=6296

Run with both double quote and a single quote in a multi-line commit message: https://github.com/chuckwagoncomputing/rusefi/actions/runs/8414519038