### PR TITLE
update AemXSeries decoder, accept invalid but no error lambda value as valid see #7011

### DIFF
--- a/firmware/controllers/sensors/impl/AemXSeriesLambda.cpp
+++ b/firmware/controllers/sensors/impl/AemXSeriesLambda.cpp
@@ -92,7 +92,9 @@ bool AemXSeriesWideband::decodeAemXSeries(const CANRxFrame& frame, efitick_t now
 	// bit 7 indicates valid
 	bool valid = frame.data8[6] & 0x80;
 	if (!valid) {
-		invalidate();
+    // open discussion about the user usability of this check as we cannot determine the reason why this lambda value is invalid, see:
+    // https://github.com/rusefi/rusefi/issues/7011
+		setValidValue(lambdaFloat, nowNt);
 		return false;
 	}
 

--- a/unit_tests/tests/controllers/can/test_can_wideband.cpp
+++ b/unit_tests/tests/controllers/can/test_can_wideband.cpp
@@ -164,7 +164,7 @@ TEST(CanWideband, DecodeValidAemFormat) {
 		0 << 7;		// Data INVALID
 
 	dut.processFrame(frame, getTimeNowNt());
-	EXPECT_FLOAT_EQ(-1, Sensor::get(SensorType::Lambda1).value_or(-1));
+	EXPECT_FLOAT_EQ(0.8f, Sensor::get(SensorType::Lambda1).value_or(-1));
 
 
 	// Now check sensor fault


### PR DESCRIPTION
pull request modifying the Aem decoder and tests to allow invalid values ​​as valid, but still display the error status implemented in: [bb4564d](https://github.com/rusefi/rusefi/commit/bb4564df82cb1efde924d99a202b91976b967272).

values ​​reported as error by the CAN controller will still be invalid.

pls @ElDominio if possible I'll need you to test this on the same setup that the error was reported before merging it