### PR TITLE
Fix building, if META_OUTPUT_ROOT_FOLDER is empty

### DIFF
--- a/firmware/gen_live_documentation.sh
+++ b/firmware/gen_live_documentation.sh
@@ -20,7 +20,7 @@ java -DSystemOut.name=logs/gen_live_documentation \
 
 java -DSystemOut.name=logs/gen_java_enum -cp ../java_tools/enum_to_string/build/libs/enum_to_string-all.jar \
  com.rusefi.ToJavaEnum -enumInputFile \
- ${META_OUTPUT_ROOT_FOLDER}/console/binary/generated/live_data_ids.h \
+ ${META_OUTPUT_ROOT_FOLDER}console/binary/generated/live_data_ids.h \
  -outputPath \
  ../java_console/io/src/main/java/com/rusefi/enums
 [ $? -eq 0 ] || { echo "ERROR generating live data ids"; exit 1; }


### PR DESCRIPTION
I cannot build unittests, if  `$META_OUTPUT_ROOT_FOLDER` is empty (in that case this utility tries to find files from the root folder).
Haven't found, why it happens on windows, but on linux works fine, but in either case all other usages of this variable expects that it should ends with slash (lets say https://github.com/rusefi/rusefi/blob/49c6b135073f3286d3aa19fc6e2bc9fc6224edaa/firmware/gen_signature.sh#L13 
or https://github.com/rusefi/rusefi/blob/49c6b135073f3286d3aa19fc6e2bc9fc6224edaa/firmware/gen_config_common.sh#L37 )