### PR TITLE
only: extract `Find out white-label` step code into `find_white_label.sh` script

### DIFF
--- a/.github/workflows/custom-board-build/action.yaml
+++ b/.github/workflows/custom-board-build/action.yaml
@@ -157,17 +157,7 @@ runs:
       shell: bash
       run: |
         : Find out white-label
-        shared_io_properties_file="shared_io.resources/shared_io.properties"  
-        if [ -f ${shared_io_properties_file} ]; then
-          white_label_property=`grep -m1 "^white_label=" "${shared_io_properties_file}"`
-          if [ -n "${white_label_property}" ]; then
-            white_label=`echo "${white_label_property}" | cut -d'=' -f2`
-          fi
-        fi
-        if [ -z "${white_label}" ]; then
-          white_label=rusefi
-        fi
-        echo "white_label=${white_label}" >> $GITHUB_OUTPUT
+        echo "white_label=$(bash ${{inputs.rusefi_dir}}/firmware/bin/find_white_label.sh shared_io.resources/shared_io.properties)" >> $GITHUB_OUTPUT
 
     - name: Set Env Variables
       shell: bash

--- a/firmware/bin/find_white_label.sh
+++ b/firmware/bin/find_white_label.sh
@@ -1,0 +1,21 @@
+# This scripts accepts .properties file name as an only argument and outputs value of `white_label` property.
+# It outputs the default white-label `rusefi` when:
+# - specified .properties file doesn't exist
+# - or `white_label` property is not initialized in specified .properties file
+set -u
+
+if [ "$#" -ne 1 ]; then
+    echo "$0 expects .properties file as the single argument" 1>&2
+    exit 1
+fi
+
+properties_file=$1
+
+if [ -f ${properties_file} ]; then
+  white_label=$(grep -m1 "^white_label=" "${properties_file}" | cut -d'=' -f2)
+fi
+
+if [ -z "${white_label:-}" ]; then
+  white_label=rusefi
+fi
+echo "${white_label}"


### PR DESCRIPTION
to fix in GHA `Error: Process completed with exit code 1.` in case when `shared_io.resources/shared_io.properties` doesn't contain `white_label` property

P. S. It's a kind of magic :)