### PR TITLE
updates on MAP_UPPER_LIMIT, change from uint8 to uint16 

### DIFF
--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -130,7 +130,7 @@ struct_no_prefix engine_configuration_s
 ! PnP boards for liquid cooled engines should override with '120'
 #define CLT_UPPER_LIMIT 250
 ! technical debt: some of these use uint8_t !!!
-#define MAP_UPPER_LIMIT 255
+#define MAP_UPPER_LIMIT 1000
 
 #define LUA_PWM_COUNT 8
 #define LUA_DIGITAL_INPUT_COUNT 8
@@ -270,8 +270,8 @@ end_struct
 
 struct stft_s
 	uint8_t autoscale maxIdleRegionRpm;Below this RPM, the idle region is active, idle+300 would be a good value;"RPM", 50, 0, 0, 12000, 0
-	uint8_t maxOverrunLoad;Below this engine load, the overrun region is active;"load", 1, 0, 0, 250, 0
-	uint8_t minPowerLoad;Above this engine load, the power region is active;"load", 1, 0, 0, 250, 0
+	uint16_t maxOverrunLoad;Below this engine load, the overrun region is active;"load", 1, 0, 0, 250, 0
+	uint16_t minPowerLoad;Above this engine load, the power region is active;"load", 1, 0, 0, 250, 0
 	uint8_t autoscale deadband;When close to correct AFR, pause correction. This can improve stability by not changing the adjustment if the error is extremely small, but is not required.;"%", 0.1, 0, 0, 3, 1
 
 	int8_t minClt;Below this temperature, correction is disabled.;"C", 1, 0, -20, 100, 0
@@ -573,7 +573,7 @@ uint32_t cylindersCount;Number of cylinder the engine has.;"", 1, 0, 1, @@MAX_CY
 custom firing_order_e 1 bits, U08, @OFFSET@, [0:6], "One Cylinder", "1-3-4-2", "1-2-4-3", "1-3-2-4", "1-5-3-6-2-4", "1-8-4-3-6-5-7-2", "1-2-4-5-3", "1-4-2-5-3-6", "1-2", "1-2-3-4-5-6", "1-2-3", "1-8-7-2-6-5-4-3", "1-5-4-2-6-3-7-8 Mustang", "1-6-3-2-5-4", "1-10-9-4-3-6-5-8-7_2", "1-7-5-11-3-9-6-12-2-8-4-10", "1-7-4-10-2-8-6-12-3-9-5-11", "1-4-3-2", "1-12-5-8-3-10-6-7-2-11-4-9", "1-2-7-8-4-5-6-3", "1-3-7-2-6-5-4-8 HO", "1-2-3-4-5-6-7-8-9", "INVALID", "1-2-3-4-5-6-7-8-9-10-11-12", "1-3-2", "1-2-3-4-5-6-7-8", "1-5-4-8-6-3-7-2", "1-4-3-6-2-5", "1-8-7-3-6-5-4-2", "1-6-2-4-3-5", "1-6-5-4-3-2", "1-4-5-2-3-6", "1-5-4-8-3-7-2-6 Voodoo", "1-6-5-10-2-7-3-8-4-9", "1-8-6-2-7-3-4-5 F136", "fo35", "fo36", "fo37"
 firing_order_e firingOrder;
 uint8_t justATempTest
-uint8_t mapSyncThreshold;Delta kPa for MAP sync;"kPa", 1, 0, 0, 50, 0
+uint16_t mapSyncThreshold;Delta kPa for MAP sync;"kPa", 1, 0, 0, 50, 0
 int8_t torqueReductionIgnitionCut;How many % of ignition events will be cut;"%", 1, 0, 0, 100, 0
 
 #define CYLINDER_BORE_UNITS "mm"
@@ -595,7 +595,7 @@ injection_mode_e injectionMode;This is where the fuel injection type is defined:
 
 uint16_t boostControlMinRpm; Minimum RPM to enable boost control. Use this to avoid solenoid noise at idle, and help spool in some cases.;"", 1, 0, 0, 25000, 0
 uint8_t boostControlMinTps; Minimum TPS to enable boost control. Use this to avoid solenoid noise at idle, and help spool in some cases.;"", 1, 0, 0, 100, 0
-uint8_t boostControlMinMap; Minimum MAP to enable boost control. Use this to avoid solenoid noise at idle, and help spool in some cases.;"", 1, 0, 0, 250, 0
+uint16_t boostControlMinMap; Minimum MAP to enable boost control. Use this to avoid solenoid noise at idle, and help spool in some cases.;"", 1, 0, 0, @@MAP_UPPER_LIMIT@@, 0
 
 angle_t crankingTimingAngle;Ignition advance angle used during engine cranking, 5-10 degrees will work as a base setting for most engines.\nThere is tapering towards running timing advance\nset cranking_timing_angle X;"deg", 1, 0, -30, 30, 0
 
@@ -796,7 +796,7 @@ spi_device_e digitalPotentiometerSpiDevice;Digital Potentiometer is used by stoc
 	pin_output_mode_e o2heaterPinModeTodO;
 
 	uint8_t autoscale lambdaProtectionMinRpm;;"RPM", 100, 0, 0, 25000, 0
-	uint8_t autoscale lambdaProtectionMinLoad;;"%", 10, 0, 0, 1000, 0
+	uint8_t autoscale lambdaProtectionMinLoad;;"%", 10, 0, 0, @@MAP_UPPER_LIMIT@@, 0
 
 bit is_enabled_spi_1
 bit is_enabled_spi_2
@@ -843,7 +843,7 @@ pin_output_mode_e hip9011IntHoldPinMode;
 	uint32_t verboseCanBaseAddress;;"", 1, 0, 0, 536870911, 0
 
 	uint8_t mc33_hvolt;Boost Voltage;"v", 1, 0, 40, 70, 0
-	uint8_t minimumBoostClosedLoopMap;Minimum MAP before closed loop boost is enabled. Use to prevent misbehavior upon entering boost.;"kPa", 1, 0, 0, @@MAP_UPPER_LIMIT@@, 0
+	uint16_t minimumBoostClosedLoopMap;Minimum MAP before closed loop boost is enabled. Use to prevent misbehavior upon entering boost.;"kPa", 1, 0, 0, @@MAP_UPPER_LIMIT@@, 0
 
     int8_t initialIgnitionCutPercent;;"%", 1, 0, 0, 100, 0
     int8_t finalIgnitionCutPercentBeforeLaunch;;"%", 1, 0, 0, 100, 0
@@ -1293,7 +1293,7 @@ int16_t tps2Max;Full throttle#2. tpsMax value as 10 bit ADC value. Not Voltage!\
 	uint16_t autoscale benchTestOnTime;Duration of each test pulse;"ms", 0.01, 0, 0, 500, 2
 
 	uint8_t lambdaProtectionRestoreTps;;"%", 1, 0, 0, 100, 0
-	uint8_t autoscale lambdaProtectionRestoreLoad;;"%", 10, 0, 0, 1000, 0
+	uint8_t autoscale lambdaProtectionRestoreLoad;;"%", 10, 0, 0, @@MAP_UPPER_LIMIT@@, 0
 
 	pin_input_mode_e launchActivatePinMode;
 	Gpio can2TxPin
@@ -1309,8 +1309,7 @@ int16_t tps2Max;Full throttle#2. tpsMax value as 10 bit ADC value. Not Voltage!\
 	output_pin_e hpfpValvePin;
 	pin_output_mode_e hpfpValvePinMode;
 
-! todo: reuse @@MAP_UPPER_LIMIT@@ once we are above uint8?
-	float boostCutPressure;MAP value above which fuel is cut in case of overboost.\nSet to 0 to disable overboost cut.;"kPa (absolute)", 1, 0, 0, 1000, 0
+	float boostCutPressure;MAP value above which fuel is cut in case of overboost.\nSet to 0 to disable overboost cut.;"kPa (absolute)", 1, 0, 0, @@MAP_UPPER_LIMIT@@ , 0
 
 	uint8_t[16] autoscale tchargeBins;;"kg/h", 5, 0, 0, 1200, 0
 	uint8_t[16] autoscale tchargeValues;;"ratio", 0.01, 0, 0, 1, 2
@@ -1836,16 +1835,15 @@ float[MAF_DECODING_COUNT] mafDecodingBins;;"V", 1, 0, -5, 150, 2
 
 int8_t[8 x 8] autoscale ignitionIatCorrTable;;"deg", 0.1, 0, -25, 25, 1
 int8_t[8] ignitionIatCorrTempBins;;"C", 1, 0, -40, 120, 0
-uint8_t[8] autoscale ignitionIatCorrLoadBins;;"Load", 5, 0, 0, 1000, 0
+uint16_t[8] autoscale ignitionIatCorrLoadBins;;"Load", 5, 0, 0, @@MAP_UPPER_LIMIT@@, 0
 
 int16_t[FUEL_LOAD_COUNT x FUEL_RPM_COUNT] injectionPhase;;"deg", 1, 0, -720, 720, 0
-uint16_t[FUEL_LOAD_COUNT] injPhaseLoadBins;;"Load", 1, 0, 0, 1000, 0
+uint16_t[FUEL_LOAD_COUNT] injPhaseLoadBins;;"Load", 1, 0, 0, @@MAP_UPPER_LIMIT@@, 0
 uint16_t[FUEL_RPM_COUNT] injPhaseRpmBins;;"RPM",	   1, 0, 0, 18000, 0
 
 uint8_t[TCU_SOLENOID_COUNT x TCU_GEAR_COUNT] tcuSolenoidTable;;"onoff", 1, 0, 0, 1, 0
 
-! todo: reuse @@MAP_UPPER_LIMIT@@ once we are above uint8?
-uint16_t[FUEL_LOAD_COUNT x FUEL_RPM_COUNT] autoscale mapEstimateTable;;"kPa", 0.01, 0, 0, 600, 2
+uint16_t[FUEL_LOAD_COUNT x FUEL_RPM_COUNT] autoscale mapEstimateTable;;"kPa", 0.01, 0, 0, @@MAP_UPPER_LIMIT@@, 2
 uint16_t[FUEL_LOAD_COUNT] autoscale mapEstimateTpsBins;;"% TPS", {1/@@TPS_2_BYTE_PACKING_MULT@@}, 0, 0, 100, 1
 uint16_t[FUEL_RPM_COUNT] mapEstimateRpmBins;;"RPM", 1, 0, 0, 18000, 0
 

--- a/unit_tests/tests/test_limp.cpp
+++ b/unit_tests/tests/test_limp.cpp
@@ -210,6 +210,36 @@ TEST(limp, boostCut) {
 	EXPECT_TRUE(dut.allowInjection());
 }
 
+TEST(limp, boostCutUint8Overflow) {
+	EngineTestHelper eth(engine_type_e::TEST_ENGINE);
+
+	// Cut above 1500kPa
+	engineConfiguration->boostCutPressure = 1500;
+	engineConfiguration->boostCutPressureHyst = 20;
+
+	LimpManager dut;
+
+	// Below threshold, injection allowed
+	Sensor::setMockValue(SensorType::Map, 80);
+	dut.updateState(1000, 0);
+	EXPECT_TRUE(dut.allowInjection());
+
+	// Above rising threshold, injection cut
+	Sensor::setMockValue(SensorType::Map, 1600);
+	dut.updateState(1000, 0);
+	EXPECT_FALSE(dut.allowInjection());
+
+	// Below rising threshold, but should have hysteresis, so not cut yet
+	Sensor::setMockValue(SensorType::Map, 1495);
+	dut.updateState(1000, 0);
+	EXPECT_FALSE(dut.allowInjection());
+
+	// Below falling threshold, fuel restored
+	Sensor::setMockValue(SensorType::Map, 79);
+	dut.updateState(1000, 0);
+	EXPECT_TRUE(dut.allowInjection());
+}
+
 TEST(limp, oilPressureStartupFailureCase) {
 	EngineTestHelper eth(engine_type_e::TEST_ENGINE);
 	engineConfiguration->minOilPressureAfterStart = 200;


### PR DESCRIPTION
related issue: #7054

- added unit tests for the int8 => int16 change
- updated load-related configs from hardcoded 1000kpa to MAP_UPPER_LIMIT
- updated MAP_UPPER_LIMIT from 255 kpa to 1000kpa

tested on simulator, f407-discovery
![image](https://github.com/user-attachments/assets/6445c027-daa2-4f10-adb8-2fb88dd715ec)
