### PR TITLE
Get rid of GTEST assertion wrappers (assertEqualsM4)

### DIFF
--- a/unit_tests/test-framework/engine_test_helper.cpp
+++ b/unit_tests/test-framework/engine_test_helper.cpp
@@ -401,10 +401,10 @@ const AngleBasedEvent * EngineTestHelper::assertTriggerEvent(const char *msg,
 	auto event = engine.module<TriggerScheduler>()->getElementAtIndexForUnitTest(index);
 
 	if (callback) {
-		assertEqualsM4(msg, " callback up/down", (void*)event->action.getCallback() == (void*) callback, 1);
+		EXPECT_EQ(reinterpret_cast<void*>(event->action.getCallback()), reinterpret_cast<void*>(callback)) << " callback up/down";
 	}
 
-	assertEqualsM4(msg, " angle", enginePhase, event->getAngle());
+	EXPECT_NEAR(enginePhase, event->getAngle(), EPS4D) << " angle";
 	return event;
 }
 

--- a/unit_tests/test-framework/unit_test_framework.cpp
+++ b/unit_tests/test-framework/unit_test_framework.cpp
@@ -9,14 +9,6 @@
 
 #include <stdlib.h>
 
-void assertEqualsM4(const char *prefix, const char *msg, float expected, float actual) {
-	ASSERT_NEAR(expected, actual, 0.0001f) << prefix << msg;
-}
-
-void assertEqualsM(const char *msg, float expected, float actual) {
-	EXPECT_NEAR_M4(expected, actual) << msg;
-}
-
 void chDbgAssert(int c, char *msg, void *arg) {
 	if (!c) {
 		printf("assert failed: %s\r\n", msg);

--- a/unit_tests/test-framework/unit_test_framework.h
+++ b/unit_tests/test-framework/unit_test_framework.h
@@ -23,10 +23,5 @@ using ::testing::Return;
 #define EPS4D 0.0001
 #define EPS5D 0.00001
 
-// todo: migrate to googletest, use EXPECT_* and ASSERT_*
-void assertEqualsM(const char *msg, float expected, float actual);
-void assertEqualsLM(const char *msg, long expected, long actual);
-void assertEqualsM4(const char *prefix, const char *msg, float expected, float actual);
-
 #define EXPECT_NO_FATAL_ERROR EXPECT_NO_THROW
 #define EXPECT_FATAL_ERROR(expr) EXPECT_THROW((expr), std::logic_error)


### PR DESCRIPTION
also remove new dead code on `unit_test_framework.cpp` 
related issue: #6477