### PR TITLE
Odd cylinder engine wasted spark

### DIFF
--- a/firmware/controllers/algo/engine_state.h
+++ b/firmware/controllers/algo/engine_state.h
@@ -26,6 +26,8 @@ public:
 	 */
 	angle_t engineCycle;
 
+	bool useOddFireWastedSpark = false;
+
 	/**
 	 * this is based on sensorChartMode and sensorSnifferRpmThreshold settings
 	 */

--- a/firmware/controllers/limp_manager.cpp
+++ b/firmware/controllers/limp_manager.cpp
@@ -27,12 +27,6 @@ static bool noFiringUntilVvtSync(vvt_mode_e vvtMode) {
 #endif
 	}
 
-	// Odd cylinder count engines don't work properly with wasted spark, so wait for full sync (so that sequential works)
-	// See https://github.com/rusefi/rusefi/issues/4195 for the issue to properly support this case
-	if (engineConfiguration->cylindersCount > 1 && engineConfiguration->cylindersCount % 2 == 1) {
-		return true;
-	}
-
 	// Symmetrical crank modes require cam sync before firing
 	// non-symmetrical cranks can use faster spin-up mode (firing in wasted/batch before VVT sync)
 	// Examples include Nissan MR/VQ, Miata NB, etc

--- a/firmware/controllers/math/engine_math.cpp
+++ b/firmware/controllers/math/engine_math.cpp
@@ -388,8 +388,7 @@ ignition_mode_e getCurrentIgnitionMode() {
 	ignition_mode_e ignitionMode = engineConfiguration->ignitionMode;
 #if EFI_SHAFT_POSITION_INPUT
 	// In spin-up cranking mode we don't have full phase sync info yet, so wasted spark mode is better
-	// However, only do this on even cylinder count engines: odd cyl count doesn't fire at all
-	if (ignitionMode == IM_INDIVIDUAL_COILS && (engineConfiguration->cylindersCount % 2 == 0)) {
+	if (ignitionMode == IM_INDIVIDUAL_COILS) {
 		bool missingPhaseInfoForSequential =
 			!engine->triggerCentral.triggerState.hasSynchronizedPhase();
 
@@ -407,7 +406,20 @@ ignition_mode_e getCurrentIgnitionMode() {
  * This heavy method is only invoked in case of a configuration change or initialization.
  */
 void prepareOutputSignals() {
-	getEngineState()->engineCycle = getEngineCycle(getEngineRotationState()->getOperationMode());
+	auto operationMode = getEngineRotationState()->getOperationMode();
+	getEngineState()->engineCycle = getEngineCycle(operationMode);
+
+	bool isOddFire = false;
+	for (size_t i = 0; i < engineConfiguration->cylindersCount; i++) {
+		if (engineConfiguration->timing_offset_cylinder[i] != 0) {
+			isOddFire = true;
+			break;
+		}
+	}
+
+	// Use odd fire wasted spark logic if not two stroke, and an odd fire or odd cylinder # engine
+	getEngineState()->useOddFireWastedSpark = operationMode != TWO_STROKE
+								&& (isOddFire | (engineConfiguration->cylindersCount % 2 == 1));
 
 #if EFI_UNIT_TEST
 	if (verboseMode) {

--- a/unit_tests/tests/ignition_injection/test_ignition_scheduling.cpp
+++ b/unit_tests/tests/ignition_injection/test_ignition_scheduling.cpp
@@ -233,7 +233,7 @@ TEST(ignition, oddCylinderWastedSpark) {
 	engine->ignitionState.sparkDwell = 1;
 
 	// dwell should start at 15 degrees ATDC and firing at 25 deg ATDC
-	engine->ignitionState.dwellAngle = 10;
+	engine->ignitionState.dwellDurationAngle = 10;
 	engine->engineState.timingAdvance[0] = -25;
 	engine->engineState.useOddFireWastedSpark = true;
 	engineConfiguration->minimumIgnitionTiming = -25;

--- a/unit_tests/tests/ignition_injection/test_ignition_scheduling.cpp
+++ b/unit_tests/tests/ignition_injection/test_ignition_scheduling.cpp
@@ -10,6 +10,8 @@
 #include "spark_logic.h"
 
 using ::testing::_;
+using ::testing::InSequence;
+using ::testing::StrictMock;
 
 TEST(ignition, twoCoils) {
 	EngineTestHelper eth(engine_type_e::FRANKENSO_BMW_M73_F);
@@ -197,7 +199,7 @@ TEST(ignition, oddCylinderWastedSpark) {
 	StrictMock<MockExecutor> mockExec;
 
 	EngineTestHelper eth(engine_type_e::TEST_ENGINE);
-	engine->scheduler.setMockExecutor(&mockExec);
+	engine->executor.setMockExecutor(&mockExec);
 	engineConfiguration->cylindersCount = 1;
 	engineConfiguration->firingOrder = FO_1;
 	engineConfiguration->ignitionMode = IM_WASTED_SPARK;

--- a/unit_tests/tests/ignition_injection/test_ignition_scheduling.cpp
+++ b/unit_tests/tests/ignition_injection/test_ignition_scheduling.cpp
@@ -217,19 +217,19 @@ TEST(ignition, oddCylinderWastedSpark) {
 		// Dwell 5 deg from now
 		float nt1deg = USF2NT(engine->rpmCalculator.oneDegreeUs);
 		efitick_t startTime = nowNt1 + nt1deg * 5;
-		EXPECT_CALL(mockExec, schedule(testing::NotNull(), _, startTime, _));
+		EXPECT_CALL(mockExec, scheduleByTimestampNt(testing::NotNull(), _, startTime, _));
 		// Spark 15 deg from now
 		efitick_t endTime = startTime + nt1deg * 10;
-		EXPECT_CALL(mockExec, schedule(testing::NotNull(), _, endTime, _));
+		EXPECT_CALL(mockExec, scheduleByTimestampNt(testing::NotNull(), _, endTime, _));
 
 
 		// Should schedule second dwell+fire pair, the out of phase copy
 		// Dwell 5 deg from now
 		startTime = nowNt2 + nt1deg * 5;
-		EXPECT_CALL(mockExec, schedule(testing::NotNull(), _, startTime, _));
+		EXPECT_CALL(mockExec, scheduleByTimestampNt(testing::NotNull(), _, startTime, _));
 		// Spark 15 deg from now
 		endTime = startTime + nt1deg * 10;
-		EXPECT_CALL(mockExec, schedule(testing::NotNull(), _, endTime, _));
+		EXPECT_CALL(mockExec, scheduleByTimestampNt(testing::NotNull(), _, endTime, _));
 	}
 
 	engine->ignitionState.sparkDwell = 1;

--- a/unit_tests/tests/ignition_injection/test_ignition_scheduling.cpp
+++ b/unit_tests/tests/ignition_injection/test_ignition_scheduling.cpp
@@ -193,3 +193,54 @@ TEST(ignition, negativeAdvance2stroke) {
 	ASSERT_NEAR(-13, engine->ignitionState.correctedIgnitionAdvance, EPS4D);
 }
 
+TEST(ignition, oddCylinderWastedSpark) {
+	StrictMock<MockExecutor> mockExec;
+
+	EngineTestHelper eth(engine_type_e::TEST_ENGINE);
+	engine->scheduler.setMockExecutor(&mockExec);
+	engineConfiguration->cylindersCount = 1;
+	engineConfiguration->firingOrder = FO_1;
+	engineConfiguration->ignitionMode = IM_WASTED_SPARK;
+
+	efitick_t nowNt1 = 1000000;
+	efitick_t nowNt2 = 2222222;
+
+
+	engine->rpmCalculator.oneDegreeUs = 100;
+
+	{
+		InSequence is;
+
+		// Should schedule one dwell+fire pair:
+		// Dwell 5 deg from now
+		float nt1deg = USF2NT(engine->rpmCalculator.oneDegreeUs);
+		efitick_t startTime = nowNt1 + nt1deg * 5;
+		EXPECT_CALL(mockExec, schedule(testing::NotNull(), _, startTime, _));
+		// Spark 15 deg from now
+		efitick_t endTime = startTime + nt1deg * 10;
+		EXPECT_CALL(mockExec, schedule(testing::NotNull(), _, endTime, _));
+
+
+		// Should schedule second dwell+fire pair, the out of phase copy
+		// Dwell 5 deg from now
+		startTime = nowNt2 + nt1deg * 5;
+		EXPECT_CALL(mockExec, schedule(testing::NotNull(), _, startTime, _));
+		// Spark 15 deg from now
+		endTime = startTime + nt1deg * 10;
+		EXPECT_CALL(mockExec, schedule(testing::NotNull(), _, endTime, _));
+	}
+
+	engine->ignitionState.sparkDwell = 1;
+
+	// dwell should start at 15 degrees ATDC and firing at 25 deg ATDC
+	engine->ignitionState.dwellAngle = 10;
+	engine->engineState.timingAdvance[0] = -25;
+	engine->engineState.useOddFireWastedSpark = true;
+	engineConfiguration->minimumIgnitionTiming = -25;
+
+	// expect to schedule the on-phase dwell and spark (not the wasted spark copy)
+	onTriggerEventSparkLogic(1200, nowNt1, 10, 30);
+
+	// expect to schedule second events, the out-of-phase dwell and spark (the wasted spark copy)
+	onTriggerEventSparkLogic(1200, nowNt2, 360 + 10, 360 + 30);
+}


### PR DESCRIPTION
port of https://github.com/FOME-Tech/fome-fw/pull/479

support wasted spark on odd cylinder count engines, including during startup before the cam position is resolved.

5 cylinder firing wasted spark (every cylinder fires every 360 degrees):

![image](https://github.com/user-attachments/assets/630adba6-21cf-4dd0-a354-4e7e4c4eec10)

https://github.com/rusefi/rusefi/issues/4195 and also https://github.com/rusefi/rusefi/issues/6662

Also supports odd-fire but even-cylinder engines, as that's the same fundamental problem!

https://github.com/rusefi/rusefi/issues/6868

Here's an odd-fire 2 cyl running in wasted spark:

![image](https://github.com/user-attachments/assets/3c22fd22-1f2d-46a5-885a-05f42ad89f8e)

