### PR TITLE
stm32: adc v2: fix include order

### DIFF
--- a/firmware/hw_layer/ports/stm32/stm32_adc_v2.cpp
+++ b/firmware/hw_layer/ports/stm32/stm32_adc_v2.cpp
@@ -57,9 +57,9 @@ void portInitAdc() {
 	}
 #endif
 
-#ifdef KNOCK_ADC
+#ifdef EFI_SOFTWARE_KNOCK
 	adcStart(&KNOCK_ADC, nullptr);
-#endif // KNOCK_ADC
+#endif // EFI_SOFTWARE_KNOCK
 }
 
 /*

--- a/firmware/hw_layer/ports/stm32/stm32_adc_v2.cpp
+++ b/firmware/hw_layer/ports/stm32/stm32_adc_v2.cpp
@@ -8,6 +8,10 @@
 
 #include "pch.h"
 
+#ifdef EFI_SOFTWARE_KNOCK
+#include "knock_config.h"
+#endif
+
 #if HAL_USE_ADC
 
 /* Depth of the conversion buffer, channels are sampled X times each.*/
@@ -53,9 +57,9 @@ void portInitAdc() {
 	}
 #endif
 
-	#ifdef KNOCK_ADC
+#ifdef KNOCK_ADC
 	adcStart(&KNOCK_ADC, nullptr);
-	#endif // KNOCK_ADC
+#endif // KNOCK_ADC
 }
 
 /*
@@ -232,7 +236,6 @@ adcsample_t getFastAdc(AdcToken token) {
 #endif
 
 #ifdef EFI_SOFTWARE_KNOCK
-#include "knock_config.h"
 
 static void knockCompletionCallback(ADCDriver* adcp) {
 	if (adcp->state == ADC_COMPLETE) {


### PR DESCRIPTION
First include knock_config.h then use KNOCK_ADC define