### PR TITLE
Possibly fix watchdog https://github.com/rusefi/rusefi/issues/1339

### DIFF
--- a/firmware/controllers/settings.cpp
+++ b/firmware/controllers/settings.cpp
@@ -739,13 +739,12 @@ void setEngineType(int value, bool isWriteToFlash) {
 		engineConfiguration->engineType = (engine_type_e)value;
 		resetConfigurationExt((engine_type_e)value);
 		engine->resetEngineSnifferIfInTestMode();
-
+    }
 #if EFI_CONFIGURATION_STORAGE
 		if (isWriteToFlash) {
 			writeToFlashNow();
 		}
 #endif /* EFI_CONFIGURATION_STORAGE */
-	}
 	incrementGlobalConfigurationVersion("engineType");
 #if EFI_ENGINE_CONTROL && ! EFI_UNIT_TEST
 	printConfiguration();

--- a/firmware/controllers/settings.cpp
+++ b/firmware/controllers/settings.cpp
@@ -739,12 +739,13 @@ void setEngineType(int value, bool isWriteToFlash) {
 		engineConfiguration->engineType = (engine_type_e)value;
 		resetConfigurationExt((engine_type_e)value);
 		engine->resetEngineSnifferIfInTestMode();
-    }
+
 #if EFI_CONFIGURATION_STORAGE
 		if (isWriteToFlash) {
 			writeToFlashNow();
 		}
 #endif /* EFI_CONFIGURATION_STORAGE */
+    }
 	incrementGlobalConfigurationVersion("engineType");
 #if EFI_ENGINE_CONTROL && ! EFI_UNIT_TEST
 	printConfiguration();

--- a/firmware/hw_layer/ports/mpu_watchdog.h
+++ b/firmware/hw_layer/ports/mpu_watchdog.h
@@ -13,8 +13,8 @@
 
 // 100 ms is our empiric choice based on 2 * SLOW_CALLBACK_PERIOD_MS
 #define WATCHDOG_RESET_MS (2 * SLOW_CALLBACK_PERIOD_MS)
-// 300 ms is our default timeout
-#define WATCHDOG_TIMEOUT_MS (3 * WATCHDOG_RESET_MS)
+// 500 ms is our default timeout
+#define WATCHDOG_TIMEOUT_MS (5 * WATCHDOG_RESET_MS)
 // 5 secs should be enough to wait until 
 #define WATCHDOG_FLASH_TIMEOUT_MS 5000
 

--- a/firmware/hw_layer/ports/stm32/stm32_common.cpp
+++ b/firmware/hw_layer/ports/stm32/stm32_common.cpp
@@ -116,8 +116,16 @@ void startWatchdog(int timeoutMs) {
 	wdgcfg.winr = 0xfff; // don't use window
 #endif
 
-  efiPrintf("Starting watchdog...");
-	wdgStart(&WDGD1, &wdgcfg);
+    static bool isStarted = false;
+    if (!isStarted) {
+		efiPrintf("Starting watchdog with timeout %d ms...", timeoutMs);
+		wdgStart(&WDGD1, &wdgcfg);
+		isStarted = true;
+	} else {
+		efiPrintf("Changing watchdog timeout to %d ms...", timeoutMs);
+		// wdgStart() uses kernel lock, thus we cannot call it here from locked or ISR code
+		wdg_lld_start(&WDGD1);
+	}
 #endif // HAL_USE_WDG
 }
 

--- a/firmware/hw_layer/ports/stm32/stm32_common.cpp
+++ b/firmware/hw_layer/ports/stm32/stm32_common.cpp
@@ -112,6 +112,10 @@ void startWatchdog(int timeoutMs) {
 	static WDGConfig wdgcfg;
 	wdgcfg.pr = STM32_IWDG_PR_64;	// t = (1/32768) * 64 = ~2 ms
 	wdgcfg.rlr = STM32_IWDG_RL((uint32_t)((32.768f / 64.0f) * timeoutMs));
+#if STM32_IWDG_IS_WINDOWED
+	wdgcfg.winr = 0xfff; // don't use window
+#endif
+
   efiPrintf("Starting watchdog...");
 	wdgStart(&WDGD1, &wdgcfg);
 #endif // HAL_USE_WDG


### PR DESCRIPTION
Tested on Proteus-F7. Also, "hard_fault" and "chibi_fault" commands lead to reboot via watchdog as expected.