### PR TITLE
now `Target AFR Table` Y axis is labeled according to `Override AFR t…

### DIFF
--- a/firmware/tunerstudio/tunerstudio.template.ini
+++ b/firmware/tunerstudio/tunerstudio.template.ini
@@ -221,6 +221,7 @@ enable2ndByteCanID = false
 	fuelUnits = bits, U08, [0:2], "kPa", "MAF", "%TPS", "Lua"
 	pwmAxisLabels = bits, U08, [0:4], "Zero", "TPS %", "MAP kPa", "CLT C", "IAT C", "Fuel Load", "Ignition Load", "Aux Temp 1 C", "Aux Temp 2 C", "Accel Pedal %", "Battery Voltage Volts", "VVT 1 I Deg", "VVT 1 E Deg", "VVT 2 I Deg", "VVT 2 E Deg", "Ethanol (Flex) %", "Aux Linear 1 *", "Aux Linear 2 *", "GPPWM Output 1 %", "GPPWM Output 2 %", "GPPWM Output 3 %", "GPPWM Output 4 %", "Lua Gauge 1", "Lua Gauge 2", "RPM", "Gear (detected)", "Baro pressure kPa", "EGT 1 C", "EGT 2 C", "INVALID", "INVALID", "INVALID"
 	veAxisLabels = bits, U08, [0:1], "load", "MAP", "TPS"
+	targetAfrAxisLabels = bits, U08, [0:2], "load", "MAP", "TPS", "Acc Pedal", "Cyl Filling %"
 
 	tuneCrcPcVariable = continuousChannelValue, tuneCrc16
 
@@ -1386,6 +1387,7 @@ curve = rangeMatrix, "Range Switch Input Matrix"
 #else
 	table = afrTableTbl,  afrTableMap,  "Target AFR Table",	1
 #endif
+		xyLabels	= "RPM", {bitStringValue(targetAfrAxisLabels, afrOverrideMode)}
 		xBins		= lambdaRpmBins,  RPMValue
 		yBins		= lambdaLoadBins, afrTableYAxis
 		zBins		= lambdaTable


### PR DESCRIPTION
…able load axis` setting (closes #7183)