### PR TITLE
etb: dead etbIntegralError

### DIFF
--- a/firmware/controllers/actuators/electronic_throttle.txt
+++ b/firmware/controllers/actuators/electronic_throttle.txt
@@ -11,7 +11,6 @@ struct_no_prefix electronic_throttle_s
 	custom percent_t 4 scalar, F32, @OFFSET@, "", 1, 0, 0, 100, 2
 
 	percent_t etbFeedForward
-	float etbIntegralError;;"", 1, 0, -10000, 10000, 3
 	float etbCurrentTarget;ETB: target for current pedal;"%", 1, 0, -10000, 10000, 3
 	int16_t autoscale m_adjustedTarget;Adjusted target;"%", 0.01, 0, -100, 100, 2
 


### PR DESCRIPTION
Dead since 3ee894594d405ceac8a98ea5838c3d11c94e9c1d