### PR TITLE
simulator job does not take proper branch name

### DIFF
--- a/.github/workflows/build-simulator.yaml
+++ b/.github/workflows/build-simulator.yaml
@@ -3,7 +3,10 @@ name: Simulator
 on: [push, pull_request]
 
 env: 
+# in a PR github executes the runner on a detached branch, so the command "git branch --show-current" returns an empty string, 
+# at the same time, github.ref_name in a PR only returns <pr_number>/merge , github.head_ref is *only* available in PR, but it does contain the branch name
     AUTOMATION_REF: ${{github.head_ref}}
+
 jobs:
   # This is just to ensure the simulator compiles on Linux
   build-simulator:

--- a/.github/workflows/build-simulator.yaml
+++ b/.github/workflows/build-simulator.yaml
@@ -2,6 +2,8 @@ name: Simulator
 
 on: [push, pull_request]
 
+env: 
+    AUTOMATION_REF: ${{github.ref_name}}
 jobs:
   # This is just to ensure the simulator compiles on Linux
   build-simulator:

--- a/.github/workflows/build-simulator.yaml
+++ b/.github/workflows/build-simulator.yaml
@@ -3,7 +3,7 @@ name: Simulator
 on: [push, pull_request]
 
 env: 
-    AUTOMATION_REF: ${{github.ref_name}}
+    AUTOMATION_REF: ${{github.head_ref}}
 jobs:
   # This is just to ensure the simulator compiles on Linux
   build-simulator:


### PR DESCRIPTION
fixes #6904 

note: needs testing, I can't reproduce with a user created fork:
https://productionresultssa13.blob.core.windows.net/actions-results/be683b96-bc09-43ac-a92a-b37cc8f8a0cf/workflow-job-run-c9cfbd07-d407-5e60-840b-fa00e0d20bac/logs/job/job-logs.txt?rsct=text%2Fplain&se=2024-11-06T01%3A59%3A59Z&sig=OE3UsX7RCIDA1w4j2wtFekCmwdy8E2Z53nyrKdLo6FQ%3D&ske=2024-11-06T13%3A02%3A09Z&skoid=ca7593d4-ee42-46cd-af88-8b886a2f84eb&sks=b&skt=2024-11-06T01%3A02%3A09Z&sktid=398a6654-997b-47e9-b12b-9515b896b4de&skv=2024-08-04&sp=r&spr=https&sr=b&st=2024-11-06T01%3A49%3A54Z&sv=2024-08-04

```
2024-10-31T18:12:58.2207843Z       |                                                              ^
2024-10-31T18:12:58.2209765Z ../firmware/console/binary/signature.cpp:29:47: note: ‘#pragma message: TS_SIGNATURE: rusEFI feature/devcontainer.2024.10.31.f407-discovery.496795309’
2024-10-31T18:12:58.2211704Z    29 | #pragma message ("TS_SIGNATURE: " TS_SIGNATURE)
2024-10-31T18:12:58.2212458Z       |     
``` 