### PR TITLE
Report analog failure to TS and rise OBD code, use TLS115 PG signal on Hellen boards, use `expected` for adc inputs

### DIFF
--- a/firmware/config/boards/hellen/alphax-8chan/board_configuration.cpp
+++ b/firmware/config/boards/hellen/alphax-8chan/board_configuration.cpp
@@ -258,3 +258,35 @@ void setup_custom_board_overrides() {
 	custom_board_DefaultConfiguration = alphax_8chan_defaultConfiguration;
 	custom_board_ConfigOverrides = alphax_8chan_boardConfigOverrides;
 }
+
+int boardGetAnalogInputDiagnostic(adc_channel_e hwChannel, float voltage) {
+	/* we do not check voltage for valid ragne yet */
+	(void)voltage;
+
+	switch (hwChannel) {
+		/* inputs that may be affected by incorrect reference voltage */
+		case MM176_IN_TPS_ANALOG:
+		case MM176_IN_TPS2_ANALOG:
+		case MM176_IN_PPS1_ANALOG:
+		case MM176_IN_PPS2_ANALOG:
+		case MM176_IN_IAT_ANALOG:
+		case MM176_IN_AT1_ANALOG:
+		case MM176_IN_CLT_ANALOG:
+		case MM176_IN_AT2_ANALOG:
+		//case MM176_IN_O2S_ANALOG:
+		//case MM176_IN_O2S2_ANALOG:
+		case MM176_IN_MAP1_ANALOG:
+		case MM176_IN_MAP2_ANALOG:
+		case MM176_IN_AUX1_ANALOG:
+		case MM176_IN_AUX2_ANALOG:
+		case MM176_IN_AUX3_ANALOG:
+		case MM176_IN_AUX4_ANALOG:
+			/* TODO: more? */
+			return boardGetAnalogDiagnostic();
+		/* all other inputs should not rely on output 5V */
+		default:
+			return 0;
+	}
+
+	return 0;
+}

--- a/firmware/config/boards/hellen/uaefi/board_configuration.cpp
+++ b/firmware/config/boards/hellen/uaefi/board_configuration.cpp
@@ -187,3 +187,29 @@ void setup_custom_board_overrides() {
 	custom_board_DefaultConfiguration = uaefi_boardDefaultConfiguration;
 	custom_board_ConfigOverrides =  uaefi_boardConfigOverrides;
 }
+
+int boardGetAnalogInputDiagnostic(adc_channel_e hwChannel, float voltage) {
+	/* we do not check voltage for valid ragne yet */
+	(void)voltage;
+
+	switch (hwChannel) {
+		/* inputs that may be affected by incorrect reference voltage */
+		case MM100_IN_TPS_ANALOG:
+		case MM100_IN_PPS_ANALOG:
+		case MM100_IN_IAT_ANALOG:
+		case MM100_IN_CLT_ANALOG:
+		case MM100_IN_O2S_ANALOG:
+		case MM100_IN_O2S2_ANALOG:
+		case MM100_IN_MAP1_ANALOG:
+		case MM100_IN_AUX1_ANALOG:
+		case MM100_IN_AUX2_ANALOG:
+		case MM100_IN_AUX4_ANALOG:
+			/* TODO: more? */
+			return boardGetAnalogDiagnostic();
+		/* all other inputs should not rely on output 5V */
+		default:
+			return 0;
+	}
+
+	return 0;
+}

--- a/firmware/console/status_loop.cpp
+++ b/firmware/console/status_loop.cpp
@@ -511,12 +511,12 @@ extern int flexCallbackCounter;
 	for (int i = 0; i < LUA_ANALOG_INPUT_COUNT; i++) {
 		adc_channel_e channel = engineConfiguration->auxAnalogInputs[i];
 		if (isAdcChannelValid(channel)) {
-			engine->outputChannels.rawAnalogInput[i] = adcGetScaledVoltage("raw aux", channel);
+			engine->outputChannels.rawAnalogInput[i] = adcGetScaledVoltage("raw aux", channel).value_or(0);
 		}
 	}
 
 	// TODO: transition AFR to new sensor model
-	engine->outputChannels.rawAfr = (engineConfiguration->afr.hwChannel == EFI_ADC_NONE) ? 0 : adcGetScaledVoltage("ego", engineConfiguration->afr.hwChannel);
+	engine->outputChannels.rawAfr = (engineConfiguration->afr.hwChannel == EFI_ADC_NONE) ? 0 : adcGetScaledVoltage("ego", engineConfiguration->afr.hwChannel).value_or(0);
 }
 static void updatePressures() {
 	engine->outputChannels.baroPressure = Sensor::getOrZero(SensorType::BarometricPressure);

--- a/firmware/controllers/sensors/impl/ego.cpp
+++ b/firmware/controllers/sensors/impl/ego.cpp
@@ -29,9 +29,9 @@ float getAfr(SensorType type) {
 		return 0;
 	}
 
-	float volts = adcGetScaledVoltage("ego", type == SensorType::Lambda1 ? sensor->hwChannel : sensor->hwChannel2);
+	auto volts = adcGetScaledVoltage("ego", type == SensorType::Lambda1 ? sensor->hwChannel : sensor->hwChannel2);
 
-	float interpolatedAfr = interpolateMsg("AFR", sensor->v1, sensor->value1, sensor->v2, sensor->value2, volts);
+	float interpolatedAfr = interpolateMsg("AFR", sensor->v1, sensor->value1, sensor->v2, sensor->value2, volts.value_or(0));
 
 	switch (type) {
 		case SensorType::Lambda1: {
@@ -48,7 +48,7 @@ float getAfr(SensorType type) {
 			break;
 	}
 
-	return interpolateMsg("AFR", sensor->v1, sensor->value1, sensor->v2, sensor->value2, volts)
+	return interpolateMsg("AFR", sensor->v1, sensor->value1, sensor->v2, sensor->value2, volts.value_or(0))
 			+ engineConfiguration->egoValueShift;
 }
 

--- a/firmware/controllers/sensors/impl/map.cpp
+++ b/firmware/controllers/sensors/impl/map.cpp
@@ -38,7 +38,8 @@ static void printMAPInfo() {
 	adc_channel_e mapAdc = engineConfiguration->map.sensor.hwChannel;
 	char pinNameBuffer[16];
 
-	efiPrintf("MAP %.2fv @%s", adcGetRawVoltage("mapinfo", mapAdc),
+	efiPrintf("MAP %.2fv @%s",
+			adcGetRawVoltage("mapinfo", mapAdc).value_or(0),
 			getPinNameByAdcChannel("map", mapAdc, pinNameBuffer, sizeof(pinNameBuffer)));
 	if (engineConfiguration->map.sensor.type == MT_CUSTOM) {
 		efiPrintf("at %.2fv=%.2f at %.2fv=%.2f",

--- a/firmware/hw_layer/adc/adc_inputs.h
+++ b/firmware/hw_layer/adc/adc_inputs.h
@@ -17,6 +17,8 @@
 
 float getAnalogInputDividerCoefficient(adc_channel_e);
 float boardAdjustVoltage(float voltage, adc_channel_e hwChannel);
+/* optional, checks if measured voltage is valid */
+int boardGetAnalogInputDiagnostic(adc_channel_e, float voltage);
 
 inline bool isAdcChannelValid(adc_channel_e hwChannel) {
 	/* Compiler will optimize, keep following if as a reminder */

--- a/firmware/hw_layer/algo/adc_math.h
+++ b/firmware/hw_layer/algo/adc_math.h
@@ -22,8 +22,8 @@
 #define voltsToAdc(volts) ((volts) * (ADC_MAX_VALUE / (engineConfiguration->adcVcc)))
 
 // voltage in MCU universe, from zero to Vref
-float adcGetRawVoltage(const char *msg, adc_channel_e channel);
+expected<float> adcGetRawVoltage(const char *msg, adc_channel_e channel);
 
 // voltage in ECU universe, with all input dividers and OpAmps gains taken into account, voltage at ECU connector pin
-float adcGetScaledVoltage(const char *msg, adc_channel_e channel);
+expected<float> adcGetScaledVoltage(const char *msg, adc_channel_e channel);
 

--- a/firmware/hw_layer/drivers/gpio/protected_gpio.cpp
+++ b/firmware/hw_layer/drivers/gpio/protected_gpio.cpp
@@ -56,11 +56,16 @@ void ProtectedGpio::check(efitick_t /*nowNt*/) {
 		return;
 	}
 
-	float senseVolts = adcGetRawVoltage("protected", m_config->SenseChannel);
-	float amps = senseVolts * m_config->AmpsPerVolt;
+	auto senseVolts = adcGetRawVoltage("protected", m_config->SenseChannel);
+	if (senseVolts) {
+		float amps = senseVolts.value_or(0) * m_config->AmpsPerVolt;
 
-	// TODO: smarter state machine
-	if (amps > m_config->MaximumAllowedCurrent) {
+		// TODO: smarter state machine
+		if (amps > m_config->MaximumAllowedCurrent) {
+			m_output.setValue(false);
+		}
+	} else {
+		/* shutdown if failed to measure current */
 		m_output.setValue(false);
 	}
 }

--- a/simulator/simulator/boards.cpp
+++ b/simulator/simulator/boards.cpp
@@ -16,11 +16,17 @@ int adcGetRawValue(const char * /*msg*/, int /*hwChannel*/) {
 }
 
 // voltage in MCU universe, from zero to VDD
-float adcGetRawVoltage(const char *msg, adc_channel_e hwChannel) {
-	return adcRawValueToRawVoltage(adcGetRawValue(msg, hwChannel));
+expected<float> adcGetRawVoltage(const char *msg, adc_channel_e hwChannel) {
+	return expected(adcRawValueToRawVoltage(adcGetRawValue(msg, hwChannel)));
 }
 
 // voltage in ECU universe, with all input dividers and OpAmps gains taken into account, voltage at ECU connector pin
-float adcGetScaledVoltage(const char *msg, adc_channel_e hwChannel) {
-	return adcGetRawVoltage(msg, hwChannel) * engineConfiguration->analogInputDividerCoefficient;
+expected<float> adcGetScaledVoltage(const char *msg, adc_channel_e hwChannel) {
+	auto rawVoltage = adcGetRawVoltage(msg, hwChannel);
+
+	if (rawVoltage) {
+		return expected(rawVoltage.value_or(0) * engineConfiguration->analogInputDividerCoefficient);
+	}
+
+	return expected(rawVoltage);
 }

--- a/unit_tests/adc_inputs.h
+++ b/unit_tests/adc_inputs.h
@@ -22,6 +22,10 @@ inline bool isAdcChannelValid(adc_channel_e hwChannel) {
 	return ((hwChannel > EFI_ADC_NONE) && (hwChannel < EFI_ADC_TOTAL_CHANNELS));
 }
 
+inline bool isAdcChannelOnChip(adc_channel_e hwChannel) {
+	return (isAdcChannelValid(hwChannel) && (hwChannel <= EFI_ADC_ONCHIP_LAST));
+}
+
 #define adcToVoltsDivided(adc) (adcToVolts(adc) * engineConfiguration->analogInputDividerCoefficient)
 #define GPT_FREQ_FAST 100000
 #define GPT_PERIOD_FAST 10

--- a/unit_tests/boards.cpp
+++ b/unit_tests/boards.cpp
@@ -9,14 +9,16 @@
 
 #include "boards.h"
 
-int adcGetRawValue(const char *msg, adc_channel_e hwChannel) {
+int adcGetRawValue(const char * /*msg*/, int /*hwChannel*/) {
 	return 0;
 }
 
-float adcGetRawVoltage(const char *msg, adc_channel_e hwChannel) {
-	return 0;
+// voltage in MCU universe, from zero to VDD
+expected<float> adcGetRawVoltage(const char *msg, adc_channel_e hwChannel) {
+	return expected(0.0f);
 }
 
-float adcGetScaledVoltage(const char *msg, adc_channel_e hwChannel) {
-	return 0;
+// voltage in ECU universe, with all input dividers and OpAmps gains taken into account, voltage at ECU connector pin
+expected<float> adcGetScaledVoltage(const char *msg, adc_channel_e hwChannel) {
+	return expected(0.0f);
 }


### PR DESCRIPTION
Now we can detect +5VP failure on few Hellen board.
![Screenshot from 2024-12-12 01-01-33](https://github.com/user-attachments/assets/b6b10bb9-d83b-4961-ae49-c6b66dd04490)
```
2024-12-12_00_34_32_433: EngineState: WARNING: P2125: Sensor fault: AcceleratorPedalPrimary has timed out
2024-12-12_00_34_32_445: EngineState: WARNING: P2130: Sensor fault: AcceleratorPedalSecondary has timed out
2024-12-12_00_34_32_447: EngineState: WARNING: P0641: Analog subsystem fault
2024-12-12_00_34_32_447: EngineState: WARNING: P0106: Sensor fault: Map has timed out
```

Also analog inputs depending on this supply is now reported invalid using `expected`. So sensor (or any other analog input user) can propagate sign of error further.
```
2024-12-12_00_35_21_160: EngineState: fast 649421 samples
2024-12-12_00_35_21_161: EngineState:  F ch[ 0] @ PC0 ADC11 12bit=  13 0.000V input 0.000V INVALID
2024-12-12_00_35_21_161: EngineState: slow 32472 samples
2024-12-12_00_35_21_162: EngineState:  S ch[ 0] @ PA0 ADC1 12bit= 189 0.000V input 0.000V INVALID
2024-12-12_00_35_21_163: EngineState:  S ch[ 1] @ PA1 ADC2 12bit= 185 0.000V input 0.000V INVALID
2024-12-12_00_35_21_165: EngineState:  S ch[ 2] @ PA2 ADC3 12bit=1531 1.230V input 2.460V valid
2024-12-12_00_35_21_165: EngineState:  S ch[ 3] @ PA3 ADC4 12bit=  11 0.000V input 0.000V INVALID
2024-12-12_00_35_21_169: EngineState:  S ch[ 4] @ PA4 ADC5 12bit= 112 0.000V input 0.000V INVALID
2024-12-12_00_35_21_170: EngineState:  S ch[ 5] @ PA5 ADC6 12bit=2510 2.016V input 4.033V valid
2024-12-12_00_35_21_171: EngineState:  S ch[ 6] @ PA6 ADC7 12bit=2215 1.779V input 3.559V valid
2024-12-12_00_35_21_175: EngineState:  S ch[ 7] @ PA7 ADC8 12bit=1928 1.548V input 3.097V valid
2024-12-12_00_35_21_175: EngineState:  S ch[ 8] @ PB0 ADC9 12bit=1720 0.000V input 0.000V INVALID
2024-12-12_00_35_21_176: EngineState:  S ch[ 9] @ PB1 ADC10 12bit=1499 1.204V input 2.408V valid
2024-12-12_00_35_21_179: EngineState:  S ch[10] @ PC0 ADC11 12bit=  12 0.000V input 0.000V INVALID
2024-12-12_00_35_21_181: EngineState:  S ch[11] @ PC1 ADC12 12bit= 132 0.106V input 0.212V valid
2024-12-12_00_35_21_182: EngineState:  S ch[12] @ PC2 ADC13 12bit=3050 0.000V input 0.000V INVALID
2024-12-12_00_35_21_184: EngineState:  S ch[13] @ PC3 ADC14 12bit=3056 0.000V input 0.000V INVALID
2024-12-12_00_35_21_185: EngineState:  S ch[14] @ PC4 ADC15 12bit=  10 0.000V input 0.000V INVALID
2024-12-12_00_35_21_187: EngineState:  S ch[15] @ PC5 ADC16 12bit= 103 0.000V input 0.000V INVALID
2024-12-12_00_35_21_189: EngineState: confirmation_adc_report:10
```

@rusefillc if in doubt - skip last commit.
