### PR TITLE
Minor: fix 'unused parameter' warning in the simulator

### DIFF
--- a/simulator/simulator/boards.cpp
+++ b/simulator/simulator/boards.cpp
@@ -11,7 +11,7 @@
 #include "engine_sniffer.h"
 #include "adc_math.h"
 
-int getAdcValue(const char *msg, int hwChannel) {
+int getAdcValue(const char * /*msg*/, int /*hwChannel*/) {
 	return 0;
 }
 

--- a/simulator/simulator/framework.cpp
+++ b/simulator/simulator/framework.cpp
@@ -36,7 +36,7 @@ const char *getMCUResetCause(Reset_Cause_t) {
 void startWatchdog(int) { }
 
 // Can be called for debug reasons to test the watchdog
-void setWatchdogResetPeriod(int resetMs) { }
+void setWatchdogResetPeriod(int /*resetMs*/) { }
 
 // A reset is done only if enough time has passed since the last reset.
 void tryResetWatchdog() { }

--- a/simulator/simulator/rusEfiFunctionalTest.cpp
+++ b/simulator/simulator/rusEfiFunctionalTest.cpp
@@ -264,7 +264,7 @@ void onFatalError(const char *msg, const char * file, int line) {
 	exit(-1);
 }
 
-void logMsg(const char *format, ...) {
+void logMsg(const char * /*format*/, ...) {
 //	FILE * fp;
 //	fp = fopen ("simulator.log", "a");
 //
@@ -277,7 +277,7 @@ void logMsg(const char *format, ...) {
 
 #if HAL_USE_CAN
 static bool didInitCan = false;
-CANDriver* detectCanDevice(brain_pin_e pinRx, brain_pin_e pinTx) {
+CANDriver* detectCanDevice(brain_pin_e /*pinRx*/, brain_pin_e /*pinTx*/) {
 	if (didInitCan) {
 		return nullptr;
 	}

--- a/simulator/simulator/system/signal_executor_sleep.cpp
+++ b/simulator/simulator/system/signal_executor_sleep.cpp
@@ -38,7 +38,7 @@ struct CallbackContext
 
 static void doScheduleForLater(scheduling_s *scheduling, int delayUs, action_s action);
 
-void SleepExecutor::schedule(const char *msg, scheduling_s* scheduling, efitick_t timeNt, action_s action) {
+void SleepExecutor::schedule(const char * /*msg*/, scheduling_s* scheduling, efitick_t timeNt, action_s action) {
 	doScheduleForLater(scheduling, NT2US(timeNt) - getTimeNowUs(), action);
 }
 


### PR DESCRIPTION
a few simple fixes to cleanup compilation output
all others modules should be fixed in the same way