### PR TITLE
bluetooth initialization bug

### DIFF
--- a/firmware/CHANGELOG.md
+++ b/firmware/CHANGELOG.md
@@ -37,6 +37,7 @@ Release template (copy/paste this for new release):
  - Allow to choose lower RPM cutoff for AC Compressor #6597
  - New TPS/TPS enrichment mode: percent adder #3167
  - Launch control has a variable ignition cut BEFORE the main Hard cut #6566
+ - Experimental mapExpAverageAlpha filtering #6579
 
 ### Fixed
  - knock logic not activated until any configuration change via TS #6462

--- a/firmware/controllers/engine_controller.cpp
+++ b/firmware/controllers/engine_controller.cpp
@@ -546,6 +546,9 @@ bool validateConfigOnStartUpOrBurn() {
     criticalError("Invalid adcVcc: %f", engineConfiguration->adcVcc);
 		return false;
 	}
+	if (engineConfiguration->mapExpAverageAlpha <= 0 || engineConfiguration->mapExpAverageAlpha > 1) {
+	  engineConfiguration->mapExpAverageAlpha = 1;
+	}
 
 	ensureArrayIsAscending("Batt Lag", engineConfiguration->injector.battLagCorrBins);
 

--- a/firmware/controllers/engine_cycle/map_averaging.cpp
+++ b/firmware/controllers/engine_cycle/map_averaging.cpp
@@ -97,6 +97,13 @@ SensorResult MapAverager::submit(float volts) {
 	return result;
 }
 
