### PR TITLE
Update to interactive-pinout 2.15

### DIFF
--- a/.github/workflows/check-pinout.yaml
+++ b/.github/workflows/check-pinout.yaml
@@ -24,7 +24,7 @@ jobs:
         echo "DELIM" >> $GITHUB_ENV
 
     - name: Generate Pinouts
-      uses: chuckwagoncomputing/interactive-pinout@2.14
+      uses: chuckwagoncomputing/interactive-pinout@2.15
       with:
         mapping-path: ${{ env.CHANGED }}
         warnings: "notice"

--- a/.github/workflows/gen-pinouts-top-level.yaml
+++ b/.github/workflows/gen-pinouts-top-level.yaml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Generate Pinouts
-        uses: chuckwagoncomputing/interactive-pinout@2.14
+        uses: chuckwagoncomputing/interactive-pinout@2.15
         with:
           mapping-path: connectors/*.yaml
           warnings: "false"

--- a/.github/workflows/gen-pinouts.yaml
+++ b/.github/workflows/gen-pinouts.yaml
@@ -17,7 +17,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Generate Pinouts
-      uses: chuckwagoncomputing/interactive-pinout@2.14
+      uses: chuckwagoncomputing/interactive-pinout@2.15
       with:
         mapping-path: firmware/config/boards/*/connectors/*.yaml
         warnings: "false"


### PR DESCRIPTION
We went back to Debian for now because yq disappeared from the Alpine repos and I'm to lazy to check if the yq release on GH works on Alpine.