### PR TITLE
Organize sensor categories in tunerstudio

### DIFF
--- a/firmware/tunerstudio/tunerstudio.template.ini
+++ b/firmware/tunerstudio/tunerstudio.template.ini
@@ -2145,16 +2145,20 @@ menuDialog = main
 		subMenu = rangeMatrixDialog,		"Range Selector Input Matrix (alpha)"@@if_ts_show_tcu
 
 	menu = "&Sensors", { 1 }, { uiMode == @@UiMode_FULL@@ || uiMode == @@UiMode_INSTALLATION@@ }
+		groupMenu = "Chassis sensors"
+		groupChildMenu = otherSensorInputs,			"Misc sensors", { 1 }, { uiMode == @@UiMode_FULL@@ || uiMode == @@UiMode_INSTALLATION@@ }
+		groupChildMenu = vrThreshold,				"VR Sensor Threshold"@@if_ts_show_vr_threshold_all
+		groupChildMenu = speedSensor,				"Vehicle speed sensor"@@if_ts_show_vehicle_speed_sensor
+		groupChildMenu = ambientTempSensor,			"Ambient temp sensor", { 1 }, { uiMode == @@UiMode_FULL@@ || uiMode == @@UiMode_INSTALLATION@@ }
+		groupChildMenu = acPressureSensor,			"A/C Pressure"@@if_ts_show_air_conditioning
+		
 		# Base analog input settings
-		subMenu = otherSensorInputs,		"Misc sensors", { 1 }, { uiMode == @@UiMode_FULL@@ || uiMode == @@UiMode_INSTALLATION@@ }
 		subMenu = analogInputSettings,		"Analog input settings", { 1 }, { uiMode == @@UiMode_FULL@@ || uiMode == @@UiMode_INSTALLATION@@ }@@if_ts_show_analog_input_settings
 		subMenu = std_separator
 
 		# Thermistors
 		subMenu = cltSensor,				"CLT sensor", { 1 }, { uiMode == @@UiMode_FULL@@ || uiMode == @@UiMode_INSTALLATION@@ }
 		subMenu = iatSensor,				"IAT sensor", { 1 }, { uiMode == @@UiMode_FULL@@ || uiMode == @@UiMode_INSTALLATION@@ }
-		subMenu = auxTempSensor1Sensor,		@@MENU_NAME_AUX_TEMP1@@, { 1 }, { uiMode == @@UiMode_FULL@@ || uiMode == @@UiMode_INSTALLATION@@ }
-		subMenu = auxTempSensor2Sensor,		@@MENU_NAME_AUX_TEMP2@@, { 1 }, { uiMode == @@UiMode_FULL@@ || uiMode == @@UiMode_INSTALLATION@@ }
 		subMenu = std_separator
 
 		# TPS/pedal
@@ -2179,21 +2183,24 @@ menuDialog = main
 		subMenu = std_separator
 
 		# Misc sensors
-		subMenu = vrThreshold,				"VR Sensor Threshold"@@if_ts_show_vr_threshold_all
-		subMenu = speedSensor,				"Vehicle speed sensor"@@if_ts_show_vehicle_speed_sensor
-		subMenu = oilPressureSensor,		"Oil pressure"@@if_ts_show_oil_pressure_sensor
-		subMenu = oilTempSensor,			"Oil temp sensor"@@if_ts_show_oil_temp_sensor
-		subMenu = fuelPressureSensor,		"Fuel pressure"@@if_ts_show_fuel_pressure_sensor
-		subMenu = fuelTempSensor,			"Fuel temp sensor"@@if_ts_show_fuel_temp_sensor
-		subMenu = fuelLevelDialog,			"Fuel level sensor"@@if_ts_show_fuel_level_sensor
-		subMenu = ambientTempSensor,		"Ambient temp sensor", { 1 }, { uiMode == @@UiMode_FULL@@ || uiMode == @@UiMode_INSTALLATION@@ }
-		subMenu = compressorDischargeTemperature,	"Compressor discharge temp"@@if_ts_show_compressor_sensor
-		subMenu = egtInputs,				"EGT" @@if_ts_show_egt
-		subMenu = wastegateIdlePos,			"Wastegate and idle position sensors"@@if_ts_show_wastegate_sensor
-		subMenu = acPressureSensor,			"A/C Pressure"@@if_ts_show_air_conditioning
+		groupMenu = "Oil sensors"
+		groupChildMenu = oilPressureSensor,	"Oil pressure"@@if_ts_show_oil_pressure_sensor
+		groupChildMenu = oilTempSensor,		"Oil temp sensor"@@if_ts_show_oil_temp_sensor
 
-		subMenu = std_separator@@if_ts_show_aux_sensors
-		subMenu = auxLinearSensors,			"Aux Sensors"@@if_ts_show_aux_sensors
+		groupMenu = "Fuel sensors"
+		groupChildMenu = fuelPressureSensor,		"Fuel pressure"@@if_ts_show_fuel_pressure_sensor
+		groupChildMenu = fuelTempSensor,			"Fuel temp sensor"@@if_ts_show_fuel_temp_sensor
+		groupChildMenu = fuelLevelDialog,			"Fuel level sensor"@@if_ts_show_fuel_level_sensor
+
+		groupMenu = "Turbo sensors"
+		groupChildMenu = egtInputs,							"EGT" @@if_ts_show_egt
+		groupChildMenu = wastegateIdlePos,					"Wastegate and idle position sensors"@@if_ts_show_wastegate_sensor
+		groupChildMenu = compressorDischargeTemperature,	"Compressor discharge temp"@@if_ts_show_compressor_sensor
+
+		groupMenu = "Aux sensors"
+		groupChildMenu = auxTempSensor1Sensor,		@@MENU_NAME_AUX_TEMP1@@, { 1 }, { uiMode == @@UiMode_FULL@@ || uiMode == @@UiMode_INSTALLATION@@ }
+		groupChildMenu = auxTempSensor2Sensor,		@@MENU_NAME_AUX_TEMP2@@, { 1 }, { uiMode == @@UiMode_FULL@@ || uiMode == @@UiMode_INSTALLATION@@ }
+		groupChildMenu = auxLinearSensors,			"Aux Sensors"@@if_ts_show_aux_sensors
 
 	menu = "CAN-bus"@@if_ts_show_top_level_can_menu
 		subMenu = canBusMain,				"CAN Bus Settings"@@if_ts_show_top_level_can_menu


### PR DESCRIPTION
fixes #6856 

new sensors categories:

- Aux sensors
- Fuel sensors
- Oil sensors
- Chassis sensors
- Turbo sensors

tested on rusefi simulator / TS v3.2.03:

![image](https://github.com/user-attachments/assets/de13bc3f-6cb9-42e1-a76b-b911fdd852ba)
![image](https://github.com/user-attachments/assets/bc2fd8d2-9a96-42ec-ace1-6b17b5c22451)
![image](https://github.com/user-attachments/assets/213da3f9-a4b6-4f18-bd55-b098ab688be9)
![image](https://github.com/user-attachments/assets/c856dc78-d726-457c-b862-b8381a10f793)
![image](https://github.com/user-attachments/assets/2470205d-ad40-4890-8592-a0578511b58c)


