### PR TITLE
error handing: save some stack on error

### DIFF
--- a/firmware/bootloader/bootloader_stubs.cpp
+++ b/firmware/bootloader/bootloader_stubs.cpp
@@ -13,7 +13,7 @@ void chDbgPanic3(const char* /*msg*/, const char* /*file*/, int /*line*/) {
 }
 
 extern "C" {
-void logHardFault(uint32_t type, uintptr_t faultAddress, struct port_extctx* ctx, uint32_t csfr) { }
+void logHardFault(uint32_t type, uintptr_t faultAddress, void* sp, struct port_extctx* ctx, uint32_t csfr) { }
 }
 
 void setPinConfigurationOverrides() { }

--- a/firmware/controllers/core/error_handling.cpp
+++ b/firmware/controllers/core/error_handling.cpp
@@ -305,6 +305,7 @@ backupErrorState *errorHandlerGetLastErrorDescriptor(void)
 #endif
 }
 
+#if EFI_BACKUP_SRAM
 static void errorHandlerSaveStack(backupErrorState *err, uint32_t *sp)
 {
 	err->sp = (uint32_t)sp;
@@ -315,6 +316,7 @@ static void errorHandlerSaveStack(backupErrorState *err, uint32_t *sp)
 		sp++;
 	}
 }
+#endif
 
 void logHardFault(uint32_t type, uintptr_t faultAddress, void* sp, port_extctx* ctx, uint32_t csfr) {
     criticalShutdown();
@@ -339,9 +341,11 @@ void logHardFault(uint32_t type, uintptr_t faultAddress, void* sp, port_extctx* 
 
 void chDbgPanic3(const char *msg, const char * file, int line) {
 #if EFI_PROD_CODE
+#if EFI_BACKUP_SRAM
 	// following is allocated on stack
 	// add some marker
 	uint32_t tmp = 0xfffffa11;
+#endif
 	// Attempt to break in to the debugger, if attached
 	if (CoreDebug->DHCSR & CoreDebug_DHCSR_C_DEBUGEN_Msk)
 	{
@@ -505,11 +509,12 @@ const char* getConfigErrorMessage() {
 }
 
 void firmwareError(ObdCode code, const char *fmt, ...) {
-
 #if EFI_PROD_CODE
+#if EFI_BACKUP_SRAM
 	// following is allocated on stack
 	// add some marker
 	uint32_t tmp = 0xfaaaaa11;
+#endif
 	if (hasCriticalFirmwareErrorFlag)
 		return;
 	hasCriticalFirmwareErrorFlag = true;

--- a/firmware/controllers/core/error_handling.cpp
+++ b/firmware/controllers/core/error_handling.cpp
@@ -309,7 +309,9 @@ static void errorHandlerSaveStack(backupErrorState *err, uint32_t *sp)
 {
 	err->sp = (uint32_t)sp;
 	for (size_t i = 0; i < ERROR_STACK_DEPTH; i++) {
-		err->stack[i] = *sp;
+		// avoid optimizatio and usage of __builtin_memcpy
+		// to avoid "error: '__builtin_memcpy' reading 128 bytes from a region of size 4"
+		err->stack[i] = *(volatile uint32_t *)sp;
 		sp++;
 	}
 }

--- a/firmware/controllers/core/error_handling.cpp
+++ b/firmware/controllers/core/error_handling.cpp
@@ -314,7 +314,7 @@ static void errorHandlerSaveStack(backupErrorState *err, uint32_t *sp)
 	}
 }
 
-void logHardFault(uint32_t type, uintptr_t faultAddress, port_extctx* ctx, uint32_t csfr) {
+void logHardFault(uint32_t type, uintptr_t faultAddress, void* sp, port_extctx* ctx, uint32_t csfr) {
     criticalShutdown();
 #if EFI_BACKUP_SRAM
     auto bkpram = getBackupSram();
@@ -325,6 +325,8 @@ void logHardFault(uint32_t type, uintptr_t faultAddress, port_extctx* ctx, uint3
 		err->Csfr = csfr;
 		memcpy(&err->FaultCtx, ctx, sizeof(port_extctx));
 		err->Cookie = ErrorCookie::HardFault;
+		// copy stack last as it can be corrupted and cause another exeption
+		errorHandlerSaveStack(err, (uint32_t *)sp);
 	}
 #endif // EFI_BACKUP_SRAM
 }

--- a/firmware/controllers/core/error_handling.cpp
+++ b/firmware/controllers/core/error_handling.cpp
@@ -336,10 +336,10 @@ void logHardFault(uint32_t type, uintptr_t faultAddress, void* sp, port_extctx* 
 #if EFI_SIMULATOR || EFI_PROD_CODE
 
 void chDbgPanic3(const char *msg, const char * file, int line) {
+#if EFI_PROD_CODE
 	// following is allocated on stack
 	// add some marker
 	uint32_t tmp = 0xfffffa11;
-#if EFI_PROD_CODE
 	// Attempt to break in to the debugger, if attached
 	if (CoreDebug->DHCSR & CoreDebug_DHCSR_C_DEBUGEN_Msk)
 	{
@@ -503,10 +503,11 @@ const char* getConfigErrorMessage() {
 }
 
 void firmwareError(ObdCode code, const char *fmt, ...) {
+
+#if EFI_PROD_CODE
 	// following is allocated on stack
 	// add some marker
 	uint32_t tmp = 0xfaaaaa11;
-#if EFI_PROD_CODE
 	if (hasCriticalFirmwareErrorFlag)
 		return;
 	hasCriticalFirmwareErrorFlag = true;

--- a/firmware/controllers/core/error_handling.cpp
+++ b/firmware/controllers/core/error_handling.cpp
@@ -503,6 +503,9 @@ const char* getConfigErrorMessage() {
 }
 
 void firmwareError(ObdCode code, const char *fmt, ...) {
+	// following is allocated on stack
+	// add some marker
+	uint32_t tmp = 0xfaaaaa11;
 #if EFI_PROD_CODE
 	if (hasCriticalFirmwareErrorFlag)
 		return;
@@ -543,6 +546,9 @@ void firmwareError(ObdCode code, const char *fmt, ...) {
 		err->msg[sizeof(err->msg) - 1] = '\0';
 		strlncpy(err->msg, criticalErrorMessageBuffer, sizeof(err->msg));
 		err->Cookie = ErrorCookie::FirmwareError;
+		// copy stack last as it can be corrupted and cause another exeption
+		uint32_t *sp = &tmp;
+		errorHandlerSaveStack(err, sp);
 	}
 #endif // EFI_BACKUP_SRAM
 #else

--- a/firmware/controllers/core/error_handling.h
+++ b/firmware/controllers/core/error_handling.h
@@ -89,6 +89,9 @@ enum class ErrorCookie : uint32_t {
 const char *errorCookieToName(ErrorCookie cookie);
 
 // Error handling/recovery/reporting information
+
+#define ERROR_STACK_DEPTH   32
+
 typedef struct {
     ErrorCookie Cookie;
 
@@ -99,6 +102,8 @@ typedef struct {
     uint32_t FaultType;
     uint32_t FaultAddress;
     uint32_t Csfr;
+    uint32_t sp;
+    uint32_t stack[ERROR_STACK_DEPTH];
 } backupErrorState;
 
 // reads backup ram and checks for any error report

--- a/firmware/controllers/core/log_hard_fault.h
+++ b/firmware/controllers/core/log_hard_fault.h
@@ -9,7 +9,7 @@ extern "C"
 #if EFI_PROD_CODE
 #include <hal.h>
 
-void logHardFault(uint32_t type, uintptr_t faultAddress, port_extctx* ctx, uint32_t csfr);
+void logHardFault(uint32_t type, uintptr_t faultAddress, void* sp, port_extctx* ctx, uint32_t csfr);
 #endif // EFI_PROD_CODE
 
 #ifdef __cplusplus

--- a/firmware/hw_layer/main_hardfault.c
+++ b/firmware/hw_layer/main_hardfault.c
@@ -29,7 +29,7 @@ typedef enum  {
 	UsageFault = 6,
 } FaultType;
 
-void logHardFault(uint32_t type, uintptr_t faultAddress, struct port_extctx* ctx, uint32_t csfr);
+void logHardFault(uint32_t type, uintptr_t faultAddress, void* sp, struct port_extctx* ctx, uint32_t csfr);
 
 void HardFault_Handler_C(void* sp) {
 	//Copy to local variables (not pointers) to allow GDB "i loc" to directly show the info
@@ -56,7 +56,7 @@ void HardFault_Handler_C(void* sp) {
 	(void)isFaultOnStacking;
 	(void)isFaultAddressValid;
 
-	logHardFault(faultType, faultAddress, &ctx, SCB->CFSR >> SCB_CFSR_BUSFAULTSR_Pos);
+	logHardFault(faultType, faultAddress, sp, &ctx, SCB->CFSR >> SCB_CFSR_BUSFAULTSR_Pos);
 
 	// check if debugger is connected
 	if (CoreDebug->DHCSR & CoreDebug_DHCSR_C_DEBUGEN_Msk)
@@ -90,7 +90,7 @@ void UsageFault_Handler_C(void* sp) {
 	(void)isUnalignedAccessFault;
 	(void)isDivideByZeroFault;
 
-	logHardFault(faultType, 0, &ctx, SCB->CFSR);
+	logHardFault(faultType, 0, sp, &ctx, SCB->CFSR);
 
 	// check if debugger is connected
 	if (CoreDebug->DHCSR & CoreDebug_DHCSR_C_DEBUGEN_Msk)
@@ -125,7 +125,7 @@ void MemManage_Handler_C(void* sp) {
 	(void)isExceptionStackingFault;
 	(void)isFaultAddressValid;
 
-	logHardFault(faultType, faultAddress, &ctx, SCB->CFSR);
+	logHardFault(faultType, faultAddress, sp, &ctx, SCB->CFSR);
 
 	// check if debugger is connected
 	if (CoreDebug->DHCSR & CoreDebug_DHCSR_C_DEBUGEN_Msk)


### PR DESCRIPTION
**chibi_fault** command.
What programmer see:
```
chDbgPanic3 (msg=0x8089d60 "operator()", file=0x807bccc "ChibiOS/os/rt/src/chsys.c", line=201) at ./controllers/core/error_handling.cpp:343
343			bkpt();
...
(gdb) bt
#0  chDbgPanic3 (msg=0x8089d60 "operator()", file=0x807bccc "ChibiOS/os/rt/src/chsys.c", line=201) at ./controllers/core/error_handling.cpp:365
#1  0x08002cc8 in chSysHalt (reason=<optimized out>) at ChibiOS/os/rt/src/chsys.c:201
#2  0x0804a58c in operator() (__closure=0x0) at ./controllers/core/error_handling.cpp:114
#3  _FUN () at ./controllers/core/error_handling.cpp:114
#4  0x0803d770 in handleActionWithParameter (current=0x40024000, current@entry=0x20015af4 <consoleActions>, argv=0x8089d60, argv@entry=0x200081d4 <usbConsole+1356>, argc=argc@entry=0)
    at ./util/cli_registry.cpp:296
#5  0x0803da52 in handleConsoleLineInternal (commandLine=commandLine@entry=0x2001c38d <usbChannel+13> "chibi_fault") at ./util/cli_registry.cpp:497
#6  0x0803daa2 in handleConsoleLine (line=0x2001c38d <usbChannel+13> "chibi_fault") at ./util/cli_registry.cpp:519
#7  0x08033018 in TunerStudio::handleExecuteCommand (this=this@entry=0x20001704 <tsInstance>, tsChannel=tsChannel@entry=0x2001c380 <usbChannel>, data=data@entry=0x2001c38d <usbChannel+13> "chibi_fault", 
    incomingPacketSize=incomingPacketSize@entry=11) at ./console/binary/tunerstudio.cpp:683
#8  0x080359e0 in TunerStudio::handleCrcCommand (this=this@entry=0x20001704 <tsInstance>, tsChannel=tsChannel@entry=0x2001c380 <usbChannel>, data=0x2001c38d <usbChannel+13> "chibi_fault", 
    data@entry=0x2001c38c <usbChannel+12> "Echibi_fault", incomingPacketSize=incomingPacketSize@entry=12) at ./console/binary/tunerstudio.cpp:739
#9  0x08035ca4 in tsProcessOne (tsChannel=tsChannel@entry=0x2001c380 <usbChannel>) at ./console/binary/tunerstudio.cpp:609
#10 0x08073e3a in TunerstudioThread::ThreadTask (this=<optimized out>) at ./console/binary/tunerstudio.cpp:629
#11 0x08030c66 in ThreadController<1200>::main (this=<optimized out>) at ./controllers/system/thread_controller.h:33
#12 0x0806cfce in chibios_rt::_thd_start (arg=<optimized out>) at ChibiOS/os/various/cpp_wrappers/ch.cpp:41
#13 0x0800112a in _port_thread_start () at ChibiOS/os/common/ports/ARMCMx/compilers/GCC/chcoreasm_v7m.S:201
Backtrace stopped: previous frame identical to this frame (corrupt stack?)
```

Report file:
```
Reset Cause: Reset from NRST pin
Power cycle count: 11
Last error type ChibiOS panic
msg operator()
file ChibiOS/os/rt/src/chsys.c
line 201
SP 0x20008184
 0x20008184: 0xfffffa11
 0x20008180: 0x20015af4
 0x2000817c: 0x08002cc9
 0x20008178: 0x0804a585
 0x20008174: 0x0804a58d
 0x20008170: 0x0804a585
 0x2000816c: 0x0803d771
 0x20008168: 0x55555555
 0x20008164: 0x55555555
 0x20008160: 0x00000000
 0x2000815c: 0x200097b4
 0x20008158: 0x0000000d
 0x20008154: 0x00000081
 0x20008150: 0x20015a88
 0x2000814c: 0x00000000
 0x20008148: 0x00000000
 0x20008144: 0x2001c38d
 0x20008140: 0x20015af4
 0x2000813c: 0x0803da53
 0x20008138: 0x20015a88
 0x20008134: 0x55555555
 0x20008130: 0x55555555
 0x2000812c: 0x55555555
 0x20008128: 0x55555555
 0x20008124: 0x55555555
 0x20008120: 0x55555555
 0x2000811c: 0x0806175f
 0x20008118: 0x00000000
 0x20008114: 0x55555555
 0x20008110: 0x55555555
 0x2000810c: 0x0000000b
 0x20008108: 0x2001c38d
```