### PR TITLE
Explicitly pass HARDWARE_CI_SERIAL_DEVICE

### DIFF
--- a/.github/workflows/hw-ci/run_hw_ci.sh
+++ b/.github/workflows/hw-ci/run_hw_ci.sh
@@ -20,4 +20,4 @@ if [ -n "$HARDWARE_CI_SERIAL" ]; then
 	done
 fi
 
-java -cp java_console/autotest/build/libs/autotest-all.jar $HW_SUITE
+java -DHARDWARE_CI_SERIAL_DEVICE=$HARDWARE_CI_SERIAL_DEVICE -cp java_console/autotest/build/libs/autotest-all.jar $HW_SUITE


### PR DESCRIPTION
I don't know the cause, but I was having trouble with a "ECU serial not detected" error from ControllerConnectorState.java in about 50% of HW CI runs. This seems to have fixed it.