### PR TITLE
Real hardware ICU coverage on nucleo-F767 #7034

### DIFF
--- a/.github/workflows/hardware-ci.yaml
+++ b/.github/workflows/hardware-ci.yaml
@@ -31,7 +31,9 @@ jobs:
             folder: config/boards/f407-discovery
             serial-device: /dev/serial/by-id/usb-rusEFI_LLC_rusEFI_Engine_Management_ECU_2B003B000A51343033393930-if01
             vbatt_supply: 12
-
+            # wiring:
+            # PD1 <=> PC6
+            # PD2 <=> PA6
           - build-target: nucleo_f767
             runs-on: hw-ci-nucleo-f7
             test-suite: com.rusefi.HwCiNucleoF7

--- a/firmware/config/engines/custom_engine.cpp
+++ b/firmware/config/engines/custom_engine.cpp
@@ -35,7 +35,7 @@
 void setDiscoveryPdm() {
 }
 
-#ifdef HW_FRANKENSO
+#if defined(HW_NUCLEO_F767) || defined(HW_NUCLEO_H743) || defined(HW_FRANKENSO)
 
 /**
  * set engine_type 59

--- a/firmware/config/engines/vw.cpp
+++ b/firmware/config/engines/vw.cpp
@@ -19,12 +19,6 @@ void setVwAba() {
 	setFrankensoConfiguration();
 	engineConfiguration->camInputs[0] = Gpio::E0; // a random unused pin needed for happy HW CI
 
-  // default PC1-5 ADC pins conflict with the ethernet module on F767, used on HW CI
-	engineConfiguration->tps1_1AdcChannel = EFI_ADC_32;
-	engineConfiguration->vbattAdcChannel = EFI_ADC_33;
-	engineConfiguration->clt.adcChannel = EFI_ADC_34;
-	engineConfiguration->iat.adcChannel = EFI_ADC_35;
-	engineConfiguration->afr.hwChannel = EFI_ADC_36;
 
 	setWholeTimingTable(20);
 	// set cranking_timing_angle 10

--- a/firmware/controllers/algo/engine_type_impl.cpp
+++ b/firmware/controllers/algo/engine_type_impl.cpp
@@ -321,7 +321,7 @@ void applyEngineType(engine_type_e engineType) {
 		testEngine6451();
 		break;
 
-#if defined(HW_FRANKENSO) || EFI_SIMULATOR
+#if defined(HW_NUCLEO_F767) || defined(HW_NUCLEO_H743) || defined(HW_FRANKENSO) || EFI_SIMULATOR
 	case engine_type_e::DEFAULT_FRANKENSO:
 		setFrankensoConfiguration();
 		break;
@@ -413,6 +413,22 @@ void applyEngineType(engine_type_e engineType) {
 	default:
 	  applyEngineTypeExt(engineType);
 	}
+
+#if defined(HW_NUCLEO_F767) || defined(HW_NUCLEO_H743)
+    // default PA1-6 ADC pins conflict with the ethernet module on F767, used on HW CI
+    engineConfiguration->tps1_1AdcChannel = EFI_ADC_32;
+    engineConfiguration->vbattAdcChannel = EFI_ADC_33;
+    engineConfiguration->clt.adcChannel = EFI_ADC_34;
+    engineConfiguration->iat.adcChannel = EFI_ADC_35;
+    engineConfiguration->afr.hwChannel = EFI_ADC_36;
+    engineConfiguration->map.sensor.hwChannel=EFI_ADC_39;
+    engineConfiguration->baroSensor.hwChannel=EFI_ADC_40;
+    engineConfiguration->throttlePedalUpPin = Gpio::Unassigned;
+    engineConfiguration->acSwitch = Gpio::Unassigned;
+    engineConfiguration->triggerInputPins[0] = Gpio::B2;
+    engineConfiguration->triggerInputPins[1] = Gpio::Unassigned;
+    engineConfiguration->camInputs[0] = Gpio::E0;
+#endif
 }
 
 PUBLIC_API_WEAK_SOMETHING_WEIRD engine_type_e getLastEngineType() {

--- a/java_console/autotest/src/main/java/com/rusefi/HwCiNucleoF7.java
+++ b/java_console/autotest/src/main/java/com/rusefi/HwCiNucleoF7.java
@@ -1,7 +1,14 @@
 package com.rusefi;
 
 import com.rusefi.common.MiscTest;
-import com.rusefi.f4discovery.*;
+import com.rusefi.f4discovery.PTraceTest;
+import com.rusefi.f4discovery.CompositeLoggerTest;
+import com.rusefi.f4discovery.HighRevTest;
+import com.rusefi.f4discovery.CommonFunctionalTest;
+import com.rusefi.f4discovery.BurnCommandTest;
+
+import com.rusefi.f7nucleo.PwmHardwareTest;
+import com.rusefi.f7nucleo.VssHardwareLoopTest;
 
 public class HwCiNucleoF7 {
     public static void main(String[] args) {
@@ -9,8 +16,12 @@ public class HwCiNucleoF7 {
             PTraceTest.class,
             CompositeLoggerTest.class,
             HighRevTest.class,
-			// removed due to extremely low temperatures on the HWCI node (or we are incorrectly reading the CPU temperature on F7)
-           	// MiscTest.class, 
+           	MiscTest.class,
+            BurnCommandTest.class,
+            CommonFunctionalTest.class,
+            VssHardwareLoopTest.class,
+			//not ok
+            //PwmHardwareTest.class,
         });
     }
 }

--- a/java_console/autotest/src/main/java/com/rusefi/f7nucleo/PwmHardwareTest.java
+++ b/java_console/autotest/src/main/java/com/rusefi/f7nucleo/PwmHardwareTest.java
@@ -1,0 +1,93 @@
+package com.rusefi.f7nucleo;
+
+import com.devexperts.logging.Logging;
+import com.rusefi.IoUtil;
+import com.rusefi.RusefiTestBase;
+import com.rusefi.Timeouts;
+import com.rusefi.config.generated.Fields;
+import com.rusefi.config.generated.Integration;
+import com.rusefi.core.Sensor;
+import com.rusefi.core.SensorCentral;
+import com.rusefi.enums.engine_type_e;
+import com.rusefi.functional_tests.EcuTestHelper;
+import org.junit.Test;
+
+import static com.devexperts.logging.Logging.getLogging;
+import static com.rusefi.IoUtil.getDisableCommand;
+import static com.rusefi.IoUtil.getEnableCommand;
+import static com.rusefi.binaryprotocol.BinaryProtocol.sleep;
+import static com.rusefi.config.generated.Fields.*;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * This test relies on jumpers connecting physical pins on Discovery:
+ * PD1<>PC6
+ * PD2<>PA6
+ */
+
+public class PwmHardwareTest extends RusefiTestBase {
+    private static final Logging log = getLogging(PwmHardwareTest.class);
+
+    @Override
+    protected boolean needsHardwareTriggerInput() {
+        // This test uses hardware trigger input!
+        return true;
+    }
+
+    private static final int FREQUENCY = 160;
+
+    @Test
+    public void scheduleBurnDoesNotAffectTriggerIssue2839() {
+        ecu.setEngineType(engine_type_e.FORD_ASPIRE_1996);
+        ecu.sendCommand(IoUtil.setTriggerType(com.rusefi.enums.trigger_type_e.TT_TOOTHED_WHEEL_60_2));
+        ecu.sendCommand(getDisableCommand(Integration.CMD_SELF_STIMULATION));
+        ecu.sendCommand(getEnableCommand(CMD_EXTERNAL_STIMULATION));
+        ecu.changeRpm(1200);
+        nextChart();
+        nextChart();
+        int triggerErrors = (int) SensorCentral.getInstance().getValueSource(Sensor.totalTriggerErrorCounter).getValue();
+        log.info("triggerErrors " + triggerErrors);
+        for (int i = 0; i < 10; i++) {
+            ecu.sendCommand(CMD_BURNCONFIG);
+            sleep(5 * Timeouts.SECOND);
+        }
+        int totalTriggerErrorsNow = (int) SensorCentral.getInstance().getValueSource(Sensor.totalTriggerErrorCounter).getValue();
+        log.info("totalTriggerErrorsNow " + totalTriggerErrorsNow);
+
+        assertEquals("totalTriggerErrorCounter", triggerErrors, totalTriggerErrorsNow);
+    }
+
+    @Test
+    public void testIdlePin() {
+        ecu.setEngineType(engine_type_e.FRANKENSO_MIATA_NA6_MAP);
+        ecu.changeRpm(1000);
+
+        ecu.sendCommand(CMD_TRIGGER_SIMULATOR_PIN + " 0 none");
+        ecu.sendCommand(CMD_TRIGGER_SIMULATOR_PIN + " 1 none");
+        ecu.sendCommand(CMD_IDLE_PIN + " PD2");
+
+        /* wasted two wire, so we really need 1..3 to be none */
+        ecu.sendCommand(CMD_IGNITION_PIN + " 1 none");
+        ecu.sendCommand(CMD_IGNITION_PIN + " 2 none");
+        ecu.sendCommand(CMD_IGNITION_PIN + " 3 none");
+
+        ecu.sendCommand(CMD_TRIGGER_PIN + " 1 PB1");
+
+        /* DBG_LOGIC_ANALYZER */
+        ecu.sendCommand("set debug_mode " +  com.rusefi.enums.debug_mode_e.DBG_LOGIC_ANALYZER.ordinal());
+
+        /* 160 Hz */
+        ecu.sendCommand("set idle_solenoid_freq " + FREQUENCY);
+
+        /* save these for last to ensure logic is started */
+        ecu.sendCommand(CMD_LOGIC_PIN + " 0 PA6");
+        ecu.sendCommand(CMD_WRITECONFIG);
+        sleep(2 * Timeouts.SECOND);
+        ecu.sendCommand(getEnableCommand(Integration.CMD_SELF_STIMULATION));
+
+        sleep(2 * Timeouts.SECOND);
+
+        /* +-2% is still acceptable */
+        EcuTestHelper.assertSomewhatClose("Idle PWM freq", FREQUENCY, SensorCentral.getInstance().getValue(Sensor.debugIntField1), 0.02);
+    }
+}

