### PR TITLE
new tests on decodeAemXSeries, fixed debug task on vscode

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -4,6 +4,7 @@
 	// For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
 	"version": "0.2.0",
 	"configurations": [
+
 		{
 			"name": "Debug Unit Tests (gdb)",
 			"type": "cppdbg",
@@ -22,7 +23,8 @@
 					"text": "-enable-pretty-printing",
 					"ignoreFailures": true
 				}
-			]
+			],
+			"preLaunchTask": "Build Unit Tests"
 		},
 		{
 			"name": "Debug simulator (gdb)",
@@ -40,7 +42,8 @@
 					"text": "-enable-pretty-printing",
 					"ignoreFailures": true
 				}
-			]
+			],
+			"preLaunchTask": "Build Simulator"
 		},
 		{
 			"name": "Debug Unit Tests (lldb)",
@@ -49,6 +52,7 @@
 			"program": "${workspaceFolder}/unit_tests/build/rusefi_test",
 			"args": [],
 			"cwd": "${workspaceFolder}/unit_tests/build/",
+			"preLaunchTask": "Build Unit Tests"
 		},
 		{
 			"name": "Debug F40x",
@@ -62,7 +66,8 @@
 			"servertype": "openocd",
 			"configFiles": ["interface/stlink.cfg", "target/stm32f4x.cfg"],
 			"rtos": "auto",
-			"runToMain": true
+			"runToMain": true,
+			"preLaunchTask": "Build Firmware (microRusEfi F4)"
 		},
 		{
 			"name": "Debug F42x",
@@ -76,7 +81,8 @@
 			"servertype": "openocd",
 			"configFiles": ["interface/stlink.cfg", "target/stm32f4x.cfg"],
 			"rtos": "auto",
-			"runToMain": true
+			"runToMain": true,
+			"preLaunchTask": "Build Firmware (Nucleo F429)"
 		},
 		{
 			"name": "Debug F7x6",
@@ -90,7 +96,8 @@
 			"servertype": "openocd",
 			"configFiles": ["interface/stlink.cfg", "target/stm32f7x.cfg"],
 			"rtos": "auto",
-			"runToMain": true
+			"runToMain": true,
+			"preLaunchTask": "Build Firmware (microRusEfi F7)"
 		},
 		{
 			"name": "Debug H743",
@@ -104,7 +111,8 @@
 			"servertype": "openocd",
 			"configFiles": ["interface/stlink.cfg", "target/stm32h7x.cfg"],
 			"rtos": "auto",
-			"runToMain": true
+			"runToMain": true,
+			"preLaunchTask": "Build Firmware (Atlas H7)"
 		}
 	]
 }

--- a/firmware/controllers/sensors/impl/AemXSeriesLambda.h
+++ b/firmware/controllers/sensors/impl/AemXSeriesLambda.h
@@ -4,11 +4,11 @@
 
 #include "wideband_state_generated.h"
 
-class AemXSeriesWideband final : public CanSensorBase, public wideband_state_s {
+class AemXSeriesWideband : public CanSensorBase, public wideband_state_s {
 public:
 	AemXSeriesWideband(uint8_t sensorIndex, SensorType type);
 
-	bool acceptFrame(const CANRxFrame& frame) const override;
+	bool acceptFrame(const CANRxFrame& frame) const override final;
 
 	void refreshState(void);
 


### PR DESCRIPTION
added tests for: #7011, also added the missing preLaunchTask for debug on sim/hw/tests
```
root@dec6eb02fbba:/workspaces/rusefi/unit_tests# build/rusefi_test --gtest_filter=CanWideband.*
Note: Google Test filter = CanWideband.*
[==========] Running 8 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 8 tests from CanWideband
[ RUN      ] CanWideband.AcceptFrameId0
commonInitEngineController
doInitElectronicThrottle No
getSpeedDensityAirmass map=96.26
Not enough data for unittest_AcceptFrameId0.logicdata
[       OK ] CanWideband.AcceptFrameId0 (0 ms)
[ RUN      ] CanWideband.AcceptFrameId1
commonInitEngineController
doInitElectronicThrottle No
getSpeedDensityAirmass map=96.26
Not enough data for unittest_AcceptFrameId1.logicdata
[       OK ] CanWideband.AcceptFrameId1 (0 ms)
[ RUN      ] CanWideband.DecodeAemXSeriesInvalidLambda
[       OK ] CanWideband.DecodeAemXSeriesInvalidLambda (0 ms)
[ RUN      ] CanWideband.DecodeAemXSeriesSensorFault
[       OK ] CanWideband.DecodeAemXSeriesSensorFault (0 ms)
[ RUN      ] CanWideband.DecodeAemXSeriesValidLambda
commonInitEngineController
doInitElectronicThrottle No
getSpeedDensityAirmass map=96.26
Not enough data for unittest_DecodeAemXSeriesValidLambda.logicdata
[       OK ] CanWideband.DecodeAemXSeriesValidLambda (0 ms)
[ RUN      ] CanWideband.DecodeValidAemFormat
commonInitEngineController
doInitElectronicThrottle No
getSpeedDensityAirmass map=96.26
Not enough data for unittest_DecodeValidAemFormat.logicdata
[       OK ] CanWideband.DecodeValidAemFormat (0 ms)
[ RUN      ] CanWideband.DecodeRusefiStandard
commonInitEngineController
doInitElectronicThrottle No
getSpeedDensityAirmass map=96.26
Not enough data for unittest_DecodeRusefiStandard.logicdata
[       OK ] CanWideband.DecodeRusefiStandard (0 ms)
[ RUN      ] CanWideband.DecodeRusefiStandardWrongVersion
commonInitEngineController
doInitElectronicThrottle No
getSpeedDensityAirmass map=96.26
>>>>>>>>>> firmwareError [Wideband controller index 0 has wrong firmware version, please update!]

Not enough data for unittest_DecodeRusefiStandardWrongVersion.logicdata
[       OK ] CanWideband.DecodeRusefiStandardWrongVersion (0 ms)
[----------] 8 tests from CanWideband (1 ms total)

[----------] Global test environment tear-down
[==========] 8 tests from 1 test suite ran. (1 ms total)
[  PASSED  ] 8 tests.
DONE returning 0
All triggers exported to triggers.txt
``` 