### PR TITLE
variable shadowing should be avoided fix #5676

### DIFF
--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -42,8 +42,6 @@ ifneq ("$(wildcard $(../.git))","")
 $(error "../.git not found. We expect source code to be cloned not downloaded as zip file.")
 endif
 
-include rusefi_rules.mk
-
 # Define project name here
 PROJECT = rusefi
 PROJECT_DIR = .
@@ -200,6 +198,9 @@ $(error SHORT_BOARD_NAME not set, something wrong with your meta-info.env file)
 endif
 endif
 DDEFS += -DSHORT_BOARD_NAME=$(SHORT_BOARD_NAME)
+
+# should be after 'board.mk'
+include rusefi_rules.mk
 
 # Include various ChibiOS mk files
 # Licensing files.

--- a/firmware/config/boards/f407-discovery/board.mk
+++ b/firmware/config/boards/f407-discovery/board.mk
@@ -17,9 +17,6 @@ endif
 
 DDEFS += -DEFI_SENT_SUPPORT=TRUE
 
-# temporary solution for variable shadowing should be avoided #5676
-DDEFS += -Werror=shadow
-
 # User can configure LIN/K-line interface
 DDEFS += -DEFI_KLINE=TRUE
 DDEFS += -DKLINE_SERIAL_DEVICE_RX=Gpio::C11 -DKLINE_SERIAL_DEVICE_TX=Gpio::C10

--- a/firmware/config/boards/proteus/board.mk
+++ b/firmware/config/boards/proteus/board.mk
@@ -16,9 +16,6 @@ DDEFS += -DEFI_MAX_31855=TRUE
 DDEFS += -DSTM32_SPI_USE_SPI5=TRUE
 DDEFS += -DEFI_TCU=TRUE
 
-# temporary solution for variable shadowing should be avoided #5676
-DDEFS += -Werror=shadow
-
 # Any Proteus-based adapter boards with discrete-VR decoder are controlled via a 5v ignition output
 DDEFS += -DVR_SUPPLY_VOLTAGE=5
 

--- a/firmware/config/boards/subaru_eg33/board.mk
+++ b/firmware/config/boards/subaru_eg33/board.mk
@@ -17,9 +17,6 @@ DDEFS += -DSTATIC_BOARD_ID=STATIC_BOARD_ID_SUBARU_EG33_F7
 # Override DEFAULT_ENGINE_TYPE
 DDEFS += -DDEFAULT_ENGINE_TYPE=engine_type_e::SUBARU_EG33
 
-# temporary solution for variable shadowing should be avoided #5676
-DDEFS += -Werror=shadow
-
 #Some options override
 DDEFS += -DHAL_USE_UART=FALSE
 DDEFS += -DUART_USE_WAIT=FALSE

--- a/firmware/rusefi_rules.mk
+++ b/firmware/rusefi_rules.mk
@@ -4,7 +4,7 @@ RUSEFI_OPT = -Werror
 RUSEFI_OPT += -Werror=stringop-truncation
 
 ifneq ($(ALLOW_SHADOW),yes)
-#     RUSEFI_OPT += -Werror=shadow
+     RUSEFI_OPT += -Werror=shadow
 endif
 
 # ...except these few


### PR DESCRIPTION
#5676

boards with Ethernet fail due to
```
ChibiOS/os/various/lwip_bindings/lwipthread.c: In function 'lwip_thread':
Compiling lwipthread.c
ChibiOS/os/various/lwip_bindings/lwipthread.c:414:20: error: declaration of 'p' shadows a parameter [-Werror=shadow]
  414 |       struct pbuf *p;
```

desire is to not do -Werror=shadow for such configurations while having it everywhere else