### PR TITLE
simpler ETB jam detection #6925

### DIFF
--- a/firmware/controllers/actuators/electronic_throttle_impl.h
+++ b/firmware/controllers/actuators/electronic_throttle_impl.h
@@ -12,7 +12,6 @@
 
 #include "sensor.h"
 #include "efi_pid.h"
-#include "error_accumulator.h"
 #include "electronic_throttle_generated.h"
 
 /**
@@ -53,9 +52,9 @@ public:
 	expected<percent_t> getClosedLoop(percent_t setpoint, percent_t observation) override;
 	expected<percent_t> getClosedLoopAutotune(percent_t setpoint, percent_t actualThrottlePosition);
 
-	void setOutput(expected<percent_t> outputValue) override;
+	void checkJam(percent_t setpoint, percent_t observation);
 
-	void checkOutput(percent_t output);
+	void setOutput(expected<percent_t> outputValue) override;
 
 	// Used to inspect the internal PID controller's state
 	const pid_state_s& getPidState() const override { return m_pid; };
@@ -94,8 +93,6 @@ private:
 	DcMotor *m_motor = nullptr;
 	Pid m_pid;
 	bool m_shouldResetPid = false;
-	// todo: rename to m_targetErrorAccumulator
-	ErrorAccumulator m_errorAccumulator;
 
 	/**
 	 * @return true if OK, false if should be disabled

--- a/unit_tests/tests/actuators/test_etb.cpp
+++ b/unit_tests/tests/actuators/test_etb.cpp
@@ -732,6 +732,8 @@ TEST(etb, setOutputLimpHome) {
 }
 
 TEST(etb, closedLoopPid) {
+	EngineTestHelper eth(engine_type_e::TEST_ENGINE);
+
 	pid_s pid = {};
 	pid.pFactor = 5;
 	pid.maxValue = 75;
@@ -746,9 +748,7 @@ TEST(etb, closedLoopPid) {
 	etb.init(DC_Throttle1, nullptr, &pid, nullptr, true);
 
 	// Disable autotune for now
-	Engine e;
-	EngineTestHelperBase base(&e, nullptr, nullptr);
-	e.etbAutoTune = false;
+	engine->etbAutoTune = false;
 
 	// Setpoint greater than actual, should be positive output
 	EXPECT_FLOAT_EQ(etb.getClosedLoop(50, 40).value_or(-1), 50);
@@ -763,15 +763,6 @@ TEST(etb, closedLoopPid) {
 TEST(etb, jamDetection) {
 	EngineTestHelper eth(engine_type_e::TEST_ENGINE);
 
-	pid_s pid = {};
-
-	// I-only since we're testing out the integrator
-	pid.pFactor = 0;
-	pid.iFactor = 1;
-	pid.dFactor = 0;
-	pid.maxValue = 50;
-	pid.minValue = -50;
-
 	// Must have TPS & PPS initialized for ETB setup
 	Sensor::setMockValue(SensorType::Tps1Primary, 0);
 	Sensor::setMockValue(SensorType::Tps1, 0.0f, true);
@@ -782,32 +773,27 @@ TEST(etb, jamDetection) {
 	engineConfiguration->etbJamTimeout = 1;
 
 	EtbController etb;
-	etb.init(DC_Throttle1, nullptr, &pid, nullptr, true);
+	etb.init(DC_Throttle1, nullptr, nullptr, nullptr, true);
 
 	setTimeNowUs(0);
 
-	// Reset timer while under integrator limit
-	EXPECT_EQ(etb.getPidState().iTerm, 0);
-	etb.checkOutput(0);
+	// Reset timer while under error limit
+	etb.checkJam(10, 14);
 	EXPECT_EQ(etb.jamTimer, 0);
 	EXPECT_FALSE(etb.jamDetected);
 
-	for (size_t i = 0; i < ETB_LOOP_FREQUENCY; i++) {
-		// Error of 10, should accumulate 10 integrator per second
-		etb.getClosedLoop(50, 40);
-	}
-
-	EXPECT_NEAR(etb.getPidState().iTerm, 10.0f, 1e-3);
+	// Start a jam
+	etb.checkJam(10, 16);
 
 	// Just under time limit, no jam yet
 	setTimeNowUs(0.9e6);
-	etb.checkOutput(0);
+	etb.checkJam(10, 16);
 	EXPECT_NEAR(etb.jamTimer, 0.9f, 1e-3);
 	EXPECT_FALSE(etb.jamDetected);
 
 	// Above the time limit, jam detected!
 	setTimeNowUs(1.1e6);
-	etb.checkOutput(0);
+	etb.checkJam(10, 16);
 	EXPECT_TRUE(etb.jamDetected);
 }
 


### PR DESCRIPTION
rather than try to integrate error over time, simply fault if there's been too much error for too long. Up to +-X error is allowed for any period of time, more is allowed for Y seconds.