### PR TITLE
ADC: rename helpers

### DIFF
--- a/firmware/console/status_loop.cpp
+++ b/firmware/console/status_loop.cpp
@@ -501,12 +501,12 @@ static void updateRawSensors() {
 	for (int i = 0; i < LUA_ANALOG_INPUT_COUNT; i++) {
 		adc_channel_e channel = engineConfiguration->auxAnalogInputs[i];
 		if (isAdcChannelValid(channel)) {
-			engine->outputChannels.rawAnalogInput[i] = getVoltageDivided("raw aux", channel);
+			engine->outputChannels.rawAnalogInput[i] = adcGetScaledVoltage("raw aux", channel);
 		}
 	}
 
 	// TODO: transition AFR to new sensor model
-	engine->outputChannels.rawAfr = (engineConfiguration->afr.hwChannel == EFI_ADC_NONE) ? 0 : getVoltageDivided("ego", engineConfiguration->afr.hwChannel);
+	engine->outputChannels.rawAfr = (engineConfiguration->afr.hwChannel == EFI_ADC_NONE) ? 0 : adcGetScaledVoltage("ego", engineConfiguration->afr.hwChannel);
 }
 static void updatePressures() {
 	engine->outputChannels.baroPressure = Sensor::getOrZero(SensorType::BarometricPressure);

--- a/firmware/controllers/sensors/impl/ego.cpp
+++ b/firmware/controllers/sensors/impl/ego.cpp
@@ -30,7 +30,7 @@ float getAfr(SensorType type) {
 		return 0;
 	}
 
-	float volts = getVoltageDivided("ego", type == SensorType::Lambda1 ? sensor->hwChannel : sensor->hwChannel2);
+	float volts = adcGetScaledVoltage("ego", type == SensorType::Lambda1 ? sensor->hwChannel : sensor->hwChannel2);
 
 	return interpolateMsg("AFR", sensor->v1, sensor->value1, sensor->v2, sensor->value2, volts)
 			+ engineConfiguration->egoValueShift;

--- a/firmware/controllers/sensors/impl/map.cpp
+++ b/firmware/controllers/sensors/impl/map.cpp
@@ -38,7 +38,7 @@ static void printMAPInfo() {
 	adc_channel_e mapAdc = engineConfiguration->map.sensor.hwChannel;
 	char pinNameBuffer[16];
 
-	efiPrintf("MAP %.2fv @%s", getVoltage("mapinfo", mapAdc),
+	efiPrintf("MAP %.2fv @%s", adcGetRawVoltage("mapinfo", mapAdc),
 			getPinNameByAdcChannel("map", mapAdc, pinNameBuffer, sizeof(pinNameBuffer)));
 	if (engineConfiguration->map.sensor.type == MT_CUSTOM) {
 		efiPrintf("at %.2fv=%.2f at %.2fv=%.2f",

--- a/firmware/hw_layer/adc/adc_external.h
+++ b/firmware/hw_layer/adc/adc_external.h
@@ -11,6 +11,8 @@
 
 #include "mcp3208.h"
 
+/* 12 bits, 5V reference */
+#define adcRawToScaledVoltage(adc) (5.0f / 4095 * (adc))
+
 #define adcGetRawValue(channel) getMcp3208adc(channel)
-#define adcToVoltsDivided(adc) (5.0f / 4095 * (adc))
-#define getVoltageDivided(msg, channel) (isAdcChannelValid(channel) ? adcToVoltsDivided(adcGetRawValue(msg, channel), channel) : 66.66)
+#define adcGetScaledVoltage(msg, channel) (isAdcChannelValid(channel) ? adcToVoltsDivided(adcGetRawValue(msg, channel), channel) : 66.66)

--- a/firmware/hw_layer/adc/adc_external.h
+++ b/firmware/hw_layer/adc/adc_external.h
@@ -12,7 +12,8 @@
 #include "mcp3208.h"
 
 /* 12 bits, 5V reference */
-#define adcRawToScaledVoltage(adc) (5.0f / 4095 * (adc))
+#define adcRawValueToScaledVoltage(adc) (5.0f / 4095 * (adc))
 
 #define adcGetRawValue(channel) getMcp3208adc(channel)
-#define adcGetScaledVoltage(msg, channel) (isAdcChannelValid(channel) ? adcToVoltsDivided(adcGetRawValue(msg, channel), channel) : 66.66)
+/* NOTE: no call to getAnalogInputDividerCoefficient() */
+#define adcGetScaledVoltage(msg, channel) (isAdcChannelValid(channel) ? adcRawValueToScaledVoltage(adcGetRawValue(msg, channel), channel) : 66.66)

--- a/firmware/hw_layer/adc/adc_external.h
+++ b/firmware/hw_layer/adc/adc_external.h
@@ -11,6 +11,6 @@
 
 #include "mcp3208.h"
 
-#define getAdcValue(channel) getMcp3208adc(channel)
+#define adcGetRawValue(channel) getMcp3208adc(channel)
 #define adcToVoltsDivided(adc) (5.0f / 4095 * (adc))
-#define getVoltageDivided(msg, channel) (isAdcChannelValid(channel) ? adcToVoltsDivided(getAdcValue(msg, channel), channel) : 66.66)
+#define getVoltageDivided(msg, channel) (isAdcChannelValid(channel) ? adcToVoltsDivided(adcGetRawValue(msg, channel), channel) : 66.66)

--- a/firmware/hw_layer/adc/adc_inputs.cpp
+++ b/firmware/hw_layer/adc/adc_inputs.cpp
@@ -74,7 +74,7 @@ static void printAdcChannedReport(const char *prefix, int internalIndex, adc_cha
 		ioportid_t port = getAdcChannelPort("print", hwChannel);
 		int pin = getAdcChannelPin(hwChannel);
 		int adcValue = adcGetRawValue("print", hwChannel);
-		float volts = getVoltage("print", hwChannel);
+		float volts = adcGetRawVoltage("print", hwChannel);
 		float voltsDivided = getVoltageDivided("print", hwChannel);
 		/* Human index starts from 1 */
 		efiPrintf(" %s ch[%2d] @ %s%d ADC%d 12bit=%4d %.3fV (input %.3fV)",
@@ -235,12 +235,12 @@ void printFullAdcReportIfNeeded(void) {
 
 #else /* not HAL_USE_ADC */
 
-__attribute__((weak)) float getVoltageDivided(const char*, adc_channel_e) {
+// voltage in MCU universe, from zero to VDD
+__attribute__((weak)) float adcGetRawVoltage(const char*, adc_channel_e) {
 	return 0;
 }
 
-// voltage in MCU universe, from zero to VDD
-__attribute__((weak)) float getVoltage(const char*, adc_channel_e) {
+__attribute__((weak)) float getVoltageDivided(const char*, adc_channel_e) {
 	return 0;
 }
 

--- a/firmware/hw_layer/adc/adc_inputs.cpp
+++ b/firmware/hw_layer/adc/adc_inputs.cpp
@@ -75,12 +75,12 @@ static void printAdcChannedReport(const char *prefix, int internalIndex, adc_cha
 		int pin = getAdcChannelPin(hwChannel);
 		int adcValue = adcGetRawValue("print", hwChannel);
 		float volts = adcGetRawVoltage("print", hwChannel);
-		float voltsDivided = getVoltageDivided("print", hwChannel);
+		float voltsInput = adcGetScaledVoltage("print", hwChannel);
 		/* Human index starts from 1 */
 		efiPrintf(" %s ch[%2d] @ %s%d ADC%d 12bit=%4d %.3fV (input %.3fV)",
 			prefix, internalIndex, portname(port), pin,
 			/* TODO: */ hwChannel - EFI_ADC_0 + 1,
-			adcValue, volts, voltsDivided);
+			adcValue, volts, voltsInput);
 	}
 }
 
@@ -240,7 +240,8 @@ __attribute__((weak)) float adcGetRawVoltage(const char*, adc_channel_e) {
 	return 0;
 }
 
-__attribute__((weak)) float getVoltageDivided(const char*, adc_channel_e) {
+// voltage in ECU universe, with all input dividers and OpAmps gains taken into account, voltage at ECU connector pin
+__attribute__((weak)) float adcGetScaledVoltage(const char*, adc_channel_e) {
 	return 0;
 }
 

--- a/firmware/hw_layer/adc/adc_inputs.cpp
+++ b/firmware/hw_layer/adc/adc_inputs.cpp
@@ -63,7 +63,7 @@ static void printAdcValue(int channel) {
 		efiPrintf("Invalid ADC channel %d", channel);
 		return;
 	}
-	int value = getAdcValue("print", (adc_channel_e)channel);
+	int value = adcGetRawValue("print", (adc_channel_e)channel);
 	float volts = adcToVoltsDivided(value, (adc_channel_e)channel);
 	efiPrintf("adc %d voltage : %.3f", channel, volts);
 }
@@ -73,7 +73,7 @@ static void printAdcChannedReport(const char *prefix, int internalIndex, adc_cha
 	if (isAdcChannelValid(hwChannel)) {
 		ioportid_t port = getAdcChannelPort("print", hwChannel);
 		int pin = getAdcChannelPin(hwChannel);
-		int adcValue = getAdcValue("print", hwChannel);
+		int adcValue = adcGetRawValue("print", hwChannel);
 		float volts = getVoltage("print", hwChannel);
 		float voltsDivided = getVoltageDivided("print", hwChannel);
 		/* Human index starts from 1 */

--- a/firmware/hw_layer/adc/adc_inputs.cpp
+++ b/firmware/hw_layer/adc/adc_inputs.cpp
@@ -63,9 +63,9 @@ static void printAdcValue(int channel) {
 		efiPrintf("Invalid ADC channel %d", channel);
 		return;
 	}
-	int value = adcGetRawValue("print", (adc_channel_e)channel);
-	float volts = adcToVoltsDivided(value, (adc_channel_e)channel);
-	efiPrintf("adc %d voltage : %.3f", channel, volts);
+	int adcValue = adcGetRawValue("print", (adc_channel_e)channel);
+	float voltsInput = adcRawValueToScaledVoltage(adcValue, (adc_channel_e)channel);
+	efiPrintf("adc %d input %.3fV", channel, voltsInput);
 }
 
 static void printAdcChannedReport(const char *prefix, int internalIndex, adc_channel_e hwChannel)
@@ -77,7 +77,7 @@ static void printAdcChannedReport(const char *prefix, int internalIndex, adc_cha
 		float volts = adcGetRawVoltage("print", hwChannel);
 		float voltsInput = adcGetScaledVoltage("print", hwChannel);
 		/* Human index starts from 1 */
-		efiPrintf(" %s ch[%2d] @ %s%d ADC%d 12bit=%4d %.3fV (input %.3fV)",
+		efiPrintf(" %s ch[%2d] @ %s%d ADC%d 12bit=%4d %.3fV input %.3fV",
 			prefix, internalIndex, portname(port), pin,
 			/* TODO: */ hwChannel - EFI_ADC_0 + 1,
 			adcValue, volts, voltsInput);

--- a/firmware/hw_layer/adc/adc_inputs.h
+++ b/firmware/hw_layer/adc/adc_inputs.h
@@ -91,7 +91,7 @@ void removeChannel(const char *name, adc_channel_e hwChannel);
 
 #define adcGetRawValue(msg, hwChannel) getInternalAdcValue(msg, hwChannel)
 
-#define adcToVoltsDivided(adc, hwChannel) (adcToVolts(adc) * getAnalogInputDividerCoefficient(hwChannel))
+#define adcToVoltsDivided(adc, hwChannel) (adcToRawVolts(adc) * getAnalogInputDividerCoefficient(hwChannel))
 
 // This callback is called by the ADC driver when a new fast ADC sample is ready
 void onFastAdcComplete(adcsample_t* samples);

--- a/firmware/hw_layer/adc/adc_inputs.h
+++ b/firmware/hw_layer/adc/adc_inputs.h
@@ -89,7 +89,7 @@ float getMCUInternalTemperature(void);
 void addFastAdcChannel(const char *name, adc_channel_e hwChannel);
 void removeChannel(const char *name, adc_channel_e hwChannel);
 
-#define getAdcValue(msg, hwChannel) getInternalAdcValue(msg, hwChannel)
+#define adcGetRawValue(msg, hwChannel) getInternalAdcValue(msg, hwChannel)
 
 #define adcToVoltsDivided(adc, hwChannel) (adcToVolts(adc) * getAnalogInputDividerCoefficient(hwChannel))
 

--- a/firmware/hw_layer/adc/adc_inputs.h
+++ b/firmware/hw_layer/adc/adc_inputs.h
@@ -91,7 +91,7 @@ void removeChannel(const char *name, adc_channel_e hwChannel);
 
 #define adcGetRawValue(msg, hwChannel) getInternalAdcValue(msg, hwChannel)
 
-#define adcToVoltsDivided(adc, hwChannel) (adcToRawVolts(adc) * getAnalogInputDividerCoefficient(hwChannel))
+#define adcRawValueToScaledVoltage(adc, hwChannel) (adcRawValueToRawVoltage(adc) * getAnalogInputDividerCoefficient(hwChannel))
 
 // This callback is called by the ADC driver when a new fast ADC sample is ready
 void onFastAdcComplete(adcsample_t* samples);

--- a/firmware/hw_layer/adc/adc_inputs_onchip.cpp
+++ b/firmware/hw_layer/adc/adc_inputs_onchip.cpp
@@ -29,14 +29,14 @@
 #include "periodic_thread_controller.h"
 #include "protected_gpio.h"
 
-// Board voltage, with divider coefficient accounted for
-float getVoltageDivided(const char *msg, adc_channel_e hwChannel) {
-	return getVoltage(msg, hwChannel) * getAnalogInputDividerCoefficient(hwChannel);
+// voltage in MCU universe, from zero to Vref
+float adcGetRawVoltage(const char *msg, adc_channel_e hwChannel) {
+	return adcToRawVolts(adcGetRawValue(msg, hwChannel));
 }
 
-// voltage in MCU universe, from zero to VDD
-float getVoltage(const char *msg, adc_channel_e hwChannel) {
-	return adcToVolts(adcGetRawValue(msg, hwChannel));
+// Board voltage, with divider coefficient accounted for
+float getVoltageDivided(const char *msg, adc_channel_e hwChannel) {
+	return adcGetRawVoltage(msg, hwChannel) * getAnalogInputDividerCoefficient(hwChannel);
 }
 
 #if EFI_USE_FAST_ADC

--- a/firmware/hw_layer/adc/adc_inputs_onchip.cpp
+++ b/firmware/hw_layer/adc/adc_inputs_onchip.cpp
@@ -34,15 +34,9 @@ float getVoltageDivided(const char *msg, adc_channel_e hwChannel) {
 	return getVoltage(msg, hwChannel) * getAnalogInputDividerCoefficient(hwChannel);
 }
 
-float PUBLIC_API_WEAK boardAdjustVoltage(float voltage, adc_channel_e hwChannel) {
-  // a hack useful when we do not trust voltage just after board EN was turned on. is this just hiding electrical design flaws?
-  return voltage;
-}
-
 // voltage in MCU universe, from zero to VDD
 float getVoltage(const char *msg, adc_channel_e hwChannel) {
-	float voltage = adcToVolts(getAdcValue(msg, hwChannel));
-	return boardAdjustVoltage(voltage, hwChannel);
+	return adcToVolts(getAdcValue(msg, hwChannel));
 }
 
 #if EFI_USE_FAST_ADC

--- a/firmware/hw_layer/adc/adc_inputs_onchip.cpp
+++ b/firmware/hw_layer/adc/adc_inputs_onchip.cpp
@@ -34,8 +34,8 @@ float adcGetRawVoltage(const char *msg, adc_channel_e hwChannel) {
 	return adcToRawVolts(adcGetRawValue(msg, hwChannel));
 }
 
-// Board voltage, with divider coefficient accounted for
-float getVoltageDivided(const char *msg, adc_channel_e hwChannel) {
+// voltage in ECU universe, with all input dividers and OpAmps gains taken into account, voltage at ECU connector pin
+float adcGetScaledVoltage(const char *msg, adc_channel_e hwChannel) {
 	return adcGetRawVoltage(msg, hwChannel) * getAnalogInputDividerCoefficient(hwChannel);
 }
 

--- a/firmware/hw_layer/adc/adc_inputs_onchip.cpp
+++ b/firmware/hw_layer/adc/adc_inputs_onchip.cpp
@@ -31,7 +31,7 @@
 
 // voltage in MCU universe, from zero to Vref
 float adcGetRawVoltage(const char *msg, adc_channel_e hwChannel) {
-	return adcToRawVolts(adcGetRawValue(msg, hwChannel));
+	return adcRawValueToRawVoltage(adcGetRawValue(msg, hwChannel));
 }
 
 // voltage in ECU universe, with all input dividers and OpAmps gains taken into account, voltage at ECU connector pin

--- a/firmware/hw_layer/adc/adc_inputs_onchip.cpp
+++ b/firmware/hw_layer/adc/adc_inputs_onchip.cpp
@@ -36,7 +36,7 @@ float getVoltageDivided(const char *msg, adc_channel_e hwChannel) {
 
 // voltage in MCU universe, from zero to VDD
 float getVoltage(const char *msg, adc_channel_e hwChannel) {
-	return adcToVolts(getAdcValue(msg, hwChannel));
+	return adcToVolts(adcGetRawValue(msg, hwChannel));
 }
 
 #if EFI_USE_FAST_ADC

--- a/firmware/hw_layer/adc/adc_subscription.cpp
+++ b/firmware/hw_layer/adc/adc_subscription.cpp
@@ -148,7 +148,7 @@ void AdcSubscription::UpdateSubscribers(efitick_t nowNt) {
 			continue;
 		}
 
-		float mcuVolts = getVoltage("sensor", entry.Channel);
+		float mcuVolts = adcGetRawVoltage("sensor", entry.Channel);
 		entry.sensorVolts = mcuVolts * entry.VoltsPerAdcVolt;
 
 		// On the very first update, preload the filter as if we've been
@@ -176,7 +176,7 @@ void AdcSubscription::PrintInfo() {
 		}
 
 		const auto name = entry.Sensor->getSensorName();
-		float mcuVolts = getVoltage("sensor", entry.Channel);
+		float mcuVolts = adcGetRawVoltage("sensor", entry.Channel);
 		float sensorVolts = mcuVolts * entry.VoltsPerAdcVolt;
 		auto channel = entry.Channel;
 

--- a/firmware/hw_layer/algo/adc_math.h
+++ b/firmware/hw_layer/algo/adc_math.h
@@ -17,7 +17,7 @@
 #define ADC_MAX_VALUE 4095
 #endif
 
-#define adcToRawVolts(adc) ((engineConfiguration->adcVcc) / ADC_MAX_VALUE * (adc))
+#define adcRawValueToRawVoltage(adc) ((engineConfiguration->adcVcc) / ADC_MAX_VALUE * (adc))
 
 #define voltsToAdc(volts) ((volts) * (ADC_MAX_VALUE / (engineConfiguration->adcVcc)))
 

--- a/firmware/hw_layer/algo/adc_math.h
+++ b/firmware/hw_layer/algo/adc_math.h
@@ -17,11 +17,12 @@
 #define ADC_MAX_VALUE 4095
 #endif
 
-#define adcToVolts(adc) ((engineConfiguration->adcVcc) / ADC_MAX_VALUE * (adc))
+#define adcToRawVolts(adc) ((engineConfiguration->adcVcc) / ADC_MAX_VALUE * (adc))
 
 #define voltsToAdc(volts) ((volts) * (ADC_MAX_VALUE / (engineConfiguration->adcVcc)))
 
-float getVoltage(const char *msg, adc_channel_e channel);
+// voltage in MCU universe, from zero to Vref
+float adcGetRawVoltage(const char *msg, adc_channel_e channel);
 
 float getVoltageDivided(const char *msg, adc_channel_e channel);
 

--- a/firmware/hw_layer/algo/adc_math.h
+++ b/firmware/hw_layer/algo/adc_math.h
@@ -24,5 +24,6 @@
 // voltage in MCU universe, from zero to Vref
 float adcGetRawVoltage(const char *msg, adc_channel_e channel);
 
-float getVoltageDivided(const char *msg, adc_channel_e channel);
+// voltage in ECU universe, with all input dividers and OpAmps gains taken into account, voltage at ECU connector pin
+float adcGetScaledVoltage(const char *msg, adc_channel_e channel);
 

--- a/firmware/hw_layer/drivers/gpio/protected_gpio.cpp
+++ b/firmware/hw_layer/drivers/gpio/protected_gpio.cpp
@@ -56,7 +56,7 @@ void ProtectedGpio::check(efitick_t /*nowNt*/) {
 		return;
 	}
 
-	float senseVolts = getVoltage("protected", m_config->SenseChannel);
+	float senseVolts = adcGetRawVoltage("protected", m_config->SenseChannel);
 	float amps = senseVolts * m_config->AmpsPerVolt;
 
 	// TODO: smarter state machine

--- a/firmware/hw_layer/hardware.cpp
+++ b/firmware/hw_layer/hardware.cpp
@@ -283,7 +283,8 @@ void onFastAdcComplete(adcsample_t*) {
 
 #if EFI_SENSOR_CHART && EFI_SHAFT_POSITION_INPUT
 	if (getEngineState()->sensorChartMode == SC_AUX_FAST1) {
-		float voltage = getAdcValue("fAux1", engineConfiguration->auxFastSensor1_adcChannel);
+		/* Why we use raw value here? */
+		float voltage = adcGetRawValue("fAux1", engineConfiguration->auxFastSensor1_adcChannel);
 		scAddData(engine->triggerCentral.getCurrentEnginePhase(getTimeNowNt()).value_or(0), voltage);
 	}
 #endif /* EFI_SENSOR_CHART */

--- a/firmware/hw_layer/hardware.cpp
+++ b/firmware/hw_layer/hardware.cpp
@@ -290,11 +290,11 @@ void onFastAdcComplete(adcsample_t*) {
 #endif /* EFI_SENSOR_CHART */
 
 #if EFI_MAP_AVERAGING
-	mapAveragingAdcCallback(adcToVoltsDivided(getFastAdc(fastMapSampleIndex), engineConfiguration->map.sensor.hwChannel));
+	mapAveragingAdcCallback(adcRawValueToScaledVoltage(getFastAdc(fastMapSampleIndex), engineConfiguration->map.sensor.hwChannel));
 #endif /* EFI_MAP_AVERAGING */
 #if EFI_HIP_9011
 	if (engineConfiguration->isHip9011Enabled) {
-		hipAdcCallback(adcToVoltsDivided(getFastAdc(hipSampleIndex), engineConfiguration->hipOutputChannel));
+		hipAdcCallback(adcRawValueToScaledVoltage(getFastAdc(hipSampleIndex), engineConfiguration->hipOutputChannel));
 	}
 #endif /* EFI_HIP_9011 */
 }

--- a/firmware/hw_layer/sensors/hip9011.cpp
+++ b/firmware/hw_layer/sensors/hip9011.cpp
@@ -651,7 +651,7 @@ static void showHipInfo() {
 	if (!instance.adv_mode) {
 		efiPrintf(" Adc input %d (%.2f V)",
 			(int)engineConfiguration->hipOutputChannel,
-			getVoltage("hipinfo", engineConfiguration->hipOutputChannel));
+			adcGetRawVoltage("hipinfo", engineConfiguration->hipOutputChannel));
 	}
 
 	for (int i = 0; i < HIP_INPUT_CHANNELS; i++) {

--- a/simulator/simulator/boards.cpp
+++ b/simulator/simulator/boards.cpp
@@ -16,11 +16,11 @@ int adcGetRawValue(const char * /*msg*/, int /*hwChannel*/) {
 }
 
 // voltage in MCU universe, from zero to VDD
-float getVoltage(const char *msg, adc_channel_e hwChannel) {
-	return adcToVolts(adcGetRawValue(msg, hwChannel));
+float adcGetRawVoltage(const char *msg, adc_channel_e hwChannel) {
+	return adcToRawVolts(adcGetRawValue(msg, hwChannel));
 }
 
 // Board voltage, with divider coefficient accounted for
 float getVoltageDivided(const char *msg, adc_channel_e hwChannel) {
-	return getVoltage(msg, hwChannel) * engineConfiguration->analogInputDividerCoefficient;
+	return adcGetRawVoltage(msg, hwChannel) * engineConfiguration->analogInputDividerCoefficient;
 }

--- a/simulator/simulator/boards.cpp
+++ b/simulator/simulator/boards.cpp
@@ -11,13 +11,13 @@
 #include "engine_sniffer.h"
 #include "adc_math.h"
 
-int getAdcValue(const char * /*msg*/, int /*hwChannel*/) {
+int adcGetRawValue(const char * /*msg*/, int /*hwChannel*/) {
 	return 0;
 }
 
 // voltage in MCU universe, from zero to VDD
 float getVoltage(const char *msg, adc_channel_e hwChannel) {
-	return adcToVolts(getAdcValue(msg, hwChannel));
+	return adcToVolts(adcGetRawValue(msg, hwChannel));
 }
 
 // Board voltage, with divider coefficient accounted for

--- a/simulator/simulator/boards.cpp
+++ b/simulator/simulator/boards.cpp
@@ -20,7 +20,7 @@ float adcGetRawVoltage(const char *msg, adc_channel_e hwChannel) {
 	return adcToRawVolts(adcGetRawValue(msg, hwChannel));
 }
 
-// Board voltage, with divider coefficient accounted for
-float getVoltageDivided(const char *msg, adc_channel_e hwChannel) {
+// voltage in ECU universe, with all input dividers and OpAmps gains taken into account, voltage at ECU connector pin
+float adcGetScaledVoltage(const char *msg, adc_channel_e hwChannel) {
 	return adcGetRawVoltage(msg, hwChannel) * engineConfiguration->analogInputDividerCoefficient;
 }

--- a/simulator/simulator/boards.cpp
+++ b/simulator/simulator/boards.cpp
@@ -17,7 +17,7 @@ int adcGetRawValue(const char * /*msg*/, int /*hwChannel*/) {
 
 // voltage in MCU universe, from zero to VDD
 float adcGetRawVoltage(const char *msg, adc_channel_e hwChannel) {
-	return adcToRawVolts(adcGetRawValue(msg, hwChannel));
+	return adcRawValueToRawVoltage(adcGetRawValue(msg, hwChannel));
 }
 
 // voltage in ECU universe, with all input dividers and OpAmps gains taken into account, voltage at ECU connector pin

--- a/simulator/simulator/boards.h
+++ b/simulator/simulator/boards.h
@@ -10,7 +10,7 @@
 #define ADC_LOGIC_INTAKE_AIR 0
 #define ADC_LOGIC_COOLANT 0
 
-int getAdcValue(const char *msg, int channel);
+int adcGetRawValue(const char *msg, int channel);
 #define waitForSlowAdc(x) {}
 
 

--- a/unit_tests/boards.cpp
+++ b/unit_tests/boards.cpp
@@ -17,6 +17,6 @@ float adcGetRawVoltage(const char *msg, adc_channel_e hwChannel) {
 	return 0;
 }
 
-float getVoltageDivided(const char *msg, adc_channel_e hwChannel) {
+float adcGetScaledVoltage(const char *msg, adc_channel_e hwChannel) {
 	return 0;
 }

--- a/unit_tests/boards.cpp
+++ b/unit_tests/boards.cpp
@@ -9,14 +9,14 @@
 
 #include "boards.h"
 
+int adcGetRawValue(const char *msg, adc_channel_e hwChannel) {
+	return 0;
+}
+
 float getVoltageDivided(const char *msg, adc_channel_e hwChannel) {
 	return 0;
 }
 
 float getVoltage(const char *msg, adc_channel_e hwChannel) {
-	return 0;
-}
-
-int getAdcValue(const char *msg, adc_channel_e hwChannel) {
 	return 0;
 }

--- a/unit_tests/boards.cpp
+++ b/unit_tests/boards.cpp
@@ -13,10 +13,10 @@ int adcGetRawValue(const char *msg, adc_channel_e hwChannel) {
 	return 0;
 }
 
-float getVoltageDivided(const char *msg, adc_channel_e hwChannel) {
+float adcGetRawVoltage(const char *msg, adc_channel_e hwChannel) {
 	return 0;
 }
 
-float getVoltage(const char *msg, adc_channel_e hwChannel) {
+float getVoltageDivided(const char *msg, adc_channel_e hwChannel) {
 	return 0;
 }

--- a/unit_tests/boards.h
+++ b/unit_tests/boards.h
@@ -12,4 +12,4 @@
 
 #define ADC_CHANNEL_VREF 0
 
-int getAdcValue(const char *msg, adc_channel_e channel);
+int adcGetRawValue(const char *msg, adc_channel_e channel);


### PR DESCRIPTION
adcGetRawValue() - get raw sample from ADC input, integer
adcGetRawVoltage() - get voltage on MCU ADC input (raw sample multiplied by ADC reference voltage)
adcGetScaledVoltage() - get voltage on ECU pin associated with provided ADC input. All input dividers and multipliers are applied.