### PR TITLE
Activate 'debug freeze' watchdog feature for debug builds https://github.com/rusefi/rusefi/issues/1339

### DIFF
--- a/firmware/hw_layer/ports/stm32/stm32_common.cpp
+++ b/firmware/hw_layer/ports/stm32/stm32_common.cpp
@@ -116,6 +116,17 @@ void startWatchdog(int timeoutMs) {
 	wdgcfg.winr = 0xfff; // don't use window
 #endif
 
+#ifndef __OPTIMIZE__ // gcc-specific built-in define
+	// if no optimizations, then it's most likely a debug version,
+	// and we need to enable a special watchdog feature to allow debugging
+	efiPrintf("Enabling 'debug freeze' watchdog feature...");
+#ifdef STM32H7XX
+    DBGMCU->APB4FZ1 |= DBGMCU_APB4FZ1_DBG_IWDG1;
+#else // F4 & F7
+	DBGMCU->APB1FZ |= DBGMCU_APB1_FZ_DBG_IWDG_STOP;
+#endif // STM32H7XX
+#endif // __OPTIMIZE__
+
     static bool isStarted = false;
     if (!isStarted) {
 		efiPrintf("Starting watchdog with timeout %d ms...", timeoutMs);


### PR DESCRIPTION
Tested on Nucleo-F767 and STM32CubeIDE debug session.