### PR TITLE
SD: calculate clock in runtime

### DIFF
--- a/firmware/hw_layer/mmc_card.cpp
+++ b/firmware/hw_layer/mmc_card.cpp
@@ -156,11 +156,15 @@ static void sdStatistics() {
 	efiPrintf("SD enabled=%s status=%s", boolToString(engineConfiguration->isSdCardEnabled),
 			sdStatus);
 	printSpiConfig("SD", mmcSpiDevice);
+#if defined(STM32F4XX) || defined(STM32F7XX)
+	efiPrintf("HS clock %d Hz", spiGetBaseClock(mmccfg.spip) / (2 << ((mmc_hs_spicfg.cr1 & SPI_CR1_BR_Msk) >> SPI_CR1_BR_Pos)));
+	efiPrintf("LS clock %d Hz", spiGetBaseClock(mmccfg.spip) / (2 << ((mmc_ls_spicfg.cr1 & SPI_CR1_BR_Msk) >> SPI_CR1_BR_Pos)));
+#endif
 	if (isSdCardAlive()) {
 		efiPrintf("filename=%s size=%d", logName, totalLoggedBytes);
 	}
 #if EFI_FILE_LOGGING
-  efiPrintf("%d SD card fields", getSdCardFieldsCount());
+	efiPrintf("%d SD card fields", getSdCardFieldsCount());
 #endif
 }
 

--- a/firmware/hw_layer/mmc_card.cpp
+++ b/firmware/hw_layer/mmc_card.cpp
@@ -339,6 +339,11 @@ static BaseBlockDevice* initializeMmcBlockDevice() {
 		return nullptr;
 	}
 
+	// max SPI rate is 25 MHz after init
+	spiCalcClockDiv(mmccfg.spip, &mmc_hs_spicfg, 25 * 1000 * 1000);
+	// and 250 KHz during initialization
+	spiCalcClockDiv(mmccfg.spip, &mmc_ls_spicfg, 250 * 1000);
+
 	// We think we have everything for the card, let's try to mount it!
 	mmcObjectInit(&MMCD1);
 	mmcStart(&MMCD1, &mmccfg);


### PR DESCRIPTION
We need 100..400 KHz clock during card initialization. And <=25MHz after.
http://elm-chan.org/docs/mmc/mmc_e.html