### PR TITLE
Allow editing `Settings` on `Shift Torque Reduction (Flat Shift)` dia…

### DIFF
--- a/firmware/tunerstudio/tunerstudio.template.ini
+++ b/firmware/tunerstudio/tunerstudio.template.ini
@@ -5021,7 +5021,7 @@ dialog = tcuControls, "Transmission Settings"
 	dialog = ShiftTorqueReductionSettingsDialog, "", yAxis
 		field = "Enable Shift Torque Reduction",		torqueReductionEnabled
 		panel = TorqueReductionActivationModeDialog,	{torqueReductionEnabled == 1}
-		panel = TorqueReductionSettings,				{torqueReductionEnabled == 1 && ((torqueReductionActivationMode == @@torqueReductionActivationMode_e_TORQUE_REDUCTION_BUTTON@@ && torqueReductionTriggerPin != 0) || (torqueReductionActivationMode == @@torqueReductionActivationMode_e_LAUNCH_BUTTON@@ && launchActivatePin != 0))}
+		panel = TorqueReductionSettings,				{torqueReductionEnabled == 1 && ((torqueReductionActivationMode == @@torqueReductionActivationMode_e_TORQUE_REDUCTION_BUTTON@@) || (torqueReductionActivationMode == @@torqueReductionActivationMode_e_LAUNCH_BUTTON@@ && launchActivatePin != 0))}
 
 	dialog = ShiftTorqueReductionDialog, "", border
 		panel = ShiftTorqueReductionSettingsDialog, West


### PR DESCRIPTION
…log when `Activation Mode` is `Torque Reduction Button` and `Torque Reduction Buttton` is `NONE`.

This makes sense for  `setTorqueReductionState` Lua hook #7160