### PR TITLE
error reporting: extract all related code to error_handling

### DIFF
--- a/firmware/console/eficonsole.cpp
+++ b/firmware/console/eficonsole.cpp
@@ -260,10 +260,6 @@ void initializeConsole() {
 	addConsoleAction("reset", scheduleReset);
 #endif
 
-  // see https://github.com/rusefi/rusefi/wiki/Resilience
-	addConsoleAction("chibi_fault", [](){ chDbgCheck(0); } );
-	addConsoleAction("soft_fault", [](){ firmwareError(ObdCode::RUNTIME_CRITICAL_TEST_ERROR, "firmwareError: %d", getRusEfiVersion()); });
-	addConsoleAction("hard_fault", [](){ causeHardFault(); } );
 	addConsoleAction("threadsinfo", cmd_threads);
 
 #if HAL_USE_WDG

--- a/firmware/controllers/core/error_handling.cpp
+++ b/firmware/controllers/core/error_handling.cpp
@@ -135,8 +135,7 @@ do {																\
 		break;														\
 	}																\
 																	\
-	PRINT("Last error type %s cookie 0x%08lx",						\
-		errorCookieToName(err->Cookie), (uint32_t)err->Cookie);		\
+	PRINT("Last error type %s", errorCookieToName(err->Cookie));	\
 																	\
 	switch (err->Cookie) {											\
 	case ErrorCookie::FirmwareError:								\

--- a/firmware/controllers/core/error_handling.cpp
+++ b/firmware/controllers/core/error_handling.cpp
@@ -16,8 +16,8 @@
 
 // Ignore following (and similar) errors
 // error: 'strncpy' output may be truncated copying 119 bytes from a string of length 119
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wstringop-truncation"
+_Pragma("GCC diagnostic push")
+_Pragma("GCC diagnostic ignored \"-Wstringop-truncation\"")
 
 static critical_msg_t warningBuffer;
 static critical_msg_t criticalErrorMessageBuffer;
@@ -443,4 +443,4 @@ void criticalErrorM(const char *msg) {
 	criticalError(msg);
 }
 
-#pragma GCC diagnostic pop
+_Pragma("GCC diagnostic pop")

--- a/firmware/controllers/core/error_handling.cpp
+++ b/firmware/controllers/core/error_handling.cpp
@@ -108,7 +108,7 @@ bool errorHandlerIsStartFromError() {
 #endif
 }
 
-static const char *errorCookieToName(ErrorCookie cookie)
+const char *errorCookieToName(ErrorCookie cookie)
 {
 	switch (cookie) {
 	case ErrorCookie::None:
@@ -204,7 +204,7 @@ void errorHandlerShowBootReasonAndErrors() {
 PUBLIC_API_WEAK void onBoardWriteErrorFile(FIL *) {
 }
 
-void errorHandlerWriteReportFile(FIL *fd) {
+void errorHandlerWriteReportFile(FIL *fd, int index) {
 	// generate file on good boot to?
 	bool needReport = false;
 #if EFI_BACKUP_SRAM
@@ -224,7 +224,11 @@ void errorHandlerWriteReportFile(FIL *fd) {
 		char fileName[_MAX_FILLER + 20];
 		memset(fd, 0, sizeof(FIL));						// clear the memory
 		//TODO: use date + time for file name?
+#if EFI_BACKUP_SRAM
 		sprintf(fileName, "%s%ld.txt", FAIL_REPORT_PREFIX, bootCount);
+#else
+		sprintf(fileName, "%s%d.txt", FAIL_REPORT_PREFIX, index);
+#endif
 		FRESULT ret = f_open(fd, fileName, FA_CREATE_ALWAYS | FA_WRITE);
 		if (ret == FR_OK) {
 			//this is file print
@@ -244,7 +248,7 @@ void errorHandlerWriteReportFile(FIL *fd) {
 
 backupErrorState *errorHandlerGetLastErrorDescriptor(void)
 {
-#ifdef EFI_BACKUP_SRAM
+#if EFI_BACKUP_SRAM
 	return &lastBootError;
 #else
 	return nullptr;

--- a/firmware/controllers/core/error_handling.cpp
+++ b/firmware/controllers/core/error_handling.cpp
@@ -14,6 +14,11 @@
 #include "log_hard_fault.h"
 #include "rusefi/critical_error.h"
 
+// Ignore following (and similar) errors
+// error: 'strncpy' output may be truncated copying 119 bytes from a string of length 119
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-truncation"
+
 static critical_msg_t warningBuffer;
 static critical_msg_t criticalErrorMessageBuffer;
 static critical_msg_t configErrorMessageBuffer; // recoverable configuration error, non-critical
@@ -437,3 +442,5 @@ void firmwareError(ObdCode code, const char *fmt, ...) {
 void criticalErrorM(const char *msg) {
 	criticalError(msg);
 }
+
+#pragma GCC diagnostic pop

--- a/firmware/controllers/core/error_handling.cpp
+++ b/firmware/controllers/core/error_handling.cpp
@@ -257,11 +257,13 @@ void logHardFault(uint32_t type, uintptr_t faultAddress, port_extctx* ctx, uint3
 #if EFI_BACKUP_SRAM
     auto bkpram = getBackupSram();
 	auto err = &bkpram->err;
-	err->Cookie = ErrorCookie::HardFault;
-	err->FaultType = type;
-	err->FaultAddress = faultAddress;
-	err->Csfr = csfr;
-	memcpy(&err->FaultCtx, ctx, sizeof(port_extctx));
+	if (err->Cookie == ErrorCookie::None) {
+		err->FaultType = type;
+		err->FaultAddress = faultAddress;
+		err->Csfr = csfr;
+		memcpy(&err->FaultCtx, ctx, sizeof(port_extctx));
+		err->Cookie = ErrorCookie::HardFault;
+	}
 #endif // EFI_BACKUP_SRAM
 }
 
@@ -278,10 +280,12 @@ void chDbgPanic3(const char *msg, const char * file, int line) {
 #if EFI_BACKUP_SRAM
     auto bkpram = getBackupSram();
 	auto err = &bkpram->err;
-	strncpy(err->file, file, efi::size(err->file) - 1);
-	err->line = line;
-	strncpy(err->msg, msg, efi::size(err->msg) - 1);
-	err->Cookie = ErrorCookie::ChibiOsPanic;
+	if (err->Cookie == ErrorCookie::None) {
+		strncpy(err->file, file, efi::size(err->file) - 1);
+		err->line = line;
+		strncpy(err->msg, msg, efi::size(err->msg) - 1);
+		err->Cookie = ErrorCookie::ChibiOsPanic;
+	}
 #endif // EFI_BACKUP_SRAM
 
 	if (hasOsPanicError())
@@ -462,8 +466,10 @@ void firmwareError(ObdCode code, const char *fmt, ...) {
 #if EFI_BACKUP_SRAM
     auto bkpram = getBackupSram();
 	auto err = &bkpram->err;
-	strncpy(err->msg, criticalErrorMessageBuffer, sizeof(err->msg) - 1);
-	err->Cookie = ErrorCookie::FirmwareError;
+	if (err->Cookie == ErrorCookie::None) {
+		strncpy(err->msg, criticalErrorMessageBuffer, sizeof(err->msg) - 1);
+		err->Cookie = ErrorCookie::FirmwareError;
+	}
 #endif // EFI_BACKUP_SRAM
 #else
 

--- a/firmware/controllers/core/error_handling.h
+++ b/firmware/controllers/core/error_handling.h
@@ -105,13 +105,8 @@ void errorHandlerInit();
 bool errorHandlerIsStartFromError();
 // If there was an error on the last boot, print out information about it now and reset state.
 void errorHandlerShowBootReasonAndErrors();
-#if EFI_FILE_LOGGING
-// for FIL
-#include "ff.h"
 
-// write error report to file
-void errorHandlerWriteReportFile(FIL *fd);
-#endif
+//void errorHandlerWriteReportFile(FIL *fd);
 
 #endif // EFI_PROD_CODE
 

--- a/firmware/controllers/core/error_handling.h
+++ b/firmware/controllers/core/error_handling.h
@@ -86,6 +86,8 @@ enum class ErrorCookie : uint32_t {
     ChibiOsPanic = 0xdeadfa11,
 };
 
+const char *errorCookieToName(ErrorCookie cookie);
+
 // Error handling/recovery/reporting information
 typedef struct {
     ErrorCookie Cookie;

--- a/firmware/controllers/core/error_handling.h
+++ b/firmware/controllers/core/error_handling.h
@@ -75,8 +75,44 @@ extern "C"
 
 #if EFI_PROD_CODE
 
+// for port_extctx
+#include "ch.h"
+
+// These use very specific values to avoid interpreting random garbage memory as a real value
+enum class ErrorCookie : uint32_t {
+    None = 0,
+    FirmwareError = 0xcafebabe,
+    HardFault = 0xdeadbeef,
+    ChibiOsPanic = 0xdeadfa11,
+};
+
+// Error handling/recovery/reporting information
+typedef struct {
+    ErrorCookie Cookie;
+
+    critical_msg_t msg;
+    critical_msg_t file;
+    int line;
+    port_extctx FaultCtx;
+    uint32_t FaultType;
+    uint32_t FaultAddress;
+    uint32_t Csfr;
+} backupErrorState;
+
+// reads backup ram and checks for any error report
+void errorHandlerInit();
+// true if we just started from some crash
+bool errorHandlerIsStartFromError();
 // If there was an error on the last boot, print out information about it now and reset state.
-void checkLastBootError();
+void errorHandlerShowBootReasonAndErrors();
+#if EFI_FILE_LOGGING
+// for FIL
+#include "ff.h"
+
+// write error report to file
+void errorHandlerWriteReportFile(FIL *fd);
+#endif
+
 #endif // EFI_PROD_CODE
 
 #ifdef __cplusplus

--- a/firmware/hw_layer/backup_ram.h
+++ b/firmware/hw_layer/backup_ram.h
@@ -40,34 +40,12 @@ void backupRamSave(backup_ram_e idx, uint32_t value);
 // make sure that all changes are saved before we shutdown the MCU
 void backupRamFlush(void);
 
-// These use very specific values to avoid interpreting random garbage memory as a real value
-enum class ErrorCookie : uint32_t {
-	None = 0,
-	FirmwareError = 0xcafebabe,
-	HardFault = 0xdeadbeef,
-};
-
 #if EFI_PROD_CODE
 struct BackupSramData {
+	uint32_t BootCount;
+	uint32_t BootCountCookie;
 
-	// Error handling/recovery/reporting information
-	struct {
-		ErrorCookie Cookie;
-
-		critical_msg_t ErrorString;
-		critical_msg_t hardFile;
-		int hardLine;
-		int check;
-		critical_msg_t rawMsg;
-		port_extctx FaultCtx;
-		uint32_t FaultType;
-		uint32_t FaultAddress;
-		uint32_t Csfr;
-
-		uint32_t BootCount;
-		uint32_t BootCountCookie;
-	} Err;
-
+	backupErrorState err;
 };
 
 BackupSramData* getBackupSram();

--- a/firmware/hw_layer/hardware.cpp
+++ b/firmware/hw_layer/hardware.cpp
@@ -654,18 +654,3 @@ void initHardware() {
 
 	efiPrintf("initHardware() OK!");
 }
-
-void checkLastResetCause() {
-#if EFI_PROD_CODE
-	Reset_Cause_t cause = getMCUResetCause();
-	// checkLastBootError
-	// see also Err.ErrorString
-	const char *causeStr = getMCUResetCause(cause);
-	efiPrintf("Last Reset Cause: %s", causeStr);
-
-	// if reset by watchdog, signal a fatal error
-	if (cause == Reset_Cause_IWatchdog || cause == Reset_Cause_WWatchdog) {
-		firmwareError(ObdCode::OBD_PCM_Processor_Fault, "Watchdog Reset");
-	}
-#endif // EFI_PROD_CODE
-}

--- a/firmware/hw_layer/hardware.h
+++ b/firmware/hw_layer/hardware.h
@@ -52,8 +52,6 @@ void initHardwareNoConfig();
 // Initialize hardware with configuration loaded
 void initHardware();
 
-void checkLastResetCause();
-
 // todo: can we do simpler here? move conditional compilation into debounce.h?
 #if EFI_PROD_CODE
 #include "debounce.h"

--- a/firmware/hw_layer/mmc_card.cpp
+++ b/firmware/hw_layer/mmc_card.cpp
@@ -42,7 +42,7 @@ static int totalSyncCounter = 0;
 // This is dirty workaround to fix compilation without adding this function prototype
 // to error_handling.h file that will also need to add "ff.h" include to same file and
 // cause simulator fail to build.
-extern void errorHandlerWriteReportFile(FIL *fd);
+extern void errorHandlerWriteReportFile(FIL *fd, int index);
 
 #define SD_STATE_INIT "init"
 #define SD_STATE_MOUNTED "MOUNTED"
@@ -387,7 +387,7 @@ static bool mountMmc() {
 		efiPrintf("MMC/SD mounted!");
 		sdStatus = SD_STATE_MOUNTED;
 		incLogFileName();
-		errorHandlerWriteReportFile(&FDLogFile);
+		errorHandlerWriteReportFile(&FDLogFile, logFileIndex);
 		createLogFile();
 		return true;
 	} else {

--- a/firmware/hw_layer/mmc_card.cpp
+++ b/firmware/hw_layer/mmc_card.cpp
@@ -39,6 +39,11 @@ static int totalSyncCounter = 0;
 
 #include "rtc_helper.h"
 
+// This is dirty workaround to fix compilation without adding this function prototype
+// to error_handling.h file that will also need to add "ff.h" include to same file and
+// cause simulator fail to build.
+extern void errorHandlerWriteReportFile(FIL *fd);
+
 #define SD_STATE_INIT "init"
 #define SD_STATE_MOUNTED "MOUNTED"
 #define SD_STATE_MOUNT_FAILED "MOUNT_FAILED"

--- a/firmware/hw_layer/mmc_card_util.cpp
+++ b/firmware/hw_layer/mmc_card_util.cpp
@@ -66,13 +66,4 @@ void incLogFileName() {
 	efiPrintf("New log file index %d", logFileIndex);
 }
 
-bool needsToWriteReportFile() {
-#if EFI_BACKUP_SRAM
-extern ErrorCookie errorCookieOnStart;
-  return errorCookieOnStart == ErrorCookie::HardFault;
-#else
-  return false;
-#endif // EFI_BACKUP_SRAM
-}
-
 #endif // EFI_PROD_CODE && EFI_FILE_LOGGING

--- a/firmware/hw_layer/mmc_card_util.cpp
+++ b/firmware/hw_layer/mmc_card_util.cpp
@@ -8,7 +8,6 @@
 #include "mmc_card.h"
 
 #define LOG_INDEX_FILENAME "index.txt"
-#define HARD_FAULT_PREFIX "hard_"
 
 // 10 because we want at least 4 character name (is that about TS protocol which we do not use any more?)
 #define MIN_FILE_INDEX 10
@@ -73,91 +72,6 @@ extern ErrorCookie errorCookieOnStart;
   return errorCookieOnStart == ErrorCookie::HardFault;
 #else
   return false;
-#endif // EFI_BACKUP_SRAM
-}
-
-PUBLIC_API_WEAK void onBoardWriteErrorFile(FIL *file) {
-  UNUSED(file);
-}
-
-#if EFI_BACKUP_SRAM
-// todo: unit test? or better file stdlib method to do same?
-static int mystrncasecmp(const char *s1, const char *s2, size_t n) {
-	if (n != 0) {
-		const char *us1 = (const char *)s1;
-		const char *us2 = (const char *)s2;
-
-		do {
-			if (mytolower(*us1) != mytolower(*us2))
-				return (mytolower(*us1) - mytolower(*us2));
-			if (*us1++ == '\0')
-				break;
-			us2++;
-		} while (--n != 0);
-	}
-	return (0);
-}
-
-static bool findFile(const char *path, const char *prefix) {
-	if (!isSdCardAlive()) {
-		efiPrintf("Error: No File system is mounted");
-		return false;
-	}
-
-	DIR dir;
-	FRESULT res = f_opendir(&dir, path);
-
-	if (res != FR_OK) {
-		efiPrintf("Error opening directory %s", path);
-		return false;
-	}
-
-  // todo: do we need paranoia loop limit?
-	while (true) {
-		FILINFO fno;
-
-		res = f_readdir(&dir, &fno);
-		if (res != FR_OK || fno.fname[0] == 0) {
-		  // done!
-			break;
-		}
-		if (fno.fname[0] == '.') {
-			continue;
-		}
-		if ((fno.fattrib & AM_DIR) || mystrncasecmp(prefix, fno.fname, strlen(prefix) - 1)) {
-		  // skipping folders and files with wrong names
-			continue;
-		}
-		efiPrintf("file found %lu:%s", (uint32_t)fno.fsize, fno.fname);
-		return true;
-
-//			efiPrintf("%c%c%c%c%c %u/%02u/%02u %02u:%02u %9lu  %-12s", (fno.fattrib & AM_DIR) ? 'D' : '-',
-//					(fno.fattrib & AM_RDO) ? 'R' : '-', (fno.fattrib & AM_HID) ? 'H' : '-',
-//					(fno.fattrib & AM_SYS) ? 'S' : '-', (fno.fattrib & AM_ARC) ? 'A' : '-', (fno.fdate >> 9) + 1980,
-//					(fno.fdate >> 5) & 15, fno.fdate & 31, (fno.ftime >> 11), (fno.ftime >> 5) & 63, fno.fsize,
-//					fno.fname);
-	}
-	return false;
-}
-#endif // EFI_BACKUP_SRAM
-
-void writeErrorReportFile() {
-#if EFI_BACKUP_SRAM
-extern ErrorCookie errorCookieOnStart;
-  static char fileName[_MAX_FILLER + 20];
-  auto sramState = getBackupSram();
-  if (errorCookieOnStart == ErrorCookie::HardFault) {
-  	memset(&FDLogFile, 0, sizeof(FIL));						// clear the memory
-  	sprintf(fileName, "%s%d.txt", HARD_FAULT_PREFIX, logFileIndex);
-  	FRESULT ret = f_open(&FDLogFile, fileName, FA_CREATE_ALWAYS | FA_WRITE);
-  	if (ret == FR_OK) {
-  	  onBoardWriteErrorFile(&FDLogFile);
-  	  f_printf(&FDLogFile, "type=%d\n", sramState->Err.FaultType);
-  	  // todo: figure out what else would be useful
-  	  f_close(&FDLogFile);
-  	}
-  }
-  findFile(".", HARD_FAULT_PREFIX);
 #endif // EFI_BACKUP_SRAM
 }
 

--- a/firmware/hw_layer/mmc_card_util.h
+++ b/firmware/hw_layer/mmc_card_util.h
@@ -4,5 +4,4 @@
 
 void incLogFileName();
 void printError(const char *str, FRESULT f_error);
-bool needsToWriteReportFile();
 void writeErrorReportFile();

--- a/firmware/rusefi.cpp
+++ b/firmware/rusefi.cpp
@@ -185,8 +185,8 @@ void runRusEfi() {
 #endif // HAL_USE_WDG
 
 #if EFI_PROD_CODE
-  // see also: checkLastResetCause
-	checkLastBootError();
+	errorHandlerInit();
+	errorHandlerShowBootReasonAndErrors();
 #endif
 
 #if defined(STM32F4) || defined(STM32F7)
@@ -229,9 +229,6 @@ void runRusEfi() {
 	 * Next we should initialize serial port console, it's important to know what's going on
 	 */
 	initializeConsole();
-
-  // see also: checkLastBootError
-	checkLastResetCause();
 
 	// Read configuration from flash memory
 	loadConfiguration();

--- a/firmware/rusefi_rules.mk
+++ b/firmware/rusefi_rules.mk
@@ -1,7 +1,7 @@
 # Warnings-as-errors...
 RUSEFI_OPT = -Werror
 # some compilers seem to have this off by default?
-RUSEFI_OPT += -Werror=stringop-truncation
+#RUSEFI_OPT += -Werror=stringop-truncation
 
 ifneq ($(ALLOW_SHADOW),yes)
      RUSEFI_OPT += -Werror=shadow


### PR DESCRIPTION
Also:
 -report ChibiOS panic message
 -use bootCount for boot report file naming
 -save few bytes in backup ram by reusing same field for different errors types