### PR TITLE
Remove 0x153 from E46 CAN dash

### DIFF
--- a/firmware/controllers/can/can_dash.cpp
+++ b/firmware/controllers/can/can_dash.cpp
@@ -88,11 +88,6 @@ static void canDashboardBmwE46(CanCycle cycle) {
 
 	if (cycle.isInterval(CI::_10ms)) {
 		{
-			CanTxMessage msg(CanCategory::NBC, CAN_BMW_E46_SPEED);
-			msg.setShortValue(10 * 8, 1);
-		}
-
-		{
 			CanTxMessage msg(CanCategory::NBC, CAN_BMW_E46_RPM);
       msg[0] = 0x05; // ASC message
       msg[1] = 0x0C; // Indexed Engine Torque in % of C_TQ_STND TBD


### PR DESCRIPTION
0x153 is being sent out by the traction control module. It should not be sent by the ecu because it's causing traction control indicator to blink even when the car is not moving.

See https://www.ms4x.net/index.php?title=CAN_Bus_ID_0x153_ASC1