### PR TITLE
engine->gearController should be nullptr until initGearController()

### DIFF
--- a/firmware/controllers/algo/engine.h
+++ b/firmware/controllers/algo/engine.h
@@ -180,7 +180,7 @@ public:
 	}
 
 #if EFI_TCU
-	GearControllerBase *gearController;
+	GearControllerBase *gearController = nullptr;
 #endif
 
 	// todo: boolean sensors should leverage sensor framework #6342


### PR DESCRIPTION
Otherwise if we have `hasFirmwareError()` `initGearController()` is never called and `engine->gearController` left unitialized and bad.
After TS connection we get hardfault:

```
Program received signal SIGTRAP, Trace/breakpoint trap.
HardFault_Handler_C (sp=<optimized out>) at ./hw_layer/main_hardfault.c:63
63		bkpt();
(gdb) bt
#0  HardFault_Handler_C (sp=<optimized out>) at ./hw_layer/main_hardfault.c:63
#1  <signal handler called>
#2  0x002431f8 in getLiveData<tcu_controller_s> () at ./console/binary/live_data.cpp:29
#3  0x0027b096 in FragmentEntry::get (this=0x200467a4 <fragments+48>) at ./libfirmware/util/include/rusefi/fragments.h:36
#4  copyRange (destination=0x20055077 <usbChannel+15> "", src=..., skip=0, size=532) at ./libfirmware/util/src/fragments.cpp:32
#5  0x0024b7fa in TunerStudio::cmdOutputChannels (this=<optimized out>, tsChannel=0x20055068 <usbChannel>, offset=<optimized out>, count=<optimized out>) at ./console/binary/tunerstudio_commands.cpp:67
#6  0x00249ace in TunerStudio::handleCrcCommand (this=this@entry=0x200216ac <tsInstance>, tsChannel=tsChannel@entry=0x20055068 <usbChannel>, data=0x20055075 <usbChannel+13> "\356\002", 
    data@entry=0x20055074 <usbChannel+12> "O\356\002", incomingPacketSize=incomingPacketSize@entry=5) at ./console/binary/tunerstudio.cpp:740
#7  0x00249de2 in tsProcessOne (tsChannel=tsChannel@entry=0x20055068 <usbChannel>) at ./console/binary/tunerstudio.cpp:633
#8  0x00249fb2 in TunerstudioThread::ThreadTask (this=<optimized out>) at ./console/binary/tunerstudio.cpp:653
#9  0x00243662 in ThreadController<1200>::main (this=<optimized out>) at ./controllers/system/thread_controller.h:33
#10 0x0021dc58 in chibios_rt::_thd_start (arg=<optimized out>) at ChibiOS/os/various/cpp_wrappers/ch.cpp:41
#11 0x00200fae in _port_thread_start () at ChibiOS/os/common/ports/ARMCMx/compilers/GCC/chcoreasm_v7m.S:201
```