### PR TITLE
get rid of unused `targetVBatt` setting

### DIFF
--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -1182,7 +1182,7 @@ int16_t tps2Max;Full throttle#2. tpsMax value as 10 bit ADC value. Not Voltage!\
 	int16_t idlePidRpmDeadZone;If the RPM closer to target than this value, disable closed loop idle correction to prevent oscillation;"RPM", 1, 0, 0, 800, 0
 
 
-	float targetVBatt;This is the target battery voltage the alternator PID control will attempt to maintain;"Volts", 1, 0, 0, 30, 1
+	float unusedTargetVBatt
 	bit mc33810DisableRecoveryMode;See Over/Undervoltage Shutdown/Retry bit in documentation
 	bit mc33810Gpgd0Mode
 	bit mc33810Gpgd1Mode

--- a/firmware/tunerstudio/tunerstudio.template.ini
+++ b/firmware/tunerstudio/tunerstudio.template.ini
@@ -4065,7 +4065,6 @@ cmd_set_engine_type_default					= "@@TS_IO_TEST_COMMAND_char@@@@ts_command_e_TS_
 		field = "Battery Input Divider Coefficient",	vbattDividerCoeff
 	dialog = alternator, "Alternator Settings",	yAxis
 		field = "Enabled",								isAlternatorControlEnabled
-		field = "Target",								targetVBatt, {isAlternatorControlEnabled == 1}
 		field = "Control output",						alternatorControlPin, {isAlternatorControlEnabled == 1}
 		field = "Control output mode",				    alternatorControlPinMode, {isAlternatorControlEnabled == 1}
 		field = "PWM frequency",						alternatorPwmFrequency, {isAlternatorControlEnabled == 1}


### PR DESCRIPTION
`Target(Volts)` setting on `Alternator Settings` area in Tuner Studio), closes #6523