### PR TITLE
TS: handle ochGetCommand with no arguments (read all)

### DIFF
--- a/firmware/console/binary/tunerstudio.cpp
+++ b/firmware/console/binary/tunerstudio.cpp
@@ -693,9 +693,11 @@ int TunerStudio::handleCrcCommand(TsChannelBase* tsChannel, char *data, int inco
 	uint16_t offset = 0;
 	uint16_t count = 0;
 
+	// command may not have offset field - keep safe default value
 	if (incomingPacketSize >= 3) {
 		offset = data16[0];
 	}
+	// command may not have count/size filed - keep safe default value
 	if (incomingPacketSize >= 5) {
 		count = data16[1];
 	}
@@ -704,7 +706,7 @@ int TunerStudio::handleCrcCommand(TsChannelBase* tsChannel, char *data, int inco
 	{
 	case TS_OUTPUT_COMMAND:
 		if (incomingPacketSize == 1) {
-			/* Read command with no offset and size - read whole livedata */
+			// Read command with no offset and size - read whole livedata
 			count = TS_TOTAL_OUTPUT_SIZE;
 		}
 		cmdOutputChannels(tsChannel, offset, count);

--- a/firmware/console/binary/tunerstudio.cpp
+++ b/firmware/console/binary/tunerstudio.cpp
@@ -690,12 +690,23 @@ int TunerStudio::handleCrcCommand(TsChannelBase* tsChannel, char *data, int inco
 
 	const uint16_t* data16 = reinterpret_cast<uint16_t*>(data);
 
-	uint16_t offset = data16[0];
-	uint16_t count = data16[1];
+	uint16_t offset = 0;
+	uint16_t count = 0;
+
+	if (incomingPacketSize >= 3) {
+		offset = data16[0];
+	}
+	if (incomingPacketSize >= 5) {
+		count = data16[1];
+	}
 
 	switch(command)
 	{
 	case TS_OUTPUT_COMMAND:
+		if (incomingPacketSize == 1) {
+			/* Read command with no offset and size - read whole livedata */
+			count = TS_TOTAL_OUTPUT_SIZE;
+		}
 		cmdOutputChannels(tsChannel, offset, count);
 		break;
 	case TS_HELLO_COMMAND:


### PR DESCRIPTION
Get all livedata with one command with no arguments. Preparation for blockingFactor = infinity.