### PR TITLE
Bootloader bin out

### DIFF
--- a/firmware/bundle.mk
+++ b/firmware/bundle.mk
@@ -15,7 +15,7 @@ endif
 #  than to try uploading them from the rusefi.snapshot.<BUNDLE_NAME> directory
 DFU = $(DELIVER)/$(PROJECT).dfu
 DBIN = $(DELIVER)/$(PROJECT).bin
-OUTBIN = $(FOLDER)/$(PROJECT).bin
+FIRMWARE_BIN_OUT = $(FOLDER)/$(PROJECT).bin
 
 # If provided with a git reference and the LTS flag, use a folder name including the ref
 # This weird if statement structure is because Make doesn't have &&
@@ -97,7 +97,7 @@ UPDATE_CONSOLE_FOLDER_TARGETS = $(addprefix $(CONSOLE_FOLDER)/,$(notdir $(UPDATE
 UPDATE_BUNDLE_FILES = \
   $(OUTS) \
   $(BOOTLOADER_BIN_OUT) \
-  $(OUTBIN) \
+  $(FIRMWARE_BIN_OUT) \
   $(SREC_TARGET) \
   $(UPDATE_FOLDER_TARGETS) \
   $(UPDATE_CONSOLE_FOLDER_TARGETS)
@@ -137,7 +137,7 @@ $(OUTS): $(FOLDER)/%: $(BUILDDIR)/% | $(FOLDER)
 $(BOOTLOADER_BIN_OUT): $(FOLDER)/openblt%: bootloader/blbuild/openblt_$(PROJECT_BOARD)% | $(FOLDER)
 	ln -rfs $< $@
 
-$(OUTBIN) $(FOLDER)/$(PROJECT).dfu: $(FOLDER)/%: $(DELIVER)/% | $(FOLDER)
+$(FIRMWARE_BIN_OUT) $(FOLDER)/$(PROJECT).dfu: $(FOLDER)/%: $(DELIVER)/% | $(FOLDER)
 	ln -rfs $< $@
 
 # The DFU is currenly not included in the bundle, so these prerequisites are listed as order-only to avoid building it.
@@ -176,7 +176,7 @@ $(ARTIFACTS)/$(BUNDLE_FULL_NAME).zip: $(BUNDLE_FILES) | $(ARTIFACTS)
 	zip -r $@ $(BUNDLE_FILES)
 
 $(ARTIFACTS)/$(BUNDLE_FULL_NAME)_obfuscated_public.zip:  $(OBFUSCATED_OUT) $(BUNDLE_FILES) | $(ARTIFACTS)
-	zip -r $@ $(filter-out $(OUTS) $(BOOTLOADER_BIN_OUT) $(OUTBIN) $(SREC_TARGET),$(BUNDLE_FILES)) $(OBFUSCATED_SREC)
+	zip -r $@ $(filter-out $(OUTS) $(BOOTLOADER_BIN_OUT) $(FIRMWARE_BIN_OUT) $(SREC_TARGET),$(BUNDLE_FILES)) $(OBFUSCATED_SREC)
 
 # The autopdate zip doesn't have a folder with the bundle contents
 $(ARTIFACTS)/$(BUNDLE_FULL_NAME)_autoupdate.zip: $(UPDATE_BUNDLE_FILES) | $(ARTIFACTS)

--- a/firmware/bundle.mk
+++ b/firmware/bundle.mk
@@ -75,8 +75,8 @@ BOOTLOADER_HEX = bootloader/blbuild/openblt_$(PROJECT_BOARD).hex
 
 # We need to put different things in the bundle depending on some meta-info flags
 ifeq ($(USE_OPENBLT),yes)
-  BOOTLOADER_OUT = $(BOOTLOADER_HEX)
-  BOUTS = $(FOLDER)/openblt.bin
+  BOOTLOADER_HEX_OUT = $(BOOTLOADER_HEX)
+  BOOTLOADER_BIN_OUT = $(FOLDER)/openblt.bin
   SREC_TARGET = $(FOLDER)/rusefi_update.srec
 else
   OUTS = $(FOLDER)/$(PROJECT).hex
@@ -96,7 +96,7 @@ UPDATE_CONSOLE_FOLDER_TARGETS = $(addprefix $(CONSOLE_FOLDER)/,$(notdir $(UPDATE
 
 UPDATE_BUNDLE_FILES = \
   $(OUTS) \
-  $(BOUTS) \
+  $(BOOTLOADER_BIN_OUT) \
   $(OUTBIN) \
   $(SREC_TARGET) \
   $(UPDATE_FOLDER_TARGETS) \
@@ -134,7 +134,7 @@ $(SREC_TARGET): $(BUILDDIR)/rusefi.srec
 $(OUTS): $(FOLDER)/%: $(BUILDDIR)/% | $(FOLDER)
 	ln -rfs $< $@
 
-$(BOUTS): $(FOLDER)/openblt%: bootloader/blbuild/openblt_$(PROJECT_BOARD)% | $(FOLDER)
+$(BOOTLOADER_BIN_OUT): $(FOLDER)/openblt%: bootloader/blbuild/openblt_$(PROJECT_BOARD)% | $(FOLDER)
 	ln -rfs $< $@
 
 $(OUTBIN) $(FOLDER)/$(PROJECT).dfu: $(FOLDER)/%: $(DELIVER)/% | $(FOLDER)
@@ -144,7 +144,7 @@ $(OUTBIN) $(FOLDER)/$(PROJECT).dfu: $(FOLDER)/%: $(DELIVER)/% | $(FOLDER)
 # If you want it, you can build it with `make rusefi.snapshot.$BUNDLE_NAME/rusefi.dfu`
 $(DFU) $(DBIN): .h2d-sentinel ;
 
-.h2d-sentinel: $(BUILDDIR)/$(PROJECT).hex $(BOOTLOADER_OUT) $(BINSRC) | $(DELIVER)
+.h2d-sentinel: $(BUILDDIR)/$(PROJECT).hex $(BOOTLOADER_HEX_OUT) $(BINSRC) | $(DELIVER)
 ifeq ($(USE_OPENBLT),yes)
 	$(H2D) -i $(BOOTLOADER_HEX) -i $(BUILDDIR)/$(PROJECT).hex -C 0x1C -o $(DFU) -b $(DBIN)
 else
@@ -176,7 +176,7 @@ $(ARTIFACTS)/$(BUNDLE_FULL_NAME).zip: $(BUNDLE_FILES) | $(ARTIFACTS)
 	zip -r $@ $(BUNDLE_FILES)
 
 $(ARTIFACTS)/$(BUNDLE_FULL_NAME)_obfuscated_public.zip:  $(OBFUSCATED_OUT) $(BUNDLE_FILES) | $(ARTIFACTS)
-	zip -r $@ $(filter-out $(OUTS) $(BOUTS) $(OUTBIN) $(SREC_TARGET),$(BUNDLE_FILES)) $(OBFUSCATED_SREC)
+	zip -r $@ $(filter-out $(OUTS) $(BOOTLOADER_BIN_OUT) $(OUTBIN) $(SREC_TARGET),$(BUNDLE_FILES)) $(OBFUSCATED_SREC)
 
 # The autopdate zip doesn't have a folder with the bundle contents
 $(ARTIFACTS)/$(BUNDLE_FULL_NAME)_autoupdate.zip: $(UPDATE_BUNDLE_FILES) | $(ARTIFACTS)

--- a/firmware/bundle.mk
+++ b/firmware/bundle.mk
@@ -79,10 +79,10 @@ ifeq ($(USE_OPENBLT),yes)
   BOOTLOADER_BIN_OUT = $(FOLDER)/openblt.bin
   SREC_TARGET = $(FOLDER)/rusefi_update.srec
 else
-  OUTS = $(FOLDER)/$(PROJECT).hex
+  FIRMWARE_OUTPUTS = $(FOLDER)/$(PROJECT).hex
   BINSRC = $(BUILDDIR)/$(PROJECT).bin
 ifeq ($(INCLUDE_ELF),yes)
-  OUTS += $(FOLDER)/$(PROJECT).elf $(FOLDER)/$(PROJECT).map $(FOLDER)/$(PROJECT).list
+  FIRMWARE_OUTPUTS += $(FOLDER)/$(PROJECT).elf $(FOLDER)/$(PROJECT).map $(FOLDER)/$(PROJECT).list
 endif
 endif
 
@@ -95,7 +95,7 @@ UPDATE_FOLDER_TARGETS = $(addprefix $(FOLDER)/,$(notdir $(UPDATE_FOLDER_SOURCES)
 UPDATE_CONSOLE_FOLDER_TARGETS = $(addprefix $(CONSOLE_FOLDER)/,$(notdir $(UPDATE_CONSOLE_FOLDER_SOURCES)))
 
 UPDATE_BUNDLE_FILES = \
-  $(OUTS) \
+  $(FIRMWARE_OUTPUTS) \
   $(BOOTLOADER_BIN_OUT) \
   $(FIRMWARE_BIN_OUT) \
   $(SREC_TARGET) \
@@ -131,7 +131,7 @@ $(BUILDDIR)/$(PROJECT).map: $(BUILDDIR)/$(PROJECT).elf
 $(SREC_TARGET): $(BUILDDIR)/rusefi.srec
 	ln -rfs $< $@
 
-$(OUTS): $(FOLDER)/%: $(BUILDDIR)/% | $(FOLDER)
+$(FIRMWARE_OUTPUTS): $(FOLDER)/%: $(BUILDDIR)/% | $(FOLDER)
 	ln -rfs $< $@
 
 $(BOOTLOADER_BIN_OUT): $(FOLDER)/openblt%: bootloader/blbuild/openblt_$(PROJECT_BOARD)% | $(FOLDER)
@@ -176,7 +176,7 @@ $(ARTIFACTS)/$(BUNDLE_FULL_NAME).zip: $(BUNDLE_FILES) | $(ARTIFACTS)
 	zip -r $@ $(BUNDLE_FILES)
 
 $(ARTIFACTS)/$(BUNDLE_FULL_NAME)_obfuscated_public.zip:  $(OBFUSCATED_OUT) $(BUNDLE_FILES) | $(ARTIFACTS)
-	zip -r $@ $(filter-out $(OUTS) $(BOOTLOADER_BIN_OUT) $(FIRMWARE_BIN_OUT) $(SREC_TARGET),$(BUNDLE_FILES)) $(OBFUSCATED_SREC)
+	zip -r $@ $(filter-out $(FIRMWARE_OUTPUTS) $(BOOTLOADER_BIN_OUT) $(FIRMWARE_BIN_OUT) $(SREC_TARGET),$(BUNDLE_FILES)) $(OBFUSCATED_SREC)
 
 # The autopdate zip doesn't have a folder with the bundle contents
 $(ARTIFACTS)/$(BUNDLE_FULL_NAME)_autoupdate.zip: $(UPDATE_BUNDLE_FILES) | $(ARTIFACTS)


### PR DESCRIPTION
only renaming entities for readability