### PR TITLE
Adc fix 13bit

### DIFF
--- a/firmware/hw_layer/adc/adc_inputs.cpp
+++ b/firmware/hw_layer/adc/adc_inputs.cpp
@@ -29,7 +29,7 @@ static uint32_t slowAdcErrorsCount = 0;
 
 static float mcuTemperature;
 
-static adc_channel_mode_e adcHwChannelMode[HW_MAX_ADC_INDEX];
+static adc_channel_mode_e adcHwChannelMode[EFI_ADC_TOTAL_CHANNELS];
 
 // todo: move this flag to Engine god object
 static int adcDebugReporting = false;

--- a/firmware/hw_layer/adc/adc_inputs_onchip.cpp
+++ b/firmware/hw_layer/adc/adc_inputs_onchip.cpp
@@ -228,6 +228,10 @@ adcsample_t AdcDevice::getAvgAdcValue(adc_channel_e hwChannel) {
 	uint32_t result = 0;
 	int numChannels = size();
 	int index = fastAdc.internalAdcIndexByHardwareIndex[hwChannel];
+	if (index == 0xff) {
+		criticalError("Fast ADC attempt to read unconfigured input %d.", hwChannel);
+		return 0;
+	}
 
 	for (size_t i = 0; i < depth; i++) {
 		adcsample_t sample = samples[index];

--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -197,7 +197,6 @@ struct_no_prefix engine_configuration_s
 #define IGN_RPM_COUNT 16
 
 #define DIGIPOT_COUNT 4
-#define HW_MAX_ADC_INDEX 17
 #define TRIGGER_SIMULATOR_PIN_COUNT 2
 #define TRIGGER_INPUT_PIN_COUNT 2
 #define LOGIC_ANALYZER_CHANNEL_COUNT 4


### PR DESCRIPTION
Out of bounds access to `adcHwChannelMode` was causing incorrect fast ADC selection for value reading.
Fast ADC had no protection of invalid channel read that cause another one out-of-bounds access to samples array and read of random data far behind this array.