### PR TITLE
TS: clear naming, isBigPacket() against actual buffer size

### DIFF
--- a/firmware/console/binary/tunerstudio_io.cpp
+++ b/firmware/console/binary/tunerstudio_io.cpp
@@ -19,7 +19,7 @@ size_t TsChannelBase::read(uint8_t* buffer, size_t size) {
 }
 #endif
 
-#define isBigPacket(size) ((size) > BLOCKING_FACTOR + 7)
+#define isBigPacket(size) ((TS_PACKET_HEADER_SIZE + size + TS_PACKET_TAIL_SIZE) > sizeof(scratchBuffer))
 
 void TsChannelBase::copyAndWriteSmallCrcPacket(uint8_t responseCode, const uint8_t* buf, size_t size) {
 	// don't transmit too large a buffer

--- a/firmware/console/binary/tunerstudio_io.h
+++ b/firmware/console/binary/tunerstudio_io.h
@@ -24,6 +24,7 @@
 #endif
 
 #define TS_PACKET_HEADER_SIZE	3
+#define TS_PACKET_TAIL_SIZE		4
 
 class TsChannelBase {
 public:


### PR DESCRIPTION
@dron0gus just to confirm, this change is a bugfix, not just refactoring, is that right?