### PR TITLE
Add more Make targets to simplify custom board action

### DIFF
--- a/.github/workflows/build-firmware.yaml
+++ b/.github/workflows/build-firmware.yaml
@@ -254,7 +254,7 @@ jobs:
       working-directory: ./firmware/
       run: |
         if [ "$full" == "true" ]; then
-          bash bin/compile.sh -b ${{env.BOARD_META_PATH}}
+          bash bin/compile.sh ${{env.BOARD_META_PATH}} bundles
         else
           bash bin/compile.sh ${{env.BOARD_META_PATH}} all deliver/rusefi.dfu deliver/rusefi.bin
         fi

--- a/.github/workflows/custom-board-build/action.yaml
+++ b/.github/workflows/custom-board-build/action.yaml
@@ -198,26 +198,10 @@ runs:
       working-directory: ${{inputs.rusefi_dir}}/firmware
       shell: bash
       run: |
-        ARTIFACTS=(${{inputs.artifacts}} ${{inputs.uploads}})
-        TARGETS=()
-        shopt -s expand_aliases
-        alias ac="printf '%s\0' "${ARTIFACTS[@]}" | grep -F -x -z --"
-        if ac 'ini'; then TARGETS+=("config"); fi
-        if ac 'bin'; then TARGETS+=("deliver/rusefi.bin"); fi
-        if ac 'dfu'; then TARGETS+=("deliver/rusefi.dfu"); fi
-        if ac 'hex'; then TARGETS+=("build/rusefi.hex"); fi
-        if ac 'map'; then TARGETS+=("build/rusefi.map"); fi
-        if ac 'elf'; then TARGETS+=("build/rusefi.elf"); fi
-        if ac 'list'; then TARGETS+=("build/rusefi.list"); fi
-        if ac 'srec'; then TARGETS+=("build/rusefi.srec"); fi
-        if ac 'bootloader'; then TARGETS+=("bootloader/blbuild/openblt_${PROJECT_BOARD}.bin"); fi
-        if ac 'bundles' || ac 'bundle'; then TARGETS+=("../artifacts/rusefi_bundle_${SHORT_BOARD_NAME}.zip"); fi
-        if ac 'bundles' || ac 'autoupdate'; then TARGETS+=("../artifacts/rusefi_bundle_${SHORT_BOARD_NAME}_autoupdate.zip"); fi
-        if ac 'obfuscated'; then TARGETS+=("../artifacts/rusefi_bundle_${SHORT_BOARD_NAME}_obfuscated_public.zip"); fi
         if [ "$RUN_SIMULATOR" == "true" ]; then
-          TARGETS+=("../simulator/build/rusefi_simulator" "../java_tools/tune-tools/build/libs/tune-tools-all.jar")
+          TARGETS=("../simulator/build/rusefi_simulator" "../java_tools/tune-tools/build/libs/tune-tools-all.jar")
         fi
-        bash bin/compile.sh $BOARD_META_PATH ${TARGETS[@]}
+        bash bin/compile.sh $BOARD_META_PATH ${{inputs.artifacts}} ${{inputs.uploads}} ${TARGETS[@]}
 
     - name: Upload Bundle
       if: ${{ contains(inputs.uploads, 'bundles') }}

--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -25,14 +25,11 @@
 # make docs-enums	Generate docs and enums
 # make config			Generate docs, enums, and configs
 # make						Generate docs, enums, configs, and build firmware
-# make bundle			Generate docs, enums, configs, built bootloader, build firmware, and package both full and autoupdate bundles
+# make bundle			Generate docs, enums, configs, build bootloader, build firmware, and package full bundle
+# make autoupdate	Generate docs, enums, configs, build bootloader, build firmware, and package autoupdate bundle
+# make bundles		Generate docs, enums, configs, build bootloader, build firmware, and package both full and autoupdate bundles
+# make bootloader Generate docs, enums, configs, and build bootloader
 #
-# You can make a single bundle by passing the target bundle path, for example:
-# make ../artifacts/rusefi_bundle_f407-discovery.zip
-# make ../artifacts/rusefi_bundle_f407-discovery_autoupdate.zip
-#
-# You can make the bootloader either by going in to the bootloader subdirectory and running make, or by passing a bootloader target:
-# make bootloader/blbuild/openblt_f407-discovery.bin
 
 CHIBIOS = ChibiOS
 RULESPATH = $(CHIBIOS)/os/common/startup/ARMCMx/compilers/GCC/mk

--- a/firmware/bundle.mk
+++ b/firmware/bundle.mk
@@ -185,11 +185,22 @@ $(ARTIFACTS)/$(BUNDLE_FULL_NAME)_obfuscated_public.zip:  $(OBFUSCATED_OUT) $(BUN
 $(ARTIFACTS)/$(BUNDLE_FULL_NAME)_autoupdate.zip: $(UPDATE_BUNDLE_FILES) | $(ARTIFACTS)
 	cd $(FOLDER) &&	zip -r ../$@ $(subst $(FOLDER)/,,$(UPDATE_BUNDLE_FILES))
 
-.PHONY: bundle obfuscated-bundle
+.PHONY: bundle bundles autoupdate obfuscated bin hex dfu map elf list srec bootloader
 
-bundle: $(ARTIFACTS)/$(BUNDLE_FULL_NAME)_autoupdate.zip $(ARTIFACTS)/$(BUNDLE_FULL_NAME).zip all
+bundle: $(ARTIFACTS)/$(BUNDLE_FULL_NAME).zip
+autoupdate: $(ARTIFACTS)/$(BUNDLE_FULL_NAME)_autoupdate.zip
+obfuscated: $(ARTIFACTS)/$(BUNDLE_FULL_NAME)_obfuscated_public.zip
+bundles: bundle autoupdate
 
-obfuscated-bundle: $(ARTIFACTS)/$(BUNDLE_FULL_NAME)_obfuscated_public.zip
+bootloader: $(BOOTLOADER_BIN)
+
+bin: $(DBIN)
+hex: $(BUILDDIR)/$(PROJECT).hex
+dfu: $(DFU)
+srec: $(BUILDDIR)/rusefi.srec
+elf: $(BUILDDIR)/$(PROJECT).elf
+map: $(BUILDDIR)/$(PROJECT).map
+list: $(BUILDDIR)/$(PROJECT).list
 
 CLEAN_BUNDLE_HOOK:
 	@echo Cleaning Bundle

--- a/firmware/rusefi_config.mk
+++ b/firmware/rusefi_config.mk
@@ -69,6 +69,8 @@ else
 endif
 	@touch $@
 
-.PHONY: config
+.PHONY: config ini
+
+ini: $(INI_FILE)
 
 config: .config-sentinel


### PR DESCRIPTION
Also `make bundle` now only builds the normal bundle, not the autoupdate as well. Use `make bundles` to build both.

Green custom https://github.com/chuckwagoncomputing/fw-custom-paralela/actions/runs/8412769451