### PR TITLE
Get rid of GTEST assertion wrappers (EngineTestHelper::assertRpm)

### DIFF
--- a/unit_tests/tests/ignition_injection/test_ignition_scheduling.cpp
+++ b/unit_tests/tests/ignition_injection/test_ignition_scheduling.cpp
@@ -165,7 +165,7 @@ TEST(ignition, negativeAdvance) {
 	// run the ignition math
 	engine->periodicFastCallback();
 
-	eth.assertRpm(0);
+	ASSERT_EQ(0, Sensor::getOrZero(SensorType::Rpm));
 
 	ASSERT_EQ(DEFAULT_CRANKING_ANGLE, getCrankingAdvance(rpm, load));
 	ASSERT_EQ(0, getAdvanceCorrections(load));
@@ -188,7 +188,7 @@ TEST(ignition, negativeAdvance2stroke) {
 	// run the ignition math
 	engine->periodicFastCallback();
 
-	eth.assertRpm(0);
+	ASSERT_EQ(0, Sensor::getOrZero(SensorType::Rpm));
 	ASSERT_EQ(347, engine->ignitionState.getWrappedAdvance(rpm, load));
 
 	ASSERT_NEAR(-13, engine->ignitionState.correctedIgnitionAdvance, EPS4D);

--- a/unit_tests/tests/ignition_injection/test_odd_firing_engine.cpp
+++ b/unit_tests/tests/ignition_injection/test_odd_firing_engine.cpp
@@ -65,7 +65,7 @@ TEST(OddFireRunningMode, hd) {
 	angle_t expectedAngle5 = -180 + cylinderTwo - timing;
 	eth.assertEvent5("spark down#5", 5, (void*)fireSparkAndPrepareNextSchedule, eth.angleToTimeUs(expectedAngle5));
 
-	eth.assertRpm( 500, "spinning-RPM#1");
+	ASSERT_EQ(500, Sensor::getOrZero(SensorType::Rpm));
 
 	engine->scheduler.executeAll(getTimeNowUs() + MS2US(1000000));
 

--- a/unit_tests/tests/ignition_injection/test_one_cylinder_logic.cpp
+++ b/unit_tests/tests/ignition_injection/test_one_cylinder_logic.cpp
@@ -25,11 +25,11 @@ TEST(issues, issueOneCylinderSpecialCase968) {
 	ASSERT_EQ( 0,  engine->scheduler.size()) << "start";
 
 	eth.fireTriggerEvents2(/* count */ 2, 50 /* ms */);
-	eth.assertRpm(0);
+	ASSERT_EQ(0, Sensor::getOrZero(SensorType::Rpm));
 	ASSERT_EQ( 0,  engine->scheduler.size()) << "first revolution(s)";
 
 	eth.fireTriggerEvents2(/* count */ 1, 50 /* ms */);
-	eth.assertRpm(600, "RPM");
+	ASSERT_EQ(600, Sensor::getOrZero(SensorType::Rpm));
 	ASSERT_EQ(engine->triggerCentral.currentEngineDecodedPhase, 90 + Gy6139_globalTriggerAngleOffset);
 	ASSERT_EQ(engine->engineState.timingAdvance[0], timing);
 

--- a/unit_tests/tests/ignition_injection/test_startOfCrankingPrimingPulse.cpp
+++ b/unit_tests/tests/ignition_injection/test_startOfCrankingPrimingPulse.cpp
@@ -23,7 +23,7 @@ TEST(engine, testPlainCrankingWithoutAdvancedFeatures) {
 
 
 	eth.fireRise(/* delayMs */ 200);
-	eth.assertRpm(300, "RPM#2");
+	ASSERT_EQ(300, Sensor::getOrZero(SensorType::Rpm));
 	// two simultaneous injections
 	ASSERT_EQ( 4,  engine->scheduler.size()) << "plain#2";
 

--- a/unit_tests/tests/trigger/test_real_bosch_quick_start.cpp
+++ b/unit_tests/tests/trigger/test_real_bosch_quick_start.cpp
@@ -46,7 +46,7 @@ TEST(realBQS, readAsCam) {
 	hwHandleShaftSignal(0, false, 1000000);
 	hwHandleShaftSignal(0, true, 2000000);
 	hwHandleShaftSignal(0, false, 3000000);
-	eth.assertRpm(3000);
+	ASSERT_EQ(3000, Sensor::getOrZero(SensorType::Rpm));
 
 	  CsvReader reader(/*triggerCount*/0, /* vvtCount */ 1);
 	  reader.open("tests/trigger/resources/BQS-longer.csv");

--- a/unit_tests/tests/trigger/test_trigger_decoder.cpp
+++ b/unit_tests/tests/trigger/test_trigger_decoder.cpp
@@ -96,7 +96,7 @@ TEST(trigger, test1995FordInline6TriggerDecoder) {
 
 	engine->periodicFastCallback();
 	eth.fireTriggerEvents(48);
-	eth.assertRpm(2000, "rpm");
+	ASSERT_EQ(2000, Sensor::getOrZero(SensorType::Rpm));
 	engine->periodicFastCallback();
 	eth.fireTriggerEvents(48);
 
@@ -212,7 +212,7 @@ TEST(misc, testRpmCalculator) {
 
 	eth.fireTriggerEvents(/* count */ 48);
 
-	eth.assertRpm(1500);
+	ASSERT_EQ(1500, Sensor::getOrZero(SensorType::Rpm));
 	ASSERT_EQ( 14,  engine->triggerCentral.triggerState.getCurrentIndex()) << "index #1";
 
 
@@ -236,7 +236,7 @@ TEST(misc, testRpmCalculator) {
 	assertEqualsM("injection angle", 499.095, ie0->injectionStartAngle);
 
 	eth.firePrimaryTriggerRise();
-	eth.assertRpm(1500);
+	ASSERT_EQ(1500, Sensor::getOrZero(SensorType::Rpm));
 
 	assertEqualsM("dwell", eth.timeToAngle(FORD_INLINE_DWELL), engine->ignitionState.dwellDurationAngle);
 	assertEqualsM("fuel #2", 4.5450, engine->engineState.injectionDuration);
@@ -291,7 +291,7 @@ TEST(misc, testRpmCalculator) {
 
 	assertEqualsM("dwell", eth.timeToAngle(FORD_INLINE_DWELL), engine->ignitionState.dwellDurationAngle);
 	assertEqualsM("fuel #3", 4.5450, engine->engineState.injectionDuration);
-	eth.assertRpm(1500);
+	ASSERT_EQ(1500, Sensor::getOrZero(SensorType::Rpm));
 
 
 	ASSERT_EQ( 6,  engine->triggerCentral.triggerState.getCurrentIndex()) << "index #4";
@@ -411,13 +411,13 @@ static void setTestBug299(EngineTestHelper *eth) {
 	Engine *engine = &eth->engine;
 
 
-	eth->assertRpm(0, "RPM=0");
+	ASSERT_EQ(0, Sensor::getOrZero(SensorType::Rpm));
 
 	eth->fireTriggerEventsWithDuration(20);
 	// still no RPM since need to cycles measure cycle duration
-	eth->assertRpm(0, "setTestBug299: RPM#1");
+	ASSERT_EQ(0, Sensor::getOrZero(SensorType::Rpm));
 	eth->fireTriggerEventsWithDuration(20);
-	eth->assertRpm(3000, "setTestBug299: RPM#2");
+	ASSERT_EQ(3000, Sensor::getOrZero(SensorType::Rpm));
 
 	eth->clearQueue();
 


### PR DESCRIPTION
without `test_fasterEngineSpinningUp.cpp` as this file needs to be treated separately (needs `EXPECT_NEAR` instead of `ASSERT_EQ`)

related issue: #6477