### PR TITLE
tunerstudio.template: no knockBandCustom

### DIFF
--- a/firmware/tunerstudio/tunerstudio.template.ini
+++ b/firmware/tunerstudio/tunerstudio.template.ini
@@ -4106,7 +4106,6 @@ cmd_set_engine_type_default					= "@@TS_IO_TEST_COMMAND_char@@@@ts_command_e_TS_
 
 	dialog = hipCurve, "Knock sensing"
 		field = "Cylinder bore",						cylinderBore
-		field = "Band Freq override",					knockBandCustom
 		field = "knockDetectionWindowStart",			knockDetectionWindowStart
 		field = "knockSamplingDuration",				knockSamplingDuration
 		panel = knockThresholdCurve


### PR DESCRIPTION
Was accidentally added back due to bad rebase