### PR TITLE
TestExecutor::executeAll accepts ticks, not microseconds

### DIFF
--- a/unit_tests/test-framework/engine_test_helper.cpp
+++ b/unit_tests/test-framework/engine_test_helper.cpp
@@ -225,7 +225,7 @@ void EngineTestHelper::clearQueue() {
 }
 
 int EngineTestHelper::executeActions() {
-	return engine.executor.executeAll(getTimeNowUs());
+	return engine.executor.executeAll(US2NT(getTimeNowUs()));
 }
 
 void EngineTestHelper::moveTimeForwardMs(float deltaTimeMs) {


### PR DESCRIPTION
I'm sure that this fix is correct, but I'm not sure how to fix broken tests