### PR TITLE
hardfault: call bkpt() only if debuger is detected

### DIFF
--- a/firmware/hw_layer/main_hardfault.c
+++ b/firmware/hw_layer/main_hardfault.c
@@ -60,7 +60,7 @@ void HardFault_Handler_C(void* sp) {
 	logHardFault(faultType, faultAddress, &ctx, SCB->CFSR >> SCB_CFSR_BUSFAULTSR_Pos);
 
 	// check if debugger is connected
-	if (CoreDebug->DHCSR & 1)
+	if (CoreDebug->DHCSR & CoreDebug_DHCSR_C_DEBUGEN_Msk)
 	{
 		bkpt();
 	}
@@ -94,7 +94,7 @@ void UsageFault_Handler_C(void* sp) {
 	logHardFault(faultType, 0, &ctx, SCB->CFSR);
 
 	// check if debugger is connected
-	if (CoreDebug->DHCSR & 1)
+	if (CoreDebug->DHCSR & CoreDebug_DHCSR_C_DEBUGEN_Msk)
 	{
 		bkpt();
 	}
@@ -129,7 +129,7 @@ void MemManage_Handler_C(void* sp) {
 	logHardFault(faultType, faultAddress, &ctx, SCB->CFSR);
 
 	// check if debugger is connected
-	if (CoreDebug->DHCSR & 1)
+	if (CoreDebug->DHCSR & CoreDebug_DHCSR_C_DEBUGEN_Msk)
 	{
 		bkpt();
 	}

--- a/firmware/hw_layer/main_hardfault.c
+++ b/firmware/hw_layer/main_hardfault.c
@@ -59,8 +59,11 @@ void HardFault_Handler_C(void* sp) {
 
 	logHardFault(faultType, faultAddress, &ctx, SCB->CFSR >> SCB_CFSR_BUSFAULTSR_Pos);
 
-	//Cause debugger to stop. Ignored if no debugger is attached
-	bkpt();
+	// check if debugger is connected
+	if (CoreDebug->DHCSR & 1)
+	{
+		bkpt();
+	}
 	NVIC_SystemReset();
 }
 
@@ -90,7 +93,11 @@ void UsageFault_Handler_C(void* sp) {
 
 	logHardFault(faultType, 0, &ctx, SCB->CFSR);
 
-	bkpt();
+	// check if debugger is connected
+	if (CoreDebug->DHCSR & 1)
+	{
+		bkpt();
+	}
 	NVIC_SystemReset();
 }
 
@@ -121,6 +128,10 @@ void MemManage_Handler_C(void* sp) {
 
 	logHardFault(faultType, faultAddress, &ctx, SCB->CFSR);
 
-	bkpt();
+	// check if debugger is connected
+	if (CoreDebug->DHCSR & 1)
+	{
+		bkpt();
+	}
 	NVIC_SystemReset();
 }


### PR DESCRIPTION
Call to bkpt() with no debuger attached will cause hang. Restart immediately instead.