### PR TITLE
fix a bug: Now we use `README.template.txt` in `create_ini_image.sh` …

### DIFF
--- a/firmware/hw_layer/mass_storage/create_ini_image.sh
+++ b/firmware/hw_layer/mass_storage/create_ini_image.sh
@@ -44,7 +44,7 @@ WIKI_FILE_PATH=hw_layer/mass_storage/rusEFI\ ${SHORT_BOARD_NAME}\ Wiki.url
 
 cp hw_layer/mass_storage/filesystem_contents/rusEFI_Wiki_template.url "${WIKI_FILE_PATH}"
 echo "URL=${BOARD_SPECIFIC_URL}" >> "${WIKI_FILE_PATH}"
-cp hw_layer/mass_storage/filesystem_contents/README.nozip.template.txt "${README_FILE_PATH}"
+cp hw_layer/mass_storage/filesystem_contents/README.template.txt "${README_FILE_PATH}"
 echo ${BOARD_SPECIFIC_URL}       >> "${README_FILE_PATH}"
 
 

--- a/firmware/hw_layer/mass_storage/create_ini_image_compressed.sh
+++ b/firmware/hw_layer/mass_storage/create_ini_image_compressed.sh
@@ -40,7 +40,7 @@ WIKI_FILE_PATH=hw_layer/mass_storage/rusEFI\ ${SHORT_BOARD_NAME}\ Wiki.url
 
 cp hw_layer/mass_storage/filesystem_contents/rusEFI_Wiki_template.url "${WIKI_FILE_PATH}"
 echo "URL=${BOARD_SPECIFIC_URL}" >> "${WIKI_FILE_PATH}"
-cp hw_layer/mass_storage/filesystem_contents/README.template.txt "${README_FILE_PATH}"
+cp hw_layer/mass_storage/filesystem_contents/README.nozip.template.txt "${README_FILE_PATH}"
 echo ${BOARD_SPECIFIC_URL}       >> "${README_FILE_PATH}"
 
 if [[ -z "${EXTRA_FILES_TO_COPY_ON_IMAGE_FOLDER}" ]]; then


### PR DESCRIPTION
…script and `README.nozip.template.txt` in `create_ini_image_compressed.sh` script