### PR TITLE
Make trailing spark angle a 3D table #5248

### DIFF
--- a/firmware/controllers/algo/defaults/default_ignition.cpp
+++ b/firmware/controllers/algo/defaults/default_ignition.cpp
@@ -30,6 +30,16 @@ static void setDefaultIatTimingCorrection() {
 	copyArray(config->ignitionIatCorrTable[2], {0, 0, 0, 0, 0, 0, -1, -2});
 }
 
+static void setDefaultTrailingSparkTable() {
+	copyArray(config->trailingSparkLoadBins, {20,60,100,150});
+    copyArray(config->trailingSparkRpmBins, {1000,3000,5000,7000});
+
+	for (size_t i = 0; i < TRAILING_SPARK_SIZE; i++) {
+		copyArray(config->trailingSparkTable[i], {7,9,10,12});
+	}
+
+}
+
 static float getAdvanceForRpm(float rpm, float advanceMax) {
 	if (rpm >= 3000) {
 		return advanceMax;
@@ -97,7 +107,7 @@ void setDefaultIgnition() {
 	setTimingRpmBin(800, 7000);
 	buildTimingMap(35);
 
-	engineConfiguration->trailingSparkAngle = 10;
+	setDefaultTrailingSparkTable();
 
 	// CLT correction
 	setLinearCurve(config->cltTimingBins, CLT_CURVE_RANGE_FROM, 120, 1);

--- a/firmware/controllers/algo/engine2.cpp
+++ b/firmware/controllers/algo/engine2.cpp
@@ -210,8 +210,7 @@ void EngineState::periodicFastCallback() {
 
 	shouldUpdateInjectionTiming = getInjectorDutyCycle(rpm) < 90;
 
-	// TODO: calculate me from a table!
-	trailingSparkAngle = engineConfiguration->trailingSparkAngle;
+	engine->ignitionState.trailingSparkAngle = engine->ignitionState.getTrailingSparkAngle(rpm, l_ignitionLoad);
 
 	multispark.count = getMultiSparkCount(rpm);
 

--- a/firmware/controllers/algo/ignition/ignition_state.cpp
+++ b/firmware/controllers/algo/ignition/ignition_state.cpp
@@ -330,4 +330,16 @@ floatms_t IgnitionState::getDwell() const {
 	return sparkDwell;
 }
 
+  angle_t IgnitionState::getTrailingSparkAngle(const float rpm, const float engineLoad){
+	if (std::isnan(engineLoad)) {
+		// default value from: https://github.com/rusefi/rusefi/commit/86683afca22ed1a8af8fd5ac9231442e2124646e#diff-6e80cdd8c55add68105618ad9e8954170a47f59814201dadd2b888509d6b2e39R176
+		return 10;
+	}
+	return interpolate3d(
+			config->trailingSparkTable,
+			config->trailingSparkLoadBins, engineLoad,
+			config->trailingSparkRpmBins, rpm
+	);
+}
+
 #endif // EFI_ENGINE_CONTROL

--- a/firmware/controllers/algo/ignition/ignition_state.h
+++ b/firmware/controllers/algo/ignition/ignition_state.h
@@ -9,6 +9,7 @@ public:
 
   floatms_t getDwell() const;
   angle_t getWrappedAdvance(const float rpm, const float engineLoad);
+  angle_t getTrailingSparkAngle(const float rpm, const float engineLoad);
 private:
   angle_t getAdvance(float rpm, float engineLoad);
 	floatms_t getSparkDwell(float rpm, bool isCranking);

--- a/firmware/controllers/algo/ignition/ignition_state.txt
+++ b/firmware/controllers/algo/ignition/ignition_state.txt
@@ -22,5 +22,7 @@ float dwellVoltageCorrection;Ign: Dwell voltage correction
     float luaTimingMult;Ign: Lua timing mult;"deg",1, 0, -20, 20, 2, @@GAUGE_CATEGORY_TIMING@@
 bit luaIgnitionSkip;Ign: Lua Spark Skip
 
+    int16_t autoscale trailingSparkAngle;Ign: Trailing spark deg;"deg",{1/@@PACK_MULT_PERCENT@@},0, -20,20, 2,@@GAUGE_CATEGORY_TIMING@@
+
 end_struct
 

--- a/firmware/controllers/engine_cycle/spark_logic.cpp
+++ b/firmware/controllers/engine_cycle/spark_logic.cpp
@@ -252,7 +252,7 @@ void fireSparkAndPrepareNextSchedule(IgnitionEvent *event) {
 
 			// Trailing sparks are enabled - schedule an event for the corresponding trailing coil
 			scheduleByAngle(
-				&event->trailingSparkFire, nowNt, engine->engineState.trailingSparkAngle,
+				&event->trailingSparkFire, nowNt, engine->ignitionState.trailingSparkAngle,
 				{ &fireTrailingSpark, &enginePins.trailingCoils[event->coilIndex] }
 			);
 		}
@@ -345,7 +345,7 @@ void turnSparkPinHighStartCharging(IgnitionEvent *event) {
 		IgnitionOutputPin *output = &enginePins.trailingCoils[event->coilIndex];
 		// Trailing sparks are enabled - schedule an event for the corresponding trailing coil
 		scheduleByAngle(
-			&event->trailingSparkCharge, nowNt, engine->engineState.trailingSparkAngle,
+			&event->trailingSparkCharge, nowNt, engine->ignitionState.trailingSparkAngle,
 			{ &chargeTrailingSpark, output }
 		);
 	}

--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -103,7 +103,7 @@
 ! Any time an incompatible change is made to the configuration format stored in flash,
 ! update this string to the current date! It is required to also update TS_SIGNATURE above
 ! when this happens.
-#define FLASH_DATA_VERSION 2501
+#define FLASH_DATA_VERSION 250206
 
 ! this offset is part of console compatibility mechanism, please DO NOT change this offset
 #define TS_FILE_VERSION_OFFSET 124
@@ -161,6 +161,7 @@ struct_no_prefix engine_configuration_s
 #define CRANKING_CYCLE_CLT_SIZE 4
 #define IDLE_ADVANCE_CURVE_SIZE 8
 #define CRANKING_ADVANCE_CURVE_SIZE 4
+#define TRAILING_SPARK_SIZE 4
 
 #define ENGINE_NOISE_CURVE_SIZE 16
 #define CLT_TIMING_CURVE_SIZE 8
@@ -649,7 +650,7 @@ adc_channel_e fuelLevelSensor;This is the processor pin that your fuel level sen
 
 
 	float idle_derivativeFilterLoss;0.1 is a good default value;"x", 1, 0, -1000000, 1000000, 4
-	int trailingSparkAngle;just a temporary solution;"angle", 1, 0, 0, 720, 0
+	int unusedTrailingSparkAngle
 
 struct trigger_config_s
 
@@ -2187,6 +2188,10 @@ int16_t dynoCarCarMassKg;
 int16_t dynoCarCargoMassKg;
 float   dynoCarCoeffOfDrag;
 float   dynoCarFrontalAreaM2;
+
+int8_t[TRAILING_SPARK_SIZE x TRAILING_SPARK_SIZE] autoscale trailingSparkTable;;"deg", 0.1, 0, 0, 20, 1
+uint8_t[TRAILING_SPARK_SIZE] autoscale trailingSparkRpmBins;;"rpm", 50, 0, 0, 12000, 0
+uint8_t[TRAILING_SPARK_SIZE] autoscale trailingSparkLoadBins;;"Load", 5, 0, 0,  @@MAP_UPPER_LIMIT@@, 0
 
 @@BOARD_CONFIG_FROM_FILE@@
 

--- a/firmware/tunerstudio/tunerstudio.template.ini
+++ b/firmware/tunerstudio/tunerstudio.template.ini
@@ -1193,6 +1193,12 @@ curve = rangeMatrix, "Range Switch Input Matrix"
 		gridOrient  = 250,	0, 340 ; Space 123 rotation of grid in degrees.
 		upDownLabel = "(RICHER)", "(LEANER)"
 
+	table = trailingSparkTable, trailingSparkMap, "Trailing spark", 1
+		xyLabels = "RPM", "Ignition Load"
+		xBins		= trailingSparkRpmBins,  RPMValue
+		yBins		= trailingSparkLoadBins,  ignitionLoad
+		zBins		= trailingSparkTable
+
 	table = torqueTableTbl, torqueTableMap, "Engine Torque", 1
 		xBins		= torqueRpmBins, RPMValue
 		yBins		= torqueLoadBins, veTableYAxis
@@ -5211,11 +5217,11 @@ dialog = tcuControls, "Transmission Settings"
 
 	dialog = rotaryDialog, "Rotary"
 		field = "Enable Trailing Sparks", enableTrailingSparks
-		field = "Trailing Spark Offset", trailingSparkAngle
 		field = "Trailing Pin 1",						trailingCoilPins1
 		field = "Trailing Pin 2",						trailingCoilPins2
 		field = "Trailing Pin 3",						trailingCoilPins3
 		field = "Trailing Pin 4",						trailingCoilPins4
+		panel = trailingSparkTable
 
 		@@BOARD_OPTIONS_FROM_FILE@@
 


### PR DESCRIPTION
* added a new table "trailingSparkAngle"
* removed trailingSparkAngle as config on rusefi.txt
* added trailingSparkAngle as variable on ignition state
* bump FLASH_DATA_VERSION

![image](https://github.com/user-attachments/assets/b4e5c2b5-7c38-4912-a91e-52bb087a1698)

needs test/review from @ElDominio 

resolve: #5248 