### PR TITLE
TCU config stuff

### DIFF
--- a/firmware/controllers/tcu/gc_generic.cpp
+++ b/firmware/controllers/tcu/gc_generic.cpp
@@ -23,10 +23,10 @@ void GenericGearController::update() {
 	// Loop through possible range states
 	// 1-9 because 0 is SelectedGear::Invalid
 	for (int i = 1; i <= 9; i++) {
-		uint8_t *rangeStates = getRangeStateArray(i);
+		float *rangeStates = getRangeStateArray(i);
 		// Loop through inputs
 		for (size_t p = 0; p < efi::size(engineConfiguration->tcu_rangeInput); p++) {
-			int cellState = rangeStates[p];
+			float cellState = rangeStates[p];
 			// If the pin isn't configured and it matters, or if we've locked out this range with 3 in a cell
 			if ((!isBrainPinValid(engineConfiguration->tcu_rangeInput[p]) && cellState != 2) || cellState == 3) {
 				gear = SelectedGear::Invalid;

--- a/firmware/controllers/tcu/gc_generic.cpp
+++ b/firmware/controllers/tcu/gc_generic.cpp
@@ -21,8 +21,8 @@ void GenericGearController::init() {
 void GenericGearController::update() {
 	SelectedGear gear = SelectedGear::Invalid;
 	// Loop through possible range states
-	// 1-9 because 0 is SelectedGear::Invalid
-	for (int i = 1; i <= 9; i++) {
+	// 1 based because 0 is SelectedGear::Invalid
+	for (int i = 1; i <= TCU_RANGE_COUNT; i++) {
 		float *rangeStates = getRangeStateArray(i);
 		// Loop through inputs
 		for (size_t p = 0; p < efi::size(engineConfiguration->tcu_rangeInput); p++) {

--- a/firmware/controllers/tcu/gear_controller.cpp
+++ b/firmware/controllers/tcu/gear_controller.cpp
@@ -71,7 +71,7 @@ void initGearController() {
 	engine->gearController->init();
 }
 
-uint8_t* GearControllerBase::getRangeStateArray(int i) {
+float* GearControllerBase::getRangeStateArray(int i) {
 	switch (i) {
 	case 1 :
 		return config->tcu_rangePlus;

--- a/firmware/controllers/tcu/gear_controller.h
+++ b/firmware/controllers/tcu/gear_controller.h
@@ -20,7 +20,7 @@ public:
 protected:
 	virtual gear_e setDesiredGear(gear_e);
 	void initTransmissionController();
-	uint8_t* getRangeStateArray(int);
+	float* getRangeStateArray(int);
 private:
 	gear_e desiredGear = NEUTRAL;
 	void postState();

--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -1941,6 +1941,14 @@ uint8_t[FUEL_LEVEL_TABLE_COUNT] fuelLevelValues;;"%", 1, 0, 0, 100, 0
 uint8_t[DWELL_CURVE_SIZE] autoscale dwellVoltageCorrVoltBins;;"volts", 0.1, 0, 0, 20, 1
 uint8_t[DWELL_CURVE_SIZE] autoscale dwellVoltageCorrValues;;"multiplier", 0.02, 0, 0, 5, 2
 
+uint8_t[TCU_TABLE_WIDTH] autoscale tcu_shiftTpsBins;;"%", 1, 0, 0, 255, 2
+uint8_t[TCU_TABLE_WIDTH] tcu_shiftSpeed12;;"MPH", 1, 0, 0, 255, 0
+uint8_t[TCU_TABLE_WIDTH] tcu_shiftSpeed23;;"MPH", 1, 0, 0, 255, 0
+uint8_t[TCU_TABLE_WIDTH] tcu_shiftSpeed34;;"MPH", 1, 0, 0, 255, 0
+uint8_t[TCU_TABLE_WIDTH] tcu_shiftSpeed21;;"MPH", 1, 0, 0, 255, 0
+uint8_t[TCU_TABLE_WIDTH] tcu_shiftSpeed32;;"MPH", 1, 0, 0, 255, 0
+uint8_t[TCU_TABLE_WIDTH] tcu_shiftSpeed43;;"MPH", 1, 0, 0, 255, 0
+
 end_struct
 
 #define CMD_SET_SENSOR_MOCK "set_sensor_mock"

--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -1949,6 +1949,8 @@ uint8_t[TCU_TABLE_WIDTH] tcu_shiftSpeed21;;"MPH", 1, 0, 0, 255, 0
 uint8_t[TCU_TABLE_WIDTH] tcu_shiftSpeed32;;"MPH", 1, 0, 0, 255, 0
 uint8_t[TCU_TABLE_WIDTH] tcu_shiftSpeed43;;"MPH", 1, 0, 0, 255, 0
 
+float tcu_shiftTime;;"ms", 1, 0, 0, 3000, 0
+
 end_struct
 
 #define CMD_SET_SENSOR_MOCK "set_sensor_mock"

--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -164,6 +164,7 @@ struct_no_prefix engine_configuration_s
 #define TCU_SOLENOID_COUNT 6
 
 #define RANGE_INPUT_COUNT 6
+#define TCU_RANGE_COUNT 11
 
 ! Matt says: The problem is the driver chip. Tle9201 can't do 20k. The drivers are too slow. On purpose to reduce EMI
 ! https://rusefi.com/forum/viewtopic.php?p=47307#p47307

--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -96,13 +96,13 @@
 ! this is used to confirm that firmware and TunerStudio are using the same rusefi.ini version
 ! todo: this not needed in light of TS_SIGNATURE but rusEFI console still uses it. Need to migrate
 ! rusEFI console from TS_FILE_VERSION to TS_SIGNATURE :(
-#define TS_FILE_VERSION 20240101
+#define TS_FILE_VERSION 20240404
 
 ! This is the version of the data stored in flash configuration
 ! Any time an incompatible change is made to the configuration format stored in flash,
 ! update this string to the current date! It is required to also update TS_SIGNATURE above
 ! when this happens.
-#define FLASH_DATA_VERSION 20015
+#define FLASH_DATA_VERSION 20016
 
 ! this offset is part of console compatibility mechanism, please DO NOT change this offset
 #define TS_FILE_VERSION_OFFSET 124
@@ -1883,17 +1883,17 @@ uint16_t[12] autoscale throttleEstimateEffectiveAreaValues;In units of g/s norma
 blend_table_s[BOOST_BLEND_COUNT iterate] boostOpenLoopBlends
 blend_table_s[BOOST_BLEND_COUNT iterate] boostClosedLoopBlends
 
-uint8_t[6] tcu_rangeP;;"level", 1, 0, 0, 3, 0
-uint8_t[6] tcu_rangeR;;"level", 1, 0, 0, 3, 0
-uint8_t[6] tcu_rangeN;;"level", 1, 0, 0, 3, 0
-uint8_t[6] tcu_rangeD;;"level", 1, 0, 0, 3, 0
-uint8_t[6] tcu_rangeM;;"level", 1, 0, 0, 3, 0
-uint8_t[6] tcu_rangeM3;;"level", 1, 0, 0, 3, 0
-uint8_t[6] tcu_rangeM2;;"level", 1, 0, 0, 3, 0
-uint8_t[6] tcu_rangeM1;;"level", 1, 0, 0, 3, 0
-uint8_t[6] tcu_rangePlus;;"level", 1, 0, 0, 3, 0
-uint8_t[6] tcu_rangeMinus;;"level", 1, 0, 0, 3, 0
-uint8_t[6] tcu_rangeLow;;"level", 1, 0, 0, 3, 0
+float[RANGE_INPUT_COUNT] tcu_rangeP;;"level", 1, 0, 0, 200000, 0
+float[RANGE_INPUT_COUNT] tcu_rangeR;;"level", 1, 0, 0, 200000, 0
+float[RANGE_INPUT_COUNT] tcu_rangeN;;"level", 1, 0, 0, 200000, 0
+float[RANGE_INPUT_COUNT] tcu_rangeD;;"level", 1, 0, 0, 200000, 0
+float[RANGE_INPUT_COUNT] tcu_rangeM;;"level", 1, 0, 0, 200000, 0
+float[RANGE_INPUT_COUNT] tcu_rangeM3;;"level", 1, 0, 0, 200000, 0
+float[RANGE_INPUT_COUNT] tcu_rangeM2;;"level", 1, 0, 0, 200000, 0
+float[RANGE_INPUT_COUNT] tcu_rangeM1;;"level", 1, 0, 0, 200000, 0
+float[RANGE_INPUT_COUNT] tcu_rangePlus;;"level", 1, 0, 0, 200000, 0
+float[RANGE_INPUT_COUNT] tcu_rangeMinus;;"level", 1, 0, 0, 200000, 0
+float[RANGE_INPUT_COUNT] tcu_rangeLow;;"level", 1, 0, 0, 200000, 0
 
 uint8_t[4 x 4] autoscale lambdaMaxDeviationTable;;"lambda", 0.01, 0, 0, 1, 2
 uint16_t[4] lambdaMaxDeviationLoadBins;;"", 1, 0, 0, 1000, 0

--- a/firmware/tunerstudio/tunerstudio.template.ini
+++ b/firmware/tunerstudio/tunerstudio.template.ini
@@ -710,7 +710,25 @@ enable2ndByteCanID = false
 		yBins = tcu_tccUnlockSpeed
 		gauge = TPSGauge
 
-	curve = pcPerGearCurve, "Transmission Line Pressure Control"
+curve = shiftSpeedCurve, "Automatic Shift Points"
+		columnLabel = "Throttle", ""
+		xAxis = 0, 100, 10
+		yAxis = 0, 200, 10
+		xBins = tcu_shiftTpsBins, TPSValue
+		yBins = tcu_shiftSpeed12
+		yBins = tcu_shiftSpeed23
+		yBins = tcu_shiftSpeed34
+		yBins = tcu_shiftSpeed21
+		yBins = tcu_shiftSpeed32
+		yBins = tcu_shiftSpeed43
+		lineLabel = "1->2"
+		lineLabel = "2->3"
+		lineLabel = "3->4"
+		lineLabel = "2->1"
+		lineLabel = "3->2"
+		lineLabel = "4->3"
+
+curve = pcPerGearCurve, "Transmission Line Pressure Control"
 		columnLabel = "Airmass", ""
 		xAxis = 0, 5, 10
 		yAxis = 0, 100, 10
@@ -1996,6 +2014,7 @@ menuDialog = main
 		subMenu = tcuControls,			"Transmission Settings (alpha)"@@if_ts_show_tcu
 		subMenu = gearControls,			"Gear Selection Settings (alpha)"@@if_ts_show_tcu
 		subMenu = inputSpeedSensor,		"Input Speed Sensor (alpha)"@@if_ts_show_tcu
+		subMenu = shiftSpeedDialog,		"Automatic Shift Points (alpha)"@@if_ts_show_tcu
 		subMenu = tcuSolenoidTableTbl,		"Shift Solenoids (alpha)"@@if_ts_show_tcu
 		subMenu = tccCurves,			"TCC Lock/Unlock Speed (alpha)"@@if_ts_show_tcu
 		subMenu = pcPerGearDialog,		"Line Pressure Per Gear (alpha)"@@if_ts_show_tcu
@@ -4339,6 +4358,9 @@ dialog = tcuControls, "Transmission Settings"
 
 	dialog = inputSpeedSensor, "Input Speed Sensor"
 		panel = inputSpeedSensorPanel
+
+	dialog = shiftSpeedDialog, "Line Pressure Per Gear Steady State"
+		panel = shiftSpeedCurve
 
 	dialog = tccCurves, "TCC Lock/Unlock Speed"
 		panel = tccLockCurve

--- a/firmware/tunerstudio/tunerstudio.template.ini
+++ b/firmware/tunerstudio/tunerstudio.template.ini
@@ -4326,6 +4326,10 @@ cmd_set_engine_type_default					= "@@TS_IO_TEST_COMMAND_char@@@@ts_command_e_TS_
 		field = "Pressure Control Solenoid Pin Mode" tcu_pc_solenoid_pin_mode, { tcuEnabled && (transmissionControllerMode == @@TransmissionControllerMode_Gm4l6x@@) }
 		field = "Pressure Control Solenoid Frequency" tcu_pc_solenoid_freq, { tcuEnabled && (transmissionControllerMode == @@TransmissionControllerMode_Gm4l6x@@) }
 
+	dialog = shiftSettingsPanel, "Shift Settings"
+		field = "Assumed Shift Time" tcu_shiftTime, { tcuEnabled }
+
+
 	dialog = buttonShiftInputPanel, "Switch/Button Shift"
 		field = "Upshift Pin"		tcuUpshiftButtonPin, { tcuEnabled && gearControllerMode == @@GearControllerMode_ButtonShift@@ }
 		field = "Upshift Pin Mode"	tcuUpshiftButtonPinMode, { tcuEnabled && gearControllerMode == @@GearControllerMode_ButtonShift@@ }
@@ -4351,6 +4355,7 @@ dialog = tcuControls, "Transmission Settings"
 		panel = transmissionPanel
 		panel = shiftSolenoidPanel
 		panel = otherSolenoidPanel
+		panel = shiftSettingsPanel
 
 	dialog = gearControls, "Gear Selection Settings"
 		panel = buttonShiftInputPanel


### PR DESCRIPTION
The big thing here is changing the type of the tcu_range arrays from uint8 to float, which if I understand correctly requires incrementing FLASH_DATA_VERSION and updating TS_FILE_VERSION. I've never done that before, so I'm not sure if I've done it correctly.

Also adds:
- TS input for automatic shift speeds.
- Option for assumed shift time in the absence of an input speed sensor
- define TCU_RANGE_COUNT instead of having a magic number (And correct bug - it was 9 when it should have been 11)