### PR TITLE
let's remove "overrideCrankingIacSetting" "Override cranking IAC CLT …

### DIFF
--- a/firmware/controllers/actuators/idle_thread.cpp
+++ b/firmware/controllers/actuators/idle_thread.cpp
@@ -91,11 +91,7 @@ float IdleController::getCrankingTaperFraction() const {
 
 float IdleController::getCrankingOpenLoop(float clt) const {
 	float mult =
-		engineConfiguration->overrideCrankingIacSetting
-		// Override to separate table
-	 	? interpolate2d(clt, config->cltCrankingCorrBins, config->cltCrankingCorr)
-		// Otherwise use plain running table
-		: interpolate2d(clt, config->cltIdleCorrBins, config->cltIdleCorr);
+		interpolate2d(clt, config->cltCrankingCorrBins, config->cltCrankingCorr);
 
 	return engineConfiguration->crankingIACposition * mult;
 }

--- a/unit_tests/tests/test_idle_controller.cpp
+++ b/unit_tests/tests/test_idle_controller.cpp
@@ -122,11 +122,6 @@ TEST(idle_v2, crankingOpenLoop) {
 		config->cltIdleCorr[i] = i * 0.2f;
 	}
 
-	// First test without override (ie, normal running CLT corr table)
-	EXPECT_FLOAT_EQ(10, dut.getCrankingOpenLoop(10));
-	EXPECT_FLOAT_EQ(50, dut.getCrankingOpenLoop(50));
-
-	// Test with override (use separate table)
 	engineConfiguration->overrideCrankingIacSetting = true;
 	EXPECT_FLOAT_EQ(5, dut.getCrankingOpenLoop(10));
 	EXPECT_FLOAT_EQ(25, dut.getCrankingOpenLoop(50));


### PR DESCRIPTION
…multiplier" flexibility and always use additional table #7482