### PR TITLE
Add VSS HW test to F767 suite

### DIFF
--- a/java_console/autotest/src/main/java/com/rusefi/HwCiNucleoF7.java
+++ b/java_console/autotest/src/main/java/com/rusefi/HwCiNucleoF7.java
@@ -3,6 +3,7 @@ package com.rusefi;
 import com.rusefi.common.MiscTest;
 import com.rusefi.f4discovery.*;
 import com.rusefi.nucleo.NucleoPwmHardwareTest;
+import com.rusefi.nucleo.NucleoVssHardwareTest;
 
 public class HwCiNucleoF7 {
     public static void main(String[] args) {
@@ -11,6 +12,7 @@ public class HwCiNucleoF7 {
             CompositeLoggerTest.class,
             HighRevTest.class,
             NucleoPwmHardwareTest.class,
+			NucleoVssHardwareTest.class,
 //            MiscTest.class,
 //            BurnCommandTest.class,
 //            CommonFunctionalTest.class,

--- a/java_console/autotest/src/main/java/com/rusefi/nucleo/NucleoVssHardwareTest.java
+++ b/java_console/autotest/src/main/java/com/rusefi/nucleo/NucleoVssHardwareTest.java
@@ -1,0 +1,24 @@
+package com.rusefi.nucleo;
+
+import com.devexperts.logging.Logging;
+import com.rusefi.RusefiTestBase;
+import com.rusefi.f4discovery.DiscoveryPwmHardwareTest;
+import com.rusefi.common.VssHardwareTestLogic;
+import org.junit.Test;
+
+import static com.devexperts.logging.Logging.getLogging;
+
+public class NucleoVssHardwareTest extends RusefiTestBase {
+    private static final Logging log = getLogging(DiscoveryPwmHardwareTest.class);
+
+    @Override
+    protected boolean needsHardwareTriggerInput() {
+        // This test uses hardware trigger input!
+        return true;
+    }
+
+    @Test
+    public void testIdlePin() {
+        VssHardwareTestLogic.runIdleVssTest(ecu, "PD2", "PA6");
+    }
+}


### PR DESCRIPTION
* ~docs for running the HW-CI tests without a github runner~ 0cb246e
* ~refactor `f4discovery/VssHardwareLoopTest.java`  with same style as  `common/PwmHardwareTestLogic.java`~  5aeba94
* added `NucleoVssHardwareTest` relevant log => https://gist.github.com/FDSoftware/819524a62d37d5e7abed18b29ef0fbed