### PR TITLE
remove legacy enableOverdwellProtection

### DIFF
--- a/firmware/controllers/algo/engine.h
+++ b/firmware/controllers/algo/engine.h
@@ -98,10 +98,6 @@ public:
 
 	StartStopState startStopState;
 
-#if ! EFI_PROD_CODE
-	// todo: technical debt: remove legacy enableOverdwellProtection #3553
-	bool enableOverdwellProtection = true;
-#endif
 
 	TunerStudioOutputChannels outputChannels;
 

--- a/firmware/controllers/engine_cycle/spark_logic.cpp
+++ b/firmware/controllers/engine_cycle/spark_logic.cpp
@@ -351,11 +351,6 @@ void turnSparkPinHighStartCharging(IgnitionEvent *event) {
 	}
 }
 
-#if EFI_PROD_CODE
-  #define ENABLE_OVERDWELL_PROTECTION (true)
-#else
-  #define ENABLE_OVERDWELL_PROTECTION (engine->enableOverdwellProtection)
-#endif
 
 static void scheduleSparkEvent(bool limitedSpark, IgnitionEvent *event,
 		float rpm, float dwellMs, float dwellAngle, float sparkAngle, efitick_t edgeTimestamp, float currentPhase, float nextPhase) {
@@ -431,7 +426,7 @@ static void scheduleSparkEvent(bool limitedSpark, IgnitionEvent *event,
 		efiPrintf("to queue sparkDown revolution=%d [%s] for id=%d angle=%.1f", getRevolutionCounter(), event->getOutputForLoggins()->getName(), event->sparkCounter, sparkAngle);
 #endif /* SPARK_EXTREME_LOGGING */
 
-		if (!limitedSpark && ENABLE_OVERDWELL_PROTECTION) {
+		if (!limitedSpark) {
 			// auto fire spark at 1.5x nominal dwell
 			efitick_t fireTime = sumTickAndFloat(chargeTime, MSF2NT(1.5f * dwellMs));
 

--- a/firmware/gen_live_documentation.sh
+++ b/firmware/gen_live_documentation.sh
@@ -10,6 +10,7 @@ java -DSystemOut.name=logs/gen_live_documentation \
 
 java -DSystemOut.name=logs/gen_live_documentation \
  -cp ../java_tools/configuration_definition_base/build/libs/config_definition_base-all.jar \
+ -DLiveDataProcessor.extra_prepend=${BOARD_DIR}/prepend.txt \
  com.rusefi.ldmp.LiveDataProcessor \
   integration/LiveData.yaml${EXTRA_LIVE_DATA_FILE} \
   integration/rusefi_config_trigger.txt \

--- a/java_tools/configuration_definition_base/src/main/java/com/rusefi/ldmp/LiveDataProcessor.java
+++ b/java_tools/configuration_definition_base/src/main/java/com/rusefi/ldmp/LiveDataProcessor.java
@@ -196,8 +196,12 @@ public class LiveDataProcessor {
                 }
 
                 if (extraPrepend != null) {
-                    log.info("extraPrepend=" + extraPrepend);
-                    state.addPrepend(extraPrepend);
+                    if (new File(extraPrepend).exists()) {
+                        log.info("extraPrepend=" + extraPrepend);
+                        state.addPrepend(extraPrepend);
+                    } else {
+                        log.info("extraPrepend=" + extraPrepend + " does not exist, skipping");
+                    }
                 }
                 state.addPrepend(prepend);
                 state.addCHeaderDestination(outFolder + File.separator + name + "_generated.h");

--- a/unit_tests/tests/ignition_injection/test_ignition_scheduling.cpp
+++ b/unit_tests/tests/ignition_injection/test_ignition_scheduling.cpp
@@ -48,14 +48,6 @@ TEST(ignition, twoCoils) {
 TEST(ignition, trailingSpark) {
 	EngineTestHelper eth(engine_type_e::TEST_ENGINE);
 	engineConfiguration->isFasterEngineSpinUpEnabled = false;
-	extern bool unitTestBusyWaitHack;
-	unitTestBusyWaitHack = true;
-
-	/**
-	// TODO #3220: this feature makes this test sad, eventually remove this line (and the ability to disable it altogether)
-	 * I am pretty sure that it's about usage of improper method clearQueue() below see it's comment
-	 */
-	engine->enableOverdwellProtection = false;
 
 	EXPECT_CALL(*eth.mockAirmass, getAirmass(_, _))
 		.WillRepeatedly(Return(AirmassResult{0.1008f, 50.0f}));
@@ -77,12 +69,11 @@ TEST(ignition, trailingSpark) {
 	// still no RPM since need to cycles measure cycle duration
 	eth.fireTriggerEventsWithDuration(20);
 	ASSERT_EQ( 3000,  Sensor::getOrZero(SensorType::Rpm)) << "RPM#0";
-	eth.clearQueue();
 
 	/**
 	 * Trigger up - scheduling fuel for full engine cycle
 	 */
-	eth.fireRise(20);
+	eth.smartFireRise(20);
 
 	// Primary coil should be high
 	EXPECT_EQ(enginePins.coils[0].getLogicValue(), true);


### PR DESCRIPTION
* edited test `ignition.trailingSpark`
* removed `enableOverdwellProtection` from `engine.h`
* removed enableOverdwellProtection usage from `spark_logic.cpp`

related issue: #3553

also one test less with the unitTestBusyWaitHack :D