### PR TITLE
Fix saving settings on STM32F7 2Mb single bank

### DIFF
--- a/firmware/controllers/flash_main.cpp
+++ b/firmware/controllers/flash_main.cpp
@@ -116,10 +116,13 @@ bool getNeedToWriteConfiguration() {
 void writeToFlashIfPending() {
 #if (EFI_FLASH_WRITE_THREAD == TRUE)
 	// with a flash write thread, the schedule happens directly from
-	// setNeedToWriteConfiguration, so there's nothing to do here
-	return;
+	// setNeedToWriteConfiguration and writing happens from flash thread,
+	// so there's nothing to do here
+	if (allowFlashWhileRunning()) {
+		return;
+	}
 #endif
-	if (allowFlashWhileRunning() || !getNeedToWriteConfiguration()) {
+	if (!getNeedToWriteConfiguration()) {
 		// Allow sensor timeouts again now that we're done (and a little time has passed)
 		Sensor::inhibitTimeouts(false);
 		return;

--- a/firmware/hw_layer/ports/at32/at32f4/mpu_util.cpp
+++ b/firmware/hw_layer/ports/at32/at32f4/mpu_util.cpp
@@ -7,7 +7,7 @@
 #include "pch.h"
 #include "flash_int.h"
 
-bool allowFlashWhileRunning() {
+bool mcuCanFlashWhileRunning() {
     /* TODO: check for actual flash configuration? */
     /* currently we support only AT32F43X with dual-bank flash, so allow flashing to second bank */
     /* TODO: Seems AT32 is still freezes even write is happen to second bank, while executing code from first */

--- a/firmware/hw_layer/ports/cypress/mpu_util.cpp
+++ b/firmware/hw_layer/ports/cypress/mpu_util.cpp
@@ -218,7 +218,7 @@ void canHwInfo(CANDriver* cand)
 
 #endif /* EFI_CAN_SUPPORT */
 
-bool allowFlashWhileRunning() {
+bool mcuCanFlashWhileRunning() {
 	return false;
 }
 

--- a/firmware/hw_layer/ports/kinetis/mpu_util.cpp
+++ b/firmware/hw_layer/ports/kinetis/mpu_util.cpp
@@ -211,7 +211,7 @@ void canHwInfo(CANDriver* cand)
 
 #endif /* EFI_CAN_SUPPORT */
 
-bool allowFlashWhileRunning() {
+bool mcuCanFlashWhileRunning() {
 	return false;
 }
 

--- a/firmware/hw_layer/ports/mpu_util.h
+++ b/firmware/hw_layer/ports/mpu_util.h
@@ -14,7 +14,9 @@ void jump_to_bootloader();
 void jump_to_openblt();
 #endif
 void causeHardFault();
-bool allowFlashWhileRunning();
+
+// If mcu can erase/write part of its internal memory without stalling CPU
+bool mcuCanFlashWhileRunning();
 
 bool ramReadProbe(volatile const char *read_address);
 #if defined(STM32F4)

--- a/firmware/hw_layer/ports/stm32/stm32f4/mpu_util.cpp
+++ b/firmware/hw_layer/ports/stm32/stm32f4/mpu_util.cpp
@@ -7,7 +7,7 @@
 #include "pch.h"
 #include "flash_int.h"
 
-bool allowFlashWhileRunning() {
+bool mcuCanFlashWhileRunning() {
 	// Never allow flash while running on F4, dual bank not implemented.
 	return false;
 }

--- a/firmware/hw_layer/ports/stm32/stm32f7/mpu_util.cpp
+++ b/firmware/hw_layer/ports/stm32/stm32f7/mpu_util.cpp
@@ -50,7 +50,7 @@ static DeviceType determineDevice() {
 	return DeviceType::Unknown;
 }
 
-bool allowFlashWhileRunning() {
+bool mcuCanFlashWhileRunning() {
 	// Allow flash-while-running if dual bank mode is enabled, and we're a 2MB device (ie, no code located in second bank)
 	return determineDevice() == DeviceType::DualBank2MB;
 }

--- a/firmware/hw_layer/ports/stm32/stm32h7/mpu_util.cpp
+++ b/firmware/hw_layer/ports/stm32/stm32h7/mpu_util.cpp
@@ -9,7 +9,7 @@
 
 #include "flash_int.h"
 
-bool allowFlashWhileRunning() {
+bool mcuCanFlashWhileRunning() {
 	// We only support dual bank H7, so always allow flash while running.
 	return true;
 }

--- a/simulator/simulator/framework.cpp
+++ b/simulator/simulator/framework.cpp
@@ -18,7 +18,7 @@ uint32_t getTimeNowLowerNt(void) {
 CANDriver* detectCanDevice(brain_pin_e pinRx, brain_pin_e pinTx);
 #endif // HAL_USE_CAN
 
-bool allowFlashWhileRunning() { return true; }
+bool mcuCanFlashWhileRunning() { return true; }
 //void causeHardFault() { }
 
 

--- a/simulator/simulator/mpu_util.h
+++ b/simulator/simulator/mpu_util.h
@@ -7,7 +7,7 @@ inline bool isValidCanRxPin(brain_pin_e) { return true; }
 inline void canHwInfo(CANDriver*) { return; }
 #endif // HAL_USE_CAN
 
- bool allowFlashWhileRunning() ;
+ bool mcuCanFlashWhileRunning() ;
  void causeHardFault() ;
 
 


### PR DESCRIPTION
Fix logic error. Previously we believed that if `EFI_FLASH_WRITE_THREAD` is TRUE we do flashing from thread.
But thread was created only if `(allowFlashWhileRunning() || (EFI_STORAGE_MFS_EXTERNAL == TRUE))`.
With STM32F7 2Mb single bank we ran into situation when `EFI_FLASH_WRITE_THREAD` is TRUE but `allowFlashWhileRunning()` is false. So not thread was created, but `writeToFlashIfPending()` was returning doing nothing.
Now we use same check on thread creation and inside `writeToFlashIfPending()`