### PR TITLE
stm32 own build-in watchdog #1339

### DIFF
--- a/firmware/CHANGELOG.md
+++ b/firmware/CHANGELOG.md
@@ -34,6 +34,7 @@ Release template (copy/paste this for new release):
  - ETB calibration automatically enables ETB if needed #7197
  - Fuel Level Sensor should have a RAW option #6979
  - SD card bit data points #7227
+ - stm32 build-in watchdog for F7/H7 #1339
 
 ### Fixed
  - Critical error when using big values on Boost Control Open Loop with Y axis as MAP #7093

--- a/firmware/hw_layer/ports/stm32/stm32f7/cfg/halconf.h
+++ b/firmware/hw_layer/ports/stm32/stm32f7/cfg/halconf.h
@@ -107,7 +107,7 @@
  * @brief   Enables the WDG subsystem.
  */
 #if !defined(HAL_USE_WDG) || defined(__DOXYGEN__)
-#define HAL_USE_WDG                 FALSE
+#define HAL_USE_WDG                 TRUE
 #endif
 
 /*===========================================================================*/

--- a/firmware/hw_layer/ports/stm32/stm32h7/cfg/halconf.h
+++ b/firmware/hw_layer/ports/stm32/stm32h7/cfg/halconf.h
@@ -113,7 +113,7 @@
  * @brief   Enables the WDG subsystem.
  */
 #if !defined(HAL_USE_WDG) || defined(__DOXYGEN__)
-#define HAL_USE_WDG                 FALSE
+#define HAL_USE_WDG                 TRUE
 #endif
 
 /*===========================================================================*/


### PR DESCRIPTION
enable watchdog for F7/H7

Looks like we leverage stm32 watchdog for over a year now? Should be safe to leverage same for F7.