### PR TITLE
Make IGN CLT Correction a 5x5 table [was 8x8 table]

### DIFF
--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -168,7 +168,7 @@ struct_no_prefix engine_configuration_s
 #define CRANKING_ADVANCE_CURVE_SIZE 4
 
 #define ENGINE_NOISE_CURVE_SIZE 16
-#define CLT_TIMING_CURVE_SIZE 8
+#define CLT_TIMING_CURVE_SIZE 5
 #define IDLE_VE_SIZE 4
 
 #define TCU_SOLENOID_COUNT 6

--- a/firmware/tunerstudio/tunerstudio.template.ini
+++ b/firmware/tunerstudio/tunerstudio.template.ini
@@ -542,8 +542,8 @@ enable2ndByteCanID = false
 
 	curve = cltTimingCorrCurve, "Warmup timing correction"
 		columnLabel = "Coolant", "Extra"
-		xAxis		=  -40, 120, 9
-		yAxis		=  0,  20, 9
+		xAxis		=  -40, 120, 6
+		yAxis		=  0,  20, 6
 		xBins		= cltTimingBins, coolant
 		yBins		= cltTimingExtra
 		gauge		= CLTGauge


### PR DESCRIPTION
Tested on simulator:
![image](https://github.com/user-attachments/assets/c83f8834-0954-4774-959a-83329a517455)

note:
Since it is a rebin to a smaller size, the user has to pay attention to how TS alters the table, can this be added as a note to the changelog?

related issue: #7163