### PR TITLE
now `VE Table` Y axis is labeled according to `Override VE table load axis` setting

### DIFF
--- a/firmware/tunerstudio/tunerstudio.template.ini
+++ b/firmware/tunerstudio/tunerstudio.template.ini
@@ -219,7 +219,8 @@ enable2ndByteCanID = false
 
 [PcVariables]
 	fuelUnits = bits, U08, [0:2], "kPa", "MAF", "%TPS", "Lua"
-  pwmAxisLabels = bits, U08, [0:4], "Zero", "TPS %", "MAP kPa", "CLT C", "IAT C", "Fuel Load", "Ignition Load", "Aux Temp 1 C", "Aux Temp 2 C", "Accel Pedal %", "Battery Voltage Volts", "VVT 1 I Deg", "VVT 1 E Deg", "VVT 2 I Deg", "VVT 2 E Deg", "Ethanol (Flex) %", "Aux Linear 1 *", "Aux Linear 2 *", "GPPWM Output 1 %", "GPPWM Output 2 %", "GPPWM Output 3 %", "GPPWM Output 4 %", "Lua Gauge 1", "Lua Gauge 2", "RPM", "Gear (detected)", "Baro pressure kPa", "EGT 1 C", "EGT 2 C", "INVALID", "INVALID", "INVALID"
+	pwmAxisLabels = bits, U08, [0:4], "Zero", "TPS %", "MAP kPa", "CLT C", "IAT C", "Fuel Load", "Ignition Load", "Aux Temp 1 C", "Aux Temp 2 C", "Accel Pedal %", "Battery Voltage Volts", "VVT 1 I Deg", "VVT 1 E Deg", "VVT 2 I Deg", "VVT 2 E Deg", "Ethanol (Flex) %", "Aux Linear 1 *", "Aux Linear 2 *", "GPPWM Output 1 %", "GPPWM Output 2 %", "GPPWM Output 3 %", "GPPWM Output 4 %", "Lua Gauge 1", "Lua Gauge 2", "RPM", "Gear (detected)", "Baro pressure kPa", "EGT 1 C", "EGT 2 C", "INVALID", "INVALID", "INVALID"
+	veAxisLabels = bits, U08, [0:1], "load", "MAP", "TPS"
 
 	tuneCrcPcVariable = continuousChannelValue, tuneCrc16
 
@@ -1198,13 +1199,13 @@ curve = rangeMatrix, "Range Switch Input Matrix"
 		zBins		= torqueTable
 
 	table = veTableTbl,  veTableMap,  @@VE_TABLE_NAME@@,	1
-		xyLabels = "RPM", "load"
+		xyLabels	= "RPM", {bitStringValue(veAxisLabels, veOverrideMode)}
 		xBins		= veRpmBins,  RPMValue
 		yBins		= veLoadBins, veTableYAxis
 		zBins		= veTable
-;		gridHeight  = 2.0
-		gridOrient  = 250,	0, 340 ; Space 123 rotation of grid in degrees.
-		upDownLabel = "(RICHER)", "(LEANER)"
+;		gridHeight	= 2.0
+		gridOrient	= 250,	0, 340 ; Space 123 rotation of grid in degrees.
+		upDownLabel	= "(RICHER)", "(LEANER)"
 
 	table = idleVeTableTbl, idleVeTable, "Idle VE"
 		xyLabels = "RPM", "load"

--- a/firmware/tunerstudio/tunerstudio.template.ini
+++ b/firmware/tunerstudio/tunerstudio.template.ini
@@ -4812,9 +4812,13 @@ dialog = tcuControls, "Transmission Settings"
 		text = "More about rusefi on the web"
 		webHelp = "https://rusefi.com/"
 
-	dialog = veTableDialog
-		topicHelp = "veTableDialogHelp"
-		panel = veTableTbl, South
+	dialog = veOverrideModeSelector, ""
+		field = "Override VE table load axis", veOverrideMode
+
+	dialog = veTableDialog, "", border
+		topicHelp	= "veTableDialogHelp"
+		panel		= veOverrideModeSelector, North
+		panel		= veTableTbl, Center
 
 	dialog = veTableDialog3D, @@VE_TABLE_NAME@@
 		topicHelp = "veTableDialogHelp"


### PR DESCRIPTION
- now `VE Table` Y axis is labeled according to `Override VE table load axis` setting
- add `Override VE table load axis combobox` to `VE` dialog
#7182