### PR TITLE
hip9011: allow user to define only clock divider, not SDO mode

### DIFF
--- a/firmware/config/boards/f407-discovery/board_configuration.cpp
+++ b/firmware/config/boards/f407-discovery/board_configuration.cpp
@@ -40,7 +40,7 @@ static void setHip9011FrankensoPinout() {
 	//	engineConfiguration->hip9011CsPin = Gpio::D0; // rev 0.1
 
 	engineConfiguration->isHip9011Enabled = true;
-	engineConfiguration->hip9011PrescalerAndSDO = HIP_8MHZ_PRESCALER; // 8MHz chip
+	engineConfiguration->hip9011Prescaler = HIP_8MHZ_PRESCALER; // 8MHz chip
 	engineConfiguration->is_enabled_spi_2 = true;
 	// todo: convert this to rusEfi, hardware-independent enum
 #if EFI_PROD_CODE

--- a/firmware/config/boards/subaru_eg33/board_configuration.cpp
+++ b/firmware/config/boards/subaru_eg33/board_configuration.cpp
@@ -195,7 +195,7 @@ void setBoardDefaultConfiguration() {
 	/* this board has TPIC8101, that supports advanced mode */
 	engineConfiguration->useTpicAdvancedMode = true;
 	/* Chip settings */
-	engineConfiguration->hip9011PrescalerAndSDO = (0x6 << 1); //HIP_16MHZ_PRESCALER;
+	engineConfiguration->hip9011Prescaler = 0x6; //HIP_16MHZ_PRESCALER;
 	engineConfiguration->hip9011Gain = 1.0;
 	engineConfiguration->knockBandCustom = 0.0;
 	engineConfiguration->cylinderBore = 96.9;

--- a/firmware/hw_layer/sensors/hip9011.cpp
+++ b/firmware/hw_layer/sensors/hip9011.cpp
@@ -560,7 +560,7 @@ void initHip9011() {
 	startHip9011_pins();
 
 	/* load settings */
-	instance.prescaler = engineConfiguration->hip9011PrescalerAndSDO;
+	instance.prescaler = engineConfiguration->hip9011Prescaler;
 
 	efiPrintf("Starting HIP9011/TPIC8101 driver");
 
@@ -662,8 +662,8 @@ static void showHipInfo() {
 	}
 }
 
-static void setPrescalerAndSDO(int value) {
-	engineConfiguration->hip9011PrescalerAndSDO = value;
+static void setPrescaler(int value) {
+	engineConfiguration->hip9011Prescaler = value;
 }
 
 static void setHipBand(float value) {
@@ -680,7 +680,7 @@ static void hip_addconsoleActions() {
 	addConsoleAction("hipinfo", showHipInfo);
 	addConsoleActionF("set_gain", setHipGain);
 	addConsoleActionF("set_band", setHipBand);
-	addConsoleActionI("set_hip_prescalerandsdo", setPrescalerAndSDO);
+	addConsoleActionI("set_hip_prescaler", setPrescaler);
 }
 
 #endif /* EFI_HIP_9011_DEBUG */

--- a/firmware/hw_layer/sensors/hip9011_logic.cpp
+++ b/firmware/hw_layer/sensors/hip9011_logic.cpp
@@ -159,7 +159,7 @@ void HIP9011::handleSettings(int rpm DEFINE_PARAM_SUFFIX(DEFINE_HIP_PARAMS)) {
 
 	setAngleWindowWidth(FORWARD_HIP_PARAMS);
 
-	int new_prescaler = GET_CONFIG_VALUE(hip9011PrescalerAndSDO);
+	int new_prescaler = GET_CONFIG_VALUE(hip9011Prescaler);
 	int new_integratorIdx = getIntegrationIndexByRpm(rpm);
 	int new_gainIdx = getGainIndex(FORWARD_HIP_PARAMS);
 	int new_bandIdx = getBandIndex(FORWARD_HIP_PARAMS);

--- a/firmware/hw_layer/sensors/hip9011_logic.h
+++ b/firmware/hw_layer/sensors/hip9011_logic.h
@@ -55,21 +55,21 @@ public:
 #define PASS_HIP_PARAMS engineConfiguration->knockBandCustom, \
 		engineConfiguration->cylinderBore, \
 		engineConfiguration->hip9011Gain, \
-		engineConfiguration->hip9011PrescalerAndSDO, \
+		engineConfiguration->hip9011Prescaler, \
 		engineConfiguration->knockDetectionWindowStart, \
 		engineConfiguration->knockDetectionWindowEnd
 
 #define FORWARD_HIP_PARAMS knockBandCustom, \
 		cylinderBore, \
 		hip9011Gain, \
-		hip9011PrescalerAndSDO, \
+		hip9011Prescaler, \
 		knockDetectionWindowStart, \
 		knockDetectionWindowEnd
 
 #define DEFINE_HIP_PARAMS float knockBandCustom,\
 		float cylinderBore, \
 		float hip9011Gain, \
-		int hip9011PrescalerAndSDO, \
+		uint8_t hip9011Prescaler, \
 		float knockDetectionWindowStart, \
 		float knockDetectionWindowEnd
 
@@ -139,8 +139,8 @@ public:
 	#endif
 };
 
-// 0b010x.xxxx
-#define SET_PRESCALER_CMD(v) 	(0x40 | ((v) & 0x1f))
+// 0b010x.xxx0, SDO always active
+#define SET_PRESCALER_CMD(v) 	(0x40 | (((v) & 0x0f) << 1) | 0)
 // 0b1110.000x
 #define SET_CHANNEL_CMD(v) 		(0xE0 | ((v) & 0x01))
 // 0b00xx.xxxx
@@ -161,21 +161,21 @@ public:
 #define SET_ADVANCED_MODE_REP	((~SET_ADVANCED_MODE_CMD) & 0xff)
 
 //	D[4:1] = 0000 : 4 MHz
-#define HIP_4MHZ_PRESCALER		(0x0 << 1)
+#define HIP_4MHZ_PRESCALER		(0x0)
 //	D[4:1] = 0001 : 5 MHz
-#define HIP_5MHZ_PRESCALER		(0x1 << 1)
+#define HIP_5MHZ_PRESCALER		(0x1)
 //	D[4:1] = 0010 : 6 MHz
-#define HIP_6MHZ_PRESCALER		(0x2 << 1)
+#define HIP_6MHZ_PRESCALER		(0x2)
 //	D[4:1] = 0011 ; 8 MHz
-#define HIP_8MHZ_PRESCALER		(0x3 << 1)
+#define HIP_8MHZ_PRESCALER		(0x3)
 //	D[4:1] = 0100 ; 10 MHz
-#define HIP_10MHZ_PRESCALER		(0x4 << 1)
+#define HIP_10MHZ_PRESCALER		(0x4)
 //	D[4:1] = 0101 ; 12 MHz
-#define HIP_12MHZ_PRESCALER		(0x5 << 1)
+#define HIP_12MHZ_PRESCALER		(0x5)
 //	D[4:1] = 0110 : 16 MHz
-#define HIP_16MHZ_PRESCALER		(0x6 << 1)
+#define HIP_16MHZ_PRESCALER		(0x6)
 //	D[4:1] = 0111 : 20 MHz
-#define HIP_20MHZ_PRESCALER		(0x7 << 1)
+#define HIP_20MHZ_PRESCALER		(0x7)
 //	D[4:1] = 1000 : 24 MHz
-#define HIP_24MHZ_PRESCALER		(0x8 << 1)
+#define HIP_24MHZ_PRESCALER		(0x8)
 

--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -532,7 +532,10 @@ ThermistorConf clt;todo: merge with channel settings, use full-scale Thermistor 
 ThermistorConf iat;
 
 	float launchTimingRetard;;"deg", 1, 0, -180, 180, 2
-	int hip9011PrescalerAndSDO;value '6' for 8MHz hw osc\nread hip9011 datasheet for details\ntodo split into two bit fields;"integer", 1, 0, 0, 32, 0
+	uint8_t hip9011Prescaler;value '6' for 8MHz hw osc\nread hip9011 datasheet for details\ntodo split into two bit fields;"integer", 1, 0, 0, 32, 0
+	uint8_t unusedHip0
+	uint8_t unusedHip1
+	uint8_t unusedHip2
 	float knockBandCustom;Use any online calculator and input your bore.\nReminder that in some cases double frequency works better!;"kHz", 1, 0, 0, 20, 2
 
 uint16_t autoscale displacement;Engine displacement in litres;"L", 0.001, 0, 0, 65, 3

--- a/firmware/tunerstudio/tunerstudio.template.ini
+++ b/firmware/tunerstudio/tunerstudio.template.ini
@@ -3875,7 +3875,7 @@ cmd_set_engine_type_default					= "@@TS_IO_TEST_COMMAND_char@@@@ts_command_e_TS_
 		field = "hip Output/stm input",					hipOutputChannel, {isHip9011Enabled == 1}
 
 	dialog = hipSettings
-		field = "prescaler & SDO",						hip9011PrescalerAndSDO, {isHip9011Enabled == 1}
+		field = "prescaler",							hip9011Prescaler, {isHip9011Enabled == 1}
 		field = "knockDetectionWindowStart",			knockDetectionWindowStart, {isHip9011Enabled == 1}
 		field = "knockDetectionWindowEnd",				knockDetectionWindowEnd, {isHip9011Enabled == 1}
 		field = "cylinder bore (mm)",					cylinderBore, {isHip9011Enabled == 1}

--- a/java_tools/tune-tools/src/test/java/com/rusefi/tune/LoadOlderTuneTest.java
+++ b/java_tools/tune-tools/src/test/java/com/rusefi/tune/LoadOlderTuneTest.java
@@ -99,8 +99,6 @@ public class LoadOlderTuneTest {
             "    engineConfiguration->idleTimingPid.maxValue = 0;\n" +
             "    // default \"false\"\n" +
             "    engineConfiguration->isHip9011Enabled = true;\n" +
-            "    // default 0.0\n" +
-            "    engineConfiguration->hip9011PrescalerAndSDO = 6;\n" +
             "    // default 20.0\n" +
             "    engineConfiguration->knockDetectionWindowStart = 35;\n" +
             "    // default 60.0\n" +
@@ -126,7 +124,9 @@ public class LoadOlderTuneTest {
             "    // default \"true\"\n" +
             "    engineConfiguration->canReadEnabled = false;\n" +
             "    // default \"None\"\n" +
-            "   ", sb.substring(0, 3500));
+            "    engineConfiguration->canNbcType = CAN_BUS_MAZDA_RX8;\n" +
+            "    // default \"Sp",
+            sb.substring(0, 3500));
     }
 
     @Test


### PR DESCRIPTION
Driver needs to read SPI reply, so SDO=1, not supported