--- a/java_console/autotest/src/main/java/com/rusefi/f7nucleo/VssHardwareLoopTest.java
+++ b/java_console/autotest/src/main/java/com/rusefi/f7nucleo/VssHardwareLoopTest.java
@@ -1,0 +1,56 @@
+package com.rusefi.f7nucleo;
+
+import com.rusefi.autotest.ControllerConnectorState;
+import com.rusefi.RusefiTestBase;
+import com.rusefi.Timeouts;
+import com.rusefi.core.Sensor;
+import com.rusefi.core.SensorCentral;
+import com.rusefi.enums.engine_type_e;
+import com.rusefi.functional_tests.EcuTestHelper;
+import org.junit.Test;
+
+import static com.rusefi.binaryprotocol.BinaryProtocol.sleep;
+import static com.rusefi.config.generated.Fields.*;
+
+/**
+ * This test relies on jumpers connecting physical pins on f7-nucleo:
+ * PD1<>PC6
+ * PD2<>PA6
+ */
+public class VssHardwareLoopTest extends RusefiTestBase {
+    @Override
+    protected boolean needsHardwareTriggerInput() {
+        // This test uses hardware trigger input!
+        return true;
+    }
+
+    @Test
+    public void test() {
+        ecu.setEngineType(engine_type_e.FRANKENSO_MIATA_NA6_MAP);
+        ecu.changeRpm(1000);
+
+        // making output pins available
+        ecu.sendCommand(CMD_TRIGGER_SIMULATOR_PIN + " 0 none");
+        ecu.sendCommand(CMD_TRIGGER_SIMULATOR_PIN + " 1 none");
+        ecu.sendCommand(CMD_TRIGGER_PIN + " 1 none");
+
+        // Hook up 1khz idle on formerly-trigger-stim pin
+        ecu.sendCommand(CMD_IDLE_PIN + " PD2");
+        ecu.sendCommand("set idle_solenoid_freq 100");
+
+        EcuTestHelper.assertSomewhatClose("VSS no input", 0, SensorCentral.getInstance().getValue(Sensor.vehicleSpeedKph));
+
+        // attaching VSS to idle output since there is a jumper on test f7-nucleo
+        ecu.sendCommand("set " + CMD_VSS_PIN + " " + "PA6");
+
+        sleep(2 * Timeouts.SECOND);
+
+        // todo: this command does not seem to work for whatever reasons :( cAsE? else?
+        ecu.sendCommand("set " + "driveWheelRevPerKm" + " " + "500");
+        EcuTestHelper.assertSomewhatClose("VSS with input", 145.58, SensorCentral.getInstance().getValue(Sensor.vehicleSpeedKph));
+
+        // not related to VSS test, just need to validate this somewhere, so this random test is as good as any
+        if (ControllerConnectorState.firmwareVersion == null)
+            throw new IllegalStateException("firmwareVersion has not arrived");
+    }
+}


### PR DESCRIPTION
- moved the `vw.cpp` change for the HWCI to `engine_type_impl.cpp` (since several switch cases need it in the tests) added with a #if to compile only for target nucleof767
- some tests uses "DEFAULT_FRANKENSO" as engine configuration, added the F7/H7 flags to the corresponding case statement
- created ` VssHardwareLoopTest.class` and `PwmHardwareTest.java` for F7 target, The last one currently does not work as expected, it is disabled on this PR
- added tests:  `MiscTest` , `BurnCommandTest`,  `CommonFunctionalTest`,  `VssHardwareLoopTest` to the F7 suite