### PR TITLE
Expose SensorType::FuelPressureInjector on TS

### DIFF
--- a/firmware/controllers/algo/fuel/injector_model.txt
+++ b/firmware/controllers/algo/fuel/injector_model.txt
@@ -3,5 +3,6 @@ float m_deadtime;@@GAUGE_NAME_INJECTOR_LAG@@;"ms",1, 0, 0, 0, 3
 
 float pressureDelta;Fuel: Injector pressure delta;"kPa", 1, 0, -1000, 1000, 1
 float pressureRatio;Fuel: Injector pressure ratio;"", 1, 0, 0, 100, 3
+float pressureCorrectionReference;@@GAUGE_NAME_FUEL_CORRECTION_REFERENCE_PRESSURE@@;"kPa", 1, 0, 0, 1000, 1
 
 end_struct

--- a/firmware/integration/rusefi_config_shared.txt
+++ b/firmware/integration/rusefi_config_shared.txt
@@ -177,6 +177,7 @@
 #define GAUGE_NAME_FUEL_LOAD "Fuel: Load"
 #define GAUGE_NAME_FUEL_CONSUMPTION "Fuel: Total consumed"
 #define GAUGE_NAME_FUEL_FLOW "Fuel: Flow rate"
+#define GAUGE_NAME_FUEL_CORRECTION_REFERENCE_PRESSURE "Fuel: corr reference pressure"
 
 #define GAUGE_NAME_FUEL_INJ_DUTY "Fuel: injector duty cycle"
 #define GAUGE_NAME_FUEL_INJ_DUTY_STAGE_2 "Fuel: injector duty cycle stage 2"

--- a/firmware/tunerstudio/tunerstudio.template.ini
+++ b/firmware/tunerstudio/tunerstudio.template.ini
@@ -1702,6 +1702,7 @@ gaugeCategory = Fueling
 	fuelFlowRateGauge = fuelFlowRate, @@GAUGE_NAME_FUEL_FLOW@@, "g/s", 0, 50, 0, 0, 50, 50, 2, 0
 	targetLambdaGauge = targetLambda,"fuel: target lambda", "",		10,	19.4,		12,	13,		15,	16,	2,	2
 	currentTargetAfrGauge = targetAFR,"fuel: target AFR", "",		0.65,	1.2,		0.7,	0.75,		1.1,	1.15,	3,	2
+	fuelPressureCorrectionReferenceGauge  = pressureCorrectionReference,	@@GAUGE_NAME_FUEL_CORRECTION_REFERENCE_PRESSURE@@, "kPa", 0, 1000, 0, 0, 1000, 1000, 0, 0
 
 gaugeCategory = Throttle Body (incl. ETB)
 	pedalPositionGauge = throttlePedalPosition, @@GAUGE_NAME_THROTTLE_PEDAL@@,		"%",	-20,	120,		-10,	-5,	105,	110,	1,	1


### PR DESCRIPTION

added the sensor as "pressureCorrectionReference" inside "injector_model_s" struct for future use inside the deadtime curve to table change (https://github.com/orgs/rusefi/projects/37/views/1?pane=issue&itemId=99441931)

For now the value is not updated at any time, the proposed change for it is the following, but I have doubts if it is the ideal place, so I do not include it in the PR

```c++
float InjectorModelWithConfig::getDeadtime() {
    switch (getInjectorCompensationMode()) {
        case ICM_FixedRailPressure:
            pressureCorrectionReference = getFuelReferencePressure();

        case ICM_SensedRailPressure: {
            auto fps = Sensor::get(SensorType::FuelPressureInjector);
        
            if (!fps) {
                pressureCorrectionReference = getFuelReferencePressure();
            } else {
                pressureCorrectionReference = fps.Value;
            }
        }
    }

    return interpolate2d(
        Sensor::get(SensorType::BatteryVoltage).value_or(VBAT_FALLBACK_VALUE),
        m_cfg->battLagCorrBins,
        m_cfg->battLagCorr
    );
}
```

note:
in the 4 possible cases (without sensor and the 3 sensor variants), the raw value is used without adding the atmospheric pressure as is done for example in `InjectorModelWithConfig::getFuelDifferentialPressure()`