### PR TITLE
fix: Remove a space to the generated board name

### DIFF
--- a/firmware/controllers/algo/generated_lookup_engine_configuration.h
+++ b/firmware/controllers/algo/generated_lookup_engine_configuration.h
@@ -3,12 +3,12 @@
 #pragma once
 
 #define META_ENGINE_GENERATED_NAME engine_configuration_generated_structures_
-#define META_ENGINE_GENERATED_EXT .h
+#define META_ENGINE_GENERATED_EXT h
 
 // todo: sad technical debt: failing to define SHORT_BOARD_NAME for unit_tests and concatenate specifically for mac os?!
 #if defined(SHORT_BOARD_NAME)
 
-#define META_ENGINE_GENERATED_H_FILENAME QUOTE(META_ENGINE_GENERATED_NAME SHORT_BOARD_NAME META_ENGINE_GENERATED_EXT)
+#define META_ENGINE_GENERATED_H_FILENAME QUOTE(CONCATENATE(META_ENGINE_GENERATED_NAME, SHORT_BOARD_NAME)) "." QUOTE(META_ENGINE_GENERATED_EXT)
 #include META_ENGINE_GENERATED_H_FILENAME
 
 #else

--- a/firmware/controllers/algo/generated_lookup_meta.h
+++ b/firmware/controllers/algo/generated_lookup_meta.h
@@ -3,12 +3,12 @@
 #pragma once
 
 #define META_GENERATED_NAME rusefi_generated_
-#define META_GENERATED_EXT .h
+#define META_GENERATED_EXT h
 
 // todo: sad technical debt: failing to define SHORT_BOARD_NAME for unit_tests and concatenate specifically for mac os?!
 #if defined(SHORT_BOARD_NAME)
 
-#define META_GENERATED_H_FILENAME QUOTE(META_GENERATED_NAME SHORT_BOARD_NAME META_GENERATED_EXT)
+#define META_GENERATED_H_FILENAME QUOTE(CONCATENATE(META_GENERATED_NAME, SHORT_BOARD_NAME)) "." QUOTE(META_GENERATED_EXT)
 #include META_GENERATED_H_FILENAME
 
 #else

--- a/firmware/util/efi_quote.h
+++ b/firmware/util/efi_quote.h
@@ -4,3 +4,6 @@
 
 #define Q(x) #x
 #define QUOTE(x) Q(x)
+
+#define C(x, y) x ## y
+#define CONCATENATE(x, y) C(x, y)


### PR DESCRIPTION
### Current issue

On both `firmware/controllers/algo/generated_lookup_engine_configuration.h` and `firmware/controllers/algo/generated_lookup_meta.h`, They concatenate string using only `QUOTE`

However, it might be adding a space between both `ENGINE_GENERATED_NAME`, `SHORT_BOARD_NAME`, `ENGINE_GENERATED_EXT`.

for Example:
https://godbolt.org/z/zWzsKr9W4

This seems normally works on `arm-none-eabi` compiler , but other compilers such as clang might got an unexpected results:
```
<source>:12:10: fatal error: 'rusefi_generated_ f407-discovery .h' file not found
   12 | #include META_GENERATED_H_FILENAME
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~
<source>:11:35: note: expanded from macro 'META_GENERATED_H_FILENAME'
   11 | #define META_GENERATED_H_FILENAME QUOTE(META_GENERATED_NAME SHORT_BOARD_NAME META_GENERATED_EXT)
      |                                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
<source>:4:18: note: expanded from macro 'QUOTE'
    4 | #define QUOTE(x) Q(x)
      |                  ^~~~
<source>:3:14: note: expanded from macro 'Q'
    3 | #define Q(x) #x
      |              ^~
<scratch space>:4:1: note: expanded from here
    4 | "rusefi_generated_ f407-discovery .h"
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
Compiler returned: 1
```

### Resolve

So, I fixed them to removing a space between  `ENGINE_GENERATED_NAME`, `SHORT_BOARD_NAME`, `ENGINE_GENERATED_EXT`.

Sample compiler result:
https://godbolt.org/z/fa15ro89h

