### PR TITLE
new env var for openblt debug options, see #7096

### DIFF
--- a/firmware/bootloader/Makefile
+++ b/firmware/bootloader/Makefile
@@ -5,9 +5,9 @@
 # by default EXTRA_PARAMS is empty and we create 'debug' version of the firmware with additional assertions and statistics
 # for 'release' options see 'clean_compile_two_versions.bat' file
 
-ifeq ($(DEBUG_LEVEL_OPT),)
+ifeq ($(DEBUG_LEVEL_BLT_OPT),)
   # this value would be used by default. For 'debug' configuration override with '-O0 -ggdb -g' or something along these lines
-  DEBUG_LEVEL_OPT = -Os -ggdb -g
+  DEBUG_LEVEL_BLT_OPT = -Os -ggdb -g
   DDEFS += -DEFI_ENABLE_ASSERTS=FALSE -DCH_DBG_ENABLE_ASSERTS=FALSE -DCH_DBG_ENABLE_STACK_CHECK=FALSE -DCH_DBG_FILL_THREADS=FALSE -DCH_DBG_THREADS_PROFILING=FALSE
 endif
 
@@ -30,7 +30,7 @@ DDEFS += -DEFI_UNIT_TEST=0 -DEFI_PROD_CODE=1 -DEFI_SIMULATOR=0
 
 # Compiler options here.
 ifeq ($(USE_OPT),)
-  USE_OPT = $(EXTRA_PARAMS) $(EXTRA_2_PARAMS) $(EXTRA_3_PARAMS) $(DEBUG_LEVEL_OPT) $(RFLAGS) -Wno-error=implicit-fallthrough -Wno-error=bool-operation -fomit-frame-pointer -falign-functions=16 -Werror -Wno-error=pointer-sign -Wno-error=unused-function -Wno-error=unused-variable -Wno-error=sign-compare -Wno-error=unused-parameter -Wno-error=missing-field-initializers -Werror=type-limits -Wno-error=strict-aliasing -Wno-error=attributes
+  USE_OPT = $(EXTRA_PARAMS) $(EXTRA_2_PARAMS) $(EXTRA_3_PARAMS) $(DEBUG_LEVEL_BLT_OPT) $(RFLAGS) -Wno-error=implicit-fallthrough -Wno-error=bool-operation -fomit-frame-pointer -falign-functions=16 -Werror -Wno-error=pointer-sign -Wno-error=unused-function -Wno-error=unused-variable -Wno-error=sign-compare -Wno-error=unused-parameter -Wno-error=missing-field-initializers -Werror=type-limits -Wno-error=strict-aliasing -Wno-error=attributes
 endif
 
 # Configure the linker script to build the bootloader, not the firmware

--- a/firmware/config/boards/readme.md
+++ b/firmware/config/boards/readme.md
@@ -47,3 +47,11 @@ A: please remember about https://github.com/rusefi/rusefi/wiki/Hardware#q-this-i
 # Q: I insist on custom
 
 A: https://github.com/rusefi/rusefi/wiki/Custom-Firmware
+
+# Q: I want to build the firmware in debug mode
+
+A: check DEBUG_LEVEL_OPT on the .env file of your board
+
+# Q: I want to build the bootloader firmware in debug mode
+
+A: check or add DEBUG_LEVEL_BLT_OPT on the .env file of your board, is the same as DEBUG_LEVEL_OPT but only for the bootloader


### PR DESCRIPTION
resolves: #7096
added DEBUG_LEVEL_BLT_OPT to define debug options in the bootloader, small comment in the boards .md to clarify the difference between both variables

cons?: by default now all boards will compile the bootloader with Os (the default option in the makefile)
