### PR TITLE
TS: implement getCommand that have no params and requests all livedata

### DIFF
--- a/firmware/console/binary/tunerstudio.cpp
+++ b/firmware/console/binary/tunerstudio.cpp
@@ -742,6 +742,11 @@ int TunerStudio::handleCrcCommand(TsChannelBase* tsChannel, char *data, int inco
 		}
 		cmdOutputChannels(tsChannel, offset, count);
 		break;
+	case TS_OUTPUT_ALL_COMMAND:
+		offset = 0;
+		count = TS_TOTAL_OUTPUT_SIZE;
+		cmdOutputChannels(tsChannel, offset, count);
+		break;
 	case TS_HELLO_COMMAND:
 		tunerStudioDebug(tsChannel, "got Query command");
 		handleQueryCommand(tsChannel, TS_CRC);

--- a/firmware/integration/ts_protocol.txt
+++ b/firmware/integration/ts_protocol.txt
@@ -2,6 +2,8 @@
 ! These commands are used by TunerStudio and the rusEFI console
 ! 0x4F ochGetCommand
 #define TS_OUTPUT_COMMAND 'O'
+! getCommand
+#define TS_OUTPUT_ALL_COMMAND 'A'
 ! 0x53 queryCommand - this one is about detailed signature
 #define TS_HELLO_COMMAND 'S'
 ! todo: replace all usages of TS_HELLO_COMMAND with TS_QUERY_COMMAND

--- a/firmware/tunerstudio/tunerstudio.template.ini
+++ b/firmware/tunerstudio/tunerstudio.template.ini
@@ -187,6 +187,9 @@ enable2ndByteCanID = false
 ;
 ; in order to add new TunerStudio data point you need to change one of *.txt files mentioned in LiveData.yaml
 ;
+[BurstMode]
+	getCommand       = "A"
+
 [OutputChannels]
 
 	ochGetCommand	= "O%2o%2c"


### PR DESCRIPTION
But until ochBlockSize is bigger than blockingFactor TS will not use this command and prefer ochGetCommand.

But you can comment out blockingFactor in ini file and get:
![Screenshot from 2024-11-04 16-06-47](https://github.com/user-attachments/assets/c27859ca-b305-4e7a-ae75-3e2c59f18405)