+PUBLIC_API_WEAK float filterMapValue(float value) {
+static float state = 0;
+  float result = state + engineConfiguration->mapExpAverageAlpha * (value - state);
+  state = result;
+  return result;
+}
+
 void MapAverager::stop() {
 	chibios_rt::CriticalSectionLocker csl;
 

--- a/firmware/controllers/generated/engine_configuration_generated_structures_alphax-2chan.h
+++ b/firmware/controllers/generated/engine_configuration_generated_structures_alphax-2chan.h
@@ -1,4 +1,4 @@
-// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sun Jun 09 23:34:45 UTC 2024
+// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:57:52 UTC 2024
 // by class com.rusefi.output.CHeaderConsumer
 // begin
 #pragma once
@@ -2175,7 +2175,7 @@ struct engine_configuration_s {
 	/**
 	 * offset 992
 	 */
-	int unusedHere13;
+	float mapExpAverageAlpha;
 	/**
 	 * offset 996
 	 */
@@ -5637,4 +5637,4 @@ struct persistent_config_s {
 static_assert(sizeof(persistent_config_s) == 22748);
 
 // end
-// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sun Jun 09 23:34:45 UTC 2024
+// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:57:52 UTC 2024

--- a/firmware/controllers/generated/engine_configuration_generated_structures_alphax-4chan.h
+++ b/firmware/controllers/generated/engine_configuration_generated_structures_alphax-4chan.h
@@ -1,4 +1,4 @@
-// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sun Jun 09 23:34:22 UTC 2024
+// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:57:29 UTC 2024
 // by class com.rusefi.output.CHeaderConsumer
 // begin
 #pragma once
@@ -2175,7 +2175,7 @@ struct engine_configuration_s {
 	/**
 	 * offset 992
 	 */
-	int unusedHere13;
+	float mapExpAverageAlpha;
 	/**
 	 * offset 996
 	 */
@@ -5637,4 +5637,4 @@ struct persistent_config_s {
 static_assert(sizeof(persistent_config_s) == 22748);
 
 // end
-// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sun Jun 09 23:34:22 UTC 2024
+// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:57:29 UTC 2024

--- a/firmware/controllers/generated/engine_configuration_generated_structures_alphax-4chan_f7.h
+++ b/firmware/controllers/generated/engine_configuration_generated_structures_alphax-4chan_f7.h
@@ -1,4 +1,4 @@
-// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sun Jun 09 23:34:20 UTC 2024
+// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:57:27 UTC 2024
 // by class com.rusefi.output.CHeaderConsumer
 // begin
 #pragma once
@@ -2175,7 +2175,7 @@ struct engine_configuration_s {
 	/**
 	 * offset 992
 	 */
-	int unusedHere13;
+	float mapExpAverageAlpha;
 	/**
 	 * offset 996
 	 */
@@ -5637,4 +5637,4 @@ struct persistent_config_s {
 static_assert(sizeof(persistent_config_s) == 22748);
 
 // end
-// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sun Jun 09 23:34:20 UTC 2024
+// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:57:27 UTC 2024

--- a/firmware/controllers/generated/engine_configuration_generated_structures_alphax-8chan-revA.h
+++ b/firmware/controllers/generated/engine_configuration_generated_structures_alphax-8chan-revA.h
@@ -1,4 +1,4 @@
-// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sun Jun 09 23:34:12 UTC 2024
+// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:57:18 UTC 2024
 // by class com.rusefi.output.CHeaderConsumer
 // begin
 #pragma once
@@ -2175,7 +2175,7 @@ struct engine_configuration_s {
 	/**
 	 * offset 992
 	 */
-	int unusedHere13;
+	float mapExpAverageAlpha;
 	/**
 	 * offset 996
 	 */
@@ -5637,4 +5637,4 @@ struct persistent_config_s {
 static_assert(sizeof(persistent_config_s) == 22748);
 
 // end
-// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sun Jun 09 23:34:12 UTC 2024
+// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:57:18 UTC 2024

--- a/firmware/controllers/generated/engine_configuration_generated_structures_alphax-8chan.h
+++ b/firmware/controllers/generated/engine_configuration_generated_structures_alphax-8chan.h
@@ -1,4 +1,4 @@
-// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sun Jun 09 23:34:35 UTC 2024
+// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:57:42 UTC 2024
 // by class com.rusefi.output.CHeaderConsumer
 // begin
 #pragma once
@@ -2175,7 +2175,7 @@ struct engine_configuration_s {
 	/**
 	 * offset 992
 	 */
-	int unusedHere13;
+	float mapExpAverageAlpha;
 	/**
 	 * offset 996
 	 */
@@ -5637,4 +5637,4 @@ struct persistent_config_s {
 static_assert(sizeof(persistent_config_s) == 22764);
 
 // end
-// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sun Jun 09 23:34:35 UTC 2024
+// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:57:42 UTC 2024

--- a/firmware/controllers/generated/engine_configuration_generated_structures_alphax-8chan_f7.h
+++ b/firmware/controllers/generated/engine_configuration_generated_structures_alphax-8chan_f7.h
@@ -1,4 +1,4 @@
-// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sun Jun 09 23:34:34 UTC 2024
+// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:57:41 UTC 2024
 // by class com.rusefi.output.CHeaderConsumer
 // begin
 #pragma once
@@ -2175,7 +2175,7 @@ struct engine_configuration_s {
 	/**
 	 * offset 992
 	 */
-	int unusedHere13;
+	float mapExpAverageAlpha;
 	/**
 	 * offset 996
 	 */
@@ -5637,4 +5637,4 @@ struct persistent_config_s {
 static_assert(sizeof(persistent_config_s) == 22764);
 
 // end
-// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sun Jun 09 23:34:34 UTC 2024
+// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:57:41 UTC 2024

--- a/firmware/controllers/generated/engine_configuration_generated_structures_alphax-silver.h
+++ b/firmware/controllers/generated/engine_configuration_generated_structures_alphax-silver.h
@@ -1,4 +1,4 @@
-// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sun Jun 09 23:34:38 UTC 2024
+// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:57:45 UTC 2024
 // by class com.rusefi.output.CHeaderConsumer
 // begin
 #pragma once
@@ -2175,7 +2175,7 @@ struct engine_configuration_s {
 	/**
 	 * offset 992
 	 */
-	int unusedHere13;
+	float mapExpAverageAlpha;
 	/**
 	 * offset 996
 	 */
@@ -5637,4 +5637,4 @@ struct persistent_config_s {
 static_assert(sizeof(persistent_config_s) == 22748);
 
 // end
-// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sun Jun 09 23:34:38 UTC 2024
+// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:57:45 UTC 2024

--- a/firmware/controllers/generated/engine_configuration_generated_structures_at_start_f435.h
+++ b/firmware/controllers/generated/engine_configuration_generated_structures_at_start_f435.h
@@ -1,4 +1,4 @@
-// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sun Jun 09 23:34:02 UTC 2024
+// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:57:08 UTC 2024
 // by class com.rusefi.output.CHeaderConsumer
 // begin
 #pragma once
@@ -2175,7 +2175,7 @@ struct engine_configuration_s {
 	/**
 	 * offset 992
 	 */
-	int unusedHere13;
+	float mapExpAverageAlpha;
 	/**
 	 * offset 996
 	 */
@@ -5637,4 +5637,4 @@ struct persistent_config_s {
 static_assert(sizeof(persistent_config_s) == 22748);
 
 // end
-// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sun Jun 09 23:34:02 UTC 2024
+// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:57:08 UTC 2024

--- a/firmware/controllers/generated/engine_configuration_generated_structures_atlas.h
+++ b/firmware/controllers/generated/engine_configuration_generated_structures_atlas.h
@@ -1,4 +1,4 @@
-// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sun Jun 09 23:34:54 UTC 2024
+// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:58:01 UTC 2024
 // by class com.rusefi.output.CHeaderConsumer
 // begin
 #pragma once
@@ -2175,7 +2175,7 @@ struct engine_configuration_s {
 	/**
 	 * offset 992
 	 */
-	int unusedHere13;
+	float mapExpAverageAlpha;
 	/**
 	 * offset 996
 	 */
@@ -5637,4 +5637,4 @@ struct persistent_config_s {
 static_assert(sizeof(persistent_config_s) == 22248);
 
 // end
-// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sun Jun 09 23:34:54 UTC 2024
+// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:58:01 UTC 2024

--- a/firmware/controllers/generated/engine_configuration_generated_structures_f407-discovery.h
+++ b/firmware/controllers/generated/engine_configuration_generated_structures_f407-discovery.h
@@ -1,4 +1,4 @@
-// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sun Jun 09 23:35:16 UTC 2024
+// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:58:23 UTC 2024
 // by class com.rusefi.output.CHeaderConsumer
 // begin
 #pragma once
@@ -2175,7 +2175,7 @@ struct engine_configuration_s {
 	/**
 	 * offset 992
 	 */
-	int unusedHere13;
+	float mapExpAverageAlpha;
 	/**
 	 * offset 996
 	 */
@@ -5637,4 +5637,4 @@ struct persistent_config_s {
 static_assert(sizeof(persistent_config_s) == 22748);
 
 // end
-// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sun Jun 09 23:35:16 UTC 2024
+// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:58:23 UTC 2024

--- a/firmware/controllers/generated/engine_configuration_generated_structures_f429-discovery.h
+++ b/firmware/controllers/generated/engine_configuration_generated_structures_f429-discovery.h
@@ -1,4 +1,4 @@
-// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sun Jun 09 23:33:59 UTC 2024
+// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:57:04 UTC 2024
 // by class com.rusefi.output.CHeaderConsumer
 // begin
 #pragma once
@@ -2175,7 +2175,7 @@ struct engine_configuration_s {
 	/**
 	 * offset 992
 	 */
-	int unusedHere13;
+	float mapExpAverageAlpha;
 	/**
 	 * offset 996
 	 */
@@ -5637,4 +5637,4 @@ struct persistent_config_s {
 static_assert(sizeof(persistent_config_s) == 22748);
 
 // end
-// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sun Jun 09 23:33:59 UTC 2024
+// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:57:04 UTC 2024

--- a/firmware/controllers/generated/engine_configuration_generated_structures_f469-discovery.h
+++ b/firmware/controllers/generated/engine_configuration_generated_structures_f469-discovery.h
@@ -1,4 +1,4 @@
-// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sun Jun 09 23:34:01 UTC 2024
+// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:57:07 UTC 2024
 // by class com.rusefi.output.CHeaderConsumer
 // begin
 #pragma once
@@ -2175,7 +2175,7 @@ struct engine_configuration_s {
 	/**
 	 * offset 992
 	 */
-	int unusedHere13;
+	float mapExpAverageAlpha;
 	/**
 	 * offset 996
 	 */
@@ -5637,4 +5637,4 @@ struct persistent_config_s {
 static_assert(sizeof(persistent_config_s) == 22748);
 
 // end
-// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sun Jun 09 23:34:01 UTC 2024
+// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:57:07 UTC 2024

--- a/firmware/controllers/generated/engine_configuration_generated_structures_frankenso_na6.h
+++ b/firmware/controllers/generated/engine_configuration_generated_structures_frankenso_na6.h
@@ -1,4 +1,4 @@
-// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sun Jun 09 23:34:53 UTC 2024
+// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:58:00 UTC 2024
 // by class com.rusefi.output.CHeaderConsumer
 // begin
 #pragma once
@@ -2175,7 +2175,7 @@ struct engine_configuration_s {
 	/**
 	 * offset 992
 	 */
-	int unusedHere13;
+	float mapExpAverageAlpha;
 	/**
 	 * offset 996
 	 */
@@ -5637,4 +5637,4 @@ struct persistent_config_s {
 static_assert(sizeof(persistent_config_s) == 22748);
 
 // end
-// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sun Jun 09 23:34:53 UTC 2024
+// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:58:00 UTC 2024

--- a/firmware/controllers/generated/engine_configuration_generated_structures_haba208.h
+++ b/firmware/controllers/generated/engine_configuration_generated_structures_haba208.h
@@ -1,4 +1,4 @@
-// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sun Jun 09 23:34:08 UTC 2024
+// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:57:14 UTC 2024
 // by class com.rusefi.output.CHeaderConsumer
 // begin
 #pragma once
@@ -2175,7 +2175,7 @@ struct engine_configuration_s {
 	/**
 	 * offset 992
 	 */
-	int unusedHere13;
+	float mapExpAverageAlpha;
 	/**
 	 * offset 996
 	 */
@@ -5637,4 +5637,4 @@ struct persistent_config_s {
 static_assert(sizeof(persistent_config_s) == 22748);
 
 // end
-// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sun Jun 09 23:34:08 UTC 2024
+// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:57:14 UTC 2024

--- a/firmware/controllers/generated/engine_configuration_generated_structures_hellen-112-17.h
+++ b/firmware/controllers/generated/engine_configuration_generated_structures_hellen-112-17.h
@@ -1,4 +1,4 @@
-// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sun Jun 09 23:34:41 UTC 2024
+// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:57:48 UTC 2024
 // by class com.rusefi.output.CHeaderConsumer
 // begin
 #pragma once
@@ -2175,7 +2175,7 @@ struct engine_configuration_s {
 	/**
 	 * offset 992
 	 */
-	int unusedHere13;
+	float mapExpAverageAlpha;
 	/**
 	 * offset 996
 	 */
@@ -5637,4 +5637,4 @@ struct persistent_config_s {
 static_assert(sizeof(persistent_config_s) == 22748);
 
 // end
-// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sun Jun 09 23:34:41 UTC 2024
+// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:57:48 UTC 2024

--- a/firmware/controllers/generated/engine_configuration_generated_structures_hellen-gm-e67.h
+++ b/firmware/controllers/generated/engine_configuration_generated_structures_hellen-gm-e67.h
@@ -1,4 +1,4 @@
-// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sun Jun 09 23:34:31 UTC 2024
+// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:57:38 UTC 2024
 // by class com.rusefi.output.CHeaderConsumer
 // begin
 #pragma once
@@ -2175,7 +2175,7 @@ struct engine_configuration_s {
 	/**
 	 * offset 992
 	 */
-	int unusedHere13;
+	float mapExpAverageAlpha;
 	/**
 	 * offset 996
 	 */
@@ -5637,4 +5637,4 @@ struct persistent_config_s {
 static_assert(sizeof(persistent_config_s) == 22748);
 
 // end
-// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sun Jun 09 23:34:31 UTC 2024
+// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:57:38 UTC 2024

--- a/firmware/controllers/generated/engine_configuration_generated_structures_hellen-honda-k.h
+++ b/firmware/controllers/generated/engine_configuration_generated_structures_hellen-honda-k.h
@@ -1,4 +1,4 @@
-// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sun Jun 09 23:34:26 UTC 2024
+// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:57:33 UTC 2024
 // by class com.rusefi.output.CHeaderConsumer
 // begin
 #pragma once
@@ -2175,7 +2175,7 @@ struct engine_configuration_s {
 	/**
 	 * offset 992
 	 */
-	int unusedHere13;
+	float mapExpAverageAlpha;
 	/**
 	 * offset 996
 	 */
@@ -5651,4 +5651,4 @@ struct persistent_config_s {
 static_assert(sizeof(persistent_config_s) == 23460);
 
 // end
-// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sun Jun 09 23:34:26 UTC 2024
+// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:57:33 UTC 2024

--- a/firmware/controllers/generated/engine_configuration_generated_structures_hellen-nb1.h
+++ b/firmware/controllers/generated/engine_configuration_generated_structures_hellen-nb1.h
@@ -1,4 +1,4 @@
-// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sun Jun 09 23:34:33 UTC 2024
+// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:57:40 UTC 2024
 // by class com.rusefi.output.CHeaderConsumer
 // begin
 #pragma once
@@ -2175,7 +2175,7 @@ struct engine_configuration_s {
 	/**
 	 * offset 992
 	 */
-	int unusedHere13;
+	float mapExpAverageAlpha;
 	/**
 	 * offset 996
 	 */
@@ -5637,4 +5637,4 @@ struct persistent_config_s {
 static_assert(sizeof(persistent_config_s) == 22748);
 
 // end
-// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sun Jun 09 23:34:33 UTC 2024
+// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:57:40 UTC 2024

--- a/firmware/controllers/generated/engine_configuration_generated_structures_hellen121nissan.h
+++ b/firmware/controllers/generated/engine_configuration_generated_structures_hellen121nissan.h
@@ -1,4 +1,4 @@
-// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sun Jun 09 23:34:24 UTC 2024
+// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:57:31 UTC 2024
 // by class com.rusefi.output.CHeaderConsumer
 // begin
 #pragma once
@@ -2175,7 +2175,7 @@ struct engine_configuration_s {
 	/**
 	 * offset 992
 	 */
-	int unusedHere13;
+	float mapExpAverageAlpha;
 	/**
 	 * offset 996
 	 */
@@ -5637,4 +5637,4 @@ struct persistent_config_s {
 static_assert(sizeof(persistent_config_s) == 22748);
 
 // end
-// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sun Jun 09 23:34:24 UTC 2024
+// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:57:31 UTC 2024

--- a/firmware/controllers/generated/engine_configuration_generated_structures_hellen121vag.h
+++ b/firmware/controllers/generated/engine_configuration_generated_structures_hellen121vag.h
@@ -1,4 +1,4 @@
-// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sun Jun 09 23:34:43 UTC 2024
+// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:57:50 UTC 2024
 // by class com.rusefi.output.CHeaderConsumer
 // begin
 #pragma once
@@ -2175,7 +2175,7 @@ struct engine_configuration_s {
 	/**
 	 * offset 992
 	 */
-	int unusedHere13;
+	float mapExpAverageAlpha;
 	/**
 	 * offset 996
 	 */
@@ -5637,4 +5637,4 @@ struct persistent_config_s {
 static_assert(sizeof(persistent_config_s) == 22748);
 
 // end
-// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sun Jun 09 23:34:43 UTC 2024
+// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:57:50 UTC 2024

--- a/firmware/controllers/generated/engine_configuration_generated_structures_hellen128.h
+++ b/firmware/controllers/generated/engine_configuration_generated_structures_hellen128.h
@@ -1,4 +1,4 @@
-// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sun Jun 09 23:34:17 UTC 2024
+// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:57:24 UTC 2024
 // by class com.rusefi.output.CHeaderConsumer
 // begin
 #pragma once
@@ -2175,7 +2175,7 @@ struct engine_configuration_s {
 	/**
 	 * offset 992
 	 */
-	int unusedHere13;
+	float mapExpAverageAlpha;
 	/**
 	 * offset 996
 	 */
@@ -5637,4 +5637,4 @@ struct persistent_config_s {
 static_assert(sizeof(persistent_config_s) == 22748);
 
 // end
-// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sun Jun 09 23:34:17 UTC 2024
+// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:57:24 UTC 2024

--- a/firmware/controllers/generated/engine_configuration_generated_structures_hellen154hyundai.h
+++ b/firmware/controllers/generated/engine_configuration_generated_structures_hellen154hyundai.h
@@ -1,4 +1,4 @@
-// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sun Jun 09 23:34:30 UTC 2024
+// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:57:37 UTC 2024
 // by class com.rusefi.output.CHeaderConsumer
 // begin
 #pragma once
@@ -2175,7 +2175,7 @@ struct engine_configuration_s {
 	/**
 	 * offset 992
 	 */
-	int unusedHere13;
+	float mapExpAverageAlpha;
 	/**
 	 * offset 996
 	 */
@@ -5637,4 +5637,4 @@ struct persistent_config_s {
 static_assert(sizeof(persistent_config_s) == 22748);
 
 // end
-// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sun Jun 09 23:34:30 UTC 2024
+// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:57:37 UTC 2024

--- a/firmware/controllers/generated/engine_configuration_generated_structures_hellen154hyundai_f7.h
+++ b/firmware/controllers/generated/engine_configuration_generated_structures_hellen154hyundai_f7.h
@@ -1,4 +1,4 @@
-// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sun Jun 09 23:34:23 UTC 2024
+// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:57:30 UTC 2024
 // by class com.rusefi.output.CHeaderConsumer
 // begin
 #pragma once
@@ -2175,7 +2175,7 @@ struct engine_configuration_s {
 	/**
 	 * offset 992
 	 */
-	int unusedHere13;
+	float mapExpAverageAlpha;
 	/**
 	 * offset 996
 	 */
@@ -5637,4 +5637,4 @@ struct persistent_config_s {
 static_assert(sizeof(persistent_config_s) == 22748);
 
 // end
-// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sun Jun 09 23:34:23 UTC 2024
+// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:57:30 UTC 2024

--- a/firmware/controllers/generated/engine_configuration_generated_structures_hellen72.h
+++ b/firmware/controllers/generated/engine_configuration_generated_structures_hellen72.h
@@ -1,4 +1,4 @@
-// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sun Jun 09 23:34:29 UTC 2024
+// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:57:35 UTC 2024
 // by class com.rusefi.output.CHeaderConsumer
 // begin
 #pragma once
@@ -2175,7 +2175,7 @@ struct engine_configuration_s {
 	/**
 	 * offset 992
 	 */
-	int unusedHere13;
+	float mapExpAverageAlpha;
 	/**
 	 * offset 996
 	 */
@@ -5637,4 +5637,4 @@ struct persistent_config_s {
 static_assert(sizeof(persistent_config_s) == 22748);
 
 // end
-// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sun Jun 09 23:34:29 UTC 2024
+// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:57:35 UTC 2024

--- a/firmware/controllers/generated/engine_configuration_generated_structures_hellen81.h
+++ b/firmware/controllers/generated/engine_configuration_generated_structures_hellen81.h
@@ -1,4 +1,4 @@
-// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sun Jun 09 23:34:16 UTC 2024
+// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:57:22 UTC 2024
 // by class com.rusefi.output.CHeaderConsumer
 // begin
 #pragma once
@@ -2175,7 +2175,7 @@ struct engine_configuration_s {
 	/**
 	 * offset 992
 	 */
-	int unusedHere13;
+	float mapExpAverageAlpha;
 	/**
 	 * offset 996
 	 */
@@ -5637,4 +5637,4 @@ struct persistent_config_s {
 static_assert(sizeof(persistent_config_s) == 22748);
 
 // end
-// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sun Jun 09 23:34:16 UTC 2024
+// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:57:22 UTC 2024

--- a/firmware/controllers/generated/engine_configuration_generated_structures_hellen88bmw.h
+++ b/firmware/controllers/generated/engine_configuration_generated_structures_hellen88bmw.h
@@ -1,4 +1,4 @@
-// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sun Jun 09 23:34:13 UTC 2024
+// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:57:19 UTC 2024
 // by class com.rusefi.output.CHeaderConsumer
 // begin
 #pragma once
@@ -2175,7 +2175,7 @@ struct engine_configuration_s {
 	/**
 	 * offset 992
 	 */
-	int unusedHere13;
+	float mapExpAverageAlpha;
 	/**
 	 * offset 996
 	 */
@@ -5637,4 +5637,4 @@ struct persistent_config_s {
 static_assert(sizeof(persistent_config_s) == 22748);
 
 // end
-// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sun Jun 09 23:34:13 UTC 2024
+// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:57:19 UTC 2024

--- a/firmware/controllers/generated/engine_configuration_generated_structures_hellenNA6.h
+++ b/firmware/controllers/generated/engine_configuration_generated_structures_hellenNA6.h
@@ -1,4 +1,4 @@
-// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sun Jun 09 23:34:39 UTC 2024
+// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:57:46 UTC 2024
 // by class com.rusefi.output.CHeaderConsumer
 // begin
 #pragma once
@@ -2175,7 +2175,7 @@ struct engine_configuration_s {
 	/**
 	 * offset 992
 	 */
-	int unusedHere13;
+	float mapExpAverageAlpha;
 	/**
 	 * offset 996
 	 */
@@ -5637,4 +5637,4 @@ struct persistent_config_s {
 static_assert(sizeof(persistent_config_s) == 22748);
 
 // end
-// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sun Jun 09 23:34:39 UTC 2024
+// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:57:46 UTC 2024

--- a/firmware/controllers/generated/engine_configuration_generated_structures_hellenNA8_96.h
+++ b/firmware/controllers/generated/engine_configuration_generated_structures_hellenNA8_96.h
@@ -1,4 +1,4 @@
-// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sun Jun 09 23:34:46 UTC 2024
+// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:57:53 UTC 2024
 // by class com.rusefi.output.CHeaderConsumer
 // begin
 #pragma once
@@ -2175,7 +2175,7 @@ struct engine_configuration_s {
 	/**
 	 * offset 992
 	 */
-	int unusedHere13;
+	float mapExpAverageAlpha;
 	/**
 	 * offset 996
 	 */
@@ -5637,4 +5637,4 @@ struct persistent_config_s {
 static_assert(sizeof(persistent_config_s) == 22748);
 
 // end
-// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sun Jun 09 23:34:46 UTC 2024
+// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:57:53 UTC 2024

--- a/firmware/controllers/generated/engine_configuration_generated_structures_m74_9.h
+++ b/firmware/controllers/generated/engine_configuration_generated_structures_m74_9.h
@@ -1,4 +1,4 @@
-// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sun Jun 09 23:34:00 UTC 2024
+// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:57:06 UTC 2024
 // by class com.rusefi.output.CHeaderConsumer
 // begin
 #pragma once
@@ -2175,7 +2175,7 @@ struct engine_configuration_s {
 	/**
 	 * offset 992
 	 */
-	int unusedHere13;
+	float mapExpAverageAlpha;
 	/**
 	 * offset 996
 	 */
@@ -5637,4 +5637,4 @@ struct persistent_config_s {
 static_assert(sizeof(persistent_config_s) == 22748);
 
 // end
-// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sun Jun 09 23:34:00 UTC 2024
+// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:57:06 UTC 2024

--- a/firmware/controllers/generated/engine_configuration_generated_structures_mre-legacy_f4.h
+++ b/firmware/controllers/generated/engine_configuration_generated_structures_mre-legacy_f4.h
@@ -1,4 +1,4 @@
-// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sun Jun 09 23:34:05 UTC 2024
+// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:57:11 UTC 2024
 // by class com.rusefi.output.CHeaderConsumer
 // begin
 #pragma once
@@ -2175,7 +2175,7 @@ struct engine_configuration_s {
 	/**
 	 * offset 992
 	 */
-	int unusedHere13;
+	float mapExpAverageAlpha;
 	/**
 	 * offset 996
 	 */
@@ -5637,4 +5637,4 @@ struct persistent_config_s {
 static_assert(sizeof(persistent_config_s) == 24748);
 
 // end
-// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sun Jun 09 23:34:05 UTC 2024
+// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:57:11 UTC 2024

--- a/firmware/controllers/generated/engine_configuration_generated_structures_mre_f4.h
+++ b/firmware/controllers/generated/engine_configuration_generated_structures_mre_f4.h
@@ -1,4 +1,4 @@
-// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sun Jun 09 23:34:04 UTC 2024
+// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:57:10 UTC 2024
 // by class com.rusefi.output.CHeaderConsumer
 // begin
 #pragma once
@@ -2175,7 +2175,7 @@ struct engine_configuration_s {
 	/**
 	 * offset 992
 	 */
-	int unusedHere13;
+	float mapExpAverageAlpha;
 	/**
 	 * offset 996
 	 */
@@ -5637,4 +5637,4 @@ struct persistent_config_s {
 static_assert(sizeof(persistent_config_s) == 24748);
 
 // end
-// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sun Jun 09 23:34:04 UTC 2024
+// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:57:10 UTC 2024

--- a/firmware/controllers/generated/engine_configuration_generated_structures_mre_f7.h
+++ b/firmware/controllers/generated/engine_configuration_generated_structures_mre_f7.h
@@ -1,4 +1,4 @@
-// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sun Jun 09 23:34:07 UTC 2024
+// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:57:12 UTC 2024
 // by class com.rusefi.output.CHeaderConsumer
 // begin
 #pragma once
@@ -2175,7 +2175,7 @@ struct engine_configuration_s {
 	/**
 	 * offset 992
 	 */
-	int unusedHere13;
+	float mapExpAverageAlpha;
 	/**
 	 * offset 996
 	 */
@@ -5637,4 +5637,4 @@ struct persistent_config_s {
 static_assert(sizeof(persistent_config_s) == 24748);
 
 // end
-// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sun Jun 09 23:34:07 UTC 2024
+// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:57:12 UTC 2024

--- a/firmware/controllers/generated/engine_configuration_generated_structures_nucleo_f413.h
+++ b/firmware/controllers/generated/engine_configuration_generated_structures_nucleo_f413.h
@@ -1,4 +1,4 @@
-// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sun Jun 09 23:34:55 UTC 2024
+// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:58:03 UTC 2024
 // by class com.rusefi.output.CHeaderConsumer
 // begin
 #pragma once
@@ -2175,7 +2175,7 @@ struct engine_configuration_s {
 	/**
 	 * offset 992
 	 */
-	int unusedHere13;
+	float mapExpAverageAlpha;
 	/**
 	 * offset 996
 	 */
@@ -5637,4 +5637,4 @@ struct persistent_config_s {
 static_assert(sizeof(persistent_config_s) == 22748);
 
 // end
-// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sun Jun 09 23:34:55 UTC 2024
+// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:58:03 UTC 2024

--- a/firmware/controllers/generated/engine_configuration_generated_structures_prometheus_405.h
+++ b/firmware/controllers/generated/engine_configuration_generated_structures_prometheus_405.h
@@ -1,4 +1,4 @@
-// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sun Jun 09 23:35:12 UTC 2024
+// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:58:19 UTC 2024
 // by class com.rusefi.output.CHeaderConsumer
 // begin
 #pragma once
@@ -2175,7 +2175,7 @@ struct engine_configuration_s {
 	/**
 	 * offset 992
 	 */
-	int unusedHere13;
+	float mapExpAverageAlpha;
 	/**
 	 * offset 996
 	 */
@@ -5637,4 +5637,4 @@ struct persistent_config_s {
 static_assert(sizeof(persistent_config_s) == 22748);
 
 // end
-// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sun Jun 09 23:35:12 UTC 2024
+// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:58:19 UTC 2024

--- a/firmware/controllers/generated/engine_configuration_generated_structures_prometheus_469.h
+++ b/firmware/controllers/generated/engine_configuration_generated_structures_prometheus_469.h
@@ -1,4 +1,4 @@
-// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sun Jun 09 23:35:11 UTC 2024
+// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:58:18 UTC 2024
 // by class com.rusefi.output.CHeaderConsumer
 // begin
 #pragma once
@@ -2175,7 +2175,7 @@ struct engine_configuration_s {
 	/**
 	 * offset 992
 	 */
-	int unusedHere13;
+	float mapExpAverageAlpha;
 	/**
 	 * offset 996
 	 */
@@ -5637,4 +5637,4 @@ struct persistent_config_s {
 static_assert(sizeof(persistent_config_s) == 22748);
 
 // end
-// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sun Jun 09 23:35:11 UTC 2024
+// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:58:18 UTC 2024

--- a/firmware/controllers/generated/engine_configuration_generated_structures_proteus_f4.h
+++ b/firmware/controllers/generated/engine_configuration_generated_structures_proteus_f4.h
@@ -1,4 +1,4 @@
-// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sun Jun 09 23:34:58 UTC 2024
+// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:58:05 UTC 2024
 // by class com.rusefi.output.CHeaderConsumer
 // begin
 #pragma once
@@ -2175,7 +2175,7 @@ struct engine_configuration_s {
 	/**
 	 * offset 992
 	 */
-	int unusedHere13;
+	float mapExpAverageAlpha;
 	/**
 	 * offset 996
 	 */
@@ -5637,4 +5637,4 @@ struct persistent_config_s {
 static_assert(sizeof(persistent_config_s) == 28248);
 
 // end
-// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sun Jun 09 23:34:58 UTC 2024
+// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:58:05 UTC 2024

--- a/firmware/controllers/generated/engine_configuration_generated_structures_proteus_f7.h
+++ b/firmware/controllers/generated/engine_configuration_generated_structures_proteus_f7.h
@@ -1,4 +1,4 @@
-// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sun Jun 09 23:34:57 UTC 2024
+// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:58:04 UTC 2024
 // by class com.rusefi.output.CHeaderConsumer
 // begin
 #pragma once
@@ -2175,7 +2175,7 @@ struct engine_configuration_s {
 	/**
 	 * offset 992
 	 */
-	int unusedHere13;
+	float mapExpAverageAlpha;
 	/**
 	 * offset 996
 	 */
@@ -5637,4 +5637,4 @@ struct persistent_config_s {
 static_assert(sizeof(persistent_config_s) == 28248);
 
 // end
-// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sun Jun 09 23:34:57 UTC 2024
+// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:58:04 UTC 2024

--- a/firmware/controllers/generated/engine_configuration_generated_structures_proteus_h7.h
+++ b/firmware/controllers/generated/engine_configuration_generated_structures_proteus_h7.h
@@ -1,4 +1,4 @@
-// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sun Jun 09 23:34:59 UTC 2024
+// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:58:07 UTC 2024
 // by class com.rusefi.output.CHeaderConsumer
 // begin
 #pragma once
@@ -2175,7 +2175,7 @@ struct engine_configuration_s {
 	/**
 	 * offset 992
 	 */
-	int unusedHere13;
+	float mapExpAverageAlpha;
 	/**
 	 * offset 996
 	 */
@@ -5637,4 +5637,4 @@ struct persistent_config_s {
 static_assert(sizeof(persistent_config_s) == 28248);
 
 // end
-// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sun Jun 09 23:34:59 UTC 2024
+// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:58:07 UTC 2024

--- a/firmware/controllers/generated/engine_configuration_generated_structures_s105.h
+++ b/firmware/controllers/generated/engine_configuration_generated_structures_s105.h
@@ -1,4 +1,4 @@
-// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sun Jun 09 23:35:15 UTC 2024
+// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:58:22 UTC 2024
 // by class com.rusefi.output.CHeaderConsumer
 // begin
 #pragma once
@@ -2175,7 +2175,7 @@ struct engine_configuration_s {
 	/**
 	 * offset 992
 	 */
-	int unusedHere13;
+	float mapExpAverageAlpha;
 	/**
 	 * offset 996
 	 */
@@ -5637,4 +5637,4 @@ struct persistent_config_s {
 static_assert(sizeof(persistent_config_s) == 22748);
 
 // end
-// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sun Jun 09 23:35:15 UTC 2024
+// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:58:22 UTC 2024

--- a/firmware/controllers/generated/engine_configuration_generated_structures_small-can-board.h
+++ b/firmware/controllers/generated/engine_configuration_generated_structures_small-can-board.h
@@ -1,4 +1,4 @@
-// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sun Jun 09 23:34:09 UTC 2024
+// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:57:15 UTC 2024
 // by class com.rusefi.output.CHeaderConsumer
 // begin
 #pragma once
@@ -2175,7 +2175,7 @@ struct engine_configuration_s {
 	/**
 	 * offset 992
 	 */
-	int unusedHere13;
+	float mapExpAverageAlpha;
 	/**
 	 * offset 996
 	 */
@@ -5637,4 +5637,4 @@ struct persistent_config_s {
 static_assert(sizeof(persistent_config_s) == 22748);
 
 // end
-// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sun Jun 09 23:34:09 UTC 2024
+// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:57:15 UTC 2024

--- a/firmware/controllers/generated/engine_configuration_generated_structures_stm32f429_nucleo.h
+++ b/firmware/controllers/generated/engine_configuration_generated_structures_stm32f429_nucleo.h
@@ -1,4 +1,4 @@
-// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sun Jun 09 23:34:52 UTC 2024
+// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:57:59 UTC 2024
 // by class com.rusefi.output.CHeaderConsumer
 // begin
 #pragma once
@@ -2175,7 +2175,7 @@ struct engine_configuration_s {
 	/**
 	 * offset 992
 	 */
-	int unusedHere13;
+	float mapExpAverageAlpha;
 	/**
 	 * offset 996
 	 */
@@ -5637,4 +5637,4 @@ struct persistent_config_s {
 static_assert(sizeof(persistent_config_s) == 22748);
 
 // end
-// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sun Jun 09 23:34:52 UTC 2024
+// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:57:59 UTC 2024

--- a/firmware/controllers/generated/engine_configuration_generated_structures_stm32f767_nucleo.h
+++ b/firmware/controllers/generated/engine_configuration_generated_structures_stm32f767_nucleo.h
@@ -1,4 +1,4 @@
-// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sun Jun 09 23:33:55 UTC 2024
+// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:57:00 UTC 2024
 // by class com.rusefi.output.CHeaderConsumer
 // begin
 #pragma once
@@ -2175,7 +2175,7 @@ struct engine_configuration_s {
 	/**
 	 * offset 992
 	 */
-	int unusedHere13;
+	float mapExpAverageAlpha;
 	/**
 	 * offset 996
 	 */
@@ -5637,4 +5637,4 @@ struct persistent_config_s {
 static_assert(sizeof(persistent_config_s) == 22748);
 
 // end
-// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sun Jun 09 23:33:55 UTC 2024
+// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:57:00 UTC 2024

--- a/firmware/controllers/generated/engine_configuration_generated_structures_stm32h743_nucleo.h
+++ b/firmware/controllers/generated/engine_configuration_generated_structures_stm32h743_nucleo.h
@@ -1,4 +1,4 @@
-// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sun Jun 09 23:35:18 UTC 2024
+// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:58:26 UTC 2024
 // by class com.rusefi.output.CHeaderConsumer
 // begin
 #pragma once
@@ -2175,7 +2175,7 @@ struct engine_configuration_s {
 	/**
 	 * offset 992
 	 */
-	int unusedHere13;
+	float mapExpAverageAlpha;
 	/**
 	 * offset 996
 	 */
@@ -5637,4 +5637,4 @@ struct persistent_config_s {
 static_assert(sizeof(persistent_config_s) == 22748);
 
 // end
-// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sun Jun 09 23:35:18 UTC 2024
+// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:58:26 UTC 2024

--- a/firmware/controllers/generated/engine_configuration_generated_structures_subaru_eg33_f7.h
+++ b/firmware/controllers/generated/engine_configuration_generated_structures_subaru_eg33_f7.h
@@ -1,4 +1,4 @@
-// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sun Jun 09 23:34:49 UTC 2024
+// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:57:56 UTC 2024
 // by class com.rusefi.output.CHeaderConsumer
 // begin
 #pragma once
@@ -2175,7 +2175,7 @@ struct engine_configuration_s {
 	/**
 	 * offset 992
 	 */
-	int unusedHere13;
+	float mapExpAverageAlpha;
 	/**
 	 * offset 996
 	 */
@@ -5637,4 +5637,4 @@ struct persistent_config_s {
 static_assert(sizeof(persistent_config_s) == 22748);
 
 // end
-// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sun Jun 09 23:34:49 UTC 2024
+// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:57:56 UTC 2024

--- a/firmware/controllers/generated/engine_configuration_generated_structures_t-b-g.h
+++ b/firmware/controllers/generated/engine_configuration_generated_structures_t-b-g.h
@@ -1,4 +1,4 @@
-// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sun Jun 09 23:34:48 UTC 2024
+// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:57:55 UTC 2024
 // by class com.rusefi.output.CHeaderConsumer
 // begin
 #pragma once
@@ -2175,7 +2175,7 @@ struct engine_configuration_s {
 	/**
 	 * offset 992
 	 */
-	int unusedHere13;
+	float mapExpAverageAlpha;
 	/**
 	 * offset 996
 	 */
@@ -5637,4 +5637,4 @@ struct persistent_config_s {
 static_assert(sizeof(persistent_config_s) == 22748);
 
 // end
-// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sun Jun 09 23:34:48 UTC 2024
+// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:57:55 UTC 2024

--- a/firmware/controllers/generated/engine_configuration_generated_structures_tdg-pdm8.h
+++ b/firmware/controllers/generated/engine_configuration_generated_structures_tdg-pdm8.h
@@ -1,4 +1,4 @@
-// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sun Jun 09 23:35:13 UTC 2024
+// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:58:21 UTC 2024
 // by class com.rusefi.output.CHeaderConsumer
 // begin
 #pragma once
@@ -2175,7 +2175,7 @@ struct engine_configuration_s {
 	/**
 	 * offset 992
 	 */
-	int unusedHere13;
+	float mapExpAverageAlpha;
 	/**
 	 * offset 996
 	 */
@@ -5637,4 +5637,4 @@ struct persistent_config_s {
 static_assert(sizeof(persistent_config_s) == 22748);
 
 // end
-// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sun Jun 09 23:35:13 UTC 2024
+// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:58:21 UTC 2024

--- a/firmware/controllers/generated/engine_configuration_generated_structures_uaefi.h
+++ b/firmware/controllers/generated/engine_configuration_generated_structures_uaefi.h
@@ -1,4 +1,4 @@
-// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sun Jun 09 23:34:19 UTC 2024
+// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:57:26 UTC 2024
 // by class com.rusefi.output.CHeaderConsumer
 // begin
 #pragma once
@@ -2175,7 +2175,7 @@ struct engine_configuration_s {
 	/**
 	 * offset 992
 	 */
-	int unusedHere13;
+	float mapExpAverageAlpha;
 	/**
 	 * offset 996
 	 */
@@ -5637,4 +5637,4 @@ struct persistent_config_s {
 static_assert(sizeof(persistent_config_s) == 22748);
 
 // end
-// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sun Jun 09 23:34:19 UTC 2024
+// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:57:26 UTC 2024

--- a/firmware/controllers/generated/engine_configuration_generated_structures_uaefi121.h
+++ b/firmware/controllers/generated/engine_configuration_generated_structures_uaefi121.h
@@ -1,4 +1,4 @@
-// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Wed Jun 12 22:08:06 UTC 2024
+// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:57:23 UTC 2024
 // by class com.rusefi.output.CHeaderConsumer
 // begin
 #pragma once
@@ -2175,7 +2175,7 @@ struct engine_configuration_s {
 	/**
 	 * offset 992
 	 */
-	int unusedHere13;
+	float mapExpAverageAlpha;
 	/**
 	 * offset 996
 	 */
@@ -5637,4 +5637,4 @@ struct persistent_config_s {
 static_assert(sizeof(persistent_config_s) == 22748);
 
 // end
-// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Wed Jun 12 22:08:06 UTC 2024
+// this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:57:23 UTC 2024

--- a/firmware/controllers/generated/rusefi_generated_alphax-2chan.h
+++ b/firmware/controllers/generated/rusefi_generated_alphax-2chan.h
@@ -1273,7 +1273,7 @@
 #define show_microRusEFI_presets false
 #define show_Proteus_presets false
 #define show_test_presets false
-#define SIGNATURE_HASH 848521784
+#define SIGNATURE_HASH 1682025143
 #define SIMULATOR_TUNE_BIN_FILE_NAME "generated/simulator_tune_image.bin"
 #define SIMULATOR_TUNE_BIN_FILE_NAME_PREFIX "generated/simulator_tune_image"
 #define SIMULATOR_TUNE_BIN_FILE_NAME_SUFFIX ".bin"
@@ -1665,7 +1665,7 @@
 #define ts_show_vr_threshold_all true
 #define ts_show_vr_threshold_pins false
 #define ts_show_vvt_output true
-#define TS_SIGNATURE "rusEFI master.2024.06.15.alphax-2chan.848521784"
+#define TS_SIGNATURE "rusEFI master.2024.06.15.alphax-2chan.1682025143"
 #define TS_SIMULATE_CAN '>'
 #define TS_SIMULATE_CAN_char >
 #define TS_SINGLE_WRITE_COMMAND 'W'

--- a/firmware/controllers/generated/rusefi_generated_alphax-4chan.h
+++ b/firmware/controllers/generated/rusefi_generated_alphax-4chan.h
@@ -1274,7 +1274,7 @@
 #define show_microRusEFI_presets false
 #define show_Proteus_presets false
 #define show_test_presets false
-#define SIGNATURE_HASH 242120885
+#define SIGNATURE_HASH 1488762938
 #define SIMULATOR_TUNE_BIN_FILE_NAME "generated/simulator_tune_image.bin"
 #define SIMULATOR_TUNE_BIN_FILE_NAME_PREFIX "generated/simulator_tune_image"
 #define SIMULATOR_TUNE_BIN_FILE_NAME_SUFFIX ".bin"
@@ -1666,7 +1666,7 @@
 #define ts_show_vr_threshold_all true
 #define ts_show_vr_threshold_pins false
 #define ts_show_vvt_output true
-#define TS_SIGNATURE "rusEFI master.2024.06.15.alphax-4chan.242120885"
+#define TS_SIGNATURE "rusEFI master.2024.06.15.alphax-4chan.1488762938"
 #define TS_SIMULATE_CAN '>'
 #define TS_SIMULATE_CAN_char >
 #define TS_SINGLE_WRITE_COMMAND 'W'

--- a/firmware/controllers/generated/rusefi_generated_alphax-4chan_f7.h
+++ b/firmware/controllers/generated/rusefi_generated_alphax-4chan_f7.h
@@ -1274,7 +1274,7 @@
 #define show_microRusEFI_presets false
 #define show_Proteus_presets false
 #define show_test_presets false
-#define SIGNATURE_HASH 242120885
+#define SIGNATURE_HASH 1488762938
 #define SIMULATOR_TUNE_BIN_FILE_NAME "generated/simulator_tune_image.bin"
 #define SIMULATOR_TUNE_BIN_FILE_NAME_PREFIX "generated/simulator_tune_image"
 #define SIMULATOR_TUNE_BIN_FILE_NAME_SUFFIX ".bin"
@@ -1666,7 +1666,7 @@
 #define ts_show_vr_threshold_all true
 #define ts_show_vr_threshold_pins false
 #define ts_show_vvt_output true
-#define TS_SIGNATURE "rusEFI master.2024.06.15.alphax-4chan_f7.242120885"
+#define TS_SIGNATURE "rusEFI master.2024.06.15.alphax-4chan_f7.1488762938"
 #define TS_SIMULATE_CAN '>'
 #define TS_SIMULATE_CAN_char >
 #define TS_SINGLE_WRITE_COMMAND 'W'

--- a/firmware/controllers/generated/rusefi_generated_alphax-8chan-revA.h
+++ b/firmware/controllers/generated/rusefi_generated_alphax-8chan-revA.h
@@ -1273,7 +1273,7 @@
 #define show_microRusEFI_presets false
 #define show_Proteus_presets false
 #define show_test_presets false
-#define SIGNATURE_HASH 98862663
+#define SIGNATURE_HASH 1396065992
 #define SIMULATOR_TUNE_BIN_FILE_NAME "generated/simulator_tune_image.bin"
 #define SIMULATOR_TUNE_BIN_FILE_NAME_PREFIX "generated/simulator_tune_image"
 #define SIMULATOR_TUNE_BIN_FILE_NAME_SUFFIX ".bin"
@@ -1665,7 +1665,7 @@
 #define ts_show_vr_threshold_all false
 #define ts_show_vr_threshold_pins true
 #define ts_show_vvt_output true
-#define TS_SIGNATURE "rusEFI master.2024.06.15.alphax-8chan-revA.98862663"
+#define TS_SIGNATURE "rusEFI master.2024.06.15.alphax-8chan-revA.1396065992"
 #define TS_SIMULATE_CAN '>'
 #define TS_SIMULATE_CAN_char >
 #define TS_SINGLE_WRITE_COMMAND 'W'

--- a/firmware/controllers/generated/rusefi_generated_alphax-8chan.h
+++ b/firmware/controllers/generated/rusefi_generated_alphax-8chan.h
@@ -1273,7 +1273,7 @@
 #define show_microRusEFI_presets false
 #define show_Proteus_presets false
 #define show_test_presets false
-#define SIGNATURE_HASH 1045018647
+#define SIGNATURE_HASH 1755019416
 #define SIMULATOR_TUNE_BIN_FILE_NAME "generated/simulator_tune_image.bin"
 #define SIMULATOR_TUNE_BIN_FILE_NAME_PREFIX "generated/simulator_tune_image"
 #define SIMULATOR_TUNE_BIN_FILE_NAME_SUFFIX ".bin"
@@ -1665,7 +1665,7 @@
 #define ts_show_vr_threshold_all true
 #define ts_show_vr_threshold_pins false
 #define ts_show_vvt_output true
-#define TS_SIGNATURE "rusEFI master.2024.06.15.alphax-8chan.1045018647"
+#define TS_SIGNATURE "rusEFI master.2024.06.15.alphax-8chan.1755019416"
 #define TS_SIMULATE_CAN '>'
 #define TS_SIMULATE_CAN_char >
 #define TS_SINGLE_WRITE_COMMAND 'W'

--- a/firmware/controllers/generated/rusefi_generated_alphax-8chan_f7.h
+++ b/firmware/controllers/generated/rusefi_generated_alphax-8chan_f7.h
@@ -1273,7 +1273,7 @@
 #define show_microRusEFI_presets false
 #define show_Proteus_presets false
 #define show_test_presets false
-#define SIGNATURE_HASH 1045018647
+#define SIGNATURE_HASH 1755019416
 #define SIMULATOR_TUNE_BIN_FILE_NAME "generated/simulator_tune_image.bin"
 #define SIMULATOR_TUNE_BIN_FILE_NAME_PREFIX "generated/simulator_tune_image"
 #define SIMULATOR_TUNE_BIN_FILE_NAME_SUFFIX ".bin"
@@ -1665,7 +1665,7 @@
 #define ts_show_vr_threshold_all true
 #define ts_show_vr_threshold_pins false
 #define ts_show_vvt_output true
-#define TS_SIGNATURE "rusEFI master.2024.06.15.alphax-8chan_f7.1045018647"
+#define TS_SIGNATURE "rusEFI master.2024.06.15.alphax-8chan_f7.1755019416"
 #define TS_SIMULATE_CAN '>'
 #define TS_SIMULATE_CAN_char >
 #define TS_SINGLE_WRITE_COMMAND 'W'

--- a/firmware/controllers/generated/rusefi_generated_alphax-silver.h
+++ b/firmware/controllers/generated/rusefi_generated_alphax-silver.h
@@ -1274,7 +1274,7 @@
 #define show_microRusEFI_presets false
 #define show_Proteus_presets false
 #define show_test_presets false
-#define SIGNATURE_HASH 1889919833
+#define SIGNATURE_HASH 645342166
 #define SIMULATOR_TUNE_BIN_FILE_NAME "generated/simulator_tune_image.bin"
 #define SIMULATOR_TUNE_BIN_FILE_NAME_PREFIX "generated/simulator_tune_image"
 #define SIMULATOR_TUNE_BIN_FILE_NAME_SUFFIX ".bin"
@@ -1666,7 +1666,7 @@
 #define ts_show_vr_threshold_all false
 #define ts_show_vr_threshold_pins true
 #define ts_show_vvt_output true
-#define TS_SIGNATURE "rusEFI master.2024.06.15.alphax-silver.1889919833"
+#define TS_SIGNATURE "rusEFI master.2024.06.15.alphax-silver.645342166"
 #define TS_SIMULATE_CAN '>'
 #define TS_SIMULATE_CAN_char >
 #define TS_SINGLE_WRITE_COMMAND 'W'

--- a/firmware/controllers/generated/rusefi_generated_at_start_f435.h
+++ b/firmware/controllers/generated/rusefi_generated_at_start_f435.h
@@ -1274,7 +1274,7 @@
 #define show_microRusEFI_presets false
 #define show_Proteus_presets false
 #define show_test_presets false
-#define SIGNATURE_HASH 3101367670
+#define SIGNATURE_HASH 3993624057
 #define SIMULATOR_TUNE_BIN_FILE_NAME "generated/simulator_tune_image.bin"
 #define SIMULATOR_TUNE_BIN_FILE_NAME_PREFIX "generated/simulator_tune_image"
 #define SIMULATOR_TUNE_BIN_FILE_NAME_SUFFIX ".bin"
@@ -1666,7 +1666,7 @@
 #define ts_show_vr_threshold_all false
 #define ts_show_vr_threshold_pins true
 #define ts_show_vvt_output true
-#define TS_SIGNATURE "rusEFI master.2024.06.15.at_start_f435.3101367670"
+#define TS_SIGNATURE "rusEFI master.2024.06.15.at_start_f435.3993624057"
 #define TS_SIMULATE_CAN '>'
 #define TS_SIMULATE_CAN_char >
 #define TS_SINGLE_WRITE_COMMAND 'W'

--- a/firmware/controllers/generated/rusefi_generated_atlas.h
+++ b/firmware/controllers/generated/rusefi_generated_atlas.h
@@ -1274,7 +1274,7 @@
 #define show_microRusEFI_presets false
 #define show_Proteus_presets false
 #define show_test_presets false
-#define SIGNATURE_HASH 4242327864
+#define SIGNATURE_HASH 2853046711
 #define SIMULATOR_TUNE_BIN_FILE_NAME "generated/simulator_tune_image.bin"
 #define SIMULATOR_TUNE_BIN_FILE_NAME_PREFIX "generated/simulator_tune_image"
 #define SIMULATOR_TUNE_BIN_FILE_NAME_SUFFIX ".bin"
@@ -1666,7 +1666,7 @@
 #define ts_show_vr_threshold_all false
 #define ts_show_vr_threshold_pins true
 #define ts_show_vvt_output true
-#define TS_SIGNATURE "rusEFI master.2024.06.15.atlas.4242327864"
+#define TS_SIGNATURE "rusEFI master.2024.06.15.atlas.2853046711"
 #define TS_SIMULATE_CAN '>'
 #define TS_SIMULATE_CAN_char >
 #define TS_SINGLE_WRITE_COMMAND 'W'

--- a/firmware/controllers/generated/rusefi_generated_f407-discovery.h
+++ b/firmware/controllers/generated/rusefi_generated_f407-discovery.h
@@ -1274,7 +1274,7 @@
 #define show_microRusEFI_presets false
 #define show_Proteus_presets false
 #define show_test_presets true
-#define SIGNATURE_HASH 478864919
+#define SIGNATURE_HASH 1247291032
 #define SIMULATOR_TUNE_BIN_FILE_NAME "generated/simulator_tune_image.bin"
 #define SIMULATOR_TUNE_BIN_FILE_NAME_PREFIX "generated/simulator_tune_image"
 #define SIMULATOR_TUNE_BIN_FILE_NAME_SUFFIX ".bin"
@@ -1666,7 +1666,7 @@
 #define ts_show_vr_threshold_all true
 #define ts_show_vr_threshold_pins true
 #define ts_show_vvt_output true
-#define TS_SIGNATURE "rusEFI master.2024.06.15.f407-discovery.478864919"
+#define TS_SIGNATURE "rusEFI master.2024.06.15.f407-discovery.1247291032"
 #define TS_SIMULATE_CAN '>'
 #define TS_SIMULATE_CAN_char >
 #define TS_SINGLE_WRITE_COMMAND 'W'

--- a/firmware/controllers/generated/rusefi_generated_f429-discovery.h
+++ b/firmware/controllers/generated/rusefi_generated_f429-discovery.h
@@ -1274,7 +1274,7 @@
 #define show_microRusEFI_presets false
 #define show_Proteus_presets false
 #define show_test_presets false
-#define SIGNATURE_HASH 3101367670
+#define SIGNATURE_HASH 3993624057
 #define SIMULATOR_TUNE_BIN_FILE_NAME "generated/simulator_tune_image.bin"
 #define SIMULATOR_TUNE_BIN_FILE_NAME_PREFIX "generated/simulator_tune_image"
 #define SIMULATOR_TUNE_BIN_FILE_NAME_SUFFIX ".bin"
@@ -1666,7 +1666,7 @@
 #define ts_show_vr_threshold_all false
 #define ts_show_vr_threshold_pins true
 #define ts_show_vvt_output true
-#define TS_SIGNATURE "rusEFI master.2024.06.15.f429-discovery.3101367670"
+#define TS_SIGNATURE "rusEFI master.2024.06.15.f429-discovery.3993624057"
 #define TS_SIMULATE_CAN '>'
 #define TS_SIMULATE_CAN_char >
 #define TS_SINGLE_WRITE_COMMAND 'W'

--- a/firmware/controllers/generated/rusefi_generated_f469-discovery.h
+++ b/firmware/controllers/generated/rusefi_generated_f469-discovery.h
@@ -1274,7 +1274,7 @@
 #define show_microRusEFI_presets false
 #define show_Proteus_presets false
 #define show_test_presets false
-#define SIGNATURE_HASH 2316049381
+#define SIGNATURE_HASH 3705592682
 #define SIMULATOR_TUNE_BIN_FILE_NAME "generated/simulator_tune_image.bin"
 #define SIMULATOR_TUNE_BIN_FILE_NAME_PREFIX "generated/simulator_tune_image"
 #define SIMULATOR_TUNE_BIN_FILE_NAME_SUFFIX ".bin"
@@ -1666,7 +1666,7 @@
 #define ts_show_vr_threshold_all false
 #define ts_show_vr_threshold_pins true
 #define ts_show_vvt_output true
-#define TS_SIGNATURE "rusEFI master.2024.06.15.f469-discovery.2316049381"
+#define TS_SIGNATURE "rusEFI master.2024.06.15.f469-discovery.3705592682"
 #define TS_SIMULATE_CAN '>'
 #define TS_SIMULATE_CAN_char >
 #define TS_SINGLE_WRITE_COMMAND 'W'

--- a/firmware/controllers/generated/rusefi_generated_frankenso_na6.h
+++ b/firmware/controllers/generated/rusefi_generated_frankenso_na6.h
@@ -1274,7 +1274,7 @@
 #define show_microRusEFI_presets false
 #define show_Proteus_presets false
 #define show_test_presets true
-#define SIGNATURE_HASH 3998771565
+#define SIGNATURE_HASH 3096095202
 #define SIMULATOR_TUNE_BIN_FILE_NAME "generated/simulator_tune_image.bin"
 #define SIMULATOR_TUNE_BIN_FILE_NAME_PREFIX "generated/simulator_tune_image"
 #define SIMULATOR_TUNE_BIN_FILE_NAME_SUFFIX ".bin"
@@ -1666,7 +1666,7 @@
 #define ts_show_vr_threshold_all false
 #define ts_show_vr_threshold_pins true
 #define ts_show_vvt_output true
-#define TS_SIGNATURE "rusEFI master.2024.06.15.frankenso_na6.3998771565"
+#define TS_SIGNATURE "rusEFI master.2024.06.15.frankenso_na6.3096095202"
 #define TS_SIMULATE_CAN '>'
 #define TS_SIMULATE_CAN_char >
 #define TS_SINGLE_WRITE_COMMAND 'W'

--- a/firmware/controllers/generated/rusefi_generated_haba208.h
+++ b/firmware/controllers/generated/rusefi_generated_haba208.h
@@ -1274,7 +1274,7 @@
 #define show_microRusEFI_presets false
 #define show_Proteus_presets false
 #define show_test_presets false
-#define SIGNATURE_HASH 3101367670
+#define SIGNATURE_HASH 3993624057
 #define SIMULATOR_TUNE_BIN_FILE_NAME "generated/simulator_tune_image.bin"
 #define SIMULATOR_TUNE_BIN_FILE_NAME_PREFIX "generated/simulator_tune_image"
 #define SIMULATOR_TUNE_BIN_FILE_NAME_SUFFIX ".bin"
@@ -1666,7 +1666,7 @@
 #define ts_show_vr_threshold_all false
 #define ts_show_vr_threshold_pins true
 #define ts_show_vvt_output true
-#define TS_SIGNATURE "rusEFI master.2024.06.15.haba208.3101367670"
+#define TS_SIGNATURE "rusEFI master.2024.06.15.haba208.3993624057"
 #define TS_SIMULATE_CAN '>'
 #define TS_SIMULATE_CAN_char >
 #define TS_SINGLE_WRITE_COMMAND 'W'

--- a/firmware/controllers/generated/rusefi_generated_hellen-112-17.h
+++ b/firmware/controllers/generated/rusefi_generated_hellen-112-17.h
@@ -1275,7 +1275,7 @@
 #define show_microRusEFI_presets false
 #define show_Proteus_presets false
 #define show_test_presets false
-#define SIGNATURE_HASH 835945970
+#define SIGNATURE_HASH 1728136573
 #define SIMULATOR_TUNE_BIN_FILE_NAME "generated/simulator_tune_image.bin"
 #define SIMULATOR_TUNE_BIN_FILE_NAME_PREFIX "generated/simulator_tune_image"
 #define SIMULATOR_TUNE_BIN_FILE_NAME_SUFFIX ".bin"
@@ -1667,7 +1667,7 @@
 #define ts_show_vr_threshold_all false
 #define ts_show_vr_threshold_pins true
 #define ts_show_vvt_output true
-#define TS_SIGNATURE "rusEFI master.2024.06.15.hellen-112-17.835945970"
+#define TS_SIGNATURE "rusEFI master.2024.06.15.hellen-112-17.1728136573"
 #define TS_SIMULATE_CAN '>'
 #define TS_SIMULATE_CAN_char >
 #define TS_SINGLE_WRITE_COMMAND 'W'

--- a/firmware/controllers/generated/rusefi_generated_hellen-gm-e67.h
+++ b/firmware/controllers/generated/rusefi_generated_hellen-gm-e67.h
@@ -1274,7 +1274,7 @@
 #define show_microRusEFI_presets false
 #define show_Proteus_presets false
 #define show_test_presets false
-#define SIGNATURE_HASH 1956805326
+#define SIGNATURE_HASH 577813057
 #define SIMULATOR_TUNE_BIN_FILE_NAME "generated/simulator_tune_image.bin"
 #define SIMULATOR_TUNE_BIN_FILE_NAME_PREFIX "generated/simulator_tune_image"
 #define SIMULATOR_TUNE_BIN_FILE_NAME_SUFFIX ".bin"
@@ -1666,7 +1666,7 @@
 #define ts_show_vr_threshold_all false
 #define ts_show_vr_threshold_pins true
 #define ts_show_vvt_output true
-#define TS_SIGNATURE "rusEFI master.2024.06.15.hellen-gm-e67.1956805326"
+#define TS_SIGNATURE "rusEFI master.2024.06.15.hellen-gm-e67.577813057"
 #define TS_SIMULATE_CAN '>'
 #define TS_SIMULATE_CAN_char >
 #define TS_SINGLE_WRITE_COMMAND 'W'

--- a/firmware/controllers/generated/rusefi_generated_hellen-honda-k.h
+++ b/firmware/controllers/generated/rusefi_generated_hellen-honda-k.h
@@ -1273,7 +1273,7 @@
 #define show_microRusEFI_presets false
 #define show_Proteus_presets false
 #define show_test_presets false
-#define SIGNATURE_HASH 3712278870
+#define SIGNATURE_HASH 2341872089
 #define SIMULATOR_TUNE_BIN_FILE_NAME "generated/simulator_tune_image.bin"
 #define SIMULATOR_TUNE_BIN_FILE_NAME_PREFIX "generated/simulator_tune_image"
 #define SIMULATOR_TUNE_BIN_FILE_NAME_SUFFIX ".bin"
@@ -1667,7 +1667,7 @@
 #define ts_show_vr_threshold_all false
 #define ts_show_vr_threshold_pins true
 #define ts_show_vvt_output true
-#define TS_SIGNATURE "rusEFI master.2024.06.15.hellen-honda-k.3712278870"
+#define TS_SIGNATURE "rusEFI master.2024.06.15.hellen-honda-k.2341872089"
 #define TS_SIMULATE_CAN '>'
 #define TS_SIMULATE_CAN_char >
 #define TS_SINGLE_WRITE_COMMAND 'W'

--- a/firmware/controllers/generated/rusefi_generated_hellen-nb1.h
+++ b/firmware/controllers/generated/rusefi_generated_hellen-nb1.h
@@ -1275,7 +1275,7 @@
 #define show_microRusEFI_presets false
 #define show_Proteus_presets false
 #define show_test_presets false
-#define SIGNATURE_HASH 1371794262
+#define SIGNATURE_HASH 118565849
 #define SIMULATOR_TUNE_BIN_FILE_NAME "generated/simulator_tune_image.bin"
 #define SIMULATOR_TUNE_BIN_FILE_NAME_PREFIX "generated/simulator_tune_image"
 #define SIMULATOR_TUNE_BIN_FILE_NAME_SUFFIX ".bin"
@@ -1667,7 +1667,7 @@
 #define ts_show_vr_threshold_all false
 #define ts_show_vr_threshold_pins true
 #define ts_show_vvt_output true
-#define TS_SIGNATURE "rusEFI master.2024.06.15.hellen-nb1.1371794262"
+#define TS_SIGNATURE "rusEFI master.2024.06.15.hellen-nb1.118565849"
 #define TS_SIMULATE_CAN '>'
 #define TS_SIMULATE_CAN_char >
 #define TS_SINGLE_WRITE_COMMAND 'W'

--- a/firmware/controllers/generated/rusefi_generated_hellen121nissan.h
+++ b/firmware/controllers/generated/rusefi_generated_hellen121nissan.h
@@ -1275,7 +1275,7 @@
 #define show_microRusEFI_presets false
 #define show_Proteus_presets false
 #define show_test_presets false
-#define SIGNATURE_HASH 4254515165
+#define SIGNATURE_HASH 2873392978
 #define SIMULATOR_TUNE_BIN_FILE_NAME "generated/simulator_tune_image.bin"
 #define SIMULATOR_TUNE_BIN_FILE_NAME_PREFIX "generated/simulator_tune_image"
 #define SIMULATOR_TUNE_BIN_FILE_NAME_SUFFIX ".bin"
@@ -1667,7 +1667,7 @@
 #define ts_show_vr_threshold_all false
 #define ts_show_vr_threshold_pins true
 #define ts_show_vvt_output true
-#define TS_SIGNATURE "rusEFI master.2024.06.15.hellen121nissan.4254515165"
+#define TS_SIGNATURE "rusEFI master.2024.06.15.hellen121nissan.2873392978"
 #define TS_SIMULATE_CAN '>'
 #define TS_SIMULATE_CAN_char >
 #define TS_SINGLE_WRITE_COMMAND 'W'

--- a/firmware/controllers/generated/rusefi_generated_hellen121vag.h
+++ b/firmware/controllers/generated/rusefi_generated_hellen121vag.h
@@ -1275,7 +1275,7 @@
 #define show_microRusEFI_presets false
 #define show_Proteus_presets false
 #define show_test_presets false
-#define SIGNATURE_HASH 2292318352
+#define SIGNATURE_HASH 3731931167
 #define SIMULATOR_TUNE_BIN_FILE_NAME "generated/simulator_tune_image.bin"
 #define SIMULATOR_TUNE_BIN_FILE_NAME_PREFIX "generated/simulator_tune_image"
 #define SIMULATOR_TUNE_BIN_FILE_NAME_SUFFIX ".bin"
@@ -1667,7 +1667,7 @@
 #define ts_show_vr_threshold_all false
 #define ts_show_vr_threshold_pins true
 #define ts_show_vvt_output true
-#define TS_SIGNATURE "rusEFI master.2024.06.15.hellen121vag.2292318352"
+#define TS_SIGNATURE "rusEFI master.2024.06.15.hellen121vag.3731931167"
 #define TS_SIMULATE_CAN '>'
 #define TS_SIMULATE_CAN_char >
 #define TS_SINGLE_WRITE_COMMAND 'W'

--- a/firmware/controllers/generated/rusefi_generated_hellen128.h
+++ b/firmware/controllers/generated/rusefi_generated_hellen128.h
@@ -1275,7 +1275,7 @@
 #define show_microRusEFI_presets false
 #define show_Proteus_presets false
 #define show_test_presets false
-#define SIGNATURE_HASH 1430861697
+#define SIGNATURE_HASH 60552974
 #define SIMULATOR_TUNE_BIN_FILE_NAME "generated/simulator_tune_image.bin"
 #define SIMULATOR_TUNE_BIN_FILE_NAME_PREFIX "generated/simulator_tune_image"
 #define SIMULATOR_TUNE_BIN_FILE_NAME_SUFFIX ".bin"
@@ -1667,7 +1667,7 @@
 #define ts_show_vr_threshold_all false
 #define ts_show_vr_threshold_pins true
 #define ts_show_vvt_output true
-#define TS_SIGNATURE "rusEFI master.2024.06.15.hellen128.1430861697"
+#define TS_SIGNATURE "rusEFI master.2024.06.15.hellen128.60552974"
 #define TS_SIMULATE_CAN '>'
 #define TS_SIMULATE_CAN_char >
 #define TS_SINGLE_WRITE_COMMAND 'W'

--- a/firmware/controllers/generated/rusefi_generated_hellen154hyundai.h
+++ b/firmware/controllers/generated/rusefi_generated_hellen154hyundai.h
@@ -1275,7 +1275,7 @@
 #define show_microRusEFI_presets false
 #define show_Proteus_presets false
 #define show_test_presets false
-#define SIGNATURE_HASH 1260422401
+#define SIGNATURE_HASH 502416782
 #define SIMULATOR_TUNE_BIN_FILE_NAME "generated/simulator_tune_image.bin"
 #define SIMULATOR_TUNE_BIN_FILE_NAME_PREFIX "generated/simulator_tune_image"
 #define SIMULATOR_TUNE_BIN_FILE_NAME_SUFFIX ".bin"
@@ -1667,7 +1667,7 @@
 #define ts_show_vr_threshold_all false
 #define ts_show_vr_threshold_pins true
 #define ts_show_vvt_output true
-#define TS_SIGNATURE "rusEFI master.2024.06.15.hellen154hyundai.1260422401"
+#define TS_SIGNATURE "rusEFI master.2024.06.15.hellen154hyundai.502416782"
 #define TS_SIMULATE_CAN '>'
 #define TS_SIMULATE_CAN_char >
 #define TS_SINGLE_WRITE_COMMAND 'W'

--- a/firmware/controllers/generated/rusefi_generated_hellen154hyundai_f7.h
+++ b/firmware/controllers/generated/rusefi_generated_hellen154hyundai_f7.h
@@ -1275,7 +1275,7 @@
 #define show_microRusEFI_presets false
 #define show_Proteus_presets false
 #define show_test_presets false
-#define SIGNATURE_HASH 1425506992
+#define SIGNATURE_HASH 35996223
 #define SIMULATOR_TUNE_BIN_FILE_NAME "generated/simulator_tune_image.bin"
 #define SIMULATOR_TUNE_BIN_FILE_NAME_PREFIX "generated/simulator_tune_image"
 #define SIMULATOR_TUNE_BIN_FILE_NAME_SUFFIX ".bin"
@@ -1667,7 +1667,7 @@
 #define ts_show_vr_threshold_all false
 #define ts_show_vr_threshold_pins true
 #define ts_show_vvt_output true
-#define TS_SIGNATURE "rusEFI master.2024.06.15.hellen154hyundai_f7.1425506992"
+#define TS_SIGNATURE "rusEFI master.2024.06.15.hellen154hyundai_f7.35996223"
 #define TS_SIMULATE_CAN '>'
 #define TS_SIMULATE_CAN_char >
 #define TS_SINGLE_WRITE_COMMAND 'W'

--- a/firmware/controllers/generated/rusefi_generated_hellen72.h
+++ b/firmware/controllers/generated/rusefi_generated_hellen72.h
@@ -1275,7 +1275,7 @@
 #define show_microRusEFI_presets false
 #define show_Proteus_presets false
 #define show_test_presets false
-#define SIGNATURE_HASH 943385066
+#define SIGNATURE_HASH 1860708709
 #define SIMULATOR_TUNE_BIN_FILE_NAME "generated/simulator_tune_image.bin"
 #define SIMULATOR_TUNE_BIN_FILE_NAME_PREFIX "generated/simulator_tune_image"
 #define SIMULATOR_TUNE_BIN_FILE_NAME_SUFFIX ".bin"
@@ -1667,7 +1667,7 @@
 #define ts_show_vr_threshold_all false
 #define ts_show_vr_threshold_pins true
 #define ts_show_vvt_output true
-#define TS_SIGNATURE "rusEFI master.2024.06.15.hellen72.943385066"
+#define TS_SIGNATURE "rusEFI master.2024.06.15.hellen72.1860708709"
 #define TS_SIMULATE_CAN '>'
 #define TS_SIMULATE_CAN_char >
 #define TS_SINGLE_WRITE_COMMAND 'W'

--- a/firmware/controllers/generated/rusefi_generated_hellen81.h
+++ b/firmware/controllers/generated/rusefi_generated_hellen81.h
@@ -1274,7 +1274,7 @@
 #define show_microRusEFI_presets false
 #define show_Proteus_presets false
 #define show_test_presets false
-#define SIGNATURE_HASH 3712716176
+#define SIGNATURE_HASH 2342079775
 #define SIMULATOR_TUNE_BIN_FILE_NAME "generated/simulator_tune_image.bin"
 #define SIMULATOR_TUNE_BIN_FILE_NAME_PREFIX "generated/simulator_tune_image"
 #define SIMULATOR_TUNE_BIN_FILE_NAME_SUFFIX ".bin"
@@ -1666,7 +1666,7 @@
 #define ts_show_vr_threshold_all false
 #define ts_show_vr_threshold_pins true
 #define ts_show_vvt_output true
-#define TS_SIGNATURE "rusEFI master.2024.06.15.hellen81.3712716176"
+#define TS_SIGNATURE "rusEFI master.2024.06.15.hellen81.2342079775"
 #define TS_SIMULATE_CAN '>'
 #define TS_SIMULATE_CAN_char >
 #define TS_SINGLE_WRITE_COMMAND 'W'

--- a/firmware/controllers/generated/rusefi_generated_hellen88bmw.h
+++ b/firmware/controllers/generated/rusefi_generated_hellen88bmw.h
@@ -1275,7 +1275,7 @@
 #define show_microRusEFI_presets false
 #define show_Proteus_presets false
 #define show_test_presets false
-#define SIGNATURE_HASH 3395852499
+#define SIGNATURE_HASH 2629458012
 #define SIMULATOR_TUNE_BIN_FILE_NAME "generated/simulator_tune_image.bin"
 #define SIMULATOR_TUNE_BIN_FILE_NAME_PREFIX "generated/simulator_tune_image"
 #define SIMULATOR_TUNE_BIN_FILE_NAME_SUFFIX ".bin"
@@ -1667,7 +1667,7 @@
 #define ts_show_vr_threshold_all false
 #define ts_show_vr_threshold_pins true
 #define ts_show_vvt_output false
-#define TS_SIGNATURE "rusEFI master.2024.06.15.hellen88bmw.3395852499"
+#define TS_SIGNATURE "rusEFI master.2024.06.15.hellen88bmw.2629458012"
 #define TS_SIMULATE_CAN '>'
 #define TS_SIMULATE_CAN_char >
 #define TS_SINGLE_WRITE_COMMAND 'W'

--- a/firmware/controllers/generated/rusefi_generated_hellenNA6.h
+++ b/firmware/controllers/generated/rusefi_generated_hellenNA6.h
@@ -1275,7 +1275,7 @@
 #define show_microRusEFI_presets false
 #define show_Proteus_presets false
 #define show_test_presets false
-#define SIGNATURE_HASH 746520214
+#define SIGNATURE_HASH 2058108441
 #define SIMULATOR_TUNE_BIN_FILE_NAME "generated/simulator_tune_image.bin"
 #define SIMULATOR_TUNE_BIN_FILE_NAME_PREFIX "generated/simulator_tune_image"
 #define SIMULATOR_TUNE_BIN_FILE_NAME_SUFFIX ".bin"
@@ -1667,7 +1667,7 @@
 #define ts_show_vr_threshold_all false
 #define ts_show_vr_threshold_pins true
 #define ts_show_vvt_output true
-#define TS_SIGNATURE "rusEFI master.2024.06.15.hellenNA6.746520214"
+#define TS_SIGNATURE "rusEFI master.2024.06.15.hellenNA6.2058108441"
 #define TS_SIMULATE_CAN '>'
 #define TS_SIMULATE_CAN_char >
 #define TS_SINGLE_WRITE_COMMAND 'W'

--- a/firmware/controllers/generated/rusefi_generated_hellenNA8_96.h
+++ b/firmware/controllers/generated/rusefi_generated_hellenNA8_96.h
@@ -1276,7 +1276,7 @@
 #define show_microRusEFI_presets false
 #define show_Proteus_presets false
 #define show_test_presets false
-#define SIGNATURE_HASH 3550788696
+#define SIGNATURE_HASH 2239134935
 #define SIMULATOR_TUNE_BIN_FILE_NAME "generated/simulator_tune_image.bin"
 #define SIMULATOR_TUNE_BIN_FILE_NAME_PREFIX "generated/simulator_tune_image"
 #define SIMULATOR_TUNE_BIN_FILE_NAME_SUFFIX ".bin"
@@ -1668,7 +1668,7 @@
 #define ts_show_vr_threshold_all false
 #define ts_show_vr_threshold_pins true
 #define ts_show_vvt_output true
-#define TS_SIGNATURE "rusEFI master.2024.06.15.hellenNA8_96.3550788696"
+#define TS_SIGNATURE "rusEFI master.2024.06.15.hellenNA8_96.2239134935"
 #define TS_SIMULATE_CAN '>'
 #define TS_SIMULATE_CAN_char >
 #define TS_SINGLE_WRITE_COMMAND 'W'

--- a/firmware/controllers/generated/rusefi_generated_m74_9.h
+++ b/firmware/controllers/generated/rusefi_generated_m74_9.h
@@ -1274,7 +1274,7 @@
 #define show_microRusEFI_presets false
 #define show_Proteus_presets false
 #define show_test_presets false
-#define SIGNATURE_HASH 207693225
+#define SIGNATURE_HASH 1521739046
 #define SIMULATOR_TUNE_BIN_FILE_NAME "generated/simulator_tune_image.bin"
 #define SIMULATOR_TUNE_BIN_FILE_NAME_PREFIX "generated/simulator_tune_image"
 #define SIMULATOR_TUNE_BIN_FILE_NAME_SUFFIX ".bin"
@@ -1667,7 +1667,7 @@
 #define ts_show_vr_threshold_all false
 #define ts_show_vr_threshold_pins true
 #define ts_show_vvt_output true
-#define TS_SIGNATURE "rusEFI master.2024.06.15.m74_9.207693225"
+#define TS_SIGNATURE "rusEFI master.2024.06.15.m74_9.1521739046"
 #define TS_SIMULATE_CAN '>'
 #define TS_SIMULATE_CAN_char >
 #define TS_SINGLE_WRITE_COMMAND 'W'

--- a/firmware/controllers/generated/rusefi_generated_mre-legacy_f4.h
+++ b/firmware/controllers/generated/rusefi_generated_mre-legacy_f4.h
@@ -1275,7 +1275,7 @@
 #define show_microRusEFI_presets true
 #define show_Proteus_presets false
 #define show_test_presets false
-#define SIGNATURE_HASH 2784780345
+#define SIGNATURE_HASH 4079919286
 #define SIMULATOR_TUNE_BIN_FILE_NAME "generated/simulator_tune_image.bin"
 #define SIMULATOR_TUNE_BIN_FILE_NAME_PREFIX "generated/simulator_tune_image"
 #define SIMULATOR_TUNE_BIN_FILE_NAME_SUFFIX ".bin"
@@ -1667,7 +1667,7 @@
 #define ts_show_vr_threshold_all false
 #define ts_show_vr_threshold_pins true
 #define ts_show_vvt_output true
-#define TS_SIGNATURE "rusEFI master.2024.06.15.mre-legacy_f4.2784780345"
+#define TS_SIGNATURE "rusEFI master.2024.06.15.mre-legacy_f4.4079919286"
 #define TS_SIMULATE_CAN '>'
 #define TS_SIMULATE_CAN_char >
 #define TS_SINGLE_WRITE_COMMAND 'W'

--- a/firmware/controllers/generated/rusefi_generated_mre_f4.h
+++ b/firmware/controllers/generated/rusefi_generated_mre_f4.h
@@ -1275,7 +1275,7 @@
 #define show_microRusEFI_presets true
 #define show_Proteus_presets false
 #define show_test_presets false
-#define SIGNATURE_HASH 2784780345
+#define SIGNATURE_HASH 4079919286
 #define SIMULATOR_TUNE_BIN_FILE_NAME "generated/simulator_tune_image.bin"
 #define SIMULATOR_TUNE_BIN_FILE_NAME_PREFIX "generated/simulator_tune_image"
 #define SIMULATOR_TUNE_BIN_FILE_NAME_SUFFIX ".bin"
@@ -1667,7 +1667,7 @@
 #define ts_show_vr_threshold_all false
 #define ts_show_vr_threshold_pins true
 #define ts_show_vvt_output true
-#define TS_SIGNATURE "rusEFI master.2024.06.15.mre_f4.2784780345"
+#define TS_SIGNATURE "rusEFI master.2024.06.15.mre_f4.4079919286"
 #define TS_SIMULATE_CAN '>'
 #define TS_SIMULATE_CAN_char >
 #define TS_SINGLE_WRITE_COMMAND 'W'

--- a/firmware/controllers/generated/rusefi_generated_mre_f7.h
+++ b/firmware/controllers/generated/rusefi_generated_mre_f7.h
@@ -1275,7 +1275,7 @@
 #define show_microRusEFI_presets true
 #define show_Proteus_presets false
 #define show_test_presets false
-#define SIGNATURE_HASH 2784780345
+#define SIGNATURE_HASH 4079919286
 #define SIMULATOR_TUNE_BIN_FILE_NAME "generated/simulator_tune_image.bin"
 #define SIMULATOR_TUNE_BIN_FILE_NAME_PREFIX "generated/simulator_tune_image"
 #define SIMULATOR_TUNE_BIN_FILE_NAME_SUFFIX ".bin"
@@ -1667,7 +1667,7 @@
 #define ts_show_vr_threshold_all false
 #define ts_show_vr_threshold_pins true
 #define ts_show_vvt_output true
-#define TS_SIGNATURE "rusEFI master.2024.06.15.mre_f7.2784780345"
+#define TS_SIGNATURE "rusEFI master.2024.06.15.mre_f7.4079919286"
 #define TS_SIMULATE_CAN '>'
 #define TS_SIMULATE_CAN_char >
 #define TS_SINGLE_WRITE_COMMAND 'W'

--- a/firmware/controllers/generated/rusefi_generated_nucleo_f413.h
+++ b/firmware/controllers/generated/rusefi_generated_nucleo_f413.h
@@ -1274,7 +1274,7 @@
 #define show_microRusEFI_presets false
 #define show_Proteus_presets false
 #define show_test_presets false
-#define SIGNATURE_HASH 3101367670
+#define SIGNATURE_HASH 3993624057
 #define SIMULATOR_TUNE_BIN_FILE_NAME "generated/simulator_tune_image.bin"
 #define SIMULATOR_TUNE_BIN_FILE_NAME_PREFIX "generated/simulator_tune_image"
 #define SIMULATOR_TUNE_BIN_FILE_NAME_SUFFIX ".bin"
@@ -1666,7 +1666,7 @@
 #define ts_show_vr_threshold_all false
 #define ts_show_vr_threshold_pins true
 #define ts_show_vvt_output true
-#define TS_SIGNATURE "rusEFI master.2024.06.15.nucleo_f413.3101367670"
+#define TS_SIGNATURE "rusEFI master.2024.06.15.nucleo_f413.3993624057"
 #define TS_SIMULATE_CAN '>'
 #define TS_SIMULATE_CAN_char >
 #define TS_SINGLE_WRITE_COMMAND 'W'

--- a/firmware/controllers/generated/rusefi_generated_prometheus_405.h
+++ b/firmware/controllers/generated/rusefi_generated_prometheus_405.h
@@ -1274,7 +1274,7 @@
 #define show_microRusEFI_presets false
 #define show_Proteus_presets false
 #define show_test_presets false
-#define SIGNATURE_HASH 2286932198
+#define SIGNATURE_HASH 3734835305
 #define SIMULATOR_TUNE_BIN_FILE_NAME "generated/simulator_tune_image.bin"
 #define SIMULATOR_TUNE_BIN_FILE_NAME_PREFIX "generated/simulator_tune_image"
 #define SIMULATOR_TUNE_BIN_FILE_NAME_SUFFIX ".bin"
@@ -1666,7 +1666,7 @@
 #define ts_show_vr_threshold_all false
 #define ts_show_vr_threshold_pins true
 #define ts_show_vvt_output true
-#define TS_SIGNATURE "rusEFI master.2024.06.15.prometheus_405.2286932198"
+#define TS_SIGNATURE "rusEFI master.2024.06.15.prometheus_405.3734835305"
 #define TS_SIMULATE_CAN '>'
 #define TS_SIMULATE_CAN_char >
 #define TS_SINGLE_WRITE_COMMAND 'W'

--- a/firmware/controllers/generated/rusefi_generated_prometheus_469.h
+++ b/firmware/controllers/generated/rusefi_generated_prometheus_469.h
@@ -1274,7 +1274,7 @@
 #define show_microRusEFI_presets false
 #define show_Proteus_presets false
 #define show_test_presets false
-#define SIGNATURE_HASH 2286932198
+#define SIGNATURE_HASH 3734835305
 #define SIMULATOR_TUNE_BIN_FILE_NAME "generated/simulator_tune_image.bin"
 #define SIMULATOR_TUNE_BIN_FILE_NAME_PREFIX "generated/simulator_tune_image"
 #define SIMULATOR_TUNE_BIN_FILE_NAME_SUFFIX ".bin"
@@ -1666,7 +1666,7 @@
 #define ts_show_vr_threshold_all false
 #define ts_show_vr_threshold_pins true
 #define ts_show_vvt_output true
-#define TS_SIGNATURE "rusEFI master.2024.06.15.prometheus_469.2286932198"
+#define TS_SIGNATURE "rusEFI master.2024.06.15.prometheus_469.3734835305"
 #define TS_SIMULATE_CAN '>'
 #define TS_SIMULATE_CAN_char >
 #define TS_SINGLE_WRITE_COMMAND 'W'

--- a/firmware/controllers/generated/rusefi_generated_proteus_f4.h
+++ b/firmware/controllers/generated/rusefi_generated_proteus_f4.h
@@ -1274,7 +1274,7 @@
 #define show_microRusEFI_presets false
 #define show_Proteus_presets true
 #define show_test_presets false
-#define SIGNATURE_HASH 1388357460
+#define SIGNATURE_HASH 68315099
 #define SIMULATOR_TUNE_BIN_FILE_NAME "generated/simulator_tune_image.bin"
 #define SIMULATOR_TUNE_BIN_FILE_NAME_PREFIX "generated/simulator_tune_image"
 #define SIMULATOR_TUNE_BIN_FILE_NAME_SUFFIX ".bin"
@@ -1666,7 +1666,7 @@
 #define ts_show_vr_threshold_all false
 #define ts_show_vr_threshold_pins true
 #define ts_show_vvt_output true
-#define TS_SIGNATURE "rusEFI master.2024.06.15.proteus_f4.1388357460"
+#define TS_SIGNATURE "rusEFI master.2024.06.15.proteus_f4.68315099"
 #define TS_SIMULATE_CAN '>'
 #define TS_SIMULATE_CAN_char >
 #define TS_SINGLE_WRITE_COMMAND 'W'

--- a/firmware/controllers/generated/rusefi_generated_proteus_f7.h
+++ b/firmware/controllers/generated/rusefi_generated_proteus_f7.h
@@ -1274,7 +1274,7 @@
 #define show_microRusEFI_presets false
 #define show_Proteus_presets true
 #define show_test_presets false
-#define SIGNATURE_HASH 1388357460
+#define SIGNATURE_HASH 68315099
 #define SIMULATOR_TUNE_BIN_FILE_NAME "generated/simulator_tune_image.bin"
 #define SIMULATOR_TUNE_BIN_FILE_NAME_PREFIX "generated/simulator_tune_image"
 #define SIMULATOR_TUNE_BIN_FILE_NAME_SUFFIX ".bin"
@@ -1666,7 +1666,7 @@
 #define ts_show_vr_threshold_all false
 #define ts_show_vr_threshold_pins true
 #define ts_show_vvt_output true
-#define TS_SIGNATURE "rusEFI master.2024.06.15.proteus_f7.1388357460"
+#define TS_SIGNATURE "rusEFI master.2024.06.15.proteus_f7.68315099"
 #define TS_SIMULATE_CAN '>'
 #define TS_SIMULATE_CAN_char >
 #define TS_SINGLE_WRITE_COMMAND 'W'

--- a/firmware/controllers/generated/rusefi_generated_proteus_h7.h
+++ b/firmware/controllers/generated/rusefi_generated_proteus_h7.h
@@ -1274,7 +1274,7 @@
 #define show_microRusEFI_presets false
 #define show_Proteus_presets true
 #define show_test_presets false
-#define SIGNATURE_HASH 1388357460
+#define SIGNATURE_HASH 68315099
 #define SIMULATOR_TUNE_BIN_FILE_NAME "generated/simulator_tune_image.bin"
 #define SIMULATOR_TUNE_BIN_FILE_NAME_PREFIX "generated/simulator_tune_image"
 #define SIMULATOR_TUNE_BIN_FILE_NAME_SUFFIX ".bin"
@@ -1666,7 +1666,7 @@
 #define ts_show_vr_threshold_all false
 #define ts_show_vr_threshold_pins true
 #define ts_show_vvt_output true
-#define TS_SIGNATURE "rusEFI master.2024.06.15.proteus_h7.1388357460"
+#define TS_SIGNATURE "rusEFI master.2024.06.15.proteus_h7.68315099"
 #define TS_SIMULATE_CAN '>'
 #define TS_SIMULATE_CAN_char >
 #define TS_SINGLE_WRITE_COMMAND 'W'

--- a/firmware/controllers/generated/rusefi_generated_s105.h
+++ b/firmware/controllers/generated/rusefi_generated_s105.h
@@ -1274,7 +1274,7 @@
 #define show_microRusEFI_presets false
 #define show_Proteus_presets false
 #define show_test_presets false
-#define SIGNATURE_HASH 122723764
+#define SIGNATURE_HASH 1367498043
 #define SIMULATOR_TUNE_BIN_FILE_NAME "generated/simulator_tune_image.bin"
 #define SIMULATOR_TUNE_BIN_FILE_NAME_PREFIX "generated/simulator_tune_image"
 #define SIMULATOR_TUNE_BIN_FILE_NAME_SUFFIX ".bin"
@@ -1667,7 +1667,7 @@
 #define ts_show_vr_threshold_all false
 #define ts_show_vr_threshold_pins true
 #define ts_show_vvt_output true
-#define TS_SIGNATURE "rusEFI master.2024.06.15.s105.122723764"
+#define TS_SIGNATURE "rusEFI master.2024.06.15.s105.1367498043"
 #define TS_SIMULATE_CAN '>'
 #define TS_SIMULATE_CAN_char >
 #define TS_SINGLE_WRITE_COMMAND 'W'

--- a/firmware/controllers/generated/rusefi_generated_small-can-board.h
+++ b/firmware/controllers/generated/rusefi_generated_small-can-board.h
@@ -1275,7 +1275,7 @@
 #define show_Proteus_presets false
 #define show_small_can_board_presets true
 #define show_test_presets false
-#define SIGNATURE_HASH 506871636
+#define SIGNATURE_HASH 1222967259
 #define SIMULATOR_TUNE_BIN_FILE_NAME "generated/simulator_tune_image.bin"
 #define SIMULATOR_TUNE_BIN_FILE_NAME_PREFIX "generated/simulator_tune_image"
 #define SIMULATOR_TUNE_BIN_FILE_NAME_SUFFIX ".bin"
@@ -1668,7 +1668,7 @@
 #define ts_show_vr_threshold_all false
 #define ts_show_vr_threshold_pins true
 #define ts_show_vvt_output true
-#define TS_SIGNATURE "rusEFI master.2024.06.15.small-can-board.506871636"
+#define TS_SIGNATURE "rusEFI master.2024.06.15.small-can-board.1222967259"
 #define TS_SIMULATE_CAN '>'
 #define TS_SIMULATE_CAN_char >
 #define TS_SINGLE_WRITE_COMMAND 'W'

--- a/firmware/controllers/generated/rusefi_generated_stm32f429_nucleo.h
+++ b/firmware/controllers/generated/rusefi_generated_stm32f429_nucleo.h
@@ -1274,7 +1274,7 @@
 #define show_microRusEFI_presets false
 #define show_Proteus_presets false
 #define show_test_presets false
-#define SIGNATURE_HASH 3101367670
+#define SIGNATURE_HASH 3993624057
 #define SIMULATOR_TUNE_BIN_FILE_NAME "generated/simulator_tune_image.bin"
 #define SIMULATOR_TUNE_BIN_FILE_NAME_PREFIX "generated/simulator_tune_image"
 #define SIMULATOR_TUNE_BIN_FILE_NAME_SUFFIX ".bin"
@@ -1666,7 +1666,7 @@
 #define ts_show_vr_threshold_all false
 #define ts_show_vr_threshold_pins true
 #define ts_show_vvt_output true
-#define TS_SIGNATURE "rusEFI master.2024.06.15.stm32f429_nucleo.3101367670"
+#define TS_SIGNATURE "rusEFI master.2024.06.15.stm32f429_nucleo.3993624057"
 #define TS_SIMULATE_CAN '>'
 #define TS_SIMULATE_CAN_char >
 #define TS_SINGLE_WRITE_COMMAND 'W'

--- a/firmware/controllers/generated/rusefi_generated_stm32f767_nucleo.h
+++ b/firmware/controllers/generated/rusefi_generated_stm32f767_nucleo.h
@@ -1274,7 +1274,7 @@
 #define show_microRusEFI_presets false
 #define show_Proteus_presets false
 #define show_test_presets false
-#define SIGNATURE_HASH 3101367670
+#define SIGNATURE_HASH 3993624057
 #define SIMULATOR_TUNE_BIN_FILE_NAME "generated/simulator_tune_image.bin"
 #define SIMULATOR_TUNE_BIN_FILE_NAME_PREFIX "generated/simulator_tune_image"
 #define SIMULATOR_TUNE_BIN_FILE_NAME_SUFFIX ".bin"
@@ -1666,7 +1666,7 @@
 #define ts_show_vr_threshold_all false
 #define ts_show_vr_threshold_pins true
 #define ts_show_vvt_output true
-#define TS_SIGNATURE "rusEFI master.2024.06.15.stm32f767_nucleo.3101367670"
+#define TS_SIGNATURE "rusEFI master.2024.06.15.stm32f767_nucleo.3993624057"
 #define TS_SIMULATE_CAN '>'
 #define TS_SIMULATE_CAN_char >
 #define TS_SINGLE_WRITE_COMMAND 'W'

--- a/firmware/controllers/generated/rusefi_generated_stm32h743_nucleo.h
+++ b/firmware/controllers/generated/rusefi_generated_stm32h743_nucleo.h
@@ -1274,7 +1274,7 @@
 #define show_microRusEFI_presets false
 #define show_Proteus_presets false
 #define show_test_presets false
-#define SIGNATURE_HASH 3101367670
+#define SIGNATURE_HASH 3993624057
 #define SIMULATOR_TUNE_BIN_FILE_NAME "generated/simulator_tune_image.bin"
 #define SIMULATOR_TUNE_BIN_FILE_NAME_PREFIX "generated/simulator_tune_image"
 #define SIMULATOR_TUNE_BIN_FILE_NAME_SUFFIX ".bin"
@@ -1666,7 +1666,7 @@
 #define ts_show_vr_threshold_all false
 #define ts_show_vr_threshold_pins true
 #define ts_show_vvt_output true
-#define TS_SIGNATURE "rusEFI master.2024.06.15.stm32h743_nucleo.3101367670"
+#define TS_SIGNATURE "rusEFI master.2024.06.15.stm32h743_nucleo.3993624057"
 #define TS_SIMULATE_CAN '>'
 #define TS_SIMULATE_CAN_char >
 #define TS_SINGLE_WRITE_COMMAND 'W'

--- a/firmware/controllers/generated/rusefi_generated_subaru_eg33_f7.h
+++ b/firmware/controllers/generated/rusefi_generated_subaru_eg33_f7.h
@@ -1274,7 +1274,7 @@
 #define show_microRusEFI_presets false
 #define show_Proteus_presets false
 #define show_test_presets false
-#define SIGNATURE_HASH 4065659205
+#define SIGNATURE_HASH 2760362442
 #define SIMULATOR_TUNE_BIN_FILE_NAME "generated/simulator_tune_image.bin"
 #define SIMULATOR_TUNE_BIN_FILE_NAME_PREFIX "generated/simulator_tune_image"
 #define SIMULATOR_TUNE_BIN_FILE_NAME_SUFFIX ".bin"
@@ -1666,7 +1666,7 @@
 #define ts_show_vr_threshold_all false
 #define ts_show_vr_threshold_pins true
 #define ts_show_vvt_output true
-#define TS_SIGNATURE "rusEFI master.2024.06.15.subaru_eg33_f7.4065659205"
+#define TS_SIGNATURE "rusEFI master.2024.06.15.subaru_eg33_f7.2760362442"
 #define TS_SIMULATE_CAN '>'
 #define TS_SIMULATE_CAN_char >
 #define TS_SINGLE_WRITE_COMMAND 'W'

--- a/firmware/controllers/generated/rusefi_generated_t-b-g.h
+++ b/firmware/controllers/generated/rusefi_generated_t-b-g.h
@@ -1274,7 +1274,7 @@
 #define show_microRusEFI_presets false
 #define show_Proteus_presets false
 #define show_test_presets false
-#define SIGNATURE_HASH 3101367670
+#define SIGNATURE_HASH 3993624057
 #define SIMULATOR_TUNE_BIN_FILE_NAME "generated/simulator_tune_image.bin"
 #define SIMULATOR_TUNE_BIN_FILE_NAME_PREFIX "generated/simulator_tune_image"
 #define SIMULATOR_TUNE_BIN_FILE_NAME_SUFFIX ".bin"
@@ -1666,7 +1666,7 @@
 #define ts_show_vr_threshold_all false
 #define ts_show_vr_threshold_pins true
 #define ts_show_vvt_output true
-#define TS_SIGNATURE "rusEFI master.2024.06.15.t-b-g.3101367670"
+#define TS_SIGNATURE "rusEFI master.2024.06.15.t-b-g.3993624057"
 #define TS_SIMULATE_CAN '>'
 #define TS_SIMULATE_CAN_char >
 #define TS_SINGLE_WRITE_COMMAND 'W'

--- a/firmware/controllers/generated/rusefi_generated_tdg-pdm8.h
+++ b/firmware/controllers/generated/rusefi_generated_tdg-pdm8.h
@@ -1274,7 +1274,7 @@
 #define show_microRusEFI_presets false
 #define show_Proteus_presets false
 #define show_test_presets false
-#define SIGNATURE_HASH 2197201406
+#define SIGNATURE_HASH 3559154033
 #define SIMULATOR_TUNE_BIN_FILE_NAME "generated/simulator_tune_image.bin"
 #define SIMULATOR_TUNE_BIN_FILE_NAME_PREFIX "generated/simulator_tune_image"
 #define SIMULATOR_TUNE_BIN_FILE_NAME_SUFFIX ".bin"
@@ -1666,7 +1666,7 @@
 #define ts_show_vr_threshold_all false
 #define ts_show_vr_threshold_pins true
 #define ts_show_vvt_output true
-#define TS_SIGNATURE "rusEFI master.2024.06.15.tdg-pdm8.2197201406"
+#define TS_SIGNATURE "rusEFI master.2024.06.15.tdg-pdm8.3559154033"
 #define TS_SIMULATE_CAN '>'
 #define TS_SIMULATE_CAN_char >
 #define TS_SINGLE_WRITE_COMMAND 'W'

--- a/firmware/controllers/generated/rusefi_generated_uaefi.h
+++ b/firmware/controllers/generated/rusefi_generated_uaefi.h
@@ -1275,7 +1275,7 @@
 #define show_Proteus_presets false
 #define show_test_presets false
 #define show_uaefi_presets true
-#define SIGNATURE_HASH 3265355853
+#define SIGNATURE_HASH 2490605762
 #define SIMULATOR_TUNE_BIN_FILE_NAME "generated/simulator_tune_image.bin"
 #define SIMULATOR_TUNE_BIN_FILE_NAME_PREFIX "generated/simulator_tune_image"
 #define SIMULATOR_TUNE_BIN_FILE_NAME_SUFFIX ".bin"
@@ -1667,7 +1667,7 @@
 #define ts_show_vr_threshold_all true
 #define ts_show_vr_threshold_pins false
 #define ts_show_vvt_output true
-#define TS_SIGNATURE "rusEFI master.2024.06.15.uaefi.3265355853"
+#define TS_SIGNATURE "rusEFI master.2024.06.15.uaefi.2490605762"
 #define TS_SIMULATE_CAN '>'
 #define TS_SIMULATE_CAN_char >
 #define TS_SINGLE_WRITE_COMMAND 'W'

--- a/firmware/controllers/generated/rusefi_generated_uaefi121.h
+++ b/firmware/controllers/generated/rusefi_generated_uaefi121.h
@@ -1274,7 +1274,7 @@
 #define show_microRusEFI_presets false
 #define show_Proteus_presets false
 #define show_test_presets false
-#define SIGNATURE_HASH 3928798276
+#define SIGNATURE_HASH 3170792651
 #define SIMULATOR_TUNE_BIN_FILE_NAME "generated/simulator_tune_image.bin"
 #define SIMULATOR_TUNE_BIN_FILE_NAME_PREFIX "generated/simulator_tune_image"
 #define SIMULATOR_TUNE_BIN_FILE_NAME_SUFFIX ".bin"
@@ -1666,7 +1666,7 @@
 #define ts_show_vr_threshold_all true
 #define ts_show_vr_threshold_pins false
 #define ts_show_vvt_output true
-#define TS_SIGNATURE "rusEFI master.2024.06.15.uaefi121.3928798276"
+#define TS_SIGNATURE "rusEFI master.2024.06.15.uaefi121.3170792651"
 #define TS_SIMULATE_CAN '>'
 #define TS_SIMULATE_CAN_char >
 #define TS_SINGLE_WRITE_COMMAND 'W'

--- a/firmware/controllers/generated/signature_alphax-2chan.h
+++ b/firmware/controllers/generated/signature_alphax-2chan.h
@@ -2,5 +2,5 @@
 // was generated automatically by rusEFI tool config_definition-all.jar based on gen_config.sh by SignatureConsumer
 //
 
-#define SIGNATURE_HASH 848521784
-#define TS_SIGNATURE "rusEFI master.2024.06.15.alphax-2chan.848521784"
+#define SIGNATURE_HASH 1682025143
+#define TS_SIGNATURE "rusEFI master.2024.06.15.alphax-2chan.1682025143"

--- a/firmware/controllers/generated/signature_alphax-4chan.h
+++ b/firmware/controllers/generated/signature_alphax-4chan.h
@@ -2,5 +2,5 @@
 // was generated automatically by rusEFI tool config_definition-all.jar based on gen_config.sh by SignatureConsumer
 //
 
-#define SIGNATURE_HASH 242120885
-#define TS_SIGNATURE "rusEFI master.2024.06.15.alphax-4chan.242120885"
+#define SIGNATURE_HASH 1488762938
+#define TS_SIGNATURE "rusEFI master.2024.06.15.alphax-4chan.1488762938"

--- a/firmware/controllers/generated/signature_alphax-4chan_f7.h
+++ b/firmware/controllers/generated/signature_alphax-4chan_f7.h
@@ -2,5 +2,5 @@
 // was generated automatically by rusEFI tool config_definition-all.jar based on gen_config.sh by SignatureConsumer
 //
 
-#define SIGNATURE_HASH 242120885
-#define TS_SIGNATURE "rusEFI master.2024.06.15.alphax-4chan_f7.242120885"
+#define SIGNATURE_HASH 1488762938
+#define TS_SIGNATURE "rusEFI master.2024.06.15.alphax-4chan_f7.1488762938"

--- a/firmware/controllers/generated/signature_alphax-8chan-revA.h
+++ b/firmware/controllers/generated/signature_alphax-8chan-revA.h
@@ -2,5 +2,5 @@
 // was generated automatically by rusEFI tool config_definition-all.jar based on gen_config.sh by SignatureConsumer
 //
 
-#define SIGNATURE_HASH 98862663
-#define TS_SIGNATURE "rusEFI master.2024.06.15.alphax-8chan-revA.98862663"
+#define SIGNATURE_HASH 1396065992
+#define TS_SIGNATURE "rusEFI master.2024.06.15.alphax-8chan-revA.1396065992"

--- a/firmware/controllers/generated/signature_alphax-8chan.h
+++ b/firmware/controllers/generated/signature_alphax-8chan.h
@@ -2,5 +2,5 @@
 // was generated automatically by rusEFI tool config_definition-all.jar based on gen_config.sh by SignatureConsumer
 //
 
-#define SIGNATURE_HASH 1045018647
-#define TS_SIGNATURE "rusEFI master.2024.06.15.alphax-8chan.1045018647"
+#define SIGNATURE_HASH 1755019416
+#define TS_SIGNATURE "rusEFI master.2024.06.15.alphax-8chan.1755019416"

--- a/firmware/controllers/generated/signature_alphax-8chan_f7.h
+++ b/firmware/controllers/generated/signature_alphax-8chan_f7.h
@@ -2,5 +2,5 @@
 // was generated automatically by rusEFI tool config_definition-all.jar based on gen_config.sh by SignatureConsumer
 //
 
-#define SIGNATURE_HASH 1045018647
-#define TS_SIGNATURE "rusEFI master.2024.06.15.alphax-8chan_f7.1045018647"
+#define SIGNATURE_HASH 1755019416
+#define TS_SIGNATURE "rusEFI master.2024.06.15.alphax-8chan_f7.1755019416"

--- a/firmware/controllers/generated/signature_alphax-silver.h
+++ b/firmware/controllers/generated/signature_alphax-silver.h
@@ -2,5 +2,5 @@
 // was generated automatically by rusEFI tool config_definition-all.jar based on gen_config.sh by SignatureConsumer
 //
 
-#define SIGNATURE_HASH 1889919833
-#define TS_SIGNATURE "rusEFI master.2024.06.15.alphax-silver.1889919833"
+#define SIGNATURE_HASH 645342166
+#define TS_SIGNATURE "rusEFI master.2024.06.15.alphax-silver.645342166"

--- a/firmware/controllers/generated/signature_at_start_f435.h
+++ b/firmware/controllers/generated/signature_at_start_f435.h
@@ -2,5 +2,5 @@
 // was generated automatically by rusEFI tool config_definition-all.jar based on gen_config.sh by SignatureConsumer
 //
 
-#define SIGNATURE_HASH 3101367670
-#define TS_SIGNATURE "rusEFI master.2024.06.15.at_start_f435.3101367670"
+#define SIGNATURE_HASH 3993624057
+#define TS_SIGNATURE "rusEFI master.2024.06.15.at_start_f435.3993624057"

--- a/firmware/controllers/generated/signature_atlas.h
+++ b/firmware/controllers/generated/signature_atlas.h
@@ -2,5 +2,5 @@
 // was generated automatically by rusEFI tool config_definition-all.jar based on gen_config.sh by SignatureConsumer
 //
 
-#define SIGNATURE_HASH 4242327864
-#define TS_SIGNATURE "rusEFI master.2024.06.15.atlas.4242327864"
+#define SIGNATURE_HASH 2853046711
+#define TS_SIGNATURE "rusEFI master.2024.06.15.atlas.2853046711"

--- a/firmware/controllers/generated/signature_f407-discovery.h
+++ b/firmware/controllers/generated/signature_f407-discovery.h
@@ -2,5 +2,5 @@
 // was generated automatically by rusEFI tool config_definition-all.jar based on gen_config.sh by SignatureConsumer
 //
 
-#define SIGNATURE_HASH 478864919
-#define TS_SIGNATURE "rusEFI master.2024.06.15.f407-discovery.478864919"
+#define SIGNATURE_HASH 1247291032
+#define TS_SIGNATURE "rusEFI master.2024.06.15.f407-discovery.1247291032"

--- a/firmware/controllers/generated/signature_f429-discovery.h
+++ b/firmware/controllers/generated/signature_f429-discovery.h
@@ -2,5 +2,5 @@
 // was generated automatically by rusEFI tool config_definition-all.jar based on gen_config.sh by SignatureConsumer
 //
 
-#define SIGNATURE_HASH 3101367670
-#define TS_SIGNATURE "rusEFI master.2024.06.15.f429-discovery.3101367670"
+#define SIGNATURE_HASH 3993624057
+#define TS_SIGNATURE "rusEFI master.2024.06.15.f429-discovery.3993624057"

--- a/firmware/controllers/generated/signature_f469-discovery.h
+++ b/firmware/controllers/generated/signature_f469-discovery.h
@@ -2,5 +2,5 @@
 // was generated automatically by rusEFI tool config_definition-all.jar based on gen_config.sh by SignatureConsumer
 //
 
-#define SIGNATURE_HASH 2316049381
-#define TS_SIGNATURE "rusEFI master.2024.06.15.f469-discovery.2316049381"
+#define SIGNATURE_HASH 3705592682
+#define TS_SIGNATURE "rusEFI master.2024.06.15.f469-discovery.3705592682"

--- a/firmware/controllers/generated/signature_frankenso_na6.h
+++ b/firmware/controllers/generated/signature_frankenso_na6.h
@@ -2,5 +2,5 @@
 // was generated automatically by rusEFI tool config_definition-all.jar based on gen_config.sh by SignatureConsumer
 //
 
-#define SIGNATURE_HASH 3998771565
-#define TS_SIGNATURE "rusEFI master.2024.06.15.frankenso_na6.3998771565"
+#define SIGNATURE_HASH 3096095202
+#define TS_SIGNATURE "rusEFI master.2024.06.15.frankenso_na6.3096095202"

--- a/firmware/controllers/generated/signature_haba208.h
+++ b/firmware/controllers/generated/signature_haba208.h
@@ -2,5 +2,5 @@
 // was generated automatically by rusEFI tool config_definition-all.jar based on gen_config.sh by SignatureConsumer
 //
 
-#define SIGNATURE_HASH 3101367670
-#define TS_SIGNATURE "rusEFI master.2024.06.15.haba208.3101367670"
+#define SIGNATURE_HASH 3993624057
+#define TS_SIGNATURE "rusEFI master.2024.06.15.haba208.3993624057"

--- a/firmware/controllers/generated/signature_hellen-112-17.h
+++ b/firmware/controllers/generated/signature_hellen-112-17.h
@@ -2,5 +2,5 @@
 // was generated automatically by rusEFI tool config_definition-all.jar based on gen_config.sh by SignatureConsumer
 //
 
-#define SIGNATURE_HASH 835945970
-#define TS_SIGNATURE "rusEFI master.2024.06.15.hellen-112-17.835945970"
+#define SIGNATURE_HASH 1728136573
+#define TS_SIGNATURE "rusEFI master.2024.06.15.hellen-112-17.1728136573"

--- a/firmware/controllers/generated/signature_hellen-gm-e67.h
+++ b/firmware/controllers/generated/signature_hellen-gm-e67.h
@@ -2,5 +2,5 @@
 // was generated automatically by rusEFI tool config_definition-all.jar based on gen_config.sh by SignatureConsumer
 //
 
-#define SIGNATURE_HASH 1956805326
-#define TS_SIGNATURE "rusEFI master.2024.06.15.hellen-gm-e67.1956805326"
+#define SIGNATURE_HASH 577813057
+#define TS_SIGNATURE "rusEFI master.2024.06.15.hellen-gm-e67.577813057"

--- a/firmware/controllers/generated/signature_hellen-honda-k.h
+++ b/firmware/controllers/generated/signature_hellen-honda-k.h
@@ -2,5 +2,5 @@
 // was generated automatically by rusEFI tool config_definition-all.jar based on gen_config.sh by SignatureConsumer
 //
 
-#define SIGNATURE_HASH 3712278870
-#define TS_SIGNATURE "rusEFI master.2024.06.15.hellen-honda-k.3712278870"
+#define SIGNATURE_HASH 2341872089
+#define TS_SIGNATURE "rusEFI master.2024.06.15.hellen-honda-k.2341872089"

--- a/firmware/controllers/generated/signature_hellen-nb1.h
+++ b/firmware/controllers/generated/signature_hellen-nb1.h
@@ -2,5 +2,5 @@
 // was generated automatically by rusEFI tool config_definition-all.jar based on gen_config.sh by SignatureConsumer
 //
 
-#define SIGNATURE_HASH 1371794262
-#define TS_SIGNATURE "rusEFI master.2024.06.15.hellen-nb1.1371794262"
+#define SIGNATURE_HASH 118565849
+#define TS_SIGNATURE "rusEFI master.2024.06.15.hellen-nb1.118565849"

--- a/firmware/controllers/generated/signature_hellen121nissan.h
+++ b/firmware/controllers/generated/signature_hellen121nissan.h
@@ -2,5 +2,5 @@
 // was generated automatically by rusEFI tool config_definition-all.jar based on gen_config.sh by SignatureConsumer
 //
 
-#define SIGNATURE_HASH 4254515165
-#define TS_SIGNATURE "rusEFI master.2024.06.15.hellen121nissan.4254515165"
+#define SIGNATURE_HASH 2873392978
+#define TS_SIGNATURE "rusEFI master.2024.06.15.hellen121nissan.2873392978"

--- a/firmware/controllers/generated/signature_hellen121vag.h
+++ b/firmware/controllers/generated/signature_hellen121vag.h
@@ -2,5 +2,5 @@
 // was generated automatically by rusEFI tool config_definition-all.jar based on gen_config.sh by SignatureConsumer
 //
 
-#define SIGNATURE_HASH 2292318352
-#define TS_SIGNATURE "rusEFI master.2024.06.15.hellen121vag.2292318352"
+#define SIGNATURE_HASH 3731931167
+#define TS_SIGNATURE "rusEFI master.2024.06.15.hellen121vag.3731931167"

--- a/firmware/controllers/generated/signature_hellen128.h
+++ b/firmware/controllers/generated/signature_hellen128.h
@@ -2,5 +2,5 @@
 // was generated automatically by rusEFI tool config_definition-all.jar based on gen_config.sh by SignatureConsumer
 //
 
-#define SIGNATURE_HASH 1430861697
-#define TS_SIGNATURE "rusEFI master.2024.06.15.hellen128.1430861697"
+#define SIGNATURE_HASH 60552974
+#define TS_SIGNATURE "rusEFI master.2024.06.15.hellen128.60552974"

--- a/firmware/controllers/generated/signature_hellen154hyundai.h
+++ b/firmware/controllers/generated/signature_hellen154hyundai.h
@@ -2,5 +2,5 @@
 // was generated automatically by rusEFI tool config_definition-all.jar based on gen_config.sh by SignatureConsumer
 //
 
-#define SIGNATURE_HASH 1260422401
-#define TS_SIGNATURE "rusEFI master.2024.06.15.hellen154hyundai.1260422401"
+#define SIGNATURE_HASH 502416782
+#define TS_SIGNATURE "rusEFI master.2024.06.15.hellen154hyundai.502416782"

--- a/firmware/controllers/generated/signature_hellen154hyundai_f7.h
+++ b/firmware/controllers/generated/signature_hellen154hyundai_f7.h
@@ -2,5 +2,5 @@
 // was generated automatically by rusEFI tool config_definition-all.jar based on gen_config.sh by SignatureConsumer
 //
 
-#define SIGNATURE_HASH 1425506992
-#define TS_SIGNATURE "rusEFI master.2024.06.15.hellen154hyundai_f7.1425506992"
+#define SIGNATURE_HASH 35996223
+#define TS_SIGNATURE "rusEFI master.2024.06.15.hellen154hyundai_f7.35996223"

--- a/firmware/controllers/generated/signature_hellen72.h
+++ b/firmware/controllers/generated/signature_hellen72.h
@@ -2,5 +2,5 @@
 // was generated automatically by rusEFI tool config_definition-all.jar based on gen_config.sh by SignatureConsumer
 //
 
-#define SIGNATURE_HASH 943385066
-#define TS_SIGNATURE "rusEFI master.2024.06.15.hellen72.943385066"
+#define SIGNATURE_HASH 1860708709
+#define TS_SIGNATURE "rusEFI master.2024.06.15.hellen72.1860708709"

--- a/firmware/controllers/generated/signature_hellen81.h
+++ b/firmware/controllers/generated/signature_hellen81.h
@@ -2,5 +2,5 @@
 // was generated automatically by rusEFI tool config_definition-all.jar based on gen_config.sh by SignatureConsumer
 //
 
-#define SIGNATURE_HASH 3712716176
-#define TS_SIGNATURE "rusEFI master.2024.06.15.hellen81.3712716176"
+#define SIGNATURE_HASH 2342079775
+#define TS_SIGNATURE "rusEFI master.2024.06.15.hellen81.2342079775"

--- a/firmware/controllers/generated/signature_hellen88bmw.h
+++ b/firmware/controllers/generated/signature_hellen88bmw.h
@@ -2,5 +2,5 @@
 // was generated automatically by rusEFI tool config_definition-all.jar based on gen_config.sh by SignatureConsumer
 //
 
-#define SIGNATURE_HASH 3395852499
-#define TS_SIGNATURE "rusEFI master.2024.06.15.hellen88bmw.3395852499"
+#define SIGNATURE_HASH 2629458012
+#define TS_SIGNATURE "rusEFI master.2024.06.15.hellen88bmw.2629458012"

--- a/firmware/controllers/generated/signature_hellenNA6.h
+++ b/firmware/controllers/generated/signature_hellenNA6.h
@@ -2,5 +2,5 @@
 // was generated automatically by rusEFI tool config_definition-all.jar based on gen_config.sh by SignatureConsumer
 //
 
-#define SIGNATURE_HASH 746520214
-#define TS_SIGNATURE "rusEFI master.2024.06.15.hellenNA6.746520214"
+#define SIGNATURE_HASH 2058108441
+#define TS_SIGNATURE "rusEFI master.2024.06.15.hellenNA6.2058108441"

--- a/firmware/controllers/generated/signature_hellenNA8_96.h
+++ b/firmware/controllers/generated/signature_hellenNA8_96.h
@@ -2,5 +2,5 @@
 // was generated automatically by rusEFI tool config_definition-all.jar based on gen_config.sh by SignatureConsumer
 //
 
-#define SIGNATURE_HASH 3550788696
-#define TS_SIGNATURE "rusEFI master.2024.06.15.hellenNA8_96.3550788696"
+#define SIGNATURE_HASH 2239134935
+#define TS_SIGNATURE "rusEFI master.2024.06.15.hellenNA8_96.2239134935"

--- a/firmware/controllers/generated/signature_m74_9.h
+++ b/firmware/controllers/generated/signature_m74_9.h
@@ -2,5 +2,5 @@
 // was generated automatically by rusEFI tool config_definition-all.jar based on gen_config.sh by SignatureConsumer
 //
 
-#define SIGNATURE_HASH 207693225
-#define TS_SIGNATURE "rusEFI master.2024.06.15.m74_9.207693225"
+#define SIGNATURE_HASH 1521739046
+#define TS_SIGNATURE "rusEFI master.2024.06.15.m74_9.1521739046"

--- a/firmware/controllers/generated/signature_mre-legacy_f4.h
+++ b/firmware/controllers/generated/signature_mre-legacy_f4.h
@@ -2,5 +2,5 @@
 // was generated automatically by rusEFI tool config_definition-all.jar based on gen_config.sh by SignatureConsumer
 //
 
-#define SIGNATURE_HASH 2784780345
-#define TS_SIGNATURE "rusEFI master.2024.06.15.mre-legacy_f4.2784780345"
+#define SIGNATURE_HASH 4079919286
+#define TS_SIGNATURE "rusEFI master.2024.06.15.mre-legacy_f4.4079919286"

--- a/firmware/controllers/generated/signature_mre_f4.h
+++ b/firmware/controllers/generated/signature_mre_f4.h
@@ -2,5 +2,5 @@
 // was generated automatically by rusEFI tool config_definition-all.jar based on gen_config.sh by SignatureConsumer
 //
 
-#define SIGNATURE_HASH 2784780345
-#define TS_SIGNATURE "rusEFI master.2024.06.15.mre_f4.2784780345"
+#define SIGNATURE_HASH 4079919286
+#define TS_SIGNATURE "rusEFI master.2024.06.15.mre_f4.4079919286"

--- a/firmware/controllers/generated/signature_mre_f7.h
+++ b/firmware/controllers/generated/signature_mre_f7.h
@@ -2,5 +2,5 @@
 // was generated automatically by rusEFI tool config_definition-all.jar based on gen_config.sh by SignatureConsumer
 //
 
-#define SIGNATURE_HASH 2784780345
-#define TS_SIGNATURE "rusEFI master.2024.06.15.mre_f7.2784780345"
+#define SIGNATURE_HASH 4079919286
+#define TS_SIGNATURE "rusEFI master.2024.06.15.mre_f7.4079919286"

--- a/firmware/controllers/generated/signature_nucleo_f413.h
+++ b/firmware/controllers/generated/signature_nucleo_f413.h
@@ -2,5 +2,5 @@
 // was generated automatically by rusEFI tool config_definition-all.jar based on gen_config.sh by SignatureConsumer
 //
 
-#define SIGNATURE_HASH 3101367670
-#define TS_SIGNATURE "rusEFI master.2024.06.15.nucleo_f413.3101367670"
+#define SIGNATURE_HASH 3993624057
+#define TS_SIGNATURE "rusEFI master.2024.06.15.nucleo_f413.3993624057"

--- a/firmware/controllers/generated/signature_prometheus_405.h
+++ b/firmware/controllers/generated/signature_prometheus_405.h
@@ -2,5 +2,5 @@
 // was generated automatically by rusEFI tool config_definition-all.jar based on gen_config.sh by SignatureConsumer
 //
 
-#define SIGNATURE_HASH 2286932198
-#define TS_SIGNATURE "rusEFI master.2024.06.15.prometheus_405.2286932198"
+#define SIGNATURE_HASH 3734835305
+#define TS_SIGNATURE "rusEFI master.2024.06.15.prometheus_405.3734835305"

--- a/firmware/controllers/generated/signature_prometheus_469.h
+++ b/firmware/controllers/generated/signature_prometheus_469.h
@@ -2,5 +2,5 @@
 // was generated automatically by rusEFI tool config_definition-all.jar based on gen_config.sh by SignatureConsumer
 //
 
-#define SIGNATURE_HASH 2286932198
-#define TS_SIGNATURE "rusEFI master.2024.06.15.prometheus_469.2286932198"
+#define SIGNATURE_HASH 3734835305
+#define TS_SIGNATURE "rusEFI master.2024.06.15.prometheus_469.3734835305"

--- a/firmware/controllers/generated/signature_proteus_f4.h
+++ b/firmware/controllers/generated/signature_proteus_f4.h
@@ -2,5 +2,5 @@
 // was generated automatically by rusEFI tool config_definition-all.jar based on gen_config.sh by SignatureConsumer
 //
 
-#define SIGNATURE_HASH 1388357460
-#define TS_SIGNATURE "rusEFI master.2024.06.15.proteus_f4.1388357460"
+#define SIGNATURE_HASH 68315099
+#define TS_SIGNATURE "rusEFI master.2024.06.15.proteus_f4.68315099"

--- a/firmware/controllers/generated/signature_proteus_f7.h
+++ b/firmware/controllers/generated/signature_proteus_f7.h
@@ -2,5 +2,5 @@
 // was generated automatically by rusEFI tool config_definition-all.jar based on gen_config.sh by SignatureConsumer
 //
 
-#define SIGNATURE_HASH 1388357460
-#define TS_SIGNATURE "rusEFI master.2024.06.15.proteus_f7.1388357460"
+#define SIGNATURE_HASH 68315099
+#define TS_SIGNATURE "rusEFI master.2024.06.15.proteus_f7.68315099"

--- a/firmware/controllers/generated/signature_proteus_h7.h
+++ b/firmware/controllers/generated/signature_proteus_h7.h
@@ -2,5 +2,5 @@
 // was generated automatically by rusEFI tool config_definition-all.jar based on gen_config.sh by SignatureConsumer
 //
 
-#define SIGNATURE_HASH 1388357460
-#define TS_SIGNATURE "rusEFI master.2024.06.15.proteus_h7.1388357460"
+#define SIGNATURE_HASH 68315099
+#define TS_SIGNATURE "rusEFI master.2024.06.15.proteus_h7.68315099"

--- a/firmware/controllers/generated/signature_s105.h
+++ b/firmware/controllers/generated/signature_s105.h
@@ -2,5 +2,5 @@
 // was generated automatically by rusEFI tool config_definition-all.jar based on gen_config.sh by SignatureConsumer
 //
 
-#define SIGNATURE_HASH 122723764
-#define TS_SIGNATURE "rusEFI master.2024.06.15.s105.122723764"
+#define SIGNATURE_HASH 1367498043
+#define TS_SIGNATURE "rusEFI master.2024.06.15.s105.1367498043"

--- a/firmware/controllers/generated/signature_small-can-board.h
+++ b/firmware/controllers/generated/signature_small-can-board.h
@@ -2,5 +2,5 @@
 // was generated automatically by rusEFI tool config_definition-all.jar based on gen_config.sh by SignatureConsumer
 //
 
-#define SIGNATURE_HASH 506871636
-#define TS_SIGNATURE "rusEFI master.2024.06.15.small-can-board.506871636"
+#define SIGNATURE_HASH 1222967259
+#define TS_SIGNATURE "rusEFI master.2024.06.15.small-can-board.1222967259"

--- a/firmware/controllers/generated/signature_stm32f429_nucleo.h
+++ b/firmware/controllers/generated/signature_stm32f429_nucleo.h
@@ -2,5 +2,5 @@
 // was generated automatically by rusEFI tool config_definition-all.jar based on gen_config.sh by SignatureConsumer
 //
 
-#define SIGNATURE_HASH 3101367670
-#define TS_SIGNATURE "rusEFI master.2024.06.15.stm32f429_nucleo.3101367670"
+#define SIGNATURE_HASH 3993624057
+#define TS_SIGNATURE "rusEFI master.2024.06.15.stm32f429_nucleo.3993624057"

--- a/firmware/controllers/generated/signature_stm32f767_nucleo.h
+++ b/firmware/controllers/generated/signature_stm32f767_nucleo.h
@@ -2,5 +2,5 @@
 // was generated automatically by rusEFI tool config_definition-all.jar based on gen_config.sh by SignatureConsumer
 //
 
-#define SIGNATURE_HASH 3101367670
-#define TS_SIGNATURE "rusEFI master.2024.06.15.stm32f767_nucleo.3101367670"
+#define SIGNATURE_HASH 3993624057
+#define TS_SIGNATURE "rusEFI master.2024.06.15.stm32f767_nucleo.3993624057"

--- a/firmware/controllers/generated/signature_stm32h743_nucleo.h
+++ b/firmware/controllers/generated/signature_stm32h743_nucleo.h
@@ -2,5 +2,5 @@
 // was generated automatically by rusEFI tool config_definition-all.jar based on gen_config.sh by SignatureConsumer
 //
 
-#define SIGNATURE_HASH 3101367670
-#define TS_SIGNATURE "rusEFI master.2024.06.15.stm32h743_nucleo.3101367670"
+#define SIGNATURE_HASH 3993624057
+#define TS_SIGNATURE "rusEFI master.2024.06.15.stm32h743_nucleo.3993624057"

--- a/firmware/controllers/generated/signature_subaru_eg33_f7.h
+++ b/firmware/controllers/generated/signature_subaru_eg33_f7.h
@@ -2,5 +2,5 @@
 // was generated automatically by rusEFI tool config_definition-all.jar based on gen_config.sh by SignatureConsumer
 //
 
-#define SIGNATURE_HASH 4065659205
-#define TS_SIGNATURE "rusEFI master.2024.06.15.subaru_eg33_f7.4065659205"
+#define SIGNATURE_HASH 2760362442
+#define TS_SIGNATURE "rusEFI master.2024.06.15.subaru_eg33_f7.2760362442"

--- a/firmware/controllers/generated/signature_t-b-g.h
+++ b/firmware/controllers/generated/signature_t-b-g.h
@@ -2,5 +2,5 @@
 // was generated automatically by rusEFI tool config_definition-all.jar based on gen_config.sh by SignatureConsumer
 //
 
-#define SIGNATURE_HASH 3101367670
-#define TS_SIGNATURE "rusEFI master.2024.06.15.t-b-g.3101367670"
+#define SIGNATURE_HASH 3993624057
+#define TS_SIGNATURE "rusEFI master.2024.06.15.t-b-g.3993624057"

--- a/firmware/controllers/generated/signature_tdg-pdm8.h
+++ b/firmware/controllers/generated/signature_tdg-pdm8.h
@@ -2,5 +2,5 @@
 // was generated automatically by rusEFI tool config_definition-all.jar based on gen_config.sh by SignatureConsumer
 //
 
-#define SIGNATURE_HASH 2197201406
-#define TS_SIGNATURE "rusEFI master.2024.06.15.tdg-pdm8.2197201406"
+#define SIGNATURE_HASH 3559154033
+#define TS_SIGNATURE "rusEFI master.2024.06.15.tdg-pdm8.3559154033"

--- a/firmware/controllers/generated/signature_uaefi.h
+++ b/firmware/controllers/generated/signature_uaefi.h
@@ -2,5 +2,5 @@
 // was generated automatically by rusEFI tool config_definition-all.jar based on gen_config.sh by SignatureConsumer
 //
 
-#define SIGNATURE_HASH 3265355853
-#define TS_SIGNATURE "rusEFI master.2024.06.15.uaefi.3265355853"
+#define SIGNATURE_HASH 2490605762
+#define TS_SIGNATURE "rusEFI master.2024.06.15.uaefi.2490605762"

--- a/firmware/controllers/generated/signature_uaefi121.h
+++ b/firmware/controllers/generated/signature_uaefi121.h
@@ -2,5 +2,5 @@
 // was generated automatically by rusEFI tool config_definition-all.jar based on gen_config.sh by SignatureConsumer
 //
 
-#define SIGNATURE_HASH 3928798276
-#define TS_SIGNATURE "rusEFI master.2024.06.15.uaefi121.3928798276"
+#define SIGNATURE_HASH 3170792651
+#define TS_SIGNATURE "rusEFI master.2024.06.15.uaefi121.3170792651"

--- a/firmware/controllers/lua/generated/value_lookup_generated.cpp
+++ b/firmware/controllers/lua/generated/value_lookup_generated.cpp
@@ -712,6 +712,9 @@ float getConfigValueByName(const char *name) {
 // triggerEventsTimeoutMs
 		case 665024981:
 			return engineConfiguration->triggerEventsTimeoutMs;
+// mapExpAverageAlpha
+		case -1852204335:
+			return engineConfiguration->mapExpAverageAlpha;
 // magicNumberAvailableForDevTricks
 		case -2071167002:
 			return engineConfiguration->magicNumberAvailableForDevTricks;
@@ -3033,6 +3036,11 @@ bool setConfigValueByName(const char *name, float value) {
 		case 665024981:
 	{
 		engineConfiguration->triggerEventsTimeoutMs = value;
+		return 1;
+	}
+		case -1852204335:
+	{
+		engineConfiguration->mapExpAverageAlpha = value;
 		return 1;
 	}
 		case -2071167002:

--- a/firmware/controllers/lua/generated/value_lookup_generated.md
+++ b/firmware/controllers/lua/generated/value_lookup_generated.md
@@ -706,6 +706,9 @@ Starting Launch RPM window to activate (subtracts from Launch RPM)
 ### triggerEventsTimeoutMs
 
 
+### mapExpAverageAlpha
+
+
 ### magicNumberAvailableForDevTricks
 null
 

--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -988,7 +988,7 @@ bit verboseCan2,"Print all","Do not print";Print incoming and outgoing second bu
     int launchSpeedThreshold;Launch disabled above this speed if setting is above zero;"Kph", 1, 0, 0, 300, 0
     int launchRpmWindow;Starting Launch RPM window to activate (subtracts from Launch RPM);"RPM", 1, 0, 0, 8000, 0
     float triggerEventsTimeoutMs;;"ms", 1, 0, 0, 3000, 3
-    int unusedHere13
+    float mapExpAverageAlpha;;"", 1, 0, 0, 3000, 3
 	float magicNumberAvailableForDevTricks
 	float turbochargerFilter
 	int launchTpsThreshold;;"", 1, 0, 0, 20000, 0

--- a/firmware/tunerstudio/generated/rusefi.ini
+++ b/firmware/tunerstudio/generated/rusefi.ini
@@ -38,12 +38,12 @@ enable2ndByteCanID = false
 
 [MegaTune]
  ; https://rusefi.com/forum/viewtopic.php?p=36201#p36201
-	signature	= "rusEFI master.2024.06.15.f407-discovery.478864919"
+	signature	= "rusEFI master.2024.06.15.f407-discovery.1247291032"
 
 [TunerStudio]
 	queryCommand	= "S"
 	versionInfo	= "V"  ; firmware version for title bar.
-	signature= "rusEFI master.2024.06.15.f407-discovery.478864919" ; signature is expected to be 7 or more characters.
+	signature= "rusEFI master.2024.06.15.f407-discovery.1247291032" ; signature is expected to be 7 or more characters.
 
 	; TS will try to use legacy temp units in some cases, showing "deg F" on a CLT gauge that's actually deg C
 	useLegacyFTempUnits = false
@@ -100,7 +100,7 @@ enable2ndByteCanID = false
 #define adc_channel_e_list="Disabled", "PA0", "PA1", "PA2", "PA3", "PA4", "PA5", "PA6", "PA7", "PB0", "PB1", "PC0", "PC1", "PC2", "PC3", "PC4", "PC5"
 
 ; CONFIG_DEFINITION_START
-; this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:26:27 UTC 2024
+; this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:58:29 UTC 2024
 
 pageSize            = 22748
 page = 1
@@ -538,7 +538,7 @@ noFuelTrimAfterDfcoTime = scalar, U08, 979, "sec", 0.1, 0, 0, 10, 1
 launchSpeedThreshold = scalar, S32, 980, "Kph", 1, 0, 0, 300, 0
 launchRpmWindow = scalar, S32, 984, "RPM", 1, 0, 0, 8000, 0
 triggerEventsTimeoutMs = scalar, F32, 988, "ms", 1, 0, 0, 3000, 3
-unusedHere13 = scalar, S32, 992, "", 1, 0, 0, 100, 0
+mapExpAverageAlpha = scalar, F32, 992, "", 1, 0, 0, 3000, 3
 magicNumberAvailableForDevTricks = scalar, F32, 996, "", 1, 0, 0, 100, 0
 turbochargerFilter = scalar, F32, 1000, "", 1, 0, 0, 100, 0
 launchTpsThreshold = scalar, S32, 1004, "", 1, 0, 0, 20000, 0
@@ -9423,6 +9423,7 @@ dialog = tcuControls, "Transmission Settings"
 
     dialog = parkingLot3, "Experimental 3"
         field = triggerEventsTimeoutMs,   triggerEventsTimeoutMs
+        field = mapExpAverageAlpha, mapExpAverageAlpha
         field = devBit0,         devBit0
         field = devBit1,         devBit1
         field = devBit2,         devBit2

--- a/firmware/tunerstudio/generated/rusefi_alphax-2chan.ini
+++ b/firmware/tunerstudio/generated/rusefi_alphax-2chan.ini
@@ -38,12 +38,12 @@ enable2ndByteCanID = false
 
 [MegaTune]
  ; https://rusefi.com/forum/viewtopic.php?p=36201#p36201
-	signature	= "rusEFI master.2024.06.15.alphax-2chan.848521784"
+	signature	= "rusEFI master.2024.06.15.alphax-2chan.1682025143"
 
 [TunerStudio]
 	queryCommand	= "S"
 	versionInfo	= "V"  ; firmware version for title bar.
-	signature= "rusEFI master.2024.06.15.alphax-2chan.848521784" ; signature is expected to be 7 or more characters.
+	signature= "rusEFI master.2024.06.15.alphax-2chan.1682025143" ; signature is expected to be 7 or more characters.
 
 	; TS will try to use legacy temp units in some cases, showing "deg F" on a CLT gauge that's actually deg C
 	useLegacyFTempUnits = false
@@ -100,7 +100,7 @@ enable2ndByteCanID = false
 #define adc_channel_e_list="NONE","INVALID","B4 - O2","On-board MAP","INVALID","B5 - TPS","A2 Battery Sense","C7 - CAM Hall/Digital","INVALID","X1 - AIN1","INVALID","INVALID","B2 - MAP","B7 - CLT","B3 - IAT","X3 - AIN2","X7 - AIN4"
 
 ; CONFIG_DEFINITION_START
-; this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:25:51 UTC 2024
+; this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:57:52 UTC 2024
 
 pageSize            = 22748
 page = 1
@@ -538,7 +538,7 @@ noFuelTrimAfterDfcoTime = scalar, U08, 979, "sec", 0.1, 0, 0, 10, 1
 launchSpeedThreshold = scalar, S32, 980, "Kph", 1, 0, 0, 300, 0
 launchRpmWindow = scalar, S32, 984, "RPM", 1, 0, 0, 8000, 0
 triggerEventsTimeoutMs = scalar, F32, 988, "ms", 1, 0, 0, 3000, 3
-unusedHere13 = scalar, S32, 992, "", 1, 0, 0, 100, 0
+mapExpAverageAlpha = scalar, F32, 992, "", 1, 0, 0, 3000, 3
 magicNumberAvailableForDevTricks = scalar, F32, 996, "", 1, 0, 0, 100, 0
 turbochargerFilter = scalar, F32, 1000, "", 1, 0, 0, 100, 0
 launchTpsThreshold = scalar, S32, 1004, "", 1, 0, 0, 20000, 0
@@ -9360,6 +9360,7 @@ dialog = tcuControls, "Transmission Settings"
 
     dialog = parkingLot3, "Experimental 3"
         field = triggerEventsTimeoutMs,   triggerEventsTimeoutMs
+        field = mapExpAverageAlpha, mapExpAverageAlpha
         field = devBit0,         devBit0
         field = devBit1,         devBit1
         field = devBit2,         devBit2

--- a/firmware/tunerstudio/generated/rusefi_alphax-4chan.ini
+++ b/firmware/tunerstudio/generated/rusefi_alphax-4chan.ini
@@ -38,12 +38,12 @@ enable2ndByteCanID = false
 
 [MegaTune]
  ; https://rusefi.com/forum/viewtopic.php?p=36201#p36201
-	signature	= "rusEFI master.2024.06.15.alphax-4chan.242120885"
+	signature	= "rusEFI master.2024.06.15.alphax-4chan.1488762938"
 
 [TunerStudio]
 	queryCommand	= "S"
 	versionInfo	= "V"  ; firmware version for title bar.
-	signature= "rusEFI master.2024.06.15.alphax-4chan.242120885" ; signature is expected to be 7 or more characters.
+	signature= "rusEFI master.2024.06.15.alphax-4chan.1488762938" ; signature is expected to be 7 or more characters.
 
 	; TS will try to use legacy temp units in some cases, showing "deg F" on a CLT gauge that's actually deg C
 	useLegacyFTempUnits = false
@@ -100,7 +100,7 @@ enable2ndByteCanID = false
 #define adc_channel_e_list="NONE","INVALID","B4 - O2","On-board MAP","D5 - PPS","B5 - TPS","F7 - Ignition Key Voltage","C7 - CAM Hall/Digital","X7 - AIN4","D4 - TPS2","INVALID","X5 - AIN3","B2 - MAP","B7 - CLT","B3 - IAT","F6 - PPS2","INVALID","INVALID","INVALID","INVALID","X3 - AIN2","X1 - AIN1 and D5 on older boards"
 
 ; CONFIG_DEFINITION_START
-; this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:25:28 UTC 2024
+; this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:57:29 UTC 2024
 
 pageSize            = 22748
 page = 1
@@ -538,7 +538,7 @@ noFuelTrimAfterDfcoTime = scalar, U08, 979, "sec", 0.1, 0, 0, 10, 1
 launchSpeedThreshold = scalar, S32, 980, "Kph", 1, 0, 0, 300, 0
 launchRpmWindow = scalar, S32, 984, "RPM", 1, 0, 0, 8000, 0
 triggerEventsTimeoutMs = scalar, F32, 988, "ms", 1, 0, 0, 3000, 3
-unusedHere13 = scalar, S32, 992, "", 1, 0, 0, 100, 0
+mapExpAverageAlpha = scalar, F32, 992, "", 1, 0, 0, 3000, 3
 magicNumberAvailableForDevTricks = scalar, F32, 996, "", 1, 0, 0, 100, 0
 turbochargerFilter = scalar, F32, 1000, "", 1, 0, 0, 100, 0
 launchTpsThreshold = scalar, S32, 1004, "", 1, 0, 0, 20000, 0
@@ -9390,6 +9390,7 @@ dialog = tcuControls, "Transmission Settings"
 
     dialog = parkingLot3, "Experimental 3"
         field = triggerEventsTimeoutMs,   triggerEventsTimeoutMs
+        field = mapExpAverageAlpha, mapExpAverageAlpha
         field = devBit0,         devBit0
         field = devBit1,         devBit1
         field = devBit2,         devBit2

--- a/firmware/tunerstudio/generated/rusefi_alphax-4chan_f7.ini
+++ b/firmware/tunerstudio/generated/rusefi_alphax-4chan_f7.ini
@@ -38,12 +38,12 @@ enable2ndByteCanID = false
 
 [MegaTune]
  ; https://rusefi.com/forum/viewtopic.php?p=36201#p36201
-	signature	= "rusEFI master.2024.06.15.alphax-4chan_f7.242120885"
+	signature	= "rusEFI master.2024.06.15.alphax-4chan_f7.1488762938"
 
 [TunerStudio]
 	queryCommand	= "S"
 	versionInfo	= "V"  ; firmware version for title bar.
-	signature= "rusEFI master.2024.06.15.alphax-4chan_f7.242120885" ; signature is expected to be 7 or more characters.
+	signature= "rusEFI master.2024.06.15.alphax-4chan_f7.1488762938" ; signature is expected to be 7 or more characters.
 
 	; TS will try to use legacy temp units in some cases, showing "deg F" on a CLT gauge that's actually deg C
 	useLegacyFTempUnits = false
@@ -100,7 +100,7 @@ enable2ndByteCanID = false
 #define adc_channel_e_list="NONE","INVALID","B4 - O2","On-board MAP","D5 - PPS","B5 - TPS","F7 - Ignition Key Voltage","C7 - CAM Hall/Digital","X7 - AIN4","D4 - TPS2","INVALID","X5 - AIN3","B2 - MAP","B7 - CLT","B3 - IAT","F6 - PPS2","INVALID","INVALID","INVALID","INVALID","X3 - AIN2","X1 - AIN1 and D5 on older boards"
 
 ; CONFIG_DEFINITION_START
-; this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:25:26 UTC 2024
+; this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:57:27 UTC 2024
 
 pageSize            = 22748
 page = 1
@@ -538,7 +538,7 @@ noFuelTrimAfterDfcoTime = scalar, U08, 979, "sec", 0.1, 0, 0, 10, 1
 launchSpeedThreshold = scalar, S32, 980, "Kph", 1, 0, 0, 300, 0
 launchRpmWindow = scalar, S32, 984, "RPM", 1, 0, 0, 8000, 0
 triggerEventsTimeoutMs = scalar, F32, 988, "ms", 1, 0, 0, 3000, 3
-unusedHere13 = scalar, S32, 992, "", 1, 0, 0, 100, 0
+mapExpAverageAlpha = scalar, F32, 992, "", 1, 0, 0, 3000, 3
 magicNumberAvailableForDevTricks = scalar, F32, 996, "", 1, 0, 0, 100, 0
 turbochargerFilter = scalar, F32, 1000, "", 1, 0, 0, 100, 0
 launchTpsThreshold = scalar, S32, 1004, "", 1, 0, 0, 20000, 0
@@ -9390,6 +9390,7 @@ dialog = tcuControls, "Transmission Settings"
 
     dialog = parkingLot3, "Experimental 3"
         field = triggerEventsTimeoutMs,   triggerEventsTimeoutMs
+        field = mapExpAverageAlpha, mapExpAverageAlpha
         field = devBit0,         devBit0
         field = devBit1,         devBit1
         field = devBit2,         devBit2

--- a/firmware/tunerstudio/generated/rusefi_alphax-8chan-revA.ini
+++ b/firmware/tunerstudio/generated/rusefi_alphax-8chan-revA.ini
@@ -38,12 +38,12 @@ enable2ndByteCanID = false
 
 [MegaTune]
  ; https://rusefi.com/forum/viewtopic.php?p=36201#p36201
-	signature	= "rusEFI master.2024.06.15.alphax-8chan-revA.98862663"
+	signature	= "rusEFI master.2024.06.15.alphax-8chan-revA.1396065992"
 
 [TunerStudio]
 	queryCommand	= "S"
 	versionInfo	= "V"  ; firmware version for title bar.
-	signature= "rusEFI master.2024.06.15.alphax-8chan-revA.98862663" ; signature is expected to be 7 or more characters.
+	signature= "rusEFI master.2024.06.15.alphax-8chan-revA.1396065992" ; signature is expected to be 7 or more characters.
 
 	; TS will try to use legacy temp units in some cases, showing "deg F" on a CLT gauge that's actually deg C
 	useLegacyFTempUnits = false
@@ -100,7 +100,7 @@ enable2ndByteCanID = false
 #define adc_channel_e_list="NONE","INVALID","INVALID","INVALID","17A - PPS","23C - TPS","Battery Sense","INVALID","15D - AN5","24C - TPS2","14A - Analog 1","22A - Analog 22","On-board MAP","16A - CLT","15A - IAT","31C - PPS2","33A - AN3","INVALID","INVALID","INVALID","INVALID","INVALID","INVALID","INVALID","16D - AN6","INVALID","INVALID","INVALID","INVALID","7C - AT4","INVALID","6C - AT3","14D - AN4"
 
 ; CONFIG_DEFINITION_START
-; this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:25:17 UTC 2024
+; this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:57:18 UTC 2024
 
 pageSize            = 22748
 page = 1
@@ -538,7 +538,7 @@ noFuelTrimAfterDfcoTime = scalar, U08, 979, "sec", 0.1, 0, 0, 10, 1
 launchSpeedThreshold = scalar, S32, 980, "Kph", 1, 0, 0, 300, 0
 launchRpmWindow = scalar, S32, 984, "RPM", 1, 0, 0, 8000, 0
 triggerEventsTimeoutMs = scalar, F32, 988, "ms", 1, 0, 0, 3000, 3
-unusedHere13 = scalar, S32, 992, "", 1, 0, 0, 100, 0
+mapExpAverageAlpha = scalar, F32, 992, "", 1, 0, 0, 3000, 3
 magicNumberAvailableForDevTricks = scalar, F32, 996, "", 1, 0, 0, 100, 0
 turbochargerFilter = scalar, F32, 1000, "", 1, 0, 0, 100, 0
 launchTpsThreshold = scalar, S32, 1004, "", 1, 0, 0, 20000, 0
@@ -9368,6 +9368,7 @@ dialog = tcuControls, "Transmission Settings"
 
     dialog = parkingLot3, "Experimental 3"
         field = triggerEventsTimeoutMs,   triggerEventsTimeoutMs
+        field = mapExpAverageAlpha, mapExpAverageAlpha
         field = devBit0,         devBit0
         field = devBit1,         devBit1
         field = devBit2,         devBit2

--- a/firmware/tunerstudio/generated/rusefi_alphax-8chan.ini
+++ b/firmware/tunerstudio/generated/rusefi_alphax-8chan.ini
@@ -38,12 +38,12 @@ enable2ndByteCanID = false
 
 [MegaTune]
  ; https://rusefi.com/forum/viewtopic.php?p=36201#p36201
-	signature	= "rusEFI master.2024.06.15.alphax-8chan.1045018647"
+	signature	= "rusEFI master.2024.06.15.alphax-8chan.1755019416"
 
 [TunerStudio]
 	queryCommand	= "S"
 	versionInfo	= "V"  ; firmware version for title bar.
-	signature= "rusEFI master.2024.06.15.alphax-8chan.1045018647" ; signature is expected to be 7 or more characters.
+	signature= "rusEFI master.2024.06.15.alphax-8chan.1755019416" ; signature is expected to be 7 or more characters.
 
 	; TS will try to use legacy temp units in some cases, showing "deg F" on a CLT gauge that's actually deg C
 	useLegacyFTempUnits = false
@@ -100,7 +100,7 @@ enable2ndByteCanID = false
 #define adc_channel_e_list="NONE","INVALID","3A - Aux Analog 2","On-board MAP","32A - PPS Sensor Input","31A - TPS Sensor Input","24 - Ignition Key Voltage","INVALID","INVALID","19A - Aux Analog 6","1A - Aux Analog 1","2A - Aux Analog 4","INVALID","29A - CLT Sensor Input","27A - IAT Sensor Input","INVALID","12A - Aux Analog 8","INVALID","11A - Aux Analog 3","INVALID","34A - PPS2 Sensor Input","33A - TPS2 Sensor Input","INVALID","INVALID","INVALID","4A - Aux Analog 7","INVALID","10A - Aux Analog 5","INVALID","28A - Aux Temp 2","28A - Aux Temp 1","INVALID","20A - Aux Analog 9"
 
 ; CONFIG_DEFINITION_START
-; this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:25:41 UTC 2024
+; this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:57:42 UTC 2024
 
 pageSize            = 22764
 page = 1
@@ -538,7 +538,7 @@ noFuelTrimAfterDfcoTime = scalar, U08, 979, "sec", 0.1, 0, 0, 10, 1
 launchSpeedThreshold = scalar, S32, 980, "Kph", 1, 0, 0, 300, 0
 launchRpmWindow = scalar, S32, 984, "RPM", 1, 0, 0, 8000, 0
 triggerEventsTimeoutMs = scalar, F32, 988, "ms", 1, 0, 0, 3000, 3
-unusedHere13 = scalar, S32, 992, "", 1, 0, 0, 100, 0
+mapExpAverageAlpha = scalar, F32, 992, "", 1, 0, 0, 3000, 3
 magicNumberAvailableForDevTricks = scalar, F32, 996, "", 1, 0, 0, 100, 0
 turbochargerFilter = scalar, F32, 1000, "", 1, 0, 0, 100, 0
 launchTpsThreshold = scalar, S32, 1004, "", 1, 0, 0, 20000, 0
@@ -9372,6 +9372,7 @@ dialog = tcuControls, "Transmission Settings"
 
     dialog = parkingLot3, "Experimental 3"
         field = triggerEventsTimeoutMs,   triggerEventsTimeoutMs
+        field = mapExpAverageAlpha, mapExpAverageAlpha
         field = devBit0,         devBit0
         field = devBit1,         devBit1
         field = devBit2,         devBit2

--- a/firmware/tunerstudio/generated/rusefi_alphax-8chan_f7.ini
+++ b/firmware/tunerstudio/generated/rusefi_alphax-8chan_f7.ini
@@ -38,12 +38,12 @@ enable2ndByteCanID = false
 
 [MegaTune]
  ; https://rusefi.com/forum/viewtopic.php?p=36201#p36201
-	signature	= "rusEFI master.2024.06.15.alphax-8chan_f7.1045018647"
+	signature	= "rusEFI master.2024.06.15.alphax-8chan_f7.1755019416"
 
 [TunerStudio]
 	queryCommand	= "S"
 	versionInfo	= "V"  ; firmware version for title bar.
-	signature= "rusEFI master.2024.06.15.alphax-8chan_f7.1045018647" ; signature is expected to be 7 or more characters.
+	signature= "rusEFI master.2024.06.15.alphax-8chan_f7.1755019416" ; signature is expected to be 7 or more characters.
 
 	; TS will try to use legacy temp units in some cases, showing "deg F" on a CLT gauge that's actually deg C
 	useLegacyFTempUnits = false
@@ -100,7 +100,7 @@ enable2ndByteCanID = false
 #define adc_channel_e_list="NONE","INVALID","3A - Aux Analog 2","On-board MAP","32A - PPS Sensor Input","31A - TPS Sensor Input","24 - Ignition Key Voltage","INVALID","INVALID","19A - Aux Analog 6","1A - Aux Analog 1","2A - Aux Analog 4","INVALID","29A - CLT Sensor Input","27A - IAT Sensor Input","INVALID","12A - Aux Analog 8","INVALID","11A - Aux Analog 3","INVALID","34A - PPS2 Sensor Input","33A - TPS2 Sensor Input","INVALID","INVALID","INVALID","4A - Aux Analog 7","INVALID","10A - Aux Analog 5","INVALID","28A - Aux Temp 2","28A - Aux Temp 1","INVALID","20A - Aux Analog 9"
 
 ; CONFIG_DEFINITION_START
-; this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:25:40 UTC 2024
+; this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:57:41 UTC 2024
 
 pageSize            = 22764
 page = 1
@@ -538,7 +538,7 @@ noFuelTrimAfterDfcoTime = scalar, U08, 979, "sec", 0.1, 0, 0, 10, 1
 launchSpeedThreshold = scalar, S32, 980, "Kph", 1, 0, 0, 300, 0
 launchRpmWindow = scalar, S32, 984, "RPM", 1, 0, 0, 8000, 0
 triggerEventsTimeoutMs = scalar, F32, 988, "ms", 1, 0, 0, 3000, 3
-unusedHere13 = scalar, S32, 992, "", 1, 0, 0, 100, 0
+mapExpAverageAlpha = scalar, F32, 992, "", 1, 0, 0, 3000, 3
 magicNumberAvailableForDevTricks = scalar, F32, 996, "", 1, 0, 0, 100, 0
 turbochargerFilter = scalar, F32, 1000, "", 1, 0, 0, 100, 0
 launchTpsThreshold = scalar, S32, 1004, "", 1, 0, 0, 20000, 0
@@ -9372,6 +9372,7 @@ dialog = tcuControls, "Transmission Settings"
 
     dialog = parkingLot3, "Experimental 3"
         field = triggerEventsTimeoutMs,   triggerEventsTimeoutMs
+        field = mapExpAverageAlpha, mapExpAverageAlpha
         field = devBit0,         devBit0
         field = devBit1,         devBit1
         field = devBit2,         devBit2

--- a/firmware/tunerstudio/generated/rusefi_alphax-silver.ini
+++ b/firmware/tunerstudio/generated/rusefi_alphax-silver.ini
@@ -38,12 +38,12 @@ enable2ndByteCanID = false
 
 [MegaTune]
  ; https://rusefi.com/forum/viewtopic.php?p=36201#p36201
-	signature	= "rusEFI master.2024.06.15.alphax-silver.1889919833"
+	signature	= "rusEFI master.2024.06.15.alphax-silver.645342166"
 
 [TunerStudio]
 	queryCommand	= "S"
 	versionInfo	= "V"  ; firmware version for title bar.
-	signature= "rusEFI master.2024.06.15.alphax-silver.1889919833" ; signature is expected to be 7 or more characters.
+	signature= "rusEFI master.2024.06.15.alphax-silver.645342166" ; signature is expected to be 7 or more characters.
 
 	; TS will try to use legacy temp units in some cases, showing "deg F" on a CLT gauge that's actually deg C
 	useLegacyFTempUnits = false
@@ -100,7 +100,7 @@ enable2ndByteCanID = false
 #define adc_channel_e_list="Disabled", "PA0", "PA1", "PA2", "PA3", "PA4", "PA5", "PA6", "PA7", "PB0", "PB1", "PC0", "PC1", "PC2", "PC3", "PC4", "PC5"
 
 ; CONFIG_DEFINITION_START
-; this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:25:44 UTC 2024
+; this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:57:45 UTC 2024
 
 pageSize            = 22748
 page = 1
@@ -538,7 +538,7 @@ noFuelTrimAfterDfcoTime = scalar, U08, 979, "sec", 0.1, 0, 0, 10, 1
 launchSpeedThreshold = scalar, S32, 980, "Kph", 1, 0, 0, 300, 0
 launchRpmWindow = scalar, S32, 984, "RPM", 1, 0, 0, 8000, 0
 triggerEventsTimeoutMs = scalar, F32, 988, "ms", 1, 0, 0, 3000, 3
-unusedHere13 = scalar, S32, 992, "", 1, 0, 0, 100, 0
+mapExpAverageAlpha = scalar, F32, 992, "", 1, 0, 0, 3000, 3
 magicNumberAvailableForDevTricks = scalar, F32, 996, "", 1, 0, 0, 100, 0
 turbochargerFilter = scalar, F32, 1000, "", 1, 0, 0, 100, 0
 launchTpsThreshold = scalar, S32, 1004, "", 1, 0, 0, 20000, 0
@@ -9355,6 +9355,7 @@ dialog = tcuControls, "Transmission Settings"
 
     dialog = parkingLot3, "Experimental 3"
         field = triggerEventsTimeoutMs,   triggerEventsTimeoutMs
+        field = mapExpAverageAlpha, mapExpAverageAlpha
         field = devBit0,         devBit0
         field = devBit1,         devBit1
         field = devBit2,         devBit2

--- a/firmware/tunerstudio/generated/rusefi_at_start_f435.ini
+++ b/firmware/tunerstudio/generated/rusefi_at_start_f435.ini
@@ -38,12 +38,12 @@ enable2ndByteCanID = false
 
 [MegaTune]
  ; https://rusefi.com/forum/viewtopic.php?p=36201#p36201
-	signature	= "rusEFI master.2024.06.15.at_start_f435.3101367670"
+	signature	= "rusEFI master.2024.06.15.at_start_f435.3993624057"
 
 [TunerStudio]
 	queryCommand	= "S"
 	versionInfo	= "V"  ; firmware version for title bar.
-	signature= "rusEFI master.2024.06.15.at_start_f435.3101367670" ; signature is expected to be 7 or more characters.
+	signature= "rusEFI master.2024.06.15.at_start_f435.3993624057" ; signature is expected to be 7 or more characters.
 
 	; TS will try to use legacy temp units in some cases, showing "deg F" on a CLT gauge that's actually deg C
 	useLegacyFTempUnits = false
@@ -100,7 +100,7 @@ enable2ndByteCanID = false
 #define adc_channel_e_list="Disabled", "PA0", "PA1", "PA2", "PA3", "PA4", "PA5", "PA6", "PA7", "PB0", "PB1", "PC0", "PC1", "PC2", "PC3", "PC4", "PC5"
 
 ; CONFIG_DEFINITION_START
-; this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:25:08 UTC 2024
+; this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:57:08 UTC 2024
 
 pageSize            = 22748
 page = 1
@@ -538,7 +538,7 @@ noFuelTrimAfterDfcoTime = scalar, U08, 979, "sec", 0.1, 0, 0, 10, 1
 launchSpeedThreshold = scalar, S32, 980, "Kph", 1, 0, 0, 300, 0
 launchRpmWindow = scalar, S32, 984, "RPM", 1, 0, 0, 8000, 0
 triggerEventsTimeoutMs = scalar, F32, 988, "ms", 1, 0, 0, 3000, 3
-unusedHere13 = scalar, S32, 992, "", 1, 0, 0, 100, 0
+mapExpAverageAlpha = scalar, F32, 992, "", 1, 0, 0, 3000, 3
 magicNumberAvailableForDevTricks = scalar, F32, 996, "", 1, 0, 0, 100, 0
 turbochargerFilter = scalar, F32, 1000, "", 1, 0, 0, 100, 0
 launchTpsThreshold = scalar, S32, 1004, "", 1, 0, 0, 20000, 0
@@ -9409,6 +9409,7 @@ dialog = tcuControls, "Transmission Settings"
 
     dialog = parkingLot3, "Experimental 3"
         field = triggerEventsTimeoutMs,   triggerEventsTimeoutMs
+        field = mapExpAverageAlpha, mapExpAverageAlpha
         field = devBit0,         devBit0
         field = devBit1,         devBit1
         field = devBit2,         devBit2

--- a/firmware/tunerstudio/generated/rusefi_atlas.ini
+++ b/firmware/tunerstudio/generated/rusefi_atlas.ini
@@ -38,12 +38,12 @@ enable2ndByteCanID = false
 
 [MegaTune]
  ; https://rusefi.com/forum/viewtopic.php?p=36201#p36201
-	signature	= "rusEFI master.2024.06.15.atlas.4242327864"
+	signature	= "rusEFI master.2024.06.15.atlas.2853046711"
 
 [TunerStudio]
 	queryCommand	= "S"
 	versionInfo	= "V"  ; firmware version for title bar.
-	signature= "rusEFI master.2024.06.15.atlas.4242327864" ; signature is expected to be 7 or more characters.
+	signature= "rusEFI master.2024.06.15.atlas.2853046711" ; signature is expected to be 7 or more characters.
 
 	; TS will try to use legacy temp units in some cases, showing "deg F" on a CLT gauge that's actually deg C
 	useLegacyFTempUnits = false
@@ -100,7 +100,7 @@ enable2ndByteCanID = false
 #define adc_channel_e_list="Disabled", "PA0", "PA1", "PA2", "PA3", "PA4", "PA5", "PA6", "PA7", "PB0", "PB1", "PC0", "PC1", "PC2", "PC3", "PC4", "PC5"
 
 ; CONFIG_DEFINITION_START
-; this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:26:00 UTC 2024
+; this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:58:01 UTC 2024
 
 pageSize            = 22248
 page = 1
@@ -538,7 +538,7 @@ noFuelTrimAfterDfcoTime = scalar, U08, 979, "sec", 0.1, 0, 0, 10, 1
 launchSpeedThreshold = scalar, S32, 980, "Kph", 1, 0, 0, 300, 0
 launchRpmWindow = scalar, S32, 984, "RPM", 1, 0, 0, 8000, 0
 triggerEventsTimeoutMs = scalar, F32, 988, "ms", 1, 0, 0, 3000, 3
-unusedHere13 = scalar, S32, 992, "", 1, 0, 0, 100, 0
+mapExpAverageAlpha = scalar, F32, 992, "", 1, 0, 0, 3000, 3
 magicNumberAvailableForDevTricks = scalar, F32, 996, "", 1, 0, 0, 100, 0
 turbochargerFilter = scalar, F32, 1000, "", 1, 0, 0, 100, 0
 launchTpsThreshold = scalar, S32, 1004, "", 1, 0, 0, 20000, 0
@@ -9400,6 +9400,7 @@ dialog = tcuControls, "Transmission Settings"
 
     dialog = parkingLot3, "Experimental 3"
         field = triggerEventsTimeoutMs,   triggerEventsTimeoutMs
+        field = mapExpAverageAlpha, mapExpAverageAlpha
         field = devBit0,         devBit0
         field = devBit1,         devBit1
         field = devBit2,         devBit2

--- a/firmware/tunerstudio/generated/rusefi_f407-discovery.ini
+++ b/firmware/tunerstudio/generated/rusefi_f407-discovery.ini
@@ -38,12 +38,12 @@ enable2ndByteCanID = false
 
 [MegaTune]
  ; https://rusefi.com/forum/viewtopic.php?p=36201#p36201
-	signature	= "rusEFI master.2024.06.15.f407-discovery.478864919"
+	signature	= "rusEFI master.2024.06.15.f407-discovery.1247291032"
 
 [TunerStudio]
 	queryCommand	= "S"
 	versionInfo	= "V"  ; firmware version for title bar.
-	signature= "rusEFI master.2024.06.15.f407-discovery.478864919" ; signature is expected to be 7 or more characters.
+	signature= "rusEFI master.2024.06.15.f407-discovery.1247291032" ; signature is expected to be 7 or more characters.
 
 	; TS will try to use legacy temp units in some cases, showing "deg F" on a CLT gauge that's actually deg C
 	useLegacyFTempUnits = false
@@ -100,7 +100,7 @@ enable2ndByteCanID = false
 #define adc_channel_e_list="Disabled", "PA0", "PA1", "PA2", "PA3", "PA4", "PA5", "PA6", "PA7", "PB0", "PB1", "PC0", "PC1", "PC2", "PC3", "PC4", "PC5"
 
 ; CONFIG_DEFINITION_START
-; this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:26:22 UTC 2024
+; this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:58:23 UTC 2024
 
 pageSize            = 22748
 page = 1
@@ -538,7 +538,7 @@ noFuelTrimAfterDfcoTime = scalar, U08, 979, "sec", 0.1, 0, 0, 10, 1
 launchSpeedThreshold = scalar, S32, 980, "Kph", 1, 0, 0, 300, 0
 launchRpmWindow = scalar, S32, 984, "RPM", 1, 0, 0, 8000, 0
 triggerEventsTimeoutMs = scalar, F32, 988, "ms", 1, 0, 0, 3000, 3
-unusedHere13 = scalar, S32, 992, "", 1, 0, 0, 100, 0
+mapExpAverageAlpha = scalar, F32, 992, "", 1, 0, 0, 3000, 3
 magicNumberAvailableForDevTricks = scalar, F32, 996, "", 1, 0, 0, 100, 0
 turbochargerFilter = scalar, F32, 1000, "", 1, 0, 0, 100, 0
 launchTpsThreshold = scalar, S32, 1004, "", 1, 0, 0, 20000, 0
@@ -9423,6 +9423,7 @@ dialog = tcuControls, "Transmission Settings"
 
     dialog = parkingLot3, "Experimental 3"
         field = triggerEventsTimeoutMs,   triggerEventsTimeoutMs
+        field = mapExpAverageAlpha, mapExpAverageAlpha
         field = devBit0,         devBit0
         field = devBit1,         devBit1
         field = devBit2,         devBit2

--- a/firmware/tunerstudio/generated/rusefi_f429-discovery.ini
+++ b/firmware/tunerstudio/generated/rusefi_f429-discovery.ini
@@ -38,12 +38,12 @@ enable2ndByteCanID = false
 
 [MegaTune]
  ; https://rusefi.com/forum/viewtopic.php?p=36201#p36201
-	signature	= "rusEFI master.2024.06.15.f429-discovery.3101367670"
+	signature	= "rusEFI master.2024.06.15.f429-discovery.3993624057"
 
 [TunerStudio]
 	queryCommand	= "S"
 	versionInfo	= "V"  ; firmware version for title bar.
-	signature= "rusEFI master.2024.06.15.f429-discovery.3101367670" ; signature is expected to be 7 or more characters.
+	signature= "rusEFI master.2024.06.15.f429-discovery.3993624057" ; signature is expected to be 7 or more characters.
 
 	; TS will try to use legacy temp units in some cases, showing "deg F" on a CLT gauge that's actually deg C
 	useLegacyFTempUnits = false
@@ -100,7 +100,7 @@ enable2ndByteCanID = false
 #define adc_channel_e_list="Disabled", "PA0", "PA1", "PA2", "PA3", "PA4", "PA5", "PA6", "PA7", "PB0", "PB1", "PC0", "PC1", "PC2", "PC3", "PC4", "PC5"
 
 ; CONFIG_DEFINITION_START
-; this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:25:04 UTC 2024
+; this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:57:04 UTC 2024
 
 pageSize            = 22748
 page = 1
@@ -538,7 +538,7 @@ noFuelTrimAfterDfcoTime = scalar, U08, 979, "sec", 0.1, 0, 0, 10, 1
 launchSpeedThreshold = scalar, S32, 980, "Kph", 1, 0, 0, 300, 0
 launchRpmWindow = scalar, S32, 984, "RPM", 1, 0, 0, 8000, 0
 triggerEventsTimeoutMs = scalar, F32, 988, "ms", 1, 0, 0, 3000, 3
-unusedHere13 = scalar, S32, 992, "", 1, 0, 0, 100, 0
+mapExpAverageAlpha = scalar, F32, 992, "", 1, 0, 0, 3000, 3
 magicNumberAvailableForDevTricks = scalar, F32, 996, "", 1, 0, 0, 100, 0
 turbochargerFilter = scalar, F32, 1000, "", 1, 0, 0, 100, 0
 launchTpsThreshold = scalar, S32, 1004, "", 1, 0, 0, 20000, 0
@@ -9409,6 +9409,7 @@ dialog = tcuControls, "Transmission Settings"
 
     dialog = parkingLot3, "Experimental 3"
         field = triggerEventsTimeoutMs,   triggerEventsTimeoutMs
+        field = mapExpAverageAlpha, mapExpAverageAlpha
         field = devBit0,         devBit0
         field = devBit1,         devBit1
         field = devBit2,         devBit2

--- a/firmware/tunerstudio/generated/rusefi_f469-discovery.ini
+++ b/firmware/tunerstudio/generated/rusefi_f469-discovery.ini
@@ -38,12 +38,12 @@ enable2ndByteCanID = false
 
 [MegaTune]
  ; https://rusefi.com/forum/viewtopic.php?p=36201#p36201
-	signature	= "rusEFI master.2024.06.15.f469-discovery.2316049381"
+	signature	= "rusEFI master.2024.06.15.f469-discovery.3705592682"
 
 [TunerStudio]
 	queryCommand	= "S"
 	versionInfo	= "V"  ; firmware version for title bar.
-	signature= "rusEFI master.2024.06.15.f469-discovery.2316049381" ; signature is expected to be 7 or more characters.
+	signature= "rusEFI master.2024.06.15.f469-discovery.3705592682" ; signature is expected to be 7 or more characters.
 
 	; TS will try to use legacy temp units in some cases, showing "deg F" on a CLT gauge that's actually deg C
 	useLegacyFTempUnits = false
@@ -100,7 +100,7 @@ enable2ndByteCanID = false
 #define adc_channel_e_list="Disabled", "PA0", "PA1", "PA2", "PA3", "PA4", "PA5", "PA6", "PA7", "PB0", "PB1", "PC0", "PC1", "PC2", "PC3", "PC4", "PC5"
 
 ; CONFIG_DEFINITION_START
-; this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:25:06 UTC 2024
+; this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:57:07 UTC 2024
 
 pageSize            = 22748
 page = 1
@@ -538,7 +538,7 @@ noFuelTrimAfterDfcoTime = scalar, U08, 979, "sec", 0.1, 0, 0, 10, 1
 launchSpeedThreshold = scalar, S32, 980, "Kph", 1, 0, 0, 300, 0
 launchRpmWindow = scalar, S32, 984, "RPM", 1, 0, 0, 8000, 0
 triggerEventsTimeoutMs = scalar, F32, 988, "ms", 1, 0, 0, 3000, 3
-unusedHere13 = scalar, S32, 992, "", 1, 0, 0, 100, 0
+mapExpAverageAlpha = scalar, F32, 992, "", 1, 0, 0, 3000, 3
 magicNumberAvailableForDevTricks = scalar, F32, 996, "", 1, 0, 0, 100, 0
 turbochargerFilter = scalar, F32, 1000, "", 1, 0, 0, 100, 0
 launchTpsThreshold = scalar, S32, 1004, "", 1, 0, 0, 20000, 0
@@ -9409,6 +9409,7 @@ dialog = tcuControls, "Transmission Settings"
 
     dialog = parkingLot3, "Experimental 3"
         field = triggerEventsTimeoutMs,   triggerEventsTimeoutMs
+        field = mapExpAverageAlpha, mapExpAverageAlpha
         field = devBit0,         devBit0
         field = devBit1,         devBit1
         field = devBit2,         devBit2

--- a/firmware/tunerstudio/generated/rusefi_frankenso_na6.ini
+++ b/firmware/tunerstudio/generated/rusefi_frankenso_na6.ini
@@ -38,12 +38,12 @@ enable2ndByteCanID = false
 
 [MegaTune]
  ; https://rusefi.com/forum/viewtopic.php?p=36201#p36201
-	signature	= "rusEFI master.2024.06.15.frankenso_na6.3998771565"
+	signature	= "rusEFI master.2024.06.15.frankenso_na6.3096095202"
 
 [TunerStudio]
 	queryCommand	= "S"
 	versionInfo	= "V"  ; firmware version for title bar.
-	signature= "rusEFI master.2024.06.15.frankenso_na6.3998771565" ; signature is expected to be 7 or more characters.
+	signature= "rusEFI master.2024.06.15.frankenso_na6.3096095202" ; signature is expected to be 7 or more characters.
 
 	; TS will try to use legacy temp units in some cases, showing "deg F" on a CLT gauge that's actually deg C
 	useLegacyFTempUnits = false
@@ -100,7 +100,7 @@ enable2ndByteCanID = false
 #define adc_channel_e_list="NONE","Analog 3O","Analog 3L","Analog 3M","Analog 3J","Analog 3I","INVALID","Analog 3H","Analog 3G","INVALID","INVALID","INVALID","Analog 3P","Analog 3Q","Analog 3N","Analog VBatt","Analog 3E"
 
 ; CONFIG_DEFINITION_START
-; this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:25:58 UTC 2024
+; this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:58:00 UTC 2024
 
 pageSize            = 22748
 page = 1
@@ -538,7 +538,7 @@ noFuelTrimAfterDfcoTime = scalar, U08, 979, "sec", 0.1, 0, 0, 10, 1
 launchSpeedThreshold = scalar, S32, 980, "Kph", 1, 0, 0, 300, 0
 launchRpmWindow = scalar, S32, 984, "RPM", 1, 0, 0, 8000, 0
 triggerEventsTimeoutMs = scalar, F32, 988, "ms", 1, 0, 0, 3000, 3
-unusedHere13 = scalar, S32, 992, "", 1, 0, 0, 100, 0
+mapExpAverageAlpha = scalar, F32, 992, "", 1, 0, 0, 3000, 3
 magicNumberAvailableForDevTricks = scalar, F32, 996, "", 1, 0, 0, 100, 0
 turbochargerFilter = scalar, F32, 1000, "", 1, 0, 0, 100, 0
 launchTpsThreshold = scalar, S32, 1004, "", 1, 0, 0, 20000, 0
@@ -9412,6 +9412,7 @@ dialog = tcuControls, "Transmission Settings"
 
     dialog = parkingLot3, "Experimental 3"
         field = triggerEventsTimeoutMs,   triggerEventsTimeoutMs
+        field = mapExpAverageAlpha, mapExpAverageAlpha
         field = devBit0,         devBit0
         field = devBit1,         devBit1
         field = devBit2,         devBit2

--- a/firmware/tunerstudio/generated/rusefi_haba208.ini
+++ b/firmware/tunerstudio/generated/rusefi_haba208.ini
@@ -38,12 +38,12 @@ enable2ndByteCanID = false
 
 [MegaTune]
  ; https://rusefi.com/forum/viewtopic.php?p=36201#p36201
-	signature	= "rusEFI master.2024.06.15.haba208.3101367670"
+	signature	= "rusEFI master.2024.06.15.haba208.3993624057"
 
 [TunerStudio]
 	queryCommand	= "S"
 	versionInfo	= "V"  ; firmware version for title bar.
-	signature= "rusEFI master.2024.06.15.haba208.3101367670" ; signature is expected to be 7 or more characters.
+	signature= "rusEFI master.2024.06.15.haba208.3993624057" ; signature is expected to be 7 or more characters.
 
 	; TS will try to use legacy temp units in some cases, showing "deg F" on a CLT gauge that's actually deg C
 	useLegacyFTempUnits = false
@@ -100,7 +100,7 @@ enable2ndByteCanID = false
 #define adc_channel_e_list="Disabled", "PA0", "PA1", "PA2", "PA3", "PA4", "PA5", "PA6", "PA7", "PB0", "PB1", "PC0", "PC1", "PC2", "PC3", "PC4", "PC5"
 
 ; CONFIG_DEFINITION_START
-; this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:25:13 UTC 2024
+; this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:57:14 UTC 2024
 
 pageSize            = 22748
 page = 1
@@ -538,7 +538,7 @@ noFuelTrimAfterDfcoTime = scalar, U08, 979, "sec", 0.1, 0, 0, 10, 1
 launchSpeedThreshold = scalar, S32, 980, "Kph", 1, 0, 0, 300, 0
 launchRpmWindow = scalar, S32, 984, "RPM", 1, 0, 0, 8000, 0
 triggerEventsTimeoutMs = scalar, F32, 988, "ms", 1, 0, 0, 3000, 3
-unusedHere13 = scalar, S32, 992, "", 1, 0, 0, 100, 0
+mapExpAverageAlpha = scalar, F32, 992, "", 1, 0, 0, 3000, 3
 magicNumberAvailableForDevTricks = scalar, F32, 996, "", 1, 0, 0, 100, 0
 turbochargerFilter = scalar, F32, 1000, "", 1, 0, 0, 100, 0
 launchTpsThreshold = scalar, S32, 1004, "", 1, 0, 0, 20000, 0
@@ -9409,6 +9409,7 @@ dialog = tcuControls, "Transmission Settings"
 
     dialog = parkingLot3, "Experimental 3"
         field = triggerEventsTimeoutMs,   triggerEventsTimeoutMs
+        field = mapExpAverageAlpha, mapExpAverageAlpha
         field = devBit0,         devBit0
         field = devBit1,         devBit1
         field = devBit2,         devBit2

--- a/firmware/tunerstudio/generated/rusefi_hellen-112-17.ini
+++ b/firmware/tunerstudio/generated/rusefi_hellen-112-17.ini
@@ -38,12 +38,12 @@ enable2ndByteCanID = false
 
 [MegaTune]
  ; https://rusefi.com/forum/viewtopic.php?p=36201#p36201
-	signature	= "rusEFI master.2024.06.15.hellen-112-17.835945970"
+	signature	= "rusEFI master.2024.06.15.hellen-112-17.1728136573"
 
 [TunerStudio]
 	queryCommand	= "S"
 	versionInfo	= "V"  ; firmware version for title bar.
-	signature= "rusEFI master.2024.06.15.hellen-112-17.835945970" ; signature is expected to be 7 or more characters.
+	signature= "rusEFI master.2024.06.15.hellen-112-17.1728136573" ; signature is expected to be 7 or more characters.
 
 	; TS will try to use legacy temp units in some cases, showing "deg F" on a CLT gauge that's actually deg C
 	useLegacyFTempUnits = false
@@ -100,7 +100,7 @@ enable2ndByteCanID = false
 #define adc_channel_e_list="NONE","B20 TPS Throttle Position 2","A14 Analog Input","INVALID","A21 PPS1","B03 TPS Throttle Position 1","INVALID","A07 TODO","A12 Analog Input","A10 Analog Input","INVALID","B19 MAP","A09 Analog Input","B15 CLT","B27 IAT","A11 Analog Input","A19 Analog Input"
 
 ; CONFIG_DEFINITION_START
-; this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:25:47 UTC 2024
+; this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:57:48 UTC 2024
 
 pageSize            = 22748
 page = 1
@@ -538,7 +538,7 @@ noFuelTrimAfterDfcoTime = scalar, U08, 979, "sec", 0.1, 0, 0, 10, 1
 launchSpeedThreshold = scalar, S32, 980, "Kph", 1, 0, 0, 300, 0
 launchRpmWindow = scalar, S32, 984, "RPM", 1, 0, 0, 8000, 0
 triggerEventsTimeoutMs = scalar, F32, 988, "ms", 1, 0, 0, 3000, 3
-unusedHere13 = scalar, S32, 992, "", 1, 0, 0, 100, 0
+mapExpAverageAlpha = scalar, F32, 992, "", 1, 0, 0, 3000, 3
 magicNumberAvailableForDevTricks = scalar, F32, 996, "", 1, 0, 0, 100, 0
 turbochargerFilter = scalar, F32, 1000, "", 1, 0, 0, 100, 0
 launchTpsThreshold = scalar, S32, 1004, "", 1, 0, 0, 20000, 0
@@ -9354,6 +9354,7 @@ dialog = tcuControls, "Transmission Settings"
 
     dialog = parkingLot3, "Experimental 3"
         field = triggerEventsTimeoutMs,   triggerEventsTimeoutMs
+        field = mapExpAverageAlpha, mapExpAverageAlpha
         field = devBit0,         devBit0
         field = devBit1,         devBit1
         field = devBit2,         devBit2

--- a/firmware/tunerstudio/generated/rusefi_hellen-gm-e67.ini
+++ b/firmware/tunerstudio/generated/rusefi_hellen-gm-e67.ini
@@ -38,12 +38,12 @@ enable2ndByteCanID = false
 
 [MegaTune]
  ; https://rusefi.com/forum/viewtopic.php?p=36201#p36201
-	signature	= "rusEFI master.2024.06.15.hellen-gm-e67.1956805326"
+	signature	= "rusEFI master.2024.06.15.hellen-gm-e67.577813057"
 
 [TunerStudio]
 	queryCommand	= "S"
 	versionInfo	= "V"  ; firmware version for title bar.
-	signature= "rusEFI master.2024.06.15.hellen-gm-e67.1956805326" ; signature is expected to be 7 or more characters.
+	signature= "rusEFI master.2024.06.15.hellen-gm-e67.577813057" ; signature is expected to be 7 or more characters.
 
 	; TS will try to use legacy temp units in some cases, showing "deg F" on a CLT gauge that's actually deg C
 	useLegacyFTempUnits = false
@@ -100,7 +100,7 @@ enable2ndByteCanID = false
 #define adc_channel_e_list="NONE","INVALID","C2-60 - Oil Pressure","C3-58 - Baro","C1-47 - PPS1","C2-64 - TPS1","C1-19 Battery Sense","C1-45 Secondary Fuel Level","C3-57 - A/C Pressure","C2-66 - TPS2","C1-44 Primary Fuel Level","C2-65 - Trans Fluids","C3-59 - MAP","C3-55 - CLT","C3-56 - IAT","C1-49 - PPS2","C1-46 Vac Sense"
 
 ; CONFIG_DEFINITION_START
-; this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:25:37 UTC 2024
+; this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:57:38 UTC 2024
 
 pageSize            = 22748
 page = 1
@@ -538,7 +538,7 @@ noFuelTrimAfterDfcoTime = scalar, U08, 979, "sec", 0.1, 0, 0, 10, 1
 launchSpeedThreshold = scalar, S32, 980, "Kph", 1, 0, 0, 300, 0
 launchRpmWindow = scalar, S32, 984, "RPM", 1, 0, 0, 8000, 0
 triggerEventsTimeoutMs = scalar, F32, 988, "ms", 1, 0, 0, 3000, 3
-unusedHere13 = scalar, S32, 992, "", 1, 0, 0, 100, 0
+mapExpAverageAlpha = scalar, F32, 992, "", 1, 0, 0, 3000, 3
 magicNumberAvailableForDevTricks = scalar, F32, 996, "", 1, 0, 0, 100, 0
 turbochargerFilter = scalar, F32, 1000, "", 1, 0, 0, 100, 0
 launchTpsThreshold = scalar, S32, 1004, "", 1, 0, 0, 20000, 0
@@ -9383,6 +9383,7 @@ dialog = tcuControls, "Transmission Settings"
 
     dialog = parkingLot3, "Experimental 3"
         field = triggerEventsTimeoutMs,   triggerEventsTimeoutMs
+        field = mapExpAverageAlpha, mapExpAverageAlpha
         field = devBit0,         devBit0
         field = devBit1,         devBit1
         field = devBit2,         devBit2

--- a/firmware/tunerstudio/generated/rusefi_hellen-honda-k.ini
+++ b/firmware/tunerstudio/generated/rusefi_hellen-honda-k.ini
@@ -4,12 +4,12 @@ enable2ndByteCanID = false
 [SettingGroups]
 
 [MegaTune]
-	signature	= "rusEFI master.2024.06.15.hellen-honda-k.3712278870"
+	signature	= "rusEFI master.2024.06.15.hellen-honda-k.2341872089"
 
 [TunerStudio]
 	queryCommand	= "S"
 	versionInfo	= "V"  ; firmware version for title bar.
-	signature= "rusEFI master.2024.06.15.hellen-honda-k.3712278870" ; signature is expected to be 7 or more characters.
+	signature= "rusEFI master.2024.06.15.hellen-honda-k.2341872089" ; signature is expected to be 7 or more characters.
 
 	useLegacyFTempUnits = false
 	ignoreMissingBitOptions = true
@@ -487,7 +487,7 @@ noFuelTrimAfterDfcoTime = scalar, U08, 979, "sec", 0.1, 0, 0, 10, 1
 launchSpeedThreshold = scalar, S32, 980, "Kph", 1, 0, 0, 300, 0
 launchRpmWindow = scalar, S32, 984, "RPM", 1, 0, 0, 8000, 0
 triggerEventsTimeoutMs = scalar, F32, 988, "ms", 1, 0, 0, 3000, 3
-unusedHere13 = scalar, S32, 992, "", 1, 0, 0, 100, 0
+mapExpAverageAlpha = scalar, F32, 992, "", 1, 0, 0, 3000, 3
 magicNumberAvailableForDevTricks = scalar, F32, 996, "", 1, 0, 0, 100, 0
 turbochargerFilter = scalar, F32, 1000, "", 1, 0, 0, 100, 0
 launchTpsThreshold = scalar, S32, 1004, "", 1, 0, 0, 20000, 0
@@ -9071,6 +9071,7 @@ dialog = tcuControls, "Transmission Settings"
 
     dialog = parkingLot3, "Experimental 3"
         field = triggerEventsTimeoutMs,   triggerEventsTimeoutMs
+        field = mapExpAverageAlpha, mapExpAverageAlpha
         field = devBit0,         devBit0
         field = devBit1,         devBit1
         field = devBit2,         devBit2

--- a/firmware/tunerstudio/generated/rusefi_hellen-nb1.ini
+++ b/firmware/tunerstudio/generated/rusefi_hellen-nb1.ini
@@ -38,12 +38,12 @@ enable2ndByteCanID = false
 
 [MegaTune]
  ; https://rusefi.com/forum/viewtopic.php?p=36201#p36201
-	signature	= "rusEFI master.2024.06.15.hellen-nb1.1371794262"
+	signature	= "rusEFI master.2024.06.15.hellen-nb1.118565849"
 
 [TunerStudio]
 	queryCommand	= "S"
 	versionInfo	= "V"  ; firmware version for title bar.
-	signature= "rusEFI master.2024.06.15.hellen-nb1.1371794262" ; signature is expected to be 7 or more characters.
+	signature= "rusEFI master.2024.06.15.hellen-nb1.118565849" ; signature is expected to be 7 or more characters.
 
 	; TS will try to use legacy temp units in some cases, showing "deg F" on a CLT gauge that's actually deg C
 	useLegacyFTempUnits = false
@@ -100,7 +100,7 @@ enable2ndByteCanID = false
 #define adc_channel_e_list="NONE","2C - O2S","TPS1","intMAP","1G - Steering/RES2","3E - TPS","1B - Battery Sense","2H - CAM","3S - EGR BOOST IN","2A - Pressure Input","2J - CRANK","2L - MAF","3D - MAP","2E - Coolant","2B - IAT","4C - IN TEMP/PPS2","1P - AC Switch"
 
 ; CONFIG_DEFINITION_START
-; this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:25:39 UTC 2024
+; this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:57:40 UTC 2024
 
 pageSize            = 22748
 page = 1
@@ -538,7 +538,7 @@ noFuelTrimAfterDfcoTime = scalar, U08, 979, "sec", 0.1, 0, 0, 10, 1
 launchSpeedThreshold = scalar, S32, 980, "Kph", 1, 0, 0, 300, 0
 launchRpmWindow = scalar, S32, 984, "RPM", 1, 0, 0, 8000, 0
 triggerEventsTimeoutMs = scalar, F32, 988, "ms", 1, 0, 0, 3000, 3
-unusedHere13 = scalar, S32, 992, "", 1, 0, 0, 100, 0
+mapExpAverageAlpha = scalar, F32, 992, "", 1, 0, 0, 3000, 3
 magicNumberAvailableForDevTricks = scalar, F32, 996, "", 1, 0, 0, 100, 0
 turbochargerFilter = scalar, F32, 1000, "", 1, 0, 0, 100, 0
 launchTpsThreshold = scalar, S32, 1004, "", 1, 0, 0, 20000, 0
@@ -9383,6 +9383,7 @@ dialog = tcuControls, "Transmission Settings"
 
     dialog = parkingLot3, "Experimental 3"
         field = triggerEventsTimeoutMs,   triggerEventsTimeoutMs
+        field = mapExpAverageAlpha, mapExpAverageAlpha
         field = devBit0,         devBit0
         field = devBit1,         devBit1
         field = devBit2,         devBit2

--- a/firmware/tunerstudio/generated/rusefi_hellen121nissan.ini
+++ b/firmware/tunerstudio/generated/rusefi_hellen121nissan.ini
@@ -38,12 +38,12 @@ enable2ndByteCanID = false
 
 [MegaTune]
  ; https://rusefi.com/forum/viewtopic.php?p=36201#p36201
-	signature	= "rusEFI master.2024.06.15.hellen121nissan.4254515165"
+	signature	= "rusEFI master.2024.06.15.hellen121nissan.2873392978"
 
 [TunerStudio]
 	queryCommand	= "S"
 	versionInfo	= "V"  ; firmware version for title bar.
-	signature= "rusEFI master.2024.06.15.hellen121nissan.4254515165" ; signature is expected to be 7 or more characters.
+	signature= "rusEFI master.2024.06.15.hellen121nissan.2873392978" ; signature is expected to be 7 or more characters.
 
 	; TS will try to use legacy temp units in some cases, showing "deg F" on a CLT gauge that's actually deg C
 	useLegacyFTempUnits = false
@@ -100,7 +100,7 @@ enable2ndByteCanID = false
 #define adc_channel_e_list="NONE","51 - MAF","INVALID","Aux P68","106 - PPS 1","50 - TPS 1","109 Ignition Key Voltage","INVALID","INVALID","69 - TPS 2","INVALID","Aux P66","Aux P67","73 - CLT","34 - IAT","98 - PPS 2"
 
 ; CONFIG_DEFINITION_START
-; this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:25:31 UTC 2024
+; this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:57:31 UTC 2024
 
 pageSize            = 22748
 page = 1
@@ -538,7 +538,7 @@ noFuelTrimAfterDfcoTime = scalar, U08, 979, "sec", 0.1, 0, 0, 10, 1
 launchSpeedThreshold = scalar, S32, 980, "Kph", 1, 0, 0, 300, 0
 launchRpmWindow = scalar, S32, 984, "RPM", 1, 0, 0, 8000, 0
 triggerEventsTimeoutMs = scalar, F32, 988, "ms", 1, 0, 0, 3000, 3
-unusedHere13 = scalar, S32, 992, "", 1, 0, 0, 100, 0
+mapExpAverageAlpha = scalar, F32, 992, "", 1, 0, 0, 3000, 3
 magicNumberAvailableForDevTricks = scalar, F32, 996, "", 1, 0, 0, 100, 0
 turbochargerFilter = scalar, F32, 1000, "", 1, 0, 0, 100, 0
 launchTpsThreshold = scalar, S32, 1004, "", 1, 0, 0, 20000, 0
@@ -9346,6 +9346,7 @@ dialog = tcuControls, "Transmission Settings"
 
     dialog = parkingLot3, "Experimental 3"
         field = triggerEventsTimeoutMs,   triggerEventsTimeoutMs
+        field = mapExpAverageAlpha, mapExpAverageAlpha
         field = devBit0,         devBit0
         field = devBit1,         devBit1
         field = devBit2,         devBit2

--- a/firmware/tunerstudio/generated/rusefi_hellen121vag.ini
+++ b/firmware/tunerstudio/generated/rusefi_hellen121vag.ini
@@ -38,12 +38,12 @@ enable2ndByteCanID = false
 
 [MegaTune]
  ; https://rusefi.com/forum/viewtopic.php?p=36201#p36201
-	signature	= "rusEFI master.2024.06.15.hellen121vag.2292318352"
+	signature	= "rusEFI master.2024.06.15.hellen121vag.3731931167"
 
 [TunerStudio]
 	queryCommand	= "S"
 	versionInfo	= "V"  ; firmware version for title bar.
-	signature= "rusEFI master.2024.06.15.hellen121vag.2292318352" ; signature is expected to be 7 or more characters.
+	signature= "rusEFI master.2024.06.15.hellen121vag.3731931167" ; signature is expected to be 7 or more characters.
 
 	; TS will try to use legacy temp units in some cases, showing "deg F" on a CLT gauge that's actually deg C
 	useLegacyFTempUnits = false
@@ -100,7 +100,7 @@ enable2ndByteCanID = false
 #define adc_channel_e_list="NONE","14 - O2","INVALID","INVALID","34 In PPS1","92 - TPS 1","106 - KNOCK","86 - CAM1","87 - CAM2","84 - TPS2","INVALID","29 In Maf","101 - MAP2","93 - CLT","85 - IAT","35 In PPS2"
 
 ; CONFIG_DEFINITION_START
-; this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:25:49 UTC 2024
+; this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:57:50 UTC 2024
 
 pageSize            = 22748
 page = 1
@@ -538,7 +538,7 @@ noFuelTrimAfterDfcoTime = scalar, U08, 979, "sec", 0.1, 0, 0, 10, 1
 launchSpeedThreshold = scalar, S32, 980, "Kph", 1, 0, 0, 300, 0
 launchRpmWindow = scalar, S32, 984, "RPM", 1, 0, 0, 8000, 0
 triggerEventsTimeoutMs = scalar, F32, 988, "ms", 1, 0, 0, 3000, 3
-unusedHere13 = scalar, S32, 992, "", 1, 0, 0, 100, 0
+mapExpAverageAlpha = scalar, F32, 992, "", 1, 0, 0, 3000, 3
 magicNumberAvailableForDevTricks = scalar, F32, 996, "", 1, 0, 0, 100, 0
 turbochargerFilter = scalar, F32, 1000, "", 1, 0, 0, 100, 0
 launchTpsThreshold = scalar, S32, 1004, "", 1, 0, 0, 20000, 0
@@ -9387,6 +9387,7 @@ dialog = tcuControls, "Transmission Settings"
 
     dialog = parkingLot3, "Experimental 3"
         field = triggerEventsTimeoutMs,   triggerEventsTimeoutMs
+        field = mapExpAverageAlpha, mapExpAverageAlpha
         field = devBit0,         devBit0
         field = devBit1,         devBit1
         field = devBit2,         devBit2

--- a/firmware/tunerstudio/generated/rusefi_hellen128.ini
+++ b/firmware/tunerstudio/generated/rusefi_hellen128.ini
@@ -38,12 +38,12 @@ enable2ndByteCanID = false
 
 [MegaTune]
  ; https://rusefi.com/forum/viewtopic.php?p=36201#p36201
-	signature	= "rusEFI master.2024.06.15.hellen128.1430861697"
+	signature	= "rusEFI master.2024.06.15.hellen128.60552974"
 
 [TunerStudio]
 	queryCommand	= "S"
 	versionInfo	= "V"  ; firmware version for title bar.
-	signature= "rusEFI master.2024.06.15.hellen128.1430861697" ; signature is expected to be 7 or more characters.
+	signature= "rusEFI master.2024.06.15.hellen128.60552974" ; signature is expected to be 7 or more characters.
 
 	; TS will try to use legacy temp units in some cases, showing "deg F" on a CLT gauge that's actually deg C
 	useLegacyFTempUnits = false
@@ -100,7 +100,7 @@ enable2ndByteCanID = false
 #define adc_channel_e_list="NONE","P36_IN_O2S","P32_IN_O2S2","P40_IN_MAP3","C24 - PPS1","E31 - TPS1","Battery Sense","E40 - IN_CAM","P30_IN_AUX4","E34 - TPS2","E37 - Crank Input","E47 - MAF","E23 - MAP","E29 - Coolant Temp","E45 - IAT","C25 - PPS2","P41_IN_AUX3"
 
 ; CONFIG_DEFINITION_START
-; this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:25:24 UTC 2024
+; this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:57:24 UTC 2024
 
 pageSize            = 22748
 page = 1
@@ -538,7 +538,7 @@ noFuelTrimAfterDfcoTime = scalar, U08, 979, "sec", 0.1, 0, 0, 10, 1
 launchSpeedThreshold = scalar, S32, 980, "Kph", 1, 0, 0, 300, 0
 launchRpmWindow = scalar, S32, 984, "RPM", 1, 0, 0, 8000, 0
 triggerEventsTimeoutMs = scalar, F32, 988, "ms", 1, 0, 0, 3000, 3
-unusedHere13 = scalar, S32, 992, "", 1, 0, 0, 100, 0
+mapExpAverageAlpha = scalar, F32, 992, "", 1, 0, 0, 3000, 3
 magicNumberAvailableForDevTricks = scalar, F32, 996, "", 1, 0, 0, 100, 0
 turbochargerFilter = scalar, F32, 1000, "", 1, 0, 0, 100, 0
 launchTpsThreshold = scalar, S32, 1004, "", 1, 0, 0, 20000, 0
@@ -9384,6 +9384,7 @@ dialog = tcuControls, "Transmission Settings"
 
     dialog = parkingLot3, "Experimental 3"
         field = triggerEventsTimeoutMs,   triggerEventsTimeoutMs
+        field = mapExpAverageAlpha, mapExpAverageAlpha
         field = devBit0,         devBit0
         field = devBit1,         devBit1
         field = devBit2,         devBit2

--- a/firmware/tunerstudio/generated/rusefi_hellen154hyundai.ini
+++ b/firmware/tunerstudio/generated/rusefi_hellen154hyundai.ini
@@ -38,12 +38,12 @@ enable2ndByteCanID = false
 
 [MegaTune]
  ; https://rusefi.com/forum/viewtopic.php?p=36201#p36201
-	signature	= "rusEFI master.2024.06.15.hellen154hyundai.1260422401"
+	signature	= "rusEFI master.2024.06.15.hellen154hyundai.502416782"
 
 [TunerStudio]
 	queryCommand	= "S"
 	versionInfo	= "V"  ; firmware version for title bar.
-	signature= "rusEFI master.2024.06.15.hellen154hyundai.1260422401" ; signature is expected to be 7 or more characters.
+	signature= "rusEFI master.2024.06.15.hellen154hyundai.502416782" ; signature is expected to be 7 or more characters.
 
 	; TS will try to use legacy temp units in some cases, showing "deg F" on a CLT gauge that's actually deg C
 	useLegacyFTempUnits = false
@@ -100,7 +100,7 @@ enable2ndByteCanID = false
 #define adc_channel_e_list="NONE","K21 Ambient Temperature","K58 Oil Temp","K54 A/C pressure","PPS 1","TPS 1","K2 Ignition Key Voltage","X10 AIN2","INVALID","TPS 2","X11 AIN1","Map Sensor K31","K10 Sensor","CLT","IAT","PPS 2"
 
 ; CONFIG_DEFINITION_START
-; this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:25:36 UTC 2024
+; this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:57:37 UTC 2024
 
 pageSize            = 22748
 page = 1
@@ -538,7 +538,7 @@ noFuelTrimAfterDfcoTime = scalar, U08, 979, "sec", 0.1, 0, 0, 10, 1
 launchSpeedThreshold = scalar, S32, 980, "Kph", 1, 0, 0, 300, 0
 launchRpmWindow = scalar, S32, 984, "RPM", 1, 0, 0, 8000, 0
 triggerEventsTimeoutMs = scalar, F32, 988, "ms", 1, 0, 0, 3000, 3
-unusedHere13 = scalar, S32, 992, "", 1, 0, 0, 100, 0
+mapExpAverageAlpha = scalar, F32, 992, "", 1, 0, 0, 3000, 3
 magicNumberAvailableForDevTricks = scalar, F32, 996, "", 1, 0, 0, 100, 0
 turbochargerFilter = scalar, F32, 1000, "", 1, 0, 0, 100, 0
 launchTpsThreshold = scalar, S32, 1004, "", 1, 0, 0, 20000, 0
@@ -9305,6 +9305,7 @@ dialog = tcuControls, "Transmission Settings"
 
     dialog = parkingLot3, "Experimental 3"
         field = triggerEventsTimeoutMs,   triggerEventsTimeoutMs
+        field = mapExpAverageAlpha, mapExpAverageAlpha
         field = devBit0,         devBit0
         field = devBit1,         devBit1
         field = devBit2,         devBit2

--- a/firmware/tunerstudio/generated/rusefi_hellen154hyundai_f7.ini
+++ b/firmware/tunerstudio/generated/rusefi_hellen154hyundai_f7.ini
@@ -38,12 +38,12 @@ enable2ndByteCanID = false
 
 [MegaTune]
  ; https://rusefi.com/forum/viewtopic.php?p=36201#p36201
-	signature	= "rusEFI master.2024.06.15.hellen154hyundai_f7.1425506992"
+	signature	= "rusEFI master.2024.06.15.hellen154hyundai_f7.35996223"
 
 [TunerStudio]
 	queryCommand	= "S"
 	versionInfo	= "V"  ; firmware version for title bar.
-	signature= "rusEFI master.2024.06.15.hellen154hyundai_f7.1425506992" ; signature is expected to be 7 or more characters.
+	signature= "rusEFI master.2024.06.15.hellen154hyundai_f7.35996223" ; signature is expected to be 7 or more characters.
 
 	; TS will try to use legacy temp units in some cases, showing "deg F" on a CLT gauge that's actually deg C
 	useLegacyFTempUnits = false
@@ -100,7 +100,7 @@ enable2ndByteCanID = false
 #define adc_channel_e_list="NONE","K21 Ambient Temperature","K58 Oil Temp","K54 A/C pressure","PPS 1","TPS 1","K2 Ignition Key Voltage","X10 AIN2","INVALID","TPS 2","X11 AIN1","Map Sensor K31","K10 Sensor","CLT","IAT","PPS 2"
 
 ; CONFIG_DEFINITION_START
-; this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:25:29 UTC 2024
+; this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:57:30 UTC 2024
 
 pageSize            = 22748
 page = 1
@@ -538,7 +538,7 @@ noFuelTrimAfterDfcoTime = scalar, U08, 979, "sec", 0.1, 0, 0, 10, 1
 launchSpeedThreshold = scalar, S32, 980, "Kph", 1, 0, 0, 300, 0
 launchRpmWindow = scalar, S32, 984, "RPM", 1, 0, 0, 8000, 0
 triggerEventsTimeoutMs = scalar, F32, 988, "ms", 1, 0, 0, 3000, 3
-unusedHere13 = scalar, S32, 992, "", 1, 0, 0, 100, 0
+mapExpAverageAlpha = scalar, F32, 992, "", 1, 0, 0, 3000, 3
 magicNumberAvailableForDevTricks = scalar, F32, 996, "", 1, 0, 0, 100, 0
 turbochargerFilter = scalar, F32, 1000, "", 1, 0, 0, 100, 0
 launchTpsThreshold = scalar, S32, 1004, "", 1, 0, 0, 20000, 0
@@ -9305,6 +9305,7 @@ dialog = tcuControls, "Transmission Settings"
 
     dialog = parkingLot3, "Experimental 3"
         field = triggerEventsTimeoutMs,   triggerEventsTimeoutMs
+        field = mapExpAverageAlpha, mapExpAverageAlpha
         field = devBit0,         devBit0
         field = devBit1,         devBit1
         field = devBit2,         devBit2

--- a/firmware/tunerstudio/generated/rusefi_hellen72.ini
+++ b/firmware/tunerstudio/generated/rusefi_hellen72.ini
@@ -38,12 +38,12 @@ enable2ndByteCanID = false
 
 [MegaTune]
  ; https://rusefi.com/forum/viewtopic.php?p=36201#p36201
-	signature	= "rusEFI master.2024.06.15.hellen72.943385066"
+	signature	= "rusEFI master.2024.06.15.hellen72.1860708709"
 
 [TunerStudio]
 	queryCommand	= "S"
 	versionInfo	= "V"  ; firmware version for title bar.
-	signature= "rusEFI master.2024.06.15.hellen72.943385066" ; signature is expected to be 7 or more characters.
+	signature= "rusEFI master.2024.06.15.hellen72.1860708709" ; signature is expected to be 7 or more characters.
 
 	; TS will try to use legacy temp units in some cases, showing "deg F" on a CLT gauge that's actually deg C
 	useLegacyFTempUnits = false
@@ -100,7 +100,7 @@ enable2ndByteCanID = false
 #define adc_channel_e_list="NONE","5N - TPS2","3L - IGN_7 / AFR","intMAP (A15)","5P - PPS1","4V - TPS (A17)","4S/4T - Alternator voltage","3V - CAM (A19)","4J - VTCS/AUX4 (A20)","4F - AC_PRES/AUX1 (A23)","3Y - CRANK (A24)","4X - MAF (A9)","4U - MAP2/Ign8 (A10)","4P - CLT (A11)","4N - IAT (A14)","5M - PPS2 OR TEMPERATURE SENSOR","4AE - EGR/MAP4 (A22)"
 
 ; CONFIG_DEFINITION_START
-; this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:25:35 UTC 2024
+; this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:57:35 UTC 2024
 
 pageSize            = 22748
 page = 1
@@ -538,7 +538,7 @@ noFuelTrimAfterDfcoTime = scalar, U08, 979, "sec", 0.1, 0, 0, 10, 1
 launchSpeedThreshold = scalar, S32, 980, "Kph", 1, 0, 0, 300, 0
 launchRpmWindow = scalar, S32, 984, "RPM", 1, 0, 0, 8000, 0
 triggerEventsTimeoutMs = scalar, F32, 988, "ms", 1, 0, 0, 3000, 3
-unusedHere13 = scalar, S32, 992, "", 1, 0, 0, 100, 0
+mapExpAverageAlpha = scalar, F32, 992, "", 1, 0, 0, 3000, 3
 magicNumberAvailableForDevTricks = scalar, F32, 996, "", 1, 0, 0, 100, 0
 turbochargerFilter = scalar, F32, 1000, "", 1, 0, 0, 100, 0
 launchTpsThreshold = scalar, S32, 1004, "", 1, 0, 0, 20000, 0
@@ -9384,6 +9384,7 @@ dialog = tcuControls, "Transmission Settings"
 
     dialog = parkingLot3, "Experimental 3"
         field = triggerEventsTimeoutMs,   triggerEventsTimeoutMs
+        field = mapExpAverageAlpha, mapExpAverageAlpha
         field = devBit0,         devBit0
         field = devBit1,         devBit1
         field = devBit2,         devBit2

--- a/firmware/tunerstudio/generated/rusefi_hellen81.ini
+++ b/firmware/tunerstudio/generated/rusefi_hellen81.ini
@@ -38,12 +38,12 @@ enable2ndByteCanID = false
 
 [MegaTune]
  ; https://rusefi.com/forum/viewtopic.php?p=36201#p36201
-	signature	= "rusEFI master.2024.06.15.hellen81.3712716176"
+	signature	= "rusEFI master.2024.06.15.hellen81.2342079775"
 
 [TunerStudio]
 	queryCommand	= "S"
 	versionInfo	= "V"  ; firmware version for title bar.
-	signature= "rusEFI master.2024.06.15.hellen81.3712716176" ; signature is expected to be 7 or more characters.
+	signature= "rusEFI master.2024.06.15.hellen81.2342079775" ; signature is expected to be 7 or more characters.
 
 	; TS will try to use legacy temp units in some cases, showing "deg F" on a CLT gauge that's actually deg C
 	useLegacyFTempUnits = false
@@ -100,7 +100,7 @@ enable2ndByteCanID = false
 #define adc_channel_e_list="NONE","18 - IN_O2S","55 - IN_O2S2","41 - IN_MAP3","78 - IN_PPS","16 - IN_TPS","13 - IN_VIGN","79 - IN_CAM","77 - IN_AUX4","74 - IN_AUX1","15 - IN_CRANK (A24)","37 - IN_MAP1","38 - IN_MAP2","39 - IN_CLT","40 - IN_IAT","75 - IN_AUX2","76 - IN_AUX3"
 
 ; CONFIG_DEFINITION_START
-; this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:25:21 UTC 2024
+; this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:57:22 UTC 2024
 
 pageSize            = 22748
 page = 1
@@ -538,7 +538,7 @@ noFuelTrimAfterDfcoTime = scalar, U08, 979, "sec", 0.1, 0, 0, 10, 1
 launchSpeedThreshold = scalar, S32, 980, "Kph", 1, 0, 0, 300, 0
 launchRpmWindow = scalar, S32, 984, "RPM", 1, 0, 0, 8000, 0
 triggerEventsTimeoutMs = scalar, F32, 988, "ms", 1, 0, 0, 3000, 3
-unusedHere13 = scalar, S32, 992, "", 1, 0, 0, 100, 0
+mapExpAverageAlpha = scalar, F32, 992, "", 1, 0, 0, 3000, 3
 magicNumberAvailableForDevTricks = scalar, F32, 996, "", 1, 0, 0, 100, 0
 turbochargerFilter = scalar, F32, 1000, "", 1, 0, 0, 100, 0
 launchTpsThreshold = scalar, S32, 1004, "", 1, 0, 0, 20000, 0
@@ -9380,6 +9380,7 @@ dialog = tcuControls, "Transmission Settings"
 
     dialog = parkingLot3, "Experimental 3"
         field = triggerEventsTimeoutMs,   triggerEventsTimeoutMs
+        field = mapExpAverageAlpha, mapExpAverageAlpha
         field = devBit0,         devBit0
         field = devBit1,         devBit1
         field = devBit2,         devBit2

--- a/firmware/tunerstudio/generated/rusefi_hellen88bmw.ini
+++ b/firmware/tunerstudio/generated/rusefi_hellen88bmw.ini
@@ -38,12 +38,12 @@ enable2ndByteCanID = false
 
 [MegaTune]
  ; https://rusefi.com/forum/viewtopic.php?p=36201#p36201
-	signature	= "rusEFI master.2024.06.15.hellen88bmw.3395852499"
+	signature	= "rusEFI master.2024.06.15.hellen88bmw.2629458012"
 
 [TunerStudio]
 	queryCommand	= "S"
 	versionInfo	= "V"  ; firmware version for title bar.
-	signature= "rusEFI master.2024.06.15.hellen88bmw.3395852499" ; signature is expected to be 7 or more characters.
+	signature= "rusEFI master.2024.06.15.hellen88bmw.2629458012" ; signature is expected to be 7 or more characters.
 
 	; TS will try to use legacy temp units in some cases, showing "deg F" on a CLT gauge that's actually deg C
 	useLegacyFTempUnits = false
@@ -100,7 +100,7 @@ enable2ndByteCanID = false
 #define adc_channel_e_list="NONE","VIN5","VIN6","INVALID","PPS1","73 - TPS","56 - Battery Sense","17 - CAM","Aux BARO","Aux TPS2","16 - CRANK","41 - MAF","Aux MAP","78 - CLT","77 - IAT","Aux PPS2","Aux TPS3"
 
 ; CONFIG_DEFINITION_START
-; this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:25:18 UTC 2024
+; this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:57:19 UTC 2024
 
 pageSize            = 22748
 page = 1
@@ -538,7 +538,7 @@ noFuelTrimAfterDfcoTime = scalar, U08, 979, "sec", 0.1, 0, 0, 10, 1
 launchSpeedThreshold = scalar, S32, 980, "Kph", 1, 0, 0, 300, 0
 launchRpmWindow = scalar, S32, 984, "RPM", 1, 0, 0, 8000, 0
 triggerEventsTimeoutMs = scalar, F32, 988, "ms", 1, 0, 0, 3000, 3
-unusedHere13 = scalar, S32, 992, "", 1, 0, 0, 100, 0
+mapExpAverageAlpha = scalar, F32, 992, "", 1, 0, 0, 3000, 3
 magicNumberAvailableForDevTricks = scalar, F32, 996, "", 1, 0, 0, 100, 0
 turbochargerFilter = scalar, F32, 1000, "", 1, 0, 0, 100, 0
 launchTpsThreshold = scalar, S32, 1004, "", 1, 0, 0, 20000, 0
@@ -9375,6 +9375,7 @@ dialog = tcuControls, "Transmission Settings"
 
     dialog = parkingLot3, "Experimental 3"
         field = triggerEventsTimeoutMs,   triggerEventsTimeoutMs
+        field = mapExpAverageAlpha, mapExpAverageAlpha
         field = devBit0,         devBit0
         field = devBit1,         devBit1
         field = devBit2,         devBit2

--- a/firmware/tunerstudio/generated/rusefi_hellenNA6.ini
+++ b/firmware/tunerstudio/generated/rusefi_hellenNA6.ini
@@ -38,12 +38,12 @@ enable2ndByteCanID = false
 
 [MegaTune]
  ; https://rusefi.com/forum/viewtopic.php?p=36201#p36201
-	signature	= "rusEFI master.2024.06.15.hellenNA6.746520214"
+	signature	= "rusEFI master.2024.06.15.hellenNA6.2058108441"
 
 [TunerStudio]
 	queryCommand	= "S"
 	versionInfo	= "V"  ; firmware version for title bar.
-	signature= "rusEFI master.2024.06.15.hellenNA6.746520214" ; signature is expected to be 7 or more characters.
+	signature= "rusEFI master.2024.06.15.hellenNA6.2058108441" ; signature is expected to be 7 or more characters.
 
 	; TS will try to use legacy temp units in some cases, showing "deg F" on a CLT gauge that's actually deg C
 	useLegacyFTempUnits = false
@@ -100,7 +100,7 @@ enable2ndByteCanID = false
 #define adc_channel_e_list="NONE","3N - O2S","2N - Temperature Sensor","intMAP (A15)","4I - PPS1","TPS Input","1B - Battery Sense","INVALID","4G - PPS2 OR TEMPERATURE SENSOR","4H - TPS2","INVALID","3O - MAF","2M - Pressure Sensor","3Q - CLT","3P - IAT","1V - Clutch Switch","1Q AC Switch"
 
 ; CONFIG_DEFINITION_START
-; this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:25:45 UTC 2024
+; this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:57:46 UTC 2024
 
 pageSize            = 22748
 page = 1
@@ -538,7 +538,7 @@ noFuelTrimAfterDfcoTime = scalar, U08, 979, "sec", 0.1, 0, 0, 10, 1
 launchSpeedThreshold = scalar, S32, 980, "Kph", 1, 0, 0, 300, 0
 launchRpmWindow = scalar, S32, 984, "RPM", 1, 0, 0, 8000, 0
 triggerEventsTimeoutMs = scalar, F32, 988, "ms", 1, 0, 0, 3000, 3
-unusedHere13 = scalar, S32, 992, "", 1, 0, 0, 100, 0
+mapExpAverageAlpha = scalar, F32, 992, "", 1, 0, 0, 3000, 3
 magicNumberAvailableForDevTricks = scalar, F32, 996, "", 1, 0, 0, 100, 0
 turbochargerFilter = scalar, F32, 1000, "", 1, 0, 0, 100, 0
 launchTpsThreshold = scalar, S32, 1004, "", 1, 0, 0, 20000, 0
@@ -9385,6 +9385,7 @@ dialog = tcuControls, "Transmission Settings"
 
     dialog = parkingLot3, "Experimental 3"
         field = triggerEventsTimeoutMs,   triggerEventsTimeoutMs
+        field = mapExpAverageAlpha, mapExpAverageAlpha
         field = devBit0,         devBit0
         field = devBit1,         devBit1
         field = devBit2,         devBit2

--- a/firmware/tunerstudio/generated/rusefi_hellenNA8_96.ini
+++ b/firmware/tunerstudio/generated/rusefi_hellenNA8_96.ini
@@ -38,12 +38,12 @@ enable2ndByteCanID = false
 
 [MegaTune]
  ; https://rusefi.com/forum/viewtopic.php?p=36201#p36201
-	signature	= "rusEFI master.2024.06.15.hellenNA8_96.3550788696"
+	signature	= "rusEFI master.2024.06.15.hellenNA8_96.2239134935"
 
 [TunerStudio]
 	queryCommand	= "S"
 	versionInfo	= "V"  ; firmware version for title bar.
-	signature= "rusEFI master.2024.06.15.hellenNA8_96.3550788696" ; signature is expected to be 7 or more characters.
+	signature= "rusEFI master.2024.06.15.hellenNA8_96.2239134935" ; signature is expected to be 7 or more characters.
 
 	; TS will try to use legacy temp units in some cases, showing "deg F" on a CLT gauge that's actually deg C
 	useLegacyFTempUnits = false
@@ -100,7 +100,7 @@ enable2ndByteCanID = false
 #define adc_channel_e_list="NONE","2C - O2S","TPS1","intMAP","PPS1","2F - TPS","3B - Battery Sense","3G - CAM","3S - EGR BOOST IN","2A - Pressure Input","3F - CRANK","2B - MAF","INVALID","2G - Coolant","2B - IAT","4C - IN TEMP/PPS2","1K - AC Switch"
 
 ; CONFIG_DEFINITION_START
-; this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:25:52 UTC 2024
+; this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:57:53 UTC 2024
 
 pageSize            = 22748
 page = 1
@@ -538,7 +538,7 @@ noFuelTrimAfterDfcoTime = scalar, U08, 979, "sec", 0.1, 0, 0, 10, 1
 launchSpeedThreshold = scalar, S32, 980, "Kph", 1, 0, 0, 300, 0
 launchRpmWindow = scalar, S32, 984, "RPM", 1, 0, 0, 8000, 0
 triggerEventsTimeoutMs = scalar, F32, 988, "ms", 1, 0, 0, 3000, 3
-unusedHere13 = scalar, S32, 992, "", 1, 0, 0, 100, 0
+mapExpAverageAlpha = scalar, F32, 992, "", 1, 0, 0, 3000, 3
 magicNumberAvailableForDevTricks = scalar, F32, 996, "", 1, 0, 0, 100, 0
 turbochargerFilter = scalar, F32, 1000, "", 1, 0, 0, 100, 0
 launchTpsThreshold = scalar, S32, 1004, "", 1, 0, 0, 20000, 0
@@ -9383,6 +9383,7 @@ dialog = tcuControls, "Transmission Settings"
 
     dialog = parkingLot3, "Experimental 3"
         field = triggerEventsTimeoutMs,   triggerEventsTimeoutMs
+        field = mapExpAverageAlpha, mapExpAverageAlpha
         field = devBit0,         devBit0
         field = devBit1,         devBit1
         field = devBit2,         devBit2

--- a/firmware/tunerstudio/generated/rusefi_m74_9.ini
+++ b/firmware/tunerstudio/generated/rusefi_m74_9.ini
@@ -38,12 +38,12 @@ enable2ndByteCanID = false
 
 [MegaTune]
  ; https://rusefi.com/forum/viewtopic.php?p=36201#p36201
-	signature	= "rusEFI master.2024.06.15.m74_9.207693225"
+	signature	= "rusEFI master.2024.06.15.m74_9.1521739046"
 
 [TunerStudio]
 	queryCommand	= "S"
 	versionInfo	= "V"  ; firmware version for title bar.
-	signature= "rusEFI master.2024.06.15.m74_9.207693225" ; signature is expected to be 7 or more characters.
+	signature= "rusEFI master.2024.06.15.m74_9.1521739046" ; signature is expected to be 7 or more characters.
 
 	; TS will try to use legacy temp units in some cases, showing "deg F" on a CLT gauge that's actually deg C
 	useLegacyFTempUnits = false
@@ -100,7 +100,7 @@ enable2ndByteCanID = false
 #define adc_channel_e_list="NONE","INVALID","MAF/MAP sensor signal","INVALID","INVALID","INVALID","INVALID","INVALID","INVALID","INVALID","INVALID","Pedal position sensor 1 signal PPS1","Pedal position sensor 2 signal PPS2","ETB TPS position sensor 1 signal","ETB TPS position sensor 2 signal"
 
 ; CONFIG_DEFINITION_START
-; this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:25:05 UTC 2024
+; this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:57:06 UTC 2024
 
 pageSize            = 22748
 page = 1
@@ -538,7 +538,7 @@ noFuelTrimAfterDfcoTime = scalar, U08, 979, "sec", 0.1, 0, 0, 10, 1
 launchSpeedThreshold = scalar, S32, 980, "Kph", 1, 0, 0, 300, 0
 launchRpmWindow = scalar, S32, 984, "RPM", 1, 0, 0, 8000, 0
 triggerEventsTimeoutMs = scalar, F32, 988, "ms", 1, 0, 0, 3000, 3
-unusedHere13 = scalar, S32, 992, "", 1, 0, 0, 100, 0
+mapExpAverageAlpha = scalar, F32, 992, "", 1, 0, 0, 3000, 3
 magicNumberAvailableForDevTricks = scalar, F32, 996, "", 1, 0, 0, 100, 0
 turbochargerFilter = scalar, F32, 1000, "", 1, 0, 0, 100, 0
 launchTpsThreshold = scalar, S32, 1004, "", 1, 0, 0, 20000, 0
@@ -9387,6 +9387,7 @@ dialog = tcuControls, "Transmission Settings"
 
     dialog = parkingLot3, "Experimental 3"
         field = triggerEventsTimeoutMs,   triggerEventsTimeoutMs
+        field = mapExpAverageAlpha, mapExpAverageAlpha
         field = devBit0,         devBit0
         field = devBit1,         devBit1
         field = devBit2,         devBit2

--- a/firmware/tunerstudio/generated/rusefi_mre-legacy_f4.ini
+++ b/firmware/tunerstudio/generated/rusefi_mre-legacy_f4.ini
@@ -38,12 +38,12 @@ enable2ndByteCanID = false
 
 [MegaTune]
  ; https://rusefi.com/forum/viewtopic.php?p=36201#p36201
-	signature	= "rusEFI master.2024.06.15.mre-legacy_f4.2784780345"
+	signature	= "rusEFI master.2024.06.15.mre-legacy_f4.4079919286"
 
 [TunerStudio]
 	queryCommand	= "S"
 	versionInfo	= "V"  ; firmware version for title bar.
-	signature= "rusEFI master.2024.06.15.mre-legacy_f4.2784780345" ; signature is expected to be 7 or more characters.
+	signature= "rusEFI master.2024.06.15.mre-legacy_f4.4079919286" ; signature is expected to be 7 or more characters.
 
 	; TS will try to use legacy temp units in some cases, showing "deg F" on a CLT gauge that's actually deg C
 	useLegacyFTempUnits = false
@@ -100,7 +100,7 @@ enable2ndByteCanID = false
 #define adc_channel_e_list="NONE","18 - AN temp 1","23 - AN temp 2","24 - AN temp 3 or Hall Input","22 - AN temp 4 or Hall Input","28 - AN volt 10, Aux Reuse","INVALID","26 - AN volt 2","31 - AN volt 3","36 - AN volt 8, Aux Reuse","40 - AN volt 9, Aux Reuse","27 - AN volt 1","Battery Sense","19 - AN volt 4","20 - AN volt 5","32 - AN volt 6, Aux Reuse","30 - AN volt 7"
 
 ; CONFIG_DEFINITION_START
-; this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:25:10 UTC 2024
+; this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:57:11 UTC 2024
 
 pageSize            = 24748
 page = 1
@@ -538,7 +538,7 @@ noFuelTrimAfterDfcoTime = scalar, U08, 979, "sec", 0.1, 0, 0, 10, 1
 launchSpeedThreshold = scalar, S32, 980, "Kph", 1, 0, 0, 300, 0
 launchRpmWindow = scalar, S32, 984, "RPM", 1, 0, 0, 8000, 0
 triggerEventsTimeoutMs = scalar, F32, 988, "ms", 1, 0, 0, 3000, 3
-unusedHere13 = scalar, S32, 992, "", 1, 0, 0, 100, 0
+mapExpAverageAlpha = scalar, F32, 992, "", 1, 0, 0, 3000, 3
 magicNumberAvailableForDevTricks = scalar, F32, 996, "", 1, 0, 0, 100, 0
 turbochargerFilter = scalar, F32, 1000, "", 1, 0, 0, 100, 0
 launchTpsThreshold = scalar, S32, 1004, "", 1, 0, 0, 20000, 0
@@ -9370,6 +9370,7 @@ dialog = tcuControls, "Transmission Settings"
 
     dialog = parkingLot3, "Experimental 3"
         field = triggerEventsTimeoutMs,   triggerEventsTimeoutMs
+        field = mapExpAverageAlpha, mapExpAverageAlpha
         field = devBit0,         devBit0
         field = devBit1,         devBit1
         field = devBit2,         devBit2

--- a/firmware/tunerstudio/generated/rusefi_mre_f4.ini
+++ b/firmware/tunerstudio/generated/rusefi_mre_f4.ini
@@ -38,12 +38,12 @@ enable2ndByteCanID = false
 
 [MegaTune]
  ; https://rusefi.com/forum/viewtopic.php?p=36201#p36201
-	signature	= "rusEFI master.2024.06.15.mre_f4.2784780345"
+	signature	= "rusEFI master.2024.06.15.mre_f4.4079919286"
 
 [TunerStudio]
 	queryCommand	= "S"
 	versionInfo	= "V"  ; firmware version for title bar.
-	signature= "rusEFI master.2024.06.15.mre_f4.2784780345" ; signature is expected to be 7 or more characters.
+	signature= "rusEFI master.2024.06.15.mre_f4.4079919286" ; signature is expected to be 7 or more characters.
 
 	; TS will try to use legacy temp units in some cases, showing "deg F" on a CLT gauge that's actually deg C
 	useLegacyFTempUnits = false
@@ -100,7 +100,7 @@ enable2ndByteCanID = false
 #define adc_channel_e_list="NONE","18 - AN temp 1","23 - AN temp 2","24 - AN temp 3 or Hall Input","22 - AN temp 4 or Hall Input","28 - AN volt 10, Aux Reuse","INVALID","26 - AN volt 2","31 - AN volt 3","36 - AN volt 8, Aux Reuse","40 - AN volt 9, Aux Reuse","27 - AN volt 1","Battery Sense","19 - AN volt 4","20 - AN volt 5","32 - AN volt 6, Aux Reuse","30 - AN volt 7"
 
 ; CONFIG_DEFINITION_START
-; this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:25:09 UTC 2024
+; this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:57:10 UTC 2024
 
 pageSize            = 24748
 page = 1
@@ -538,7 +538,7 @@ noFuelTrimAfterDfcoTime = scalar, U08, 979, "sec", 0.1, 0, 0, 10, 1
 launchSpeedThreshold = scalar, S32, 980, "Kph", 1, 0, 0, 300, 0
 launchRpmWindow = scalar, S32, 984, "RPM", 1, 0, 0, 8000, 0
 triggerEventsTimeoutMs = scalar, F32, 988, "ms", 1, 0, 0, 3000, 3
-unusedHere13 = scalar, S32, 992, "", 1, 0, 0, 100, 0
+mapExpAverageAlpha = scalar, F32, 992, "", 1, 0, 0, 3000, 3
 magicNumberAvailableForDevTricks = scalar, F32, 996, "", 1, 0, 0, 100, 0
 turbochargerFilter = scalar, F32, 1000, "", 1, 0, 0, 100, 0
 launchTpsThreshold = scalar, S32, 1004, "", 1, 0, 0, 20000, 0
@@ -9370,6 +9370,7 @@ dialog = tcuControls, "Transmission Settings"
 
     dialog = parkingLot3, "Experimental 3"
         field = triggerEventsTimeoutMs,   triggerEventsTimeoutMs
+        field = mapExpAverageAlpha, mapExpAverageAlpha
         field = devBit0,         devBit0
         field = devBit1,         devBit1
         field = devBit2,         devBit2

--- a/firmware/tunerstudio/generated/rusefi_mre_f7.ini
+++ b/firmware/tunerstudio/generated/rusefi_mre_f7.ini
@@ -38,12 +38,12 @@ enable2ndByteCanID = false
 
 [MegaTune]
  ; https://rusefi.com/forum/viewtopic.php?p=36201#p36201
-	signature	= "rusEFI master.2024.06.15.mre_f7.2784780345"
+	signature	= "rusEFI master.2024.06.15.mre_f7.4079919286"
 
 [TunerStudio]
 	queryCommand	= "S"
 	versionInfo	= "V"  ; firmware version for title bar.
-	signature= "rusEFI master.2024.06.15.mre_f7.2784780345" ; signature is expected to be 7 or more characters.
+	signature= "rusEFI master.2024.06.15.mre_f7.4079919286" ; signature is expected to be 7 or more characters.
 
 	; TS will try to use legacy temp units in some cases, showing "deg F" on a CLT gauge that's actually deg C
 	useLegacyFTempUnits = false
@@ -100,7 +100,7 @@ enable2ndByteCanID = false
 #define adc_channel_e_list="NONE","18 - AN temp 1","23 - AN temp 2","24 - AN temp 3 or Hall Input","22 - AN temp 4 or Hall Input","28 - AN volt 10, Aux Reuse","INVALID","26 - AN volt 2","31 - AN volt 3","36 - AN volt 8, Aux Reuse","40 - AN volt 9, Aux Reuse","27 - AN volt 1","Battery Sense","19 - AN volt 4","20 - AN volt 5","32 - AN volt 6, Aux Reuse","30 - AN volt 7"
 
 ; CONFIG_DEFINITION_START
-; this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:25:12 UTC 2024
+; this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:57:12 UTC 2024
 
 pageSize            = 24748
 page = 1
@@ -538,7 +538,7 @@ noFuelTrimAfterDfcoTime = scalar, U08, 979, "sec", 0.1, 0, 0, 10, 1
 launchSpeedThreshold = scalar, S32, 980, "Kph", 1, 0, 0, 300, 0
 launchRpmWindow = scalar, S32, 984, "RPM", 1, 0, 0, 8000, 0
 triggerEventsTimeoutMs = scalar, F32, 988, "ms", 1, 0, 0, 3000, 3
-unusedHere13 = scalar, S32, 992, "", 1, 0, 0, 100, 0
+mapExpAverageAlpha = scalar, F32, 992, "", 1, 0, 0, 3000, 3
 magicNumberAvailableForDevTricks = scalar, F32, 996, "", 1, 0, 0, 100, 0
 turbochargerFilter = scalar, F32, 1000, "", 1, 0, 0, 100, 0
 launchTpsThreshold = scalar, S32, 1004, "", 1, 0, 0, 20000, 0
@@ -9370,6 +9370,7 @@ dialog = tcuControls, "Transmission Settings"
 
     dialog = parkingLot3, "Experimental 3"
         field = triggerEventsTimeoutMs,   triggerEventsTimeoutMs
+        field = mapExpAverageAlpha, mapExpAverageAlpha
         field = devBit0,         devBit0
         field = devBit1,         devBit1
         field = devBit2,         devBit2

--- a/firmware/tunerstudio/generated/rusefi_nucleo_f413.ini
+++ b/firmware/tunerstudio/generated/rusefi_nucleo_f413.ini
@@ -38,12 +38,12 @@ enable2ndByteCanID = false
 
 [MegaTune]
  ; https://rusefi.com/forum/viewtopic.php?p=36201#p36201
-	signature	= "rusEFI master.2024.06.15.nucleo_f413.3101367670"
+	signature	= "rusEFI master.2024.06.15.nucleo_f413.3993624057"
 
 [TunerStudio]
 	queryCommand	= "S"
 	versionInfo	= "V"  ; firmware version for title bar.
-	signature= "rusEFI master.2024.06.15.nucleo_f413.3101367670" ; signature is expected to be 7 or more characters.
+	signature= "rusEFI master.2024.06.15.nucleo_f413.3993624057" ; signature is expected to be 7 or more characters.
 
 	; TS will try to use legacy temp units in some cases, showing "deg F" on a CLT gauge that's actually deg C
 	useLegacyFTempUnits = false
@@ -100,7 +100,7 @@ enable2ndByteCanID = false
 #define adc_channel_e_list="Disabled", "PA0", "PA1", "PA2", "PA3", "PA4", "PA5", "PA6", "PA7", "PB0", "PB1", "PC0", "PC1", "PC2", "PC3", "PC4", "PC5"
 
 ; CONFIG_DEFINITION_START
-; this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:26:01 UTC 2024
+; this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:58:03 UTC 2024
 
 pageSize            = 22748
 page = 1
@@ -538,7 +538,7 @@ noFuelTrimAfterDfcoTime = scalar, U08, 979, "sec", 0.1, 0, 0, 10, 1
 launchSpeedThreshold = scalar, S32, 980, "Kph", 1, 0, 0, 300, 0
 launchRpmWindow = scalar, S32, 984, "RPM", 1, 0, 0, 8000, 0
 triggerEventsTimeoutMs = scalar, F32, 988, "ms", 1, 0, 0, 3000, 3
-unusedHere13 = scalar, S32, 992, "", 1, 0, 0, 100, 0
+mapExpAverageAlpha = scalar, F32, 992, "", 1, 0, 0, 3000, 3
 magicNumberAvailableForDevTricks = scalar, F32, 996, "", 1, 0, 0, 100, 0
 turbochargerFilter = scalar, F32, 1000, "", 1, 0, 0, 100, 0
 launchTpsThreshold = scalar, S32, 1004, "", 1, 0, 0, 20000, 0
@@ -9409,6 +9409,7 @@ dialog = tcuControls, "Transmission Settings"
 
     dialog = parkingLot3, "Experimental 3"
         field = triggerEventsTimeoutMs,   triggerEventsTimeoutMs
+        field = mapExpAverageAlpha, mapExpAverageAlpha
         field = devBit0,         devBit0
         field = devBit1,         devBit1
         field = devBit2,         devBit2

--- a/firmware/tunerstudio/generated/rusefi_prometheus_405.ini
+++ b/firmware/tunerstudio/generated/rusefi_prometheus_405.ini
@@ -38,12 +38,12 @@ enable2ndByteCanID = false
 
 [MegaTune]
  ; https://rusefi.com/forum/viewtopic.php?p=36201#p36201
-	signature	= "rusEFI master.2024.06.15.prometheus_405.2286932198"
+	signature	= "rusEFI master.2024.06.15.prometheus_405.3734835305"
 
 [TunerStudio]
 	queryCommand	= "S"
 	versionInfo	= "V"  ; firmware version for title bar.
-	signature= "rusEFI master.2024.06.15.prometheus_405.2286932198" ; signature is expected to be 7 or more characters.
+	signature= "rusEFI master.2024.06.15.prometheus_405.3734835305" ; signature is expected to be 7 or more characters.
 
 	; TS will try to use legacy temp units in some cases, showing "deg F" on a CLT gauge that's actually deg C
 	useLegacyFTempUnits = false
@@ -100,7 +100,7 @@ enable2ndByteCanID = false
 #define adc_channel_e_list="Disabled", "PA0", "PA1", "PA2", "PA3", "PA4", "PA5", "PA6", "PA7", "PB0", "PB1", "PC0", "PC1", "PC2", "PC3", "PC4", "PC5"
 
 ; CONFIG_DEFINITION_START
-; this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:26:18 UTC 2024
+; this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:58:19 UTC 2024
 
 pageSize            = 22748
 page = 1
@@ -538,7 +538,7 @@ noFuelTrimAfterDfcoTime = scalar, U08, 979, "sec", 0.1, 0, 0, 10, 1
 launchSpeedThreshold = scalar, S32, 980, "Kph", 1, 0, 0, 300, 0
 launchRpmWindow = scalar, S32, 984, "RPM", 1, 0, 0, 8000, 0
 triggerEventsTimeoutMs = scalar, F32, 988, "ms", 1, 0, 0, 3000, 3
-unusedHere13 = scalar, S32, 992, "", 1, 0, 0, 100, 0
+mapExpAverageAlpha = scalar, F32, 992, "", 1, 0, 0, 3000, 3
 magicNumberAvailableForDevTricks = scalar, F32, 996, "", 1, 0, 0, 100, 0
 turbochargerFilter = scalar, F32, 1000, "", 1, 0, 0, 100, 0
 launchTpsThreshold = scalar, S32, 1004, "", 1, 0, 0, 20000, 0
@@ -9404,6 +9404,7 @@ dialog = tcuControls, "Transmission Settings"
 
     dialog = parkingLot3, "Experimental 3"
         field = triggerEventsTimeoutMs,   triggerEventsTimeoutMs
+        field = mapExpAverageAlpha, mapExpAverageAlpha
         field = devBit0,         devBit0
         field = devBit1,         devBit1
         field = devBit2,         devBit2

--- a/firmware/tunerstudio/generated/rusefi_prometheus_469.ini
+++ b/firmware/tunerstudio/generated/rusefi_prometheus_469.ini
@@ -38,12 +38,12 @@ enable2ndByteCanID = false
 
 [MegaTune]
  ; https://rusefi.com/forum/viewtopic.php?p=36201#p36201
-	signature	= "rusEFI master.2024.06.15.prometheus_469.2286932198"
+	signature	= "rusEFI master.2024.06.15.prometheus_469.3734835305"
 
 [TunerStudio]
 	queryCommand	= "S"
 	versionInfo	= "V"  ; firmware version for title bar.
-	signature= "rusEFI master.2024.06.15.prometheus_469.2286932198" ; signature is expected to be 7 or more characters.
+	signature= "rusEFI master.2024.06.15.prometheus_469.3734835305" ; signature is expected to be 7 or more characters.
 
 	; TS will try to use legacy temp units in some cases, showing "deg F" on a CLT gauge that's actually deg C
 	useLegacyFTempUnits = false
@@ -100,7 +100,7 @@ enable2ndByteCanID = false
 #define adc_channel_e_list="Disabled", "PA0", "PA1", "PA2", "PA3", "PA4", "PA5", "PA6", "PA7", "PB0", "PB1", "PC0", "PC1", "PC2", "PC3", "PC4", "PC5"
 
 ; CONFIG_DEFINITION_START
-; this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:26:16 UTC 2024
+; this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:58:18 UTC 2024
 
 pageSize            = 22748
 page = 1
@@ -538,7 +538,7 @@ noFuelTrimAfterDfcoTime = scalar, U08, 979, "sec", 0.1, 0, 0, 10, 1
 launchSpeedThreshold = scalar, S32, 980, "Kph", 1, 0, 0, 300, 0
 launchRpmWindow = scalar, S32, 984, "RPM", 1, 0, 0, 8000, 0
 triggerEventsTimeoutMs = scalar, F32, 988, "ms", 1, 0, 0, 3000, 3
-unusedHere13 = scalar, S32, 992, "", 1, 0, 0, 100, 0
+mapExpAverageAlpha = scalar, F32, 992, "", 1, 0, 0, 3000, 3
 magicNumberAvailableForDevTricks = scalar, F32, 996, "", 1, 0, 0, 100, 0
 turbochargerFilter = scalar, F32, 1000, "", 1, 0, 0, 100, 0
 launchTpsThreshold = scalar, S32, 1004, "", 1, 0, 0, 20000, 0
@@ -9404,6 +9404,7 @@ dialog = tcuControls, "Transmission Settings"
 
     dialog = parkingLot3, "Experimental 3"
         field = triggerEventsTimeoutMs,   triggerEventsTimeoutMs
+        field = mapExpAverageAlpha, mapExpAverageAlpha
         field = devBit0,         devBit0
         field = devBit1,         devBit1
         field = devBit2,         devBit2

--- a/firmware/tunerstudio/generated/rusefi_proteus_f4.ini
+++ b/firmware/tunerstudio/generated/rusefi_proteus_f4.ini
@@ -38,12 +38,12 @@ enable2ndByteCanID = false
 
 [MegaTune]
  ; https://rusefi.com/forum/viewtopic.php?p=36201#p36201
-	signature	= "rusEFI master.2024.06.15.proteus_f4.1388357460"
+	signature	= "rusEFI master.2024.06.15.proteus_f4.68315099"
 
 [TunerStudio]
 	queryCommand	= "S"
 	versionInfo	= "V"  ; firmware version for title bar.
-	signature= "rusEFI master.2024.06.15.proteus_f4.1388357460" ; signature is expected to be 7 or more characters.
+	signature= "rusEFI master.2024.06.15.proteus_f4.68315099" ; signature is expected to be 7 or more characters.
 
 	; TS will try to use legacy temp units in some cases, showing "deg F" on a CLT gauge that's actually deg C
 	useLegacyFTempUnits = false
@@ -100,7 +100,7 @@ enable2ndByteCanID = false
 #define adc_channel_e_list="NONE","Analog Volt 5","Analog Volt 6","Analog Volt 7","Analog Volt 8","Analog Volt 9","Analog Volt 10","Analog Volt 11","Battery Sense","Analog Temp 3","Analog Temp 4","Analog Volt 1","Analog Volt 2","Analog Volt 3","Analog Volt 4","Analog Temp 1","Analog Temp 2"
 
 ; CONFIG_DEFINITION_START
-; this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:26:04 UTC 2024
+; this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:58:05 UTC 2024
 
 pageSize            = 28248
 page = 1
@@ -538,7 +538,7 @@ noFuelTrimAfterDfcoTime = scalar, U08, 979, "sec", 0.1, 0, 0, 10, 1
 launchSpeedThreshold = scalar, S32, 980, "Kph", 1, 0, 0, 300, 0
 launchRpmWindow = scalar, S32, 984, "RPM", 1, 0, 0, 8000, 0
 triggerEventsTimeoutMs = scalar, F32, 988, "ms", 1, 0, 0, 3000, 3
-unusedHere13 = scalar, S32, 992, "", 1, 0, 0, 100, 0
+mapExpAverageAlpha = scalar, F32, 992, "", 1, 0, 0, 3000, 3
 magicNumberAvailableForDevTricks = scalar, F32, 996, "", 1, 0, 0, 100, 0
 turbochargerFilter = scalar, F32, 1000, "", 1, 0, 0, 100, 0
 launchTpsThreshold = scalar, S32, 1004, "", 1, 0, 0, 20000, 0
@@ -9433,6 +9433,7 @@ dialog = tcuControls, "Transmission Settings"
 
     dialog = parkingLot3, "Experimental 3"
         field = triggerEventsTimeoutMs,   triggerEventsTimeoutMs
+        field = mapExpAverageAlpha, mapExpAverageAlpha
         field = devBit0,         devBit0
         field = devBit1,         devBit1
         field = devBit2,         devBit2

--- a/firmware/tunerstudio/generated/rusefi_proteus_f7.ini
+++ b/firmware/tunerstudio/generated/rusefi_proteus_f7.ini
@@ -38,12 +38,12 @@ enable2ndByteCanID = false
 
 [MegaTune]
  ; https://rusefi.com/forum/viewtopic.php?p=36201#p36201
-	signature	= "rusEFI master.2024.06.15.proteus_f7.1388357460"
+	signature	= "rusEFI master.2024.06.15.proteus_f7.68315099"
 
 [TunerStudio]
 	queryCommand	= "S"
 	versionInfo	= "V"  ; firmware version for title bar.
-	signature= "rusEFI master.2024.06.15.proteus_f7.1388357460" ; signature is expected to be 7 or more characters.
+	signature= "rusEFI master.2024.06.15.proteus_f7.68315099" ; signature is expected to be 7 or more characters.
 
 	; TS will try to use legacy temp units in some cases, showing "deg F" on a CLT gauge that's actually deg C
 	useLegacyFTempUnits = false
@@ -100,7 +100,7 @@ enable2ndByteCanID = false
 #define adc_channel_e_list="NONE","Analog Volt 5","Analog Volt 6","Analog Volt 7","Analog Volt 8","Analog Volt 9","Analog Volt 10","Analog Volt 11","Battery Sense","Analog Temp 3","Analog Temp 4","Analog Volt 1","Analog Volt 2","Analog Volt 3","Analog Volt 4","Analog Temp 1","Analog Temp 2"
 
 ; CONFIG_DEFINITION_START
-; this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:26:02 UTC 2024
+; this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:58:04 UTC 2024
 
 pageSize            = 28248
 page = 1
@@ -538,7 +538,7 @@ noFuelTrimAfterDfcoTime = scalar, U08, 979, "sec", 0.1, 0, 0, 10, 1
 launchSpeedThreshold = scalar, S32, 980, "Kph", 1, 0, 0, 300, 0
 launchRpmWindow = scalar, S32, 984, "RPM", 1, 0, 0, 8000, 0
 triggerEventsTimeoutMs = scalar, F32, 988, "ms", 1, 0, 0, 3000, 3
-unusedHere13 = scalar, S32, 992, "", 1, 0, 0, 100, 0
+mapExpAverageAlpha = scalar, F32, 992, "", 1, 0, 0, 3000, 3
 magicNumberAvailableForDevTricks = scalar, F32, 996, "", 1, 0, 0, 100, 0
 turbochargerFilter = scalar, F32, 1000, "", 1, 0, 0, 100, 0
 launchTpsThreshold = scalar, S32, 1004, "", 1, 0, 0, 20000, 0
@@ -9433,6 +9433,7 @@ dialog = tcuControls, "Transmission Settings"
 
     dialog = parkingLot3, "Experimental 3"
         field = triggerEventsTimeoutMs,   triggerEventsTimeoutMs
+        field = mapExpAverageAlpha, mapExpAverageAlpha
         field = devBit0,         devBit0
         field = devBit1,         devBit1
         field = devBit2,         devBit2

--- a/firmware/tunerstudio/generated/rusefi_proteus_h7.ini
+++ b/firmware/tunerstudio/generated/rusefi_proteus_h7.ini
@@ -38,12 +38,12 @@ enable2ndByteCanID = false
 
 [MegaTune]
  ; https://rusefi.com/forum/viewtopic.php?p=36201#p36201
-	signature	= "rusEFI master.2024.06.15.proteus_h7.1388357460"
+	signature	= "rusEFI master.2024.06.15.proteus_h7.68315099"
 
 [TunerStudio]
 	queryCommand	= "S"
 	versionInfo	= "V"  ; firmware version for title bar.
-	signature= "rusEFI master.2024.06.15.proteus_h7.1388357460" ; signature is expected to be 7 or more characters.
+	signature= "rusEFI master.2024.06.15.proteus_h7.68315099" ; signature is expected to be 7 or more characters.
 
 	; TS will try to use legacy temp units in some cases, showing "deg F" on a CLT gauge that's actually deg C
 	useLegacyFTempUnits = false
@@ -100,7 +100,7 @@ enable2ndByteCanID = false
 #define adc_channel_e_list="NONE","Analog Volt 5","Analog Volt 6","Analog Volt 7","Analog Volt 8","Analog Volt 9","Analog Volt 10","Analog Volt 11","Battery Sense","Analog Temp 3","Analog Temp 4","Analog Volt 1","Analog Volt 2","Analog Volt 3","Analog Volt 4","Analog Temp 1","Analog Temp 2"
 
 ; CONFIG_DEFINITION_START
-; this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:26:05 UTC 2024
+; this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:58:07 UTC 2024
 
 pageSize            = 28248
 page = 1
@@ -538,7 +538,7 @@ noFuelTrimAfterDfcoTime = scalar, U08, 979, "sec", 0.1, 0, 0, 10, 1
 launchSpeedThreshold = scalar, S32, 980, "Kph", 1, 0, 0, 300, 0
 launchRpmWindow = scalar, S32, 984, "RPM", 1, 0, 0, 8000, 0
 triggerEventsTimeoutMs = scalar, F32, 988, "ms", 1, 0, 0, 3000, 3
-unusedHere13 = scalar, S32, 992, "", 1, 0, 0, 100, 0
+mapExpAverageAlpha = scalar, F32, 992, "", 1, 0, 0, 3000, 3
 magicNumberAvailableForDevTricks = scalar, F32, 996, "", 1, 0, 0, 100, 0
 turbochargerFilter = scalar, F32, 1000, "", 1, 0, 0, 100, 0
 launchTpsThreshold = scalar, S32, 1004, "", 1, 0, 0, 20000, 0
@@ -9433,6 +9433,7 @@ dialog = tcuControls, "Transmission Settings"
 
     dialog = parkingLot3, "Experimental 3"
         field = triggerEventsTimeoutMs,   triggerEventsTimeoutMs
+        field = mapExpAverageAlpha, mapExpAverageAlpha
         field = devBit0,         devBit0
         field = devBit1,         devBit1
         field = devBit2,         devBit2

--- a/firmware/tunerstudio/generated/rusefi_s105.ini
+++ b/firmware/tunerstudio/generated/rusefi_s105.ini
@@ -38,12 +38,12 @@ enable2ndByteCanID = false
 
 [MegaTune]
  ; https://rusefi.com/forum/viewtopic.php?p=36201#p36201
-	signature	= "rusEFI master.2024.06.15.s105.122723764"
+	signature	= "rusEFI master.2024.06.15.s105.1367498043"
 
 [TunerStudio]
 	queryCommand	= "S"
 	versionInfo	= "V"  ; firmware version for title bar.
-	signature= "rusEFI master.2024.06.15.s105.122723764" ; signature is expected to be 7 or more characters.
+	signature= "rusEFI master.2024.06.15.s105.1367498043" ; signature is expected to be 7 or more characters.
 
 	; TS will try to use legacy temp units in some cases, showing "deg F" on a CLT gauge that's actually deg C
 	useLegacyFTempUnits = false
@@ -100,7 +100,7 @@ enable2ndByteCanID = false
 #define adc_channel_e_list="NONE","56 - MAP","16 - TPS","19 - Knock","39 - CLT","INVALID","opt 55 - AFR 2","opt 21 - AC Press","18 - AFR 1","13 - Ignition switch in (15)","44 - +12 sense (MR)","INVALID","na 37 - MAF","INVALID","INVALID","40 - IAT"
 
 ; CONFIG_DEFINITION_START
-; this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:26:20 UTC 2024
+; this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:58:22 UTC 2024
 
 pageSize            = 22748
 page = 1
@@ -538,7 +538,7 @@ noFuelTrimAfterDfcoTime = scalar, U08, 979, "sec", 0.1, 0, 0, 10, 1
 launchSpeedThreshold = scalar, S32, 980, "Kph", 1, 0, 0, 300, 0
 launchRpmWindow = scalar, S32, 984, "RPM", 1, 0, 0, 8000, 0
 triggerEventsTimeoutMs = scalar, F32, 988, "ms", 1, 0, 0, 3000, 3
-unusedHere13 = scalar, S32, 992, "", 1, 0, 0, 100, 0
+mapExpAverageAlpha = scalar, F32, 992, "", 1, 0, 0, 3000, 3
 magicNumberAvailableForDevTricks = scalar, F32, 996, "", 1, 0, 0, 100, 0
 turbochargerFilter = scalar, F32, 1000, "", 1, 0, 0, 100, 0
 launchTpsThreshold = scalar, S32, 1004, "", 1, 0, 0, 20000, 0
@@ -9385,6 +9385,7 @@ dialog = tcuControls, "Transmission Settings"
 
     dialog = parkingLot3, "Experimental 3"
         field = triggerEventsTimeoutMs,   triggerEventsTimeoutMs
+        field = mapExpAverageAlpha, mapExpAverageAlpha
         field = devBit0,         devBit0
         field = devBit1,         devBit1
         field = devBit2,         devBit2

--- a/firmware/tunerstudio/generated/rusefi_small-can-board.ini
+++ b/firmware/tunerstudio/generated/rusefi_small-can-board.ini
@@ -38,12 +38,12 @@ enable2ndByteCanID = false
 
 [MegaTune]
  ; https://rusefi.com/forum/viewtopic.php?p=36201#p36201
-	signature	= "rusEFI master.2024.06.15.small-can-board.506871636"
+	signature	= "rusEFI master.2024.06.15.small-can-board.1222967259"
 
 [TunerStudio]
 	queryCommand	= "S"
 	versionInfo	= "V"  ; firmware version for title bar.
-	signature= "rusEFI master.2024.06.15.small-can-board.506871636" ; signature is expected to be 7 or more characters.
+	signature= "rusEFI master.2024.06.15.small-can-board.1222967259" ; signature is expected to be 7 or more characters.
 
 	; TS will try to use legacy temp units in some cases, showing "deg F" on a CLT gauge that's actually deg C
 	useLegacyFTempUnits = false
@@ -100,7 +100,7 @@ enable2ndByteCanID = false
 #define adc_channel_e_list="NONE","INVALID","INVALID","B2 - Analog/Digital Input","B3 - Analog/Digital Input","B4 - Analog/Digital Input","B5 - Analog/Digital Input","B7 - Analog/Digital Input","C1 - Analog/Digital Input 6","INVALID","INVALID","INVALID","A2 Battery Sense","INVALID","INVALID","C2 - Analog/Digital Input 7","C4 - Analog/Digital Input 8"
 
 ; CONFIG_DEFINITION_START
-; this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:25:14 UTC 2024
+; this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:57:15 UTC 2024
 
 pageSize            = 22748
 page = 1
@@ -538,7 +538,7 @@ noFuelTrimAfterDfcoTime = scalar, U08, 979, "sec", 0.1, 0, 0, 10, 1
 launchSpeedThreshold = scalar, S32, 980, "Kph", 1, 0, 0, 300, 0
 launchRpmWindow = scalar, S32, 984, "RPM", 1, 0, 0, 8000, 0
 triggerEventsTimeoutMs = scalar, F32, 988, "ms", 1, 0, 0, 3000, 3
-unusedHere13 = scalar, S32, 992, "", 1, 0, 0, 100, 0
+mapExpAverageAlpha = scalar, F32, 992, "", 1, 0, 0, 3000, 3
 magicNumberAvailableForDevTricks = scalar, F32, 996, "", 1, 0, 0, 100, 0
 turbochargerFilter = scalar, F32, 1000, "", 1, 0, 0, 100, 0
 launchTpsThreshold = scalar, S32, 1004, "", 1, 0, 0, 20000, 0
@@ -9400,6 +9400,7 @@ dialog = tcuControls, "Transmission Settings"
 
     dialog = parkingLot3, "Experimental 3"
         field = triggerEventsTimeoutMs,   triggerEventsTimeoutMs
+        field = mapExpAverageAlpha, mapExpAverageAlpha
         field = devBit0,         devBit0
         field = devBit1,         devBit1
         field = devBit2,         devBit2

--- a/firmware/tunerstudio/generated/rusefi_stm32f429_nucleo.ini
+++ b/firmware/tunerstudio/generated/rusefi_stm32f429_nucleo.ini
@@ -38,12 +38,12 @@ enable2ndByteCanID = false
 
 [MegaTune]
  ; https://rusefi.com/forum/viewtopic.php?p=36201#p36201
-	signature	= "rusEFI master.2024.06.15.stm32f429_nucleo.3101367670"
+	signature	= "rusEFI master.2024.06.15.stm32f429_nucleo.3993624057"
 
 [TunerStudio]
 	queryCommand	= "S"
 	versionInfo	= "V"  ; firmware version for title bar.
-	signature= "rusEFI master.2024.06.15.stm32f429_nucleo.3101367670" ; signature is expected to be 7 or more characters.
+	signature= "rusEFI master.2024.06.15.stm32f429_nucleo.3993624057" ; signature is expected to be 7 or more characters.
 
 	; TS will try to use legacy temp units in some cases, showing "deg F" on a CLT gauge that's actually deg C
 	useLegacyFTempUnits = false
@@ -100,7 +100,7 @@ enable2ndByteCanID = false
 #define adc_channel_e_list="Disabled", "PA0", "PA1", "PA2", "PA3", "PA4", "PA5", "PA6", "PA7", "PB0", "PB1", "PC0", "PC1", "PC2", "PC3", "PC4", "PC5"
 
 ; CONFIG_DEFINITION_START
-; this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:25:57 UTC 2024
+; this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:57:59 UTC 2024
 
 pageSize            = 22748
 page = 1
@@ -538,7 +538,7 @@ noFuelTrimAfterDfcoTime = scalar, U08, 979, "sec", 0.1, 0, 0, 10, 1
 launchSpeedThreshold = scalar, S32, 980, "Kph", 1, 0, 0, 300, 0
 launchRpmWindow = scalar, S32, 984, "RPM", 1, 0, 0, 8000, 0
 triggerEventsTimeoutMs = scalar, F32, 988, "ms", 1, 0, 0, 3000, 3
-unusedHere13 = scalar, S32, 992, "", 1, 0, 0, 100, 0
+mapExpAverageAlpha = scalar, F32, 992, "", 1, 0, 0, 3000, 3
 magicNumberAvailableForDevTricks = scalar, F32, 996, "", 1, 0, 0, 100, 0
 turbochargerFilter = scalar, F32, 1000, "", 1, 0, 0, 100, 0
 launchTpsThreshold = scalar, S32, 1004, "", 1, 0, 0, 20000, 0
@@ -9409,6 +9409,7 @@ dialog = tcuControls, "Transmission Settings"
 
     dialog = parkingLot3, "Experimental 3"
         field = triggerEventsTimeoutMs,   triggerEventsTimeoutMs
+        field = mapExpAverageAlpha, mapExpAverageAlpha
         field = devBit0,         devBit0
         field = devBit1,         devBit1
         field = devBit2,         devBit2

--- a/firmware/tunerstudio/generated/rusefi_stm32f767_nucleo.ini
+++ b/firmware/tunerstudio/generated/rusefi_stm32f767_nucleo.ini
@@ -38,12 +38,12 @@ enable2ndByteCanID = false
 
 [MegaTune]
  ; https://rusefi.com/forum/viewtopic.php?p=36201#p36201
-	signature	= "rusEFI master.2024.06.15.stm32f767_nucleo.3101367670"
+	signature	= "rusEFI master.2024.06.15.stm32f767_nucleo.3993624057"
 
 [TunerStudio]
 	queryCommand	= "S"
 	versionInfo	= "V"  ; firmware version for title bar.
-	signature= "rusEFI master.2024.06.15.stm32f767_nucleo.3101367670" ; signature is expected to be 7 or more characters.
+	signature= "rusEFI master.2024.06.15.stm32f767_nucleo.3993624057" ; signature is expected to be 7 or more characters.
 
 	; TS will try to use legacy temp units in some cases, showing "deg F" on a CLT gauge that's actually deg C
 	useLegacyFTempUnits = false
@@ -100,7 +100,7 @@ enable2ndByteCanID = false
 #define adc_channel_e_list="Disabled", "PA0", "PA1", "PA2", "PA3", "PA4", "PA5", "PA6", "PA7", "PB0", "PB1", "PC0", "PC1", "PC2", "PC3", "PC4", "PC5"
 
 ; CONFIG_DEFINITION_START
-; this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:25:00 UTC 2024
+; this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:57:00 UTC 2024
 
 pageSize            = 22748
 page = 1
@@ -538,7 +538,7 @@ noFuelTrimAfterDfcoTime = scalar, U08, 979, "sec", 0.1, 0, 0, 10, 1
 launchSpeedThreshold = scalar, S32, 980, "Kph", 1, 0, 0, 300, 0
 launchRpmWindow = scalar, S32, 984, "RPM", 1, 0, 0, 8000, 0
 triggerEventsTimeoutMs = scalar, F32, 988, "ms", 1, 0, 0, 3000, 3
-unusedHere13 = scalar, S32, 992, "", 1, 0, 0, 100, 0
+mapExpAverageAlpha = scalar, F32, 992, "", 1, 0, 0, 3000, 3
 magicNumberAvailableForDevTricks = scalar, F32, 996, "", 1, 0, 0, 100, 0
 turbochargerFilter = scalar, F32, 1000, "", 1, 0, 0, 100, 0
 launchTpsThreshold = scalar, S32, 1004, "", 1, 0, 0, 20000, 0
@@ -9409,6 +9409,7 @@ dialog = tcuControls, "Transmission Settings"
 
     dialog = parkingLot3, "Experimental 3"
         field = triggerEventsTimeoutMs,   triggerEventsTimeoutMs
+        field = mapExpAverageAlpha, mapExpAverageAlpha
         field = devBit0,         devBit0
         field = devBit1,         devBit1
         field = devBit2,         devBit2

--- a/firmware/tunerstudio/generated/rusefi_stm32h743_nucleo.ini
+++ b/firmware/tunerstudio/generated/rusefi_stm32h743_nucleo.ini
@@ -38,12 +38,12 @@ enable2ndByteCanID = false
 
 [MegaTune]
  ; https://rusefi.com/forum/viewtopic.php?p=36201#p36201
-	signature	= "rusEFI master.2024.06.15.stm32h743_nucleo.3101367670"
+	signature	= "rusEFI master.2024.06.15.stm32h743_nucleo.3993624057"
 
 [TunerStudio]
 	queryCommand	= "S"
 	versionInfo	= "V"  ; firmware version for title bar.
-	signature= "rusEFI master.2024.06.15.stm32h743_nucleo.3101367670" ; signature is expected to be 7 or more characters.
+	signature= "rusEFI master.2024.06.15.stm32h743_nucleo.3993624057" ; signature is expected to be 7 or more characters.
 
 	; TS will try to use legacy temp units in some cases, showing "deg F" on a CLT gauge that's actually deg C
 	useLegacyFTempUnits = false
@@ -100,7 +100,7 @@ enable2ndByteCanID = false
 #define adc_channel_e_list="Disabled", "PA0", "PA1", "PA2", "PA3", "PA4", "PA5", "PA6", "PA7", "PB0", "PB1", "PC0", "PC1", "PC2", "PC3", "PC4", "PC5"
 
 ; CONFIG_DEFINITION_START
-; this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:26:24 UTC 2024
+; this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:58:26 UTC 2024
 
 pageSize            = 22748
 page = 1
@@ -538,7 +538,7 @@ noFuelTrimAfterDfcoTime = scalar, U08, 979, "sec", 0.1, 0, 0, 10, 1
 launchSpeedThreshold = scalar, S32, 980, "Kph", 1, 0, 0, 300, 0
 launchRpmWindow = scalar, S32, 984, "RPM", 1, 0, 0, 8000, 0
 triggerEventsTimeoutMs = scalar, F32, 988, "ms", 1, 0, 0, 3000, 3
-unusedHere13 = scalar, S32, 992, "", 1, 0, 0, 100, 0
+mapExpAverageAlpha = scalar, F32, 992, "", 1, 0, 0, 3000, 3
 magicNumberAvailableForDevTricks = scalar, F32, 996, "", 1, 0, 0, 100, 0
 turbochargerFilter = scalar, F32, 1000, "", 1, 0, 0, 100, 0
 launchTpsThreshold = scalar, S32, 1004, "", 1, 0, 0, 20000, 0
@@ -9409,6 +9409,7 @@ dialog = tcuControls, "Transmission Settings"
 
     dialog = parkingLot3, "Experimental 3"
         field = triggerEventsTimeoutMs,   triggerEventsTimeoutMs
+        field = mapExpAverageAlpha, mapExpAverageAlpha
         field = devBit0,         devBit0
         field = devBit1,         devBit1
         field = devBit2,         devBit2

--- a/firmware/tunerstudio/generated/rusefi_subaru_eg33_f7.ini
+++ b/firmware/tunerstudio/generated/rusefi_subaru_eg33_f7.ini
@@ -38,12 +38,12 @@ enable2ndByteCanID = false
 
 [MegaTune]
  ; https://rusefi.com/forum/viewtopic.php?p=36201#p36201
-	signature	= "rusEFI master.2024.06.15.subaru_eg33_f7.4065659205"
+	signature	= "rusEFI master.2024.06.15.subaru_eg33_f7.2760362442"
 
 [TunerStudio]
 	queryCommand	= "S"
 	versionInfo	= "V"  ; firmware version for title bar.
-	signature= "rusEFI master.2024.06.15.subaru_eg33_f7.4065659205" ; signature is expected to be 7 or more characters.
+	signature= "rusEFI master.2024.06.15.subaru_eg33_f7.2760362442" ; signature is expected to be 7 or more characters.
 
 	; TS will try to use legacy temp units in some cases, showing "deg F" on a CLT gauge that's actually deg C
 	useLegacyFTempUnits = false
@@ -100,7 +100,7 @@ enable2ndByteCanID = false
 #define adc_channel_e_list="NONE","AUX0_18 - MAP Ain","INVALID","INVALID","B05 - MAF Ain","INVALID","AUX0_19 - IAT Ain","A02 - VBat","INVALID","A06 - Oxyg 2 Ain","A04 - EGR t Ain","INVALID","A18 - AUX0 Ain","B02 - TPS Ain","INVALID","A03 - Coolant t Ain","A06 - Oxyg 1 Ain"
 
 ; CONFIG_DEFINITION_START
-; this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:25:55 UTC 2024
+; this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:57:56 UTC 2024
 
 pageSize            = 22748
 page = 1
@@ -538,7 +538,7 @@ noFuelTrimAfterDfcoTime = scalar, U08, 979, "sec", 0.1, 0, 0, 10, 1
 launchSpeedThreshold = scalar, S32, 980, "Kph", 1, 0, 0, 300, 0
 launchRpmWindow = scalar, S32, 984, "RPM", 1, 0, 0, 8000, 0
 triggerEventsTimeoutMs = scalar, F32, 988, "ms", 1, 0, 0, 3000, 3
-unusedHere13 = scalar, S32, 992, "", 1, 0, 0, 100, 0
+mapExpAverageAlpha = scalar, F32, 992, "", 1, 0, 0, 3000, 3
 magicNumberAvailableForDevTricks = scalar, F32, 996, "", 1, 0, 0, 100, 0
 turbochargerFilter = scalar, F32, 1000, "", 1, 0, 0, 100, 0
 launchTpsThreshold = scalar, S32, 1004, "", 1, 0, 0, 20000, 0
@@ -9407,6 +9407,7 @@ dialog = tcuControls, "Transmission Settings"
 
     dialog = parkingLot3, "Experimental 3"
         field = triggerEventsTimeoutMs,   triggerEventsTimeoutMs
+        field = mapExpAverageAlpha, mapExpAverageAlpha
         field = devBit0,         devBit0
         field = devBit1,         devBit1
         field = devBit2,         devBit2

--- a/firmware/tunerstudio/generated/rusefi_t-b-g.ini
+++ b/firmware/tunerstudio/generated/rusefi_t-b-g.ini
@@ -38,12 +38,12 @@ enable2ndByteCanID = false
 
 [MegaTune]
  ; https://rusefi.com/forum/viewtopic.php?p=36201#p36201
-	signature	= "rusEFI master.2024.06.15.t-b-g.3101367670"
+	signature	= "rusEFI master.2024.06.15.t-b-g.3993624057"
 
 [TunerStudio]
 	queryCommand	= "S"
 	versionInfo	= "V"  ; firmware version for title bar.
-	signature= "rusEFI master.2024.06.15.t-b-g.3101367670" ; signature is expected to be 7 or more characters.
+	signature= "rusEFI master.2024.06.15.t-b-g.3993624057" ; signature is expected to be 7 or more characters.
 
 	; TS will try to use legacy temp units in some cases, showing "deg F" on a CLT gauge that's actually deg C
 	useLegacyFTempUnits = false
@@ -100,7 +100,7 @@ enable2ndByteCanID = false
 #define adc_channel_e_list="Disabled", "PA0", "PA1", "PA2", "PA3", "PA4", "PA5", "PA6", "PA7", "PB0", "PB1", "PC0", "PC1", "PC2", "PC3", "PC4", "PC5"
 
 ; CONFIG_DEFINITION_START
-; this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:25:53 UTC 2024
+; this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:57:55 UTC 2024
 
 pageSize            = 22748
 page = 1
@@ -538,7 +538,7 @@ noFuelTrimAfterDfcoTime = scalar, U08, 979, "sec", 0.1, 0, 0, 10, 1
 launchSpeedThreshold = scalar, S32, 980, "Kph", 1, 0, 0, 300, 0
 launchRpmWindow = scalar, S32, 984, "RPM", 1, 0, 0, 8000, 0
 triggerEventsTimeoutMs = scalar, F32, 988, "ms", 1, 0, 0, 3000, 3
-unusedHere13 = scalar, S32, 992, "", 1, 0, 0, 100, 0
+mapExpAverageAlpha = scalar, F32, 992, "", 1, 0, 0, 3000, 3
 magicNumberAvailableForDevTricks = scalar, F32, 996, "", 1, 0, 0, 100, 0
 turbochargerFilter = scalar, F32, 1000, "", 1, 0, 0, 100, 0
 launchTpsThreshold = scalar, S32, 1004, "", 1, 0, 0, 20000, 0
@@ -9409,6 +9409,7 @@ dialog = tcuControls, "Transmission Settings"
 
     dialog = parkingLot3, "Experimental 3"
         field = triggerEventsTimeoutMs,   triggerEventsTimeoutMs
+        field = mapExpAverageAlpha, mapExpAverageAlpha
         field = devBit0,         devBit0
         field = devBit1,         devBit1
         field = devBit2,         devBit2

--- a/firmware/tunerstudio/generated/rusefi_tdg-pdm8.ini
+++ b/firmware/tunerstudio/generated/rusefi_tdg-pdm8.ini
@@ -38,12 +38,12 @@ enable2ndByteCanID = false
 
 [MegaTune]
  ; https://rusefi.com/forum/viewtopic.php?p=36201#p36201
-	signature	= "rusEFI master.2024.06.15.tdg-pdm8.2197201406"
+	signature	= "rusEFI master.2024.06.15.tdg-pdm8.3559154033"
 
 [TunerStudio]
 	queryCommand	= "S"
 	versionInfo	= "V"  ; firmware version for title bar.
-	signature= "rusEFI master.2024.06.15.tdg-pdm8.2197201406" ; signature is expected to be 7 or more characters.
+	signature= "rusEFI master.2024.06.15.tdg-pdm8.3559154033" ; signature is expected to be 7 or more characters.
 
 	; TS will try to use legacy temp units in some cases, showing "deg F" on a CLT gauge that's actually deg C
 	useLegacyFTempUnits = false
@@ -100,7 +100,7 @@ enable2ndByteCanID = false
 #define adc_channel_e_list="NONE","INVALID","INVALID","INVALID","INVALID","Battery Sense","INVALID","INVALID","INVALID","Sense 7","Sense 8","Sense 1","Sense 2","Sense 3","Sense 4","Sense 5","Sense 6"
 
 ; CONFIG_DEFINITION_START
-; this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:26:19 UTC 2024
+; this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:58:21 UTC 2024
 
 pageSize            = 22748
 page = 1
@@ -538,7 +538,7 @@ noFuelTrimAfterDfcoTime = scalar, U08, 979, "sec", 0.1, 0, 0, 10, 1
 launchSpeedThreshold = scalar, S32, 980, "Kph", 1, 0, 0, 300, 0
 launchRpmWindow = scalar, S32, 984, "RPM", 1, 0, 0, 8000, 0
 triggerEventsTimeoutMs = scalar, F32, 988, "ms", 1, 0, 0, 3000, 3
-unusedHere13 = scalar, S32, 992, "", 1, 0, 0, 100, 0
+mapExpAverageAlpha = scalar, F32, 992, "", 1, 0, 0, 3000, 3
 magicNumberAvailableForDevTricks = scalar, F32, 996, "", 1, 0, 0, 100, 0
 turbochargerFilter = scalar, F32, 1000, "", 1, 0, 0, 100, 0
 launchTpsThreshold = scalar, S32, 1004, "", 1, 0, 0, 20000, 0
@@ -9409,6 +9409,7 @@ dialog = tcuControls, "Transmission Settings"
 
     dialog = parkingLot3, "Experimental 3"
         field = triggerEventsTimeoutMs,   triggerEventsTimeoutMs
+        field = mapExpAverageAlpha, mapExpAverageAlpha
         field = devBit0,         devBit0
         field = devBit1,         devBit1
         field = devBit2,         devBit2

--- a/firmware/tunerstudio/generated/rusefi_uaefi.ini
+++ b/firmware/tunerstudio/generated/rusefi_uaefi.ini
@@ -38,12 +38,12 @@ enable2ndByteCanID = false
 
 [MegaTune]
  ; https://rusefi.com/forum/viewtopic.php?p=36201#p36201
-	signature	= "rusEFI master.2024.06.15.uaefi.3265355853"
+	signature	= "rusEFI master.2024.06.15.uaefi.2490605762"
 
 [TunerStudio]
 	queryCommand	= "S"
 	versionInfo	= "V"  ; firmware version for title bar.
-	signature= "rusEFI master.2024.06.15.uaefi.3265355853" ; signature is expected to be 7 or more characters.
+	signature= "rusEFI master.2024.06.15.uaefi.2490605762" ; signature is expected to be 7 or more characters.
 
 	; TS will try to use legacy temp units in some cases, showing "deg F" on a CLT gauge that's actually deg C
 	useLegacyFTempUnits = false
@@ -100,7 +100,7 @@ enable2ndByteCanID = false
 #define adc_channel_e_list="NONE","D1 AUX1","C3 AUX2","INVALID","D6 PPS1","D13 TPS1","A7 Voltage From Key","INVALID","C15 Fuel Pressure / AUX3","C14 TPS2","INVALID","D9 MAP","On-board MAP","D16 CLT Coolant","D15 IAT","C4 PPS2"
 
 ; CONFIG_DEFINITION_START
-; this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:25:25 UTC 2024
+; this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:57:26 UTC 2024
 
 pageSize            = 22748
 page = 1
@@ -538,7 +538,7 @@ noFuelTrimAfterDfcoTime = scalar, U08, 979, "sec", 0.1, 0, 0, 10, 1
 launchSpeedThreshold = scalar, S32, 980, "Kph", 1, 0, 0, 300, 0
 launchRpmWindow = scalar, S32, 984, "RPM", 1, 0, 0, 8000, 0
 triggerEventsTimeoutMs = scalar, F32, 988, "ms", 1, 0, 0, 3000, 3
-unusedHere13 = scalar, S32, 992, "", 1, 0, 0, 100, 0
+mapExpAverageAlpha = scalar, F32, 992, "", 1, 0, 0, 3000, 3
 magicNumberAvailableForDevTricks = scalar, F32, 996, "", 1, 0, 0, 100, 0
 turbochargerFilter = scalar, F32, 1000, "", 1, 0, 0, 100, 0
 launchTpsThreshold = scalar, S32, 1004, "", 1, 0, 0, 20000, 0
@@ -9387,6 +9387,7 @@ dialog = tcuControls, "Transmission Settings"
 
     dialog = parkingLot3, "Experimental 3"
         field = triggerEventsTimeoutMs,   triggerEventsTimeoutMs
+        field = mapExpAverageAlpha, mapExpAverageAlpha
         field = devBit0,         devBit0
         field = devBit1,         devBit1
         field = devBit2,         devBit2

--- a/firmware/tunerstudio/generated/rusefi_uaefi121.ini
+++ b/firmware/tunerstudio/generated/rusefi_uaefi121.ini
@@ -38,12 +38,12 @@ enable2ndByteCanID = false
 
 [MegaTune]
  ; https://rusefi.com/forum/viewtopic.php?p=36201#p36201
-	signature	= "rusEFI master.2024.06.15.uaefi121.3928798276"
+	signature	= "rusEFI master.2024.06.15.uaefi121.3170792651"
 
 [TunerStudio]
 	queryCommand	= "S"
 	versionInfo	= "V"  ; firmware version for title bar.
-	signature= "rusEFI master.2024.06.15.uaefi121.3928798276" ; signature is expected to be 7 or more characters.
+	signature= "rusEFI master.2024.06.15.uaefi121.3170792651" ; signature is expected to be 7 or more characters.
 
 	; TS will try to use legacy temp units in some cases, showing "deg F" on a CLT gauge that's actually deg C
 	useLegacyFTempUnits = false
@@ -100,7 +100,7 @@ enable2ndByteCanID = false
 #define adc_channel_e_list="Disabled", "PA0", "PA1", "PA2", "PA3", "PA4", "PA5", "PA6", "PA7", "PB0", "PB1", "PC0", "PC1", "PC2", "PC3", "PC4", "PC5"
 
 ; CONFIG_DEFINITION_START
-; this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:25:22 UTC 2024
+; this section was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:57:23 UTC 2024
 
 pageSize            = 22748
 page = 1
@@ -538,7 +538,7 @@ noFuelTrimAfterDfcoTime = scalar, U08, 979, "sec", 0.1, 0, 0, 10, 1
 launchSpeedThreshold = scalar, S32, 980, "Kph", 1, 0, 0, 300, 0
 launchRpmWindow = scalar, S32, 984, "RPM", 1, 0, 0, 8000, 0
 triggerEventsTimeoutMs = scalar, F32, 988, "ms", 1, 0, 0, 3000, 3
-unusedHere13 = scalar, S32, 992, "", 1, 0, 0, 100, 0
+mapExpAverageAlpha = scalar, F32, 992, "", 1, 0, 0, 3000, 3
 magicNumberAvailableForDevTricks = scalar, F32, 996, "", 1, 0, 0, 100, 0
 turbochargerFilter = scalar, F32, 1000, "", 1, 0, 0, 100, 0
 launchTpsThreshold = scalar, S32, 1004, "", 1, 0, 0, 20000, 0
@@ -9383,6 +9383,7 @@ dialog = tcuControls, "Transmission Settings"
 
     dialog = parkingLot3, "Experimental 3"
         field = triggerEventsTimeoutMs,   triggerEventsTimeoutMs
+        field = mapExpAverageAlpha, mapExpAverageAlpha
         field = devBit0,         devBit0
         field = devBit1,         devBit1
         field = devBit2,         devBit2

--- a/firmware/tunerstudio/tunerstudio.template.ini
+++ b/firmware/tunerstudio/tunerstudio.template.ini
@@ -4861,6 +4861,7 @@ dialog = tcuControls, "Transmission Settings"
 
     dialog = parkingLot3, "Experimental 3"
         field = triggerEventsTimeoutMs,   triggerEventsTimeoutMs
+        field = mapExpAverageAlpha, mapExpAverageAlpha
         field = devBit0,         devBit0
         field = devBit1,         devBit1
         field = devBit2,         devBit2

--- a/java_console/models/src/main/java/com/rusefi/config/generated/Fields.java
+++ b/java_console/models/src/main/java/com/rusefi/config/generated/Fields.java
@@ -1,6 +1,6 @@
 package com.rusefi.config.generated;
 
-// this file was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:26:27 UTC 2024
+// this file was generated automatically by rusEFI tool config_definition-all.jar based on (unknown script) integration/rusefi_config.txt Sat Jun 15 05:58:29 UTC 2024
 
 // by class com.rusefi.output.FileJavaFieldsConsumer
 import com.rusefi.config.*;
@@ -1197,7 +1197,7 @@ public class Fields {
 	public static final int SentEtbType_FORD_TYPE_1 = 2;
 	public static final int SentEtbType_GM_TYPE_1 = 1;
 	public static final int SentEtbType_NONE = 0;
-	public static final int SIGNATURE_HASH = 478864919;
+	public static final int SIGNATURE_HASH = 1247291032;
 	public static final String SIMULATOR_TUNE_BIN_FILE_NAME = "generated/simulator_tune_image.bin";
 	public static final String SIMULATOR_TUNE_BIN_FILE_NAME_PREFIX = "generated/simulator_tune_image";
 	public static final String SIMULATOR_TUNE_BIN_FILE_NAME_SUFFIX = ".bin";
@@ -1453,7 +1453,7 @@ public class Fields {
 	public static final int TS_RESPONSE_UNDERRUN = 0x80;
 	public static final int TS_RESPONSE_UNRECOGNIZED_COMMAND = 0x83;
 	public static final char TS_SET_LOGGER_SWITCH = 'l';
-	public static final String TS_SIGNATURE = "rusEFI master.2024.06.15.f407-discovery.478864919";
+	public static final String TS_SIGNATURE = "rusEFI master.2024.06.15.f407-discovery.1247291032";
 	public static final char TS_SIMULATE_CAN = '>';
 	public static final char TS_SINGLE_WRITE_COMMAND = 'W';
 	public static final char TS_TEST_COMMAND = 't';
@@ -1992,7 +1992,7 @@ public class Fields {
 	public static final Field LAUNCHSPEEDTHRESHOLD = Field.create("LAUNCHSPEEDTHRESHOLD", 980, FieldType.INT).setScale(1.0).setBaseOffset(0);
 	public static final Field LAUNCHRPMWINDOW = Field.create("LAUNCHRPMWINDOW", 984, FieldType.INT).setScale(1.0).setBaseOffset(0);
 	public static final Field TRIGGEREVENTSTIMEOUTMS = Field.create("TRIGGEREVENTSTIMEOUTMS", 988, FieldType.FLOAT).setBaseOffset(0);
-	public static final Field UNUSEDHERE13 = Field.create("UNUSEDHERE13", 992, FieldType.INT).setScale(1.0).setBaseOffset(0);
+	public static final Field MAPEXPAVERAGEALPHA = Field.create("MAPEXPAVERAGEALPHA", 992, FieldType.FLOAT).setBaseOffset(0);
 	public static final Field MAGICNUMBERAVAILABLEFORDEVTRICKS = Field.create("MAGICNUMBERAVAILABLEFORDEVTRICKS", 996, FieldType.FLOAT).setBaseOffset(0);
 	public static final Field TURBOCHARGERFILTER = Field.create("TURBOCHARGERFILTER", 1000, FieldType.FLOAT).setBaseOffset(0);
 	public static final Field LAUNCHTPSTHRESHOLD = Field.create("LAUNCHTPSTHRESHOLD", 1004, FieldType.INT).setScale(1.0).setBaseOffset(0);
@@ -3663,7 +3663,7 @@ public class Fields {
 	LAUNCHSPEEDTHRESHOLD,
 	LAUNCHRPMWINDOW,
 	TRIGGEREVENTSTIMEOUTMS,
-	UNUSEDHERE13,
+	MAPEXPAVERAGEALPHA,
 	MAGICNUMBERAVAILABLEFORDEVTRICKS,
 	TURBOCHARGERFILTER,
 	LAUNCHTPSTHRESHOLD,

--- a/simulator/generated/simulator_tune.msq
+++ b/simulator/generated/simulator_tune.msq
@@ -508,7 +508,7 @@
         <constant digits="0" name="launchSpeedThreshold" units="Kph">30.0</constant>
         <constant digits="0" name="launchRpmWindow" units="RPM">500.0</constant>
         <constant digits="3" name="triggerEventsTimeoutMs" units="ms">0.0</constant>
-        <constant digits="0" name="unusedHere13" units="">0.0</constant>
+        <constant digits="3" name="mapExpAverageAlpha" units="">0.0</constant>
         <constant digits="0" name="magicNumberAvailableForDevTricks" units="">1.0</constant>
         <constant digits="0" name="turbochargerFilter" units="">0.01</constant>
         <constant digits="0" name="launchTpsThreshold" units="">0.0</constant>
@@ -4719,7 +4719,7 @@ end</constant>
 </constant>
         <constant digits="0" name="tcu_shiftTime" units="ms">0.0</constant>
     </page>
-    <versionInfo firmwareInfo="20240607" nPages="1" signature="rusEFI master.2024.06.15.f407-discovery.478864919" version="5.0"/>
+    <versionInfo firmwareInfo="20240607" nPages="1" signature="rusEFI master.2024.06.15.f407-discovery.1247291032" version="5.0"/>
     <bibliography author="rusEFI 20240607" writeDate="date"/>
     <settings/>
     <userComments/>

--- a/simulator/generated/simulator_tune_BMW_M52.msq
+++ b/simulator/generated/simulator_tune_BMW_M52.msq
@@ -508,7 +508,7 @@
         <constant digits="0" name="launchSpeedThreshold" units="Kph">30.0</constant>
         <constant digits="0" name="launchRpmWindow" units="RPM">500.0</constant>
         <constant digits="3" name="triggerEventsTimeoutMs" units="ms">0.0</constant>
-        <constant digits="0" name="unusedHere13" units="">0.0</constant>
+        <constant digits="3" name="mapExpAverageAlpha" units="">0.0</constant>
         <constant digits="0" name="magicNumberAvailableForDevTricks" units="">1.0</constant>
         <constant digits="0" name="turbochargerFilter" units="">0.01</constant>
         <constant digits="0" name="launchTpsThreshold" units="">0.0</constant>
@@ -4719,7 +4719,7 @@ end</constant>
 </constant>
         <constant digits="0" name="tcu_shiftTime" units="ms">0.0</constant>
     </page>
-    <versionInfo firmwareInfo="20240607" nPages="1" signature="rusEFI master.2024.06.15.f407-discovery.478864919" version="5.0"/>
+    <versionInfo firmwareInfo="20240607" nPages="1" signature="rusEFI master.2024.06.15.f407-discovery.1247291032" version="5.0"/>
     <bibliography author="rusEFI 20240607" writeDate="date"/>
     <settings/>
     <userComments/>

--- a/simulator/generated/simulator_tune_HARLEY.msq
+++ b/simulator/generated/simulator_tune_HARLEY.msq
@@ -508,7 +508,7 @@
         <constant digits="0" name="launchSpeedThreshold" units="Kph">30.0</constant>
         <constant digits="0" name="launchRpmWindow" units="RPM">500.0</constant>
         <constant digits="3" name="triggerEventsTimeoutMs" units="ms">0.0</constant>
-        <constant digits="0" name="unusedHere13" units="">0.0</constant>
+        <constant digits="3" name="mapExpAverageAlpha" units="">0.0</constant>
         <constant digits="0" name="magicNumberAvailableForDevTricks" units="">1.0</constant>
         <constant digits="0" name="turbochargerFilter" units="">0.01</constant>
         <constant digits="0" name="launchTpsThreshold" units="">0.0</constant>
@@ -4795,7 +4795,7 @@ end</constant>
 </constant>
         <constant digits="0" name="tcu_shiftTime" units="ms">0.0</constant>
     </page>
-    <versionInfo firmwareInfo="20240607" nPages="1" signature="rusEFI master.2024.06.15.f407-discovery.478864919" version="5.0"/>
+    <versionInfo firmwareInfo="20240607" nPages="1" signature="rusEFI master.2024.06.15.f407-discovery.1247291032" version="5.0"/>
     <bibliography author="rusEFI 20240607" writeDate="date"/>
     <settings/>
     <userComments/>

--- a/simulator/generated/simulator_tune_HELLEN_121_NISSAN_6_CYL.msq
+++ b/simulator/generated/simulator_tune_HELLEN_121_NISSAN_6_CYL.msq
@@ -508,7 +508,7 @@
         <constant digits="0" name="launchSpeedThreshold" units="Kph">30.0</constant>
         <constant digits="0" name="launchRpmWindow" units="RPM">500.0</constant>
         <constant digits="3" name="triggerEventsTimeoutMs" units="ms">0.0</constant>
-        <constant digits="0" name="unusedHere13" units="">0.0</constant>
+        <constant digits="3" name="mapExpAverageAlpha" units="">0.0</constant>
         <constant digits="0" name="magicNumberAvailableForDevTricks" units="">1.0</constant>
         <constant digits="0" name="turbochargerFilter" units="">0.01</constant>
         <constant digits="0" name="launchTpsThreshold" units="">0.0</constant>
@@ -4807,7 +4807,7 @@ canRxAdd(IN_35D, onCanRxAc)</constant>
 </constant>
         <constant digits="0" name="tcu_shiftTime" units="ms">0.0</constant>
     </page>
-    <versionInfo firmwareInfo="20240607" nPages="1" signature="rusEFI master.2024.06.15.f407-discovery.478864919" version="5.0"/>
+    <versionInfo firmwareInfo="20240607" nPages="1" signature="rusEFI master.2024.06.15.f407-discovery.1247291032" version="5.0"/>
     <bibliography author="rusEFI 20240607" writeDate="date"/>
     <settings/>
     <userComments/>

--- a/simulator/generated/simulator_tune_HELLEN_154_HYUNDAI_COUPE_BK1.msq
+++ b/simulator/generated/simulator_tune_HELLEN_154_HYUNDAI_COUPE_BK1.msq
@@ -508,7 +508,7 @@
         <constant digits="0" name="launchSpeedThreshold" units="Kph">30.0</constant>
         <constant digits="0" name="launchRpmWindow" units="RPM">500.0</constant>
         <constant digits="3" name="triggerEventsTimeoutMs" units="ms">0.0</constant>
-        <constant digits="0" name="unusedHere13" units="">0.0</constant>
+        <constant digits="3" name="mapExpAverageAlpha" units="">0.0</constant>
         <constant digits="0" name="magicNumberAvailableForDevTricks" units="">1.0</constant>
         <constant digits="0" name="turbochargerFilter" units="">0.01</constant>
         <constant digits="0" name="launchTpsThreshold" units="">0.0</constant>
@@ -4768,7 +4768,7 @@ end</constant>
 </constant>
         <constant digits="0" name="tcu_shiftTime" units="ms">0.0</constant>
     </page>
-    <versionInfo firmwareInfo="20240607" nPages="1" signature="rusEFI master.2024.06.15.f407-discovery.478864919" version="5.0"/>
+    <versionInfo firmwareInfo="20240607" nPages="1" signature="rusEFI master.2024.06.15.f407-discovery.1247291032" version="5.0"/>
     <bibliography author="rusEFI 20240607" writeDate="date"/>
     <settings/>
     <userComments/>

--- a/simulator/generated/simulator_tune_HELLEN_154_HYUNDAI_COUPE_BK2.msq
+++ b/simulator/generated/simulator_tune_HELLEN_154_HYUNDAI_COUPE_BK2.msq
@@ -508,7 +508,7 @@
         <constant digits="0" name="launchSpeedThreshold" units="Kph">30.0</constant>
         <constant digits="0" name="launchRpmWindow" units="RPM">500.0</constant>
         <constant digits="3" name="triggerEventsTimeoutMs" units="ms">0.0</constant>
-        <constant digits="0" name="unusedHere13" units="">0.0</constant>
+        <constant digits="3" name="mapExpAverageAlpha" units="">0.0</constant>
         <constant digits="0" name="magicNumberAvailableForDevTricks" units="">1.0</constant>
         <constant digits="0" name="turbochargerFilter" units="">0.01</constant>
         <constant digits="0" name="launchTpsThreshold" units="">0.0</constant>
@@ -4768,7 +4768,7 @@ end</constant>
 </constant>
         <constant digits="0" name="tcu_shiftTime" units="ms">0.0</constant>
     </page>
-    <versionInfo firmwareInfo="20240607" nPages="1" signature="rusEFI master.2024.06.15.f407-discovery.478864919" version="5.0"/>
+    <versionInfo firmwareInfo="20240607" nPages="1" signature="rusEFI master.2024.06.15.f407-discovery.1247291032" version="5.0"/>
     <bibliography author="rusEFI 20240607" writeDate="date"/>
     <settings/>
     <userComments/>

--- a/simulator/generated/simulator_tune_HONDA_K.msq
+++ b/simulator/generated/simulator_tune_HONDA_K.msq
@@ -508,7 +508,7 @@
         <constant digits="0" name="launchSpeedThreshold" units="Kph">30.0</constant>
         <constant digits="0" name="launchRpmWindow" units="RPM">500.0</constant>
         <constant digits="3" name="triggerEventsTimeoutMs" units="ms">0.0</constant>
-        <constant digits="0" name="unusedHere13" units="">0.0</constant>
+        <constant digits="3" name="mapExpAverageAlpha" units="">0.0</constant>
         <constant digits="0" name="magicNumberAvailableForDevTricks" units="">1.0</constant>
         <constant digits="0" name="turbochargerFilter" units="">0.01</constant>
         <constant digits="0" name="launchTpsThreshold" units="">0.0</constant>
@@ -4721,7 +4721,7 @@ end</constant>
 </constant>
         <constant digits="0" name="tcu_shiftTime" units="ms">0.0</constant>
     </page>
-    <versionInfo firmwareInfo="20240607" nPages="1" signature="rusEFI master.2024.06.15.f407-discovery.478864919" version="5.0"/>
+    <versionInfo firmwareInfo="20240607" nPages="1" signature="rusEFI master.2024.06.15.f407-discovery.1247291032" version="5.0"/>
     <bibliography author="rusEFI 20240607" writeDate="date"/>
     <settings/>
     <userComments/>

--- a/simulator/generated/simulator_tune_HONDA_OBD1.msq
+++ b/simulator/generated/simulator_tune_HONDA_OBD1.msq
@@ -508,7 +508,7 @@
         <constant digits="0" name="launchSpeedThreshold" units="Kph">30.0</constant>
         <constant digits="0" name="launchRpmWindow" units="RPM">500.0</constant>
         <constant digits="3" name="triggerEventsTimeoutMs" units="ms">0.0</constant>
-        <constant digits="0" name="unusedHere13" units="">0.0</constant>
+        <constant digits="3" name="mapExpAverageAlpha" units="">0.0</constant>
         <constant digits="0" name="magicNumberAvailableForDevTricks" units="">1.0</constant>
         <constant digits="0" name="turbochargerFilter" units="">0.01</constant>
         <constant digits="0" name="launchTpsThreshold" units="">0.0</constant>
@@ -4720,7 +4720,7 @@ end</constant>
 </constant>
         <constant digits="0" name="tcu_shiftTime" units="ms">0.0</constant>
     </page>
-    <versionInfo firmwareInfo="20240607" nPages="1" signature="rusEFI master.2024.06.15.f407-discovery.478864919" version="5.0"/>
+    <versionInfo firmwareInfo="20240607" nPages="1" signature="rusEFI master.2024.06.15.f407-discovery.1247291032" version="5.0"/>
     <bibliography author="rusEFI 20240607" writeDate="date"/>
     <settings/>
     <userComments/>

--- a/simulator/generated/simulator_tune_HYUNDAI_PB.msq
+++ b/simulator/generated/simulator_tune_HYUNDAI_PB.msq
@@ -508,7 +508,7 @@
         <constant digits="0" name="launchSpeedThreshold" units="Kph">30.0</constant>
         <constant digits="0" name="launchRpmWindow" units="RPM">500.0</constant>
         <constant digits="3" name="triggerEventsTimeoutMs" units="ms">0.0</constant>
-        <constant digits="0" name="unusedHere13" units="">0.0</constant>
+        <constant digits="3" name="mapExpAverageAlpha" units="">0.0</constant>
         <constant digits="0" name="magicNumberAvailableForDevTricks" units="">1.0</constant>
         <constant digits="0" name="turbochargerFilter" units="">0.01</constant>
         <constant digits="0" name="launchTpsThreshold" units="">0.0</constant>
@@ -4811,7 +4811,7 @@ end</constant>
 </constant>
         <constant digits="0" name="tcu_shiftTime" units="ms">0.0</constant>
     </page>
-    <versionInfo firmwareInfo="20240607" nPages="1" signature="rusEFI master.2024.06.15.f407-discovery.478864919" version="5.0"/>
+    <versionInfo firmwareInfo="20240607" nPages="1" signature="rusEFI master.2024.06.15.f407-discovery.1247291032" version="5.0"/>
     <bibliography author="rusEFI 20240607" writeDate="date"/>
     <settings/>
     <userComments/>

--- a/simulator/generated/simulator_tune_MAVERICK_X3.msq
+++ b/simulator/generated/simulator_tune_MAVERICK_X3.msq
@@ -508,7 +508,7 @@
         <constant digits="0" name="launchSpeedThreshold" units="Kph">30.0</constant>
         <constant digits="0" name="launchRpmWindow" units="RPM">500.0</constant>
         <constant digits="3" name="triggerEventsTimeoutMs" units="ms">0.0</constant>
-        <constant digits="0" name="unusedHere13" units="">0.0</constant>
+        <constant digits="3" name="mapExpAverageAlpha" units="">0.0</constant>
         <constant digits="0" name="magicNumberAvailableForDevTricks" units="">1.0</constant>
         <constant digits="0" name="turbochargerFilter" units="">0.01</constant>
         <constant digits="0" name="launchTpsThreshold" units="">0.0</constant>
@@ -4718,7 +4718,7 @@ end</constant>
 </constant>
         <constant digits="0" name="tcu_shiftTime" units="ms">0.0</constant>
     </page>
-    <versionInfo firmwareInfo="20240607" nPages="1" signature="rusEFI master.2024.06.15.f407-discovery.478864919" version="5.0"/>
+    <versionInfo firmwareInfo="20240607" nPages="1" signature="rusEFI master.2024.06.15.f407-discovery.1247291032" version="5.0"/>
     <bibliography author="rusEFI 20240607" writeDate="date"/>
     <settings/>
     <userComments/>

--- a/simulator/generated/simulator_tune_MAZDA_MIATA_NA6.msq
+++ b/simulator/generated/simulator_tune_MAZDA_MIATA_NA6.msq
@@ -508,7 +508,7 @@
         <constant digits="0" name="launchSpeedThreshold" units="Kph">30.0</constant>
         <constant digits="0" name="launchRpmWindow" units="RPM">500.0</constant>
         <constant digits="3" name="triggerEventsTimeoutMs" units="ms">0.0</constant>
-        <constant digits="0" name="unusedHere13" units="">0.0</constant>
+        <constant digits="3" name="mapExpAverageAlpha" units="">0.0</constant>
         <constant digits="0" name="magicNumberAvailableForDevTricks" units="">1.0</constant>
         <constant digits="0" name="turbochargerFilter" units="">0.01</constant>
         <constant digits="0" name="launchTpsThreshold" units="">0.0</constant>
@@ -4721,7 +4721,7 @@ end</constant>
 </constant>
         <constant digits="0" name="tcu_shiftTime" units="ms">0.0</constant>
     </page>
-    <versionInfo firmwareInfo="20240607" nPages="1" signature="rusEFI master.2024.06.15.f407-discovery.478864919" version="5.0"/>
+    <versionInfo firmwareInfo="20240607" nPages="1" signature="rusEFI master.2024.06.15.f407-discovery.1247291032" version="5.0"/>
     <bibliography author="rusEFI 20240607" writeDate="date"/>
     <settings/>
     <userComments/>

--- a/simulator/generated/simulator_tune_MAZDA_MIATA_NA94.msq
+++ b/simulator/generated/simulator_tune_MAZDA_MIATA_NA94.msq
@@ -508,7 +508,7 @@
         <constant digits="0" name="launchSpeedThreshold" units="Kph">30.0</constant>
         <constant digits="0" name="launchRpmWindow" units="RPM">500.0</constant>
         <constant digits="3" name="triggerEventsTimeoutMs" units="ms">0.0</constant>
-        <constant digits="0" name="unusedHere13" units="">0.0</constant>
+        <constant digits="3" name="mapExpAverageAlpha" units="">0.0</constant>
         <constant digits="0" name="magicNumberAvailableForDevTricks" units="">1.0</constant>
         <constant digits="0" name="turbochargerFilter" units="">0.01</constant>
         <constant digits="0" name="launchTpsThreshold" units="">0.0</constant>
@@ -4721,7 +4721,7 @@ end</constant>
 </constant>
         <constant digits="0" name="tcu_shiftTime" units="ms">0.0</constant>
     </page>
-    <versionInfo firmwareInfo="20240607" nPages="1" signature="rusEFI master.2024.06.15.f407-discovery.478864919" version="5.0"/>
+    <versionInfo firmwareInfo="20240607" nPages="1" signature="rusEFI master.2024.06.15.f407-discovery.1247291032" version="5.0"/>
     <bibliography author="rusEFI 20240607" writeDate="date"/>
     <settings/>
     <userComments/>

--- a/simulator/generated/simulator_tune_MAZDA_MIATA_NA96.msq
+++ b/simulator/generated/simulator_tune_MAZDA_MIATA_NA96.msq
@@ -508,7 +508,7 @@
         <constant digits="0" name="launchSpeedThreshold" units="Kph">30.0</constant>
         <constant digits="0" name="launchRpmWindow" units="RPM">500.0</constant>
         <constant digits="3" name="triggerEventsTimeoutMs" units="ms">0.0</constant>
-        <constant digits="0" name="unusedHere13" units="">0.0</constant>
+        <constant digits="3" name="mapExpAverageAlpha" units="">0.0</constant>
         <constant digits="0" name="magicNumberAvailableForDevTricks" units="">1.0</constant>
         <constant digits="0" name="turbochargerFilter" units="">0.01</constant>
         <constant digits="0" name="launchTpsThreshold" units="">0.0</constant>
@@ -4721,7 +4721,7 @@ end</constant>
 </constant>
         <constant digits="0" name="tcu_shiftTime" units="ms">0.0</constant>
     </page>
-    <versionInfo firmwareInfo="20240607" nPages="1" signature="rusEFI master.2024.06.15.f407-discovery.478864919" version="5.0"/>
+    <versionInfo firmwareInfo="20240607" nPages="1" signature="rusEFI master.2024.06.15.f407-discovery.1247291032" version="5.0"/>
     <bibliography author="rusEFI 20240607" writeDate="date"/>
     <settings/>
     <userComments/>

--- a/simulator/generated/simulator_tune_MAZDA_MIATA_NB1.msq
+++ b/simulator/generated/simulator_tune_MAZDA_MIATA_NB1.msq
@@ -508,7 +508,7 @@
         <constant digits="0" name="launchSpeedThreshold" units="Kph">30.0</constant>
         <constant digits="0" name="launchRpmWindow" units="RPM">500.0</constant>
         <constant digits="3" name="triggerEventsTimeoutMs" units="ms">0.0</constant>
-        <constant digits="0" name="unusedHere13" units="">0.0</constant>
+        <constant digits="3" name="mapExpAverageAlpha" units="">0.0</constant>
         <constant digits="0" name="magicNumberAvailableForDevTricks" units="">1.0</constant>
         <constant digits="0" name="turbochargerFilter" units="">0.01</constant>
         <constant digits="0" name="launchTpsThreshold" units="">0.0</constant>
@@ -4721,7 +4721,7 @@ end</constant>
 </constant>
         <constant digits="0" name="tcu_shiftTime" units="ms">0.0</constant>
     </page>
-    <versionInfo firmwareInfo="20240607" nPages="1" signature="rusEFI master.2024.06.15.f407-discovery.478864919" version="5.0"/>
+    <versionInfo firmwareInfo="20240607" nPages="1" signature="rusEFI master.2024.06.15.f407-discovery.1247291032" version="5.0"/>
     <bibliography author="rusEFI 20240607" writeDate="date"/>
     <settings/>
     <userComments/>

--- a/simulator/generated/simulator_tune_MAZDA_MIATA_NB2.msq
+++ b/simulator/generated/simulator_tune_MAZDA_MIATA_NB2.msq
@@ -508,7 +508,7 @@
         <constant digits="0" name="launchSpeedThreshold" units="Kph">30.0</constant>
         <constant digits="0" name="launchRpmWindow" units="RPM">500.0</constant>
         <constant digits="3" name="triggerEventsTimeoutMs" units="ms">0.0</constant>
-        <constant digits="0" name="unusedHere13" units="">0.0</constant>
+        <constant digits="3" name="mapExpAverageAlpha" units="">0.0</constant>
         <constant digits="0" name="magicNumberAvailableForDevTricks" units="">1.0</constant>
         <constant digits="0" name="turbochargerFilter" units="">0.01</constant>
         <constant digits="0" name="launchTpsThreshold" units="">0.0</constant>
@@ -4722,7 +4722,7 @@ end</constant>
 </constant>
         <constant digits="0" name="tcu_shiftTime" units="ms">0.0</constant>
     </page>
-    <versionInfo firmwareInfo="20240607" nPages="1" signature="rusEFI master.2024.06.15.f407-discovery.478864919" version="5.0"/>
+    <versionInfo firmwareInfo="20240607" nPages="1" signature="rusEFI master.2024.06.15.f407-discovery.1247291032" version="5.0"/>
     <bibliography author="rusEFI 20240607" writeDate="date"/>
     <settings/>
     <userComments/>

--- a/simulator/generated/simulator_tune_MERCEDES_M111.msq
+++ b/simulator/generated/simulator_tune_MERCEDES_M111.msq
@@ -508,7 +508,7 @@
         <constant digits="0" name="launchSpeedThreshold" units="Kph">30.0</constant>
         <constant digits="0" name="launchRpmWindow" units="RPM">500.0</constant>
         <constant digits="3" name="triggerEventsTimeoutMs" units="ms">0.0</constant>
-        <constant digits="0" name="unusedHere13" units="">0.0</constant>
+        <constant digits="3" name="mapExpAverageAlpha" units="">0.0</constant>
         <constant digits="0" name="magicNumberAvailableForDevTricks" units="">1.0</constant>
         <constant digits="0" name="turbochargerFilter" units="">0.01</constant>
         <constant digits="0" name="launchTpsThreshold" units="">0.0</constant>
@@ -4721,7 +4721,7 @@ end</constant>
 </constant>
         <constant digits="0" name="tcu_shiftTime" units="ms">0.0</constant>
     </page>
-    <versionInfo firmwareInfo="20240607" nPages="1" signature="rusEFI master.2024.06.15.f407-discovery.478864919" version="5.0"/>
+    <versionInfo firmwareInfo="20240607" nPages="1" signature="rusEFI master.2024.06.15.f407-discovery.1247291032" version="5.0"/>
     <bibliography author="rusEFI 20240607" writeDate="date"/>
     <settings/>
     <userComments/>

--- a/simulator/generated/simulator_tune_POLARIS_RZR.msq
+++ b/simulator/generated/simulator_tune_POLARIS_RZR.msq
@@ -508,7 +508,7 @@
         <constant digits="0" name="launchSpeedThreshold" units="Kph">30.0</constant>
         <constant digits="0" name="launchRpmWindow" units="RPM">500.0</constant>
         <constant digits="3" name="triggerEventsTimeoutMs" units="ms">0.0</constant>
-        <constant digits="0" name="unusedHere13" units="">0.0</constant>
+        <constant digits="3" name="mapExpAverageAlpha" units="">0.0</constant>
         <constant digits="0" name="magicNumberAvailableForDevTricks" units="">1.0</constant>
         <constant digits="0" name="turbochargerFilter" units="">0.01</constant>
         <constant digits="0" name="launchTpsThreshold" units="">0.0</constant>
@@ -4718,7 +4718,7 @@ end</constant>
 </constant>
         <constant digits="0" name="tcu_shiftTime" units="ms">0.0</constant>
     </page>
-    <versionInfo firmwareInfo="20240607" nPages="1" signature="rusEFI master.2024.06.15.f407-discovery.478864919" version="5.0"/>
+    <versionInfo firmwareInfo="20240607" nPages="1" signature="rusEFI master.2024.06.15.f407-discovery.1247291032" version="5.0"/>
     <bibliography author="rusEFI 20240607" writeDate="date"/>
     <settings/>
     <userComments/>


### PR DESCRIPTION
When a baud rate change was requested, we were trying to connect at the new baud rate instead of the current "working" baud rate. This was reporting back to the console as a NAME change failure.

Also moved some code to create a "findBaudIndex" function. This is not necessary but helped me keep things organized.