### PR TITLE
Fix `Auto Update Firmware` flow for obfuscated firmware. Now we don't…

### DIFF
--- a/java_console/ui/src/main/java/com/rusefi/maintenance/CalibrationsUpdater.java
+++ b/java_console/ui/src/main/java/com/rusefi/maintenance/CalibrationsUpdater.java
@@ -2,10 +2,10 @@ package com.rusefi.maintenance;
 
 import com.devexperts.logging.Logging;
 import com.opensr5.ConfigurationImage;
+import com.rusefi.SerialPortScanner;
 import com.rusefi.io.LinkManager;
 import com.rusefi.io.UpdateOperationCallbacks;
 
-import javax.swing.*;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -29,55 +29,71 @@ public enum CalibrationsUpdater {
         final ConfigurationImage calibrationsImage = calibrationsToUpload;
         if (calibrationsImage != null) {
             final int calibrationsImageSize = calibrationsImage.getSize();
-            try (LinkManager linkManager = new LinkManager()
-                .setNeedPullText(false)
-                .setNeedPullLiveData(true)) {
-
-                callbacks.logLine(String.format("Connecting to port %s...", port));
+            try {
+                callbacks.logLine("Suspending port scanning...");
                 try {
-                    linkManager.connect(port).await(60, TimeUnit.SECONDS);
+                    SerialPortScanner.INSTANCE.suspend().await(1, TimeUnit.MINUTES);
+                    callbacks.logLine("Port scanning is suspended.");
                 } catch (final InterruptedException e) {
-                    final String errorMsg = String.format("Failed to connect to port %s", port);
-                    log.error(errorMsg, e);
-                    callbacks.logLine(errorMsg);
+                    callbacks.logLine("Failed to  suspend port scanning in a minute.");
                     callbacks.error();
                     return;
                 }
-                callbacks.logLine(String.format(
-                    "Updating configuration image (%d bytes) to port %s...",
-                    calibrationsImageSize,
-                    port
-                ));
-                final CountDownLatch latch = new CountDownLatch(1);
-                linkManager.execute(() -> {
-                    linkManager.getBinaryProtocol().uploadChanges(calibrationsImage);
-                    latch.countDown();
-                });
-                try {
-                    if (!latch.await(1, TimeUnit.MINUTES)) {
-                        callbacks.logLine(String.format(
-                            "Failed to update configuration image (%d bytes) to port %s in a minute",
-                            calibrationsImageSize,
-                            port
-                        ));
+
+                try (LinkManager linkManager = new LinkManager()
+                    .setNeedPullText(false)
+                    .setNeedPullLiveData(true)) {
+
+                    callbacks.logLine(String.format("Connecting to port %s...", port));
+                    try {
+                        linkManager.connect(port).await(60, TimeUnit.SECONDS);
+                    } catch (final InterruptedException e) {
+                        final String errorMsg = String.format("Failed to connect to port %s", port);
+                        log.error(errorMsg, e);
+                        callbacks.logLine(errorMsg);
                         callbacks.error();
-                    } else {
-                        callbacks.logLine(String.format(
-                            "Configuration image (%d bytes) has been uploaded to port %s",
-                            calibrationsImageSize,
-                            port
-                        ));
-                        callbacks.done();
+                        return;
                     }
-                } catch (final InterruptedException e) {
-                    final String errorMsg = String.format(
-                        "Updating calibrations to port %s was interrupted",
+                    callbacks.logLine(String.format(
+                        "Updating configuration image (%d bytes) to port %s...",
+                        calibrationsImageSize,
                         port
-                    );
-                    log.error(errorMsg, e);
-                    callbacks.logLine(errorMsg);
-                    callbacks.error();
+                    ));
+                    final CountDownLatch latch = new CountDownLatch(1);
+                    linkManager.execute(() -> {
+                        linkManager.getBinaryProtocol().uploadChanges(calibrationsImage);
+                        latch.countDown();
+                    });
+                    try {
+                        if (!latch.await(1, TimeUnit.MINUTES)) {
+                            callbacks.logLine(String.format(
+                                "Failed to update configuration image (%d bytes) to port %s in a minute",
+                                calibrationsImageSize,
+                                port
+                            ));
+                            callbacks.error();
+                        } else {
+                            callbacks.logLine(String.format(
+                                "Configuration image (%d bytes) has been uploaded to port %s",
+                                calibrationsImageSize,
+                                port
+                            ));
+                            callbacks.done();
+                        }
+                    } catch (final InterruptedException e) {
+                        final String errorMsg = String.format(
+                            "Updating calibrations to port %s was interrupted",
+                            port
+                        );
+                        log.error(errorMsg, e);
+                        callbacks.logLine(errorMsg);
+                        callbacks.error();
+                    }
                 }
+            } finally {
+                callbacks.logLine("Resuming port scanning...");
+                SerialPortScanner.INSTANCE.resume();
+                callbacks.logLine("Port scanning is resumed.");
             }
         } else {
             callbacks.logLine("ERROR: Calibrations to update are undefined");

--- a/java_console/ui/src/main/java/com/rusefi/maintenance/ProgramSelector.java
+++ b/java_console/ui/src/main/java/com/rusefi/maintenance/ProgramSelector.java
@@ -146,24 +146,8 @@ public class ProgramSelector {
                 }
 
                 final UpdateOperationCallbacks callbacks = new UpdateStatusWindow(appendBundleName(jobName + " " + Launcher.CONSOLE_VERSION));
-                final Runnable jobWithSuspendedPortScanning = () -> {
-                    try {
-                        callbacks.logLine("Suspending port scanning...");
-                        try {
-                            SerialPortScanner.INSTANCE.suspend().await(1, TimeUnit.MINUTES);
-                            callbacks.logLine("Port scanning is suspended.");
-                            job.accept(callbacks);
-                        } catch (final InterruptedException e) {
-                            callbacks.logLine("Failed to  suspend port scanning in a minute.");
-                            callbacks.error();
-                        }
-                    } finally {
-                        callbacks.logLine("Resuming port scanning...");
-                        SerialPortScanner.INSTANCE.resume();
-                        callbacks.logLine("Port scanning is resumed.");
-                    }
-                };
-                ExecHelper.submitAction(jobWithSuspendedPortScanning, "mx");
+                final Runnable jobToExecute = () -> job.accept(callbacks);
+                ExecHelper.submitAction(jobToExecute, "mx");
     }
 
     private static void rebootToDfu(JComponent parent, String selectedPort, UpdateOperationCallbacks callbacks) {


### PR DESCRIPTION
… suspend serial port monitoring for all jobs, but only for `Update Calibrations` job.

(cherry picked from commit 3c85f646dce3ae524aee069fb4def570465b4074)