### PR TITLE
ADC: FastAdcToken rename to AdcToken

### DIFF
--- a/firmware/hw_layer/adc/AdcDevice.h
+++ b/firmware/hw_layer/adc/AdcDevice.h
@@ -27,7 +27,7 @@ public:
 	int enableChannel(adc_channel_e hwChannel);
 	adc_channel_e getAdcChannelByInternalIndex(int index) const;
 	adcsample_t getAvgAdcValue(adc_channel_e hwChannel, size_t bufDepth);
-	FastAdcToken getAdcChannelToken(adc_channel_e hwChannel);
+	AdcToken getAdcChannelToken(adc_channel_e hwChannel);
 	int size() const;
 	void init(void);
 	uint32_t conversionCount = 0;

--- a/firmware/hw_layer/adc/adc_inputs.cpp
+++ b/firmware/hw_layer/adc/adc_inputs.cpp
@@ -289,7 +289,7 @@ adc_channel_e AdcDevice::getAdcChannelByInternalIndex(int hwChannel) const {
 	return EFI_ADC_NONE;
 }
 
-FastAdcToken AdcDevice::getAdcChannelToken(adc_channel_e hwChannel) {
+AdcToken AdcDevice::getAdcChannelToken(adc_channel_e hwChannel) {
 	return fastAdc.internalAdcIndexByHardwareIndex[hwChannel];
 }
 

--- a/firmware/hw_layer/adc/adc_inputs.h
+++ b/firmware/hw_layer/adc/adc_inputs.h
@@ -78,11 +78,11 @@ void removeChannel(const char *name, adc_channel_e hwChannel);
 // This callback is called by the ADC driver when a new fast ADC sample is ready
 void onFastAdcComplete(adcsample_t* samples);
 
-using FastAdcToken = size_t;
-static constexpr FastAdcToken invalidAdcToken = (FastAdcToken)(-1);
+using AdcToken = size_t;
+static constexpr AdcToken invalidAdcToken = (AdcToken)(-1);
 
-FastAdcToken enableFastAdcChannel(const char* msg, adc_channel_e channel);
-adcsample_t getFastAdc(FastAdcToken token);
+AdcToken enableFastAdcChannel(const char* msg, adc_channel_e channel);
+adcsample_t getFastAdc(AdcToken token);
 #endif // HAL_USE_ADC
 
 void printFullAdcReport(void);

--- a/firmware/hw_layer/hardware.cpp
+++ b/firmware/hw_layer/hardware.cpp
@@ -257,11 +257,11 @@ void printSpiConfig(const char *msg, spi_device_e device) {
 
 #if HAL_USE_ADC
 
-static FastAdcToken fastMapSampleIndex;
-static FastAdcToken hipSampleIndex;
+static AdcToken fastMapSampleIndex;
+static AdcToken hipSampleIndex;
 
 #if HAL_TRIGGER_USE_ADC
-static FastAdcToken triggerSampleIndex;
+static AdcToken triggerSampleIndex;
 #endif // HAL_TRIGGER_USE_ADC
 
 extern AdcDevice fastAdc;

--- a/firmware/hw_layer/ports/cypress/mpu_util.cpp
+++ b/firmware/hw_layer/ports/cypress/mpu_util.cpp
@@ -259,7 +259,7 @@ bool readSlowAnalogInputs(adcsample_t* convertedSamples) {
 	return true;
 }
 
-FastAdcToken enableFastAdcChannel(const char*, adc_channel_e channel) {
+AdcToken enableFastAdcChannel(const char*, adc_channel_e channel) {
 	if (!isAdcChannelValid(channel)) {
 		return invalidAdcToken;
 	}
@@ -268,7 +268,7 @@ FastAdcToken enableFastAdcChannel(const char*, adc_channel_e channel) {
 	return invalidAdcToken;
 }
 
-adcsample_t getFastAdc(FastAdcToken token) {
+adcsample_t getFastAdc(AdcToken token) {
 	if (token == invalidAdcToken) {
 		return 0;
 	}

--- a/firmware/hw_layer/ports/kinetis/mpu_util.cpp
+++ b/firmware/hw_layer/ports/kinetis/mpu_util.cpp
@@ -265,7 +265,7 @@ bool readSlowAnalogInputs(adcsample_t* convertedSamples) {
 	return true;
 }
 
-FastAdcToken enableFastAdcChannel(const char*, adc_channel_e channel) {
+AdcToken enableFastAdcChannel(const char*, adc_channel_e channel) {
 	if (!isAdcChannelValid(channel)) {
 		return invalidAdcToken;
 	}
@@ -274,7 +274,7 @@ FastAdcToken enableFastAdcChannel(const char*, adc_channel_e channel) {
 	return invalidAdcToken;
 }
 
-adcsample_t getFastAdc(FastAdcToken token) {
+adcsample_t getFastAdc(AdcToken token) {
 	if (token == invalidAdcToken) {
 		return 0;
 	}

--- a/firmware/hw_layer/ports/stm32/stm32_adc_v2.cpp
+++ b/firmware/hw_layer/ports/stm32/stm32_adc_v2.cpp
@@ -205,7 +205,7 @@ bool readSlowAnalogInputs(adcsample_t* convertedSamples) {
 
 extern AdcDevice fastAdc;
 
-FastAdcToken enableFastAdcChannel(const char*, adc_channel_e channel) {
+AdcToken enableFastAdcChannel(const char*, adc_channel_e channel) {
 	if (!isAdcChannelValid(channel)) {
 		return invalidAdcToken;
 	}
@@ -213,7 +213,7 @@ FastAdcToken enableFastAdcChannel(const char*, adc_channel_e channel) {
 	return fastAdc.getAdcChannelToken(channel);
 }
 
-adcsample_t getFastAdc(FastAdcToken token) {
+adcsample_t getFastAdc(AdcToken token) {
 	if (token == invalidAdcToken) {
 		return 0;
 	}

--- a/firmware/hw_layer/ports/stm32/stm32_adc_v4.cpp
+++ b/firmware/hw_layer/ports/stm32/stm32_adc_v4.cpp
@@ -171,7 +171,7 @@ bool readSlowAnalogInputs(adcsample_t* convertedSamples) {
 	return true;
 }
 
-FastAdcToken enableFastAdcChannel(const char*, adc_channel_e channel) {
+AdcToken enableFastAdcChannel(const char*, adc_channel_e channel) {
 	if (!isAdcChannelValid(channel)) {
 		return invalidAdcToken;
 	}
@@ -180,7 +180,7 @@ FastAdcToken enableFastAdcChannel(const char*, adc_channel_e channel) {
 	return channel - EFI_ADC_0;
 }
 
-adcsample_t getFastAdc(FastAdcToken token) {
+adcsample_t getFastAdc(AdcToken token) {
 	if (token == invalidAdcToken) {
 		return 0;
 	}


### PR DESCRIPTION
`AdcToken` is planned to be used for all ADCs.
Only rename. No code logic changes.