### PR TITLE
Fix tagging for nightly builds

### DIFF
--- a/.github/workflows/custom-board-build/action.yaml
+++ b/.github/workflows/custom-board-build/action.yaml
@@ -153,7 +153,7 @@ runs:
         echo "RUSEFI_SSH_PASS=${{inputs.RUSEFI_SSH_PASS}}" >> $GITHUB_ENV
         echo "bundle_upload_folder=${{inputs.bundle_upload_folder}}" >> $GITHUB_ENV
         echo "AUTOMATION_LTS=${{toJSON(inputs.lts)}}" >> $GITHUB_ENV
-        echo "release_date=${{toJSON(inputs.release_date)}}" >> $GITHUB_ENV
+        echo "release_date=${{toJSON(env.release_date)}}" >> $GITHUB_ENV
         echo "BUNDLE_SIMULATOR=${{toJSON(inputs.bundle_simulator)}}" >> $GITHUB_ENV
         echo "RUN_SIMULATOR=${{toJSON(inputs.run_simulator)}}" >> $GITHUB_ENV
         echo "AUTOMATION_REF=${{github.ref_name}}" >> $GITHUB_ENV

--- a/.github/workflows/custom-board-build/action.yaml
+++ b/.github/workflows/custom-board-build/action.yaml
@@ -475,11 +475,11 @@ runs:
       with:
         tag: ${{ env.release_date }}
 
-#    - name: Create Release Tag
-#      if: ${{ steps.checkTag.outputs.exists == 'false' }}
-#      id: tag
-#      uses: mathieudutour/github-tag-action@v6.2
-#      with:
-#        github_token: ${{env.TOKEN}}
-#        custom_tag: ${{ env.release_date }}
-#        tag_prefix: ''
+    - name: Create Release Tag
+      if: ${{ steps.checkTag.outputs.exists == 'false' }}
+      id: tag
+      uses: mathieudutour/github-tag-action@v6.2
+      with:
+        github_token: ${{env.TOKEN}}
+        custom_tag: ${{ env.release_date }}
+        tag_prefix: ''


### PR DESCRIPTION
now we get release_date from env, not from inputs - it allows tag nightly builds with tags like '2024-06-05' instead of '0.0.1' (https://github.com/rusefi/rusefi/issues/6392)