### PR TITLE
Should rusefi_config.mk track rusefi_hw_*.h files changes?

### DIFF
--- a/firmware/rusefi_config.mk
+++ b/firmware/rusefi_config.mk
@@ -6,6 +6,8 @@ SIG_FILE = $(PROJECT_DIR)/$(META_OUTPUT_ROOT_FOLDER)tunerstudio/generated/signat
 
 CONFIG_INPUTS = \
   $(SIG_FILE) \
+  $(PROJECT_DIR)/controllers/algo/rusefi_hw_stm32_enums.h \
+  $(PROJECT_DIR)/controllers/algo/rusefi_hw_adc_enums.h \
   $(PROJECT_DIR)/integration/rusefi_config.txt \
   $(PROJECT_DIR)/tunerstudio/tunerstudio.template.ini \
   $(PROJECT_DIR)/console/binary/generated/output_channels.ini \


### PR DESCRIPTION
Change of these files currently does not cause regeneration of auto-generated files.

@rusefillc @chuckwagoncomputing 