### PR TITLE
Minor: generate the same java enum files on windows as on linux

### DIFF
--- a/java_tools/enum_to_string/src/main/java/com/rusefi/ToJavaEnum.java
+++ b/java_tools/enum_to_string/src/main/java/com/rusefi/ToJavaEnum.java
@@ -36,7 +36,9 @@ public class ToJavaEnum {
         for (String inputFile : invokeReader.getInputFiles()) {
             File f = new File(invokeReader.getInputPath() + File.separator + inputFile);
             log.info("Reading enums from " + f);
-            sb.append("// based on ").append(f).append("\n");
+            // print unix-style path on windows
+            String fname = f.toString().replace("\\", "/");
+            sb.append("// based on ").append(fname).append("\n");
 
             enumsReader.read(new FileReader(f), registry, enumWithValues);
         }


### PR DESCRIPTION
Running build on Windows makes autogenerated files with 'inverted' slashes.
To reduce the number of differences would be better to use the same slashes (since it's in either case just a comments)