### PR TITLE
tunerstudio: add separate menu for CAN and related

### DIFF
--- a/firmware/tunerstudio/tunerstudio.template.ini
+++ b/firmware/tunerstudio/tunerstudio.template.ini
@@ -2072,6 +2072,14 @@ menuDialog = main
 
 		subMenu = auxLinearSensors,			"Aux Sensors"
 
+	menu = "CAN-bus"
+		subMenu = canBusMain,				"CAN Bus Settings"
+		subMenu = std_separator
+
+		subMenu = speedSensorCan			"CAN Vehicle speed sensor"
+		subMenu = uegoCan,					"CAN O2 sensors"
+		subMune = egtInputsCan				"CAN EGT sensors"
+
 	menu = "&Controller"
 		subMenu = ecuStimulator,			"ECU stimulator"
 		subMenu = ioTest,					"Bench test"
@@ -2084,7 +2092,6 @@ menuDialog = main
 		subMenu = monitoringSettings,		"rusEFI console"
 		subMenu = std_separator
 
-		subMenu = canBusMain,				"CAN Bus Communication"
 		subMenu = sdCard,					"SD Card Logger" @@if_ts_show_sd_card
 		subMenu = connection,					"Connection"
 		subMenu = std_separator
@@ -3461,17 +3468,28 @@ cmd_set_engine_type_default					= "@@TS_IO_TEST_COMMAND_char@@@@ts_command_e_TS_
 	dialog = egoSettings_IO2,	"O2 Sensor 2 I/O"
 		field = "Input channel",						afr_hwChannel2
 
-	dialog = egoSettings, "", yAxis
-		field = "Enable CAN Wideband",			enableAemXSeries, { canReadEnabled }
+	dialog = uegoCan, "CAN UEGO/wideband O2"
+		field = "Support for AEM or RusEFI CAN UEGO"
+		field = "Enable CAN Wideband", enableAemXSeries, { canReadEnabled }
+		field = "Wideband CAN bus", widebandOnSecondBus
+		field = "Force O2 sensor heating", forceO2Heating
+
+	dialog = uegoSerial, "Innovale LC-2 serial"
 		field = "Enable Innovate LC-2 Serial",			enableInnovateLC2, { auxSerialRxPin && auxSerialTxPin }
+
+	dialog = egoSettings, "", yAxis
+		panel = uegoCan
+		panel = uegoSerial
 		panel = egoSettings_IO1
 		panel = egoSettings_IO2, {afr_hwChannel != @@ADC_CHANNEL_NONE@@ && enableAemXSeries == 0 && !auxSerialRxPin && !auxSerialTxPin}
 		panel = egoSettings_sensor, {afr_hwChannel != @@ADC_CHANNEL_NONE@@ && enableAemXSeries == 0 && !auxSerialRxPin && !auxSerialTxPin}
 
 ;			Engine->EGT inputs
-	dialog = egtInputs, "EGT inputs"
-		field = "CAN support only EGT1 and EGT2"
+	dialog = egtInputsCan, "CAN EGT sensors"
+		field = "CAN support only EGT1 and EGT2 inputs"
 		field = "CAN EGT (AEM X series of RusEFI)"		enableAemXSeriesEgt, { canReadEnabled }
+
+	dialog = egtInputsSpi, "SPI EGT sensors"
 		field = "If both CAN and SPI EGT sensors are used, please leave two first for CAN"
 		field = "MAX31855/MAX31856 SPI",				max31855spiDevice
 		field = "CS for EGT1",							max31855_cs1
@@ -3482,6 +3500,10 @@ cmd_set_engine_type_default					= "@@TS_IO_TEST_COMMAND_char@@@@ts_command_e_TS_
 		field = "CS for EGT6",							max31855_cs6
 		field = "CS for EGT7",							max31855_cs7
 		field = "CS for EGT8",							max31855_cs8
+
+	dialog = egtInputs, "EGT inputs"
+		panel = egtInputsCan
+		panel = egtInputsSpi
 
 ;			Engine->idle Settings
 	dialog = idleSolenoid, "Solenoid"
@@ -4606,8 +4628,6 @@ dialog = tcuControls, "Transmission Settings"
 		field = "!Disconnect all controllers you don't want to set!"
 		commandButton = "Set Index 0",	cmd_set_wideband_idx_0
 		commandButton = "Set Index 1",	cmd_set_wideband_idx_1
-		field = "Wideband CAN bus", widebandOnSecondBus
-		field = "Force O2 sensor heating", forceO2Heating
 
 	dialog = engineTypeDialog, "Popular vehicles"
 		field = "!These buttons send a command to rusEFI controller to apply preset values"

--- a/firmware/tunerstudio/tunerstudio.template.ini
+++ b/firmware/tunerstudio/tunerstudio.template.ini
@@ -2078,7 +2078,7 @@ menuDialog = main
 
 		subMenu = speedSensorCan			"CAN Vehicle speed sensor"
 		subMenu = uegoCan,					"CAN O2 sensors"
-		subMune = egtInputsCan				"CAN EGT sensors"
+		subMenu = egtInputsCan,				"CAN EGT sensors"
 
 	menu = "&Controller"
 		subMenu = ecuStimulator,			"ECU stimulator"
@@ -3487,7 +3487,7 @@ cmd_set_engine_type_default					= "@@TS_IO_TEST_COMMAND_char@@@@ts_command_e_TS_
 ;			Engine->EGT inputs
 	dialog = egtInputsCan, "CAN EGT sensors"
 		field = "CAN support only EGT1 and EGT2 inputs"
-		field = "CAN EGT (AEM X series of RusEFI)"		enableAemXSeriesEgt, { canReadEnabled }
+		field = "CAN EGT (AEM X series of RusEFI)", senableAemXSeriesEgt, { canReadEnabled }
 
 	dialog = egtInputsSpi, "SPI EGT sensors"
 		field = "If both CAN and SPI EGT sensors are used, please leave two first for CAN"


### PR DESCRIPTION
Duplicate some settings dialogs under this menu.
![Screenshot from 2024-04-20 11-27-10](https://github.com/rusefi/rusefi/assets/28624689/be19cc12-58d8-4c2b-9d81-237cae678164)
