### PR TITLE
Bluetooth initialization order bug fix (and housekeeping)

### DIFF
--- a/firmware/console/binary/bluetooth.cpp
+++ b/firmware/console/binary/bluetooth.cpp
@@ -242,7 +242,7 @@ uint8_t findBaudIndex(SerialTsChannelBase* tsChannel) {
 			return 255;//failed
 		}
 
-		efiPrintf("Restarting at %d", baudRates[baudIdx].rate);
+		efiPrintf("Restarting at %lu", baudRates[baudIdx].rate);
 		tsChannel->start(baudRates[baudIdx].rate);
 		chThdSleepMilliseconds(10);	// safety
 

--- a/firmware/console/binary/bluetooth.h
+++ b/firmware/console/binary/bluetooth.h
@@ -45,3 +45,8 @@ void bluetoothStart(bluetooth_module_e moduleType, const char *baudRate, const c
  */
 void bluetoothSoftwareDisconnectNotify(SerialTsChannelBase* tsChannel);
 
+/**
+ * Called during bluetooth initialization. Checks to see if module responds to common baud rates
+ * returns the index of the found baud
+ */
+uint8_t findBaudIndex(SerialTsChannelBase* tsChannel);


### PR DESCRIPTION
When a baud rate change was requested, we were trying to connect at the new baud rate instead of the current "working" baud rate. This was reporting back to the console as a NAME change failure.

Also moved some code to create a "findBaudIndex" function. This is not necessary but helped me keep things organized.