### PR TITLE
Add 'Idle Stepper Target Position' as a gauge in Tunerstudio SEE: #7134

### DIFF
--- a/firmware/tunerstudio/tunerstudio.template.ini
+++ b/firmware/tunerstudio/tunerstudio.template.ini
@@ -1520,6 +1520,7 @@ gaugeCategory = Boost PID
 gaugeCategory = Idle
 	idlePosSensGauge  = idlePositionSensor,		@@GAUGE_NAME_IDLE_POSITION@@,		"%",		0,	100,		0,		0,	100,	100,	1,	1
 	idleAirValvePositionGauge = currentIdlePosition, "Idle position", "%",	0,	100,	0,	0,	100,  100,	1,	1
+	idleStepperTargetPositionGauge = idleStepperTargetPosition, "Idle steps", "#",	0,	idleStepperTotalSteps,	0,	0,	idleStepperTotalSteps,  idleStepperTotalSteps,	1,	1
 	idleStatus_iTermGauge = idleStatus_iTerm,"Idle PID iTerm", "", -10000.0,10000.0, -10000.0,10000.0, -10000.0,10000.0, 3,3
 	idleStatus_dTermGauge = idleStatus_dTerm,"Idle PID dTerm", "", -10000.0,10000.0, -10000.0,10000.0, -10000.0,10000.0, 3,3
 	idleStatus_outputGauge = idleStatus_output,"Idle PID output", "", -10000.0,10000.0, -10000.0,10000.0, -10000.0,10000.0, 3,3


### PR DESCRIPTION
added new Idle gauge, tested on simulator F407, preview:

![image](https://github.com/user-attachments/assets/e9216260-f8db-415a-9cd1-3649a8cd716b)