### PR TITLE
SD in MSD: Speed up a bit

### DIFF
--- a/firmware/hw_layer/mass_storage/mass_storage_device.cpp
+++ b/firmware/hw_layer/mass_storage/mass_storage_device.cpp
@@ -161,7 +161,7 @@ static const scsi_unit_serial_number_inquiry_response_t default_scsi_unit_serial
 };
 
 void MassStorageController::attachLun(uint8_t lunIndex,
-						BaseBlockDevice *blkdev, uint8_t *blkbuf,
+						BaseBlockDevice *blkdev, uint8_t *blkbuf, size_t blkbufsize,
 						const scsi_inquiry_response_t *inquiry,
 						const scsi_unit_serial_number_inquiry_response_t *serialInquiry) {
 	chibios_rt::MutexLocker lock(m_lunMutex);
@@ -182,6 +182,7 @@ void MassStorageController::attachLun(uint8_t lunIndex,
 		lun.config.unit_serial_number_inquiry_response = serialInquiry;
 	}
 	lun.config.blkbuf = blkbuf;
+	lun.config.blkbufsize = blkbufsize;
 	lun.config.blkdev = blkdev;
 	lun.config.transport = &m_scsiTransport;
 

--- a/firmware/hw_layer/mass_storage/mass_storage_device.h
+++ b/firmware/hw_layer/mass_storage/mass_storage_device.h
@@ -16,7 +16,7 @@ class MassStorageController : public ThreadController<USB_MSD_THREAD_WA_SIZE> {
 public:
 	MassStorageController(USBDriver* usb);
 
-	void attachLun(uint8_t lunIndex, BaseBlockDevice *blkdev, uint8_t *blkbuf,
+	void attachLun(uint8_t lunIndex, BaseBlockDevice *blkdev, uint8_t *blkbuf, size_t blkbufsize,
 					const scsi_inquiry_response_t *inquiry,
 					const scsi_unit_serial_number_inquiry_response_t *serialInquiry);
 protected:

--- a/firmware/hw_layer/mass_storage/mass_storage_init.cpp
+++ b/firmware/hw_layer/mass_storage/mass_storage_init.cpp
@@ -43,7 +43,8 @@
 
 // One block buffer per LUN
 static NO_CACHE uint8_t blkbuf0[MMCSD_BLOCK_SIZE];
-static NO_CACHE uint8_t blkbuf1[MMCSD_BLOCK_SIZE];
+// Speed-up SD card
+static NO_CACHE uint8_t blkbuf1[4 * MMCSD_BLOCK_SIZE];
 
 static MassStorageController msd(usb_driver);
 
@@ -76,7 +77,7 @@ static const scsi_inquiry_response_t sdCardInquiry = {
 };
 
 void attachMsdSdCard(BaseBlockDevice* blkdev) {
-	msd.attachLun(1, blkdev, blkbuf1, &sdCardInquiry, nullptr);
+	msd.attachLun(1, blkdev, blkbuf1, sizeof(blkbuf1), &sdCardInquiry, nullptr);
 
 #if EFI_TUNER_STUDIO
 	// SD MSD attached, enable indicator in TS
@@ -85,7 +86,7 @@ void attachMsdSdCard(BaseBlockDevice* blkdev) {
 }
 
 void deattachMsdSdCard(void) {
-	msd.attachLun(1, (BaseBlockDevice*)&ND1, blkbuf1, &sdCardInquiry, nullptr);
+	msd.attachLun(1, (BaseBlockDevice*)&ND1, blkbuf1, sizeof(blkbuf1), &sdCardInquiry, nullptr);
 
 #if EFI_TUNER_STUDIO
 	// SD MSD attached, enable indicator in TS
@@ -123,10 +124,10 @@ static BaseBlockDevice* getRamdiskDevice() {
 
 void initUsbMsd() {
 	// Attach the ini ramdisk
-	msd.attachLun(0, getRamdiskDevice(), blkbuf0, &iniDriveInquiry, nullptr);
+	msd.attachLun(0, getRamdiskDevice(), blkbuf0, sizeof(blkbuf0), &iniDriveInquiry, nullptr);
 
 	// attach a null device in place of the SD card for now - the SD thread may replace it later
-	msd.attachLun(1, (BaseBlockDevice*)&ND1, blkbuf1, &sdCardInquiry, nullptr);
+	msd.attachLun(1, (BaseBlockDevice*)&ND1, blkbuf1, sizeof(blkbuf1), &sdCardInquiry, nullptr);
 
 	// start the mass storage thread
 	msd.start();

--- a/firmware/hw_layer/mass_storage/mass_storage_init.h
+++ b/firmware/hw_layer/mass_storage/mass_storage_init.h
@@ -4,6 +4,6 @@
 
 #if HAL_USE_USB_MSD
 void initUsbMsd();
-void attachMsdSdCard(BaseBlockDevice* blkdev);
+void attachMsdSdCard(BaseBlockDevice* blkdev, uint8_t *blkbuf, size_t blkbufsize);
 void deattachMsdSdCard(void);
 #endif

--- a/firmware/hw_layer/mmc_card.cpp
+++ b/firmware/hw_layer/mmc_card.cpp
@@ -82,7 +82,7 @@ struct SdLogBufferWriter final : public BufferedWriter<512> {
 		}
 
 		size_t bytesWritten;
-    efiAssert(ObdCode::CUSTOM_STACK_6627, hasLotsOfRemainingStack(), "sdlow#3", 0);
+		efiAssert(ObdCode::CUSTOM_STACK_6627, hasLotsOfRemainingStack(), "sdlow#3", 0);
 		FRESULT err = f_write(m_fd, buffer, count, &bytesWritten);
 
 		if (err) {


### PR DESCRIPTION
Read using UAEFI before this patch:
```
$ dd if=test.bin of=/dev/zero status=progress
133939712 bytes (134 MB, 128 MiB) copied, 269 s, 498 kB/s
262144+0 records in
262144+0 records out
134217728 bytes (134 MB, 128 MiB) copied, 269.492 s, 498 kB/s
```

Read using UAEFI with blkbuf1 = 2K bytes:
```
$ dd if=B5A4-271B/test.bin of=/dev/zero status=progress
133677568 bytes (134 MB, 127 MiB) copied, 202 s, 661 kB/s
262144+0 records in
262144+0 records out
134217728 bytes (134 MB, 128 MiB) copied, 202.69 s, 662 kB/s
```