### PR TITLE
SENT: count HW timer overcapture events

### DIFF
--- a/firmware/hw_layer/drivers/sent/sent.h
+++ b/firmware/hw_layer/drivers/sent/sent.h
@@ -14,8 +14,10 @@
 /* SENT decoder init */
 void initSent();
 
+#define SENT_FLAG_HW_OVERFLOW	(1 << 0)
+
 /* ISR hook */
-void SENT_ISR_Handler(uint8_t ch, uint16_t val_res);
+void SENT_ISR_Handler(uint8_t channels, uint16_t clocks, uint8_t flags);
 
 /* Stop/Start for config update */
 void startSent();

--- a/firmware/hw_layer/drivers/sent/sent_hw_icu.cpp
+++ b/firmware/hw_layer/drivers/sent/sent_hw_icu.cpp
@@ -22,38 +22,57 @@
 /* This SENT HW driver is based on ChibiOS ICU driver */
 #if (HAL_USE_ICU == TRUE)
 
+/* TODO: do we care about scaling abstract timer ticks to some time base? */
 /* TODO: get at runtime */
 /* Max timer clock for most timers on STM32 is CPU clock / 2 */
 #define SENT_TIMER_CLOCK_DIV	2
 #define SENT_ICU_FREQ			(CORE_CLOCK / SENT_TIMER_CLOCK_DIV) // == CPU freq / 2
 
 static uint16_t lastPulse[SENT_INPUT_COUNT];
+static bool overcapture[SENT_INPUT_COUNT];
 
 static void icuperiodcb(ICUDriver *icup, size_t index)
 {
+	uint16_t clocks;
+	uint8_t flags = 0;
 	const ICUConfig *icucfg = icup->config;
 
 	if ((icucfg->channel == ICU_CHANNEL_1) || (icucfg->channel == ICU_CHANNEL_2)) {
 		/* channel 1 and channel 2 supports period measurements */
-		SENT_ISR_Handler(index, icuGetPeriodX(icup) * SENT_TIMER_CLOCK_DIV);
+		clocks = icuGetPeriodX(icup);
 	} else {
 		/* this is freerunnig timer and we need to calculate period using just captured timer value and previous one */
 		/* TODO: support 32 bit timers too? */
 		uint16_t val = icuGetWidthX(icup);
 
 		/* can overflow */
-		uint16_t clocks = val - lastPulse[index];
-
-		SENT_ISR_Handler(index, clocks /* * SENT_TIMER_CLOCK_DIV */);
+		clocks = val - lastPulse[index];
 
 		lastPulse[index] = val;
 	}
+
+	if (overcapture[index]) {
+		flags |= SENT_FLAG_HW_OVERFLOW;
+		overcapture[index] = false;
+	}
+
+	SENT_ISR_Handler(index, clocks, flags);
+}
+
+static void icuovercapture(ICUDriver *icup, size_t index)
+{
+	overcapture[index] = true;
 }
 
 /* ICU callbacks */
 static void icuperiodcb_in1(ICUDriver *icup)
 {
 	icuperiodcb(icup, 0);
+}
+
+static void icuovercapture_in1(ICUDriver *icup)
+{
+	icuovercapture(icup, 0);
 }
 
 /* ICU configs */
@@ -68,6 +87,7 @@ static ICUConfig icucfg[SENT_INPUT_COUNT] =
 		.channel = ICU_CHANNEL_1,	/* will be overwriten on startSent() */
 		.dier = 0U,
 		.arr = 0xFFFFFFFFU,
+		.overcapture_cb = icuovercapture_in1,
 	}
 };
 

--- a/firmware/hw_layer/drivers/sent/sent_logic.h
+++ b/firmware/hw_layer/drivers/sent/sent_logic.h
@@ -30,6 +30,8 @@ typedef enum
 } SENT_STATE_enum;
 
 struct sent_channel_stat {
+	uint32_t hwOverflowCnt;
+
 	uint32_t ShortIntervalErr;
 	uint32_t LongIntervalErr;
 	uint32_t SyncErr;
@@ -107,7 +109,7 @@ public:
 #endif // SENT_STATISTIC_COUNTERS
 
 	/* Decoder */
-	int Decoder(uint32_t clocks);
+	int Decoder(uint32_t clocks, uint8_t flags = 0);
 
 	/* Get last raw message */
 	int GetMsg(uint32_t* rx);


### PR DESCRIPTION
Ok, we get decode errors because we lost events from HW.
Now we need to find why.

https://github.com/rusefi/rusefi/issues/7077

```
2024-12-07_00_44_44_072: EngineState: ---- SENT input 1 ---- on 24A - Hall Input 3 / SENT
2024-12-07_00_44_44_073: EngineState: Unit time 354 CPU ticks 1.638888832 uS
2024-12-07_00_44_44_073: EngineState: Pause pulse detected No
2024-12-07_00_44_44_073: EngineState: Total pulses 3528938
2024-12-07_00_44_44_074: EngineState: Last valid fast msg Status 0x0 Sig0 0xAD6 Sig1 0x529
2024-12-07_00_44_44_076: EngineState: HW overflows 102831 
2024-12-07_00_44_44_076: EngineState: Pause pulses 31323 
2024-12-07_00_44_44_080: EngineState: Restarts 2
2024-12-07_00_44_44_081: EngineState: Interval errors 30916 short, 43928 long
2024-12-07_00_44_44_081: EngineState: Total frames 293421 with CRC error 3471 (1.182941920%)
2024-12-07_00_44_44_084: EngineState: Total slow channel messages 0 with crc6 errors 0 (NaN%)
2024-12-07_00_44_44_085: EngineState: Sync errors 30951
2024-12-07_00_44_44_085: EngineState: --------------------
2024-12-07_00_44_44_086: EngineState: confirmation_sentinfo:8
```
