### PR TITLE
error_handling: do not pass va_list to variable argument list function

### DIFF
--- a/firmware/controllers/core/error_handling.cpp
+++ b/firmware/controllers/core/error_handling.cpp
@@ -640,10 +640,7 @@ static void firmwareErrorV(ObdCode code, const char *fmt, va_list ap) {
 	// large buffer on stack is risky we better use normal memory
 	static char errorBuffer[200];
 
-	va_list ap;
-	va_start(ap, fmt);
 	vsnprintf(errorBuffer, sizeof(errorBuffer), fmt, ap);
-	va_end(ap);
 
 	printf("\x1B[31m>>>>>>>>>> firmwareError [%s]\r\n\x1B[0m\r\n", errorBuffer);
 

--- a/firmware/controllers/core/error_handling.h
+++ b/firmware/controllers/core/error_handling.h
@@ -34,7 +34,7 @@ using critical_msg_t = char[CRITICAL_BUFFER_SIZE];
  */
 void firmwareError(ObdCode code, const char *fmt, ...);
 
-void criticalError(const char *fmt, ...);
+#define criticalError(...) firmwareError(ObdCode::OBD_PCM_Processor_Fault, __VA_ARGS__)
 
 extern bool hasCriticalFirmwareErrorFlag;
 

--- a/firmware/controllers/core/error_handling_c.h
+++ b/firmware/controllers/core/error_handling_c.h
@@ -8,9 +8,7 @@ extern "C"
 {
 #endif /* __cplusplus */
 
-void criticalErrorM(const char *msg);
-
-void criticalError(const char *fmt, ...);
+void criticalErrorC(const char *fmt, ...);
 
 #ifdef __cplusplus
 }

--- a/firmware/hw_layer/ports/rusefi_halconf.h
+++ b/firmware/hw_layer/ports/rusefi_halconf.h
@@ -215,7 +215,7 @@
   { int limit = 1000000 ;                  \
     while (condition) {                    \
       if (limit-- == 0) {                  \
-        criticalError(__VA_ARGS__);        \
+        criticalErrorC(__VA_ARGS__);       \
         break;                             \
       }                                    \
     }                                      \


### PR DESCRIPTION
There is not way to pass '...' argument to another function. We need to switch to va_list first

Fixes bug introduced in 36ee662a34649f5ce94341b6ca9c9937cfb752e7

This should fix incorrect serialization of arguments. Like this:
 
![Screenshot from 2025-02-05 19-05-54](https://github.com/user-attachments/assets/24950e47-a849-4621-9084-eade216603cd)
