### PR TITLE
ts: handleWriteChunkCommand() and handlePageReadCommand() now with page

### DIFF
--- a/firmware/console/binary/tunerstudio.h
+++ b/firmware/console/binary/tunerstudio.h
@@ -55,9 +55,9 @@ void updateTunerStudioState();
 void startTunerStudioConnectivity(void);
 
 typedef struct {
-	short int offset;
-	short int count;
-} TunerStudioWriteChunkRequest;
+	uint16_t offset;
+	uint16_t count;
+} TunerStudioRWChunkRequest;
 
 #if EFI_PROD_CODE || EFI_SIMULATOR
 #define CONNECTIVITY_THREAD_STACK (3 * UTILITY_THREAD_STACK_SIZE)

--- a/firmware/console/binary/tunerstudio_impl.h
+++ b/firmware/console/binary/tunerstudio_impl.h
@@ -33,10 +33,10 @@ public:
 	void handleExecuteCommand(TsChannelBase* tsChannel, char *data, int incomingPacketSize);
 	// does more or less nothing, we only handle the command to make frontend application happy
 	void handlePageSelectCommand(TsChannelBase *tsChannel);
-	void handleWriteChunkCommand(TsChannelBase* tsChannel, uint16_t offset, uint16_t count,
+	void handleWriteChunkCommand(TsChannelBase* tsChannel, uint16_t page, uint16_t offset, uint16_t count,
 			void *content);
 	void handleCrc32Check(TsChannelBase *tsChannel, uint16_t offset, uint16_t count);
-	void handlePageReadCommand(TsChannelBase* tsChannel, uint16_t offset, uint16_t count);
+	void handlePageReadCommand(TsChannelBase* tsChannel, uint16_t page, uint16_t offset, uint16_t count);
 	void handleScatteredReadCommand(TsChannelBase* tsChannel);
 
 private:

--- a/unit_tests/tests/test_tunerstudio.cpp
+++ b/unit_tests/tests/test_tunerstudio.cpp
@@ -80,7 +80,7 @@ TEST(TunerstudioCommands, writeChunkEngineConfig) {
 	// two step - writes to the engineConfiguration section require a burn
 	uint8_t val = 50;
 	TunerStudio instance;
-	instance.handleWriteChunkCommand(&channel, 100, 1, &val);
+	instance.handleWriteChunkCommand(&channel, 0, 100, 1, &val);
 
 	EXPECT_EQ(configBytes[100], 50);
 }


### PR DESCRIPTION
Initial support for page addressing. This is needed to move scatteredOffsetArray to separate page that is not saved in TS and ECU.