### PR TITLE
Fix realpath on macos

### DIFF
--- a/.github/workflows/build-unit-tests.yaml
+++ b/.github/workflows/build-unit-tests.yaml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-12]
+        os: [ubuntu-latest, macos-latest]
 
     steps:
     - uses: actions/checkout@v4
@@ -23,17 +23,17 @@ jobs:
         git submodule update --init --depth=1 java_console/peak-can-basic
 
     - name: Discover cores
-      if: ${{ matrix.os != 'macos-12' }}
+      if: ${{ matrix.os != 'macos-latest' }}
       run: lscpu | egrep 'Model name|Socket|Thread|NUMA|CPU\(s\)'
 
     - name: Install required software (ubuntu)
-      if: ${{ matrix.os != 'macos-12' }}
+      if: ${{ matrix.os != 'macos-latest' }}
       run: |
         sudo bash misc/actions/add-ubuntu-latest-apt-mirrors.sh
         sudo apt-get install mtools zip dosfstools sshpass lcov valgrind
 
     - name: Install required software (macos)
-      if: ${{ matrix.os == 'macos-12' }}
+      if: ${{ matrix.os == 'macos-latest' }}
       run: |
         brew install mtools zip dosfstools flock coreutils
 
@@ -74,7 +74,7 @@ jobs:
         fi
 
     - name: Generate Code Coverage
-      if: ${{ matrix.os != 'macos-12' && github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+      if: ${{ matrix.os != 'macos-latest' && github.event_name == 'push' && github.ref == 'refs/heads/master' }}
       working-directory: ./unit_tests/
       run: ./ci_gcov.sh ${{ secrets.RUSEFI_SSH_USER }} ${{ secrets.RUSEFI_SSH_PASS }} ${{ secrets.RUSEFI_SSH_SERVER }}
 
@@ -85,13 +85,13 @@ jobs:
 
     - name: Rebuild Tests For Valgrind
       # Valgrind isn't compatible with address sanitizer, so we have to rebuild the code
-      if: ${{ matrix.os != 'macos-12' }}
+      if: ${{ matrix.os != 'macos-latest' }}
       working-directory: ./unit_tests/
       run: |
         make clean
         make -j4 SANITIZE=no
 
     - name: Run Tests (Valgrind)
-      if: ${{ matrix.os != 'macos-12' }}
+      if: ${{ matrix.os != 'macos-latest' }}
       working-directory: ./unit_tests/
       run: valgrind --error-exitcode=1 --exit-on-first-error=yes --leak-check=no --show-error-list=yes build/rusefi_test

--- a/.github/workflows/custom-board-build/action.yaml
+++ b/.github/workflows/custom-board-build/action.yaml
@@ -142,7 +142,8 @@ runs:
         echo "RUN_SIMULATOR=${{toJSON(inputs.run_simulator)}}" >> $GITHUB_ENV
         echo "REF=${{github.ref_name}}" >> $GITHUB_ENV
         echo "${{ inputs.ADDITIONAL_ENV }}" >> $GITHUB_ENV
-        which realpath >/dev/null 2>&1 || (which grealpath >/dev/null 2>&1 && alias realpath='grealpath')
+        shopt -s expand_aliases
+        if which grealpath >/dev/null 2>&1; then alias realpath='grealpath'; fi
         echo "META_OUTPUT_ROOT_FOLDER=$(realpath --relative-to=${{inputs.rusefi_dir}}/firmware ${{inputs.meta_output}})/" >> $GITHUB_ENV
         echo "SIM_OUTPUT_ROOT_FOLDER=$(realpath --relative-to=${{inputs.rusefi_dir}}/firmware ${{inputs.sim_output}})/" >> $GITHUB_ENV
         source ${{inputs.rusefi_dir}}/firmware/config/boards/common_script_read_meta_env.inc "${{inputs.meta_info}}"

--- a/firmware/bin/gen_image_board.sh
+++ b/firmware/bin/gen_image_board.sh
@@ -4,7 +4,8 @@ BOARD_DIR=${1:-$BOARD_DIR}
 SHORT_BOARD_NAME=${2:-$SHORT_BOARD_NAME}
 INI=${3:-"rusefi_$SHORT_BOARD_NAME.ini"}
 
-which realpath >/dev/null 2>&1 || (which grealpath >/dev/null 2>&1 && alias realpath='grealpath')
+shopt -s expand_aliases
+if which grealpath >/dev/null 2>&1; then alias realpath='grealpath'; fi
 FDIR=$(realpath $(dirname "$0")/..)
 BOARD_DIR=$(realpath --relative-to "$FDIR" "$BOARD_DIR")
 

--- a/firmware/gen_config_board.sh
+++ b/firmware/gen_config_board.sh
@@ -31,7 +31,8 @@ fi
 
 echo "BOARD_DIR=${BOARD_DIR} SHORT_BOARD_NAME=${SHORT_BOARD_NAME}"
 
-which realpath >/dev/null 2>&1 || (which grealpath >/dev/null 2>&1 && alias realpath='grealpath')
+shopt -s expand_aliases
+if which grealpath >/dev/null 2>&1; then alias realpath='grealpath'; fi
 FDIR=$(realpath $(dirname "$0"))
 BOARD_DIR=$(realpath --relative-to "$FDIR" "$BOARD_DIR")
 


### PR DESCRIPTION
#6405
- always use grealpath if it exists
- enable aliases - they're only enabled by default for interactive shells