### PR TITLE
Y label for AFR blends

### DIFF
--- a/firmware/tunerstudio/tunerstudio.template.ini
+++ b/firmware/tunerstudio/tunerstudio.template.ini
@@ -1146,16 +1146,16 @@ curve = rangeMatrix, "Range Switch Input Matrix"
 		gridOrient  = 250, 0, 340
 
 	table = targetAfrBlend1Table, targetAfrBlend1Map, "Target AFR adder 1", 1
-		xyLabels = "RPM", "TPS"
+		xyLabels = "RPM", "Fueling Load"
 		xBins		= targetAfrBlends1_rpmBins, RPMValue
-		yBins		= targetAfrBlends1_loadBins, TPSValue
+		yBins		= targetAfrBlends1_loadBins, fuelingLoad
 		zBins		= targetAfrBlends1_table
 		gridOrient	= 250, 0, 340
 
 	table = targetAfrBlend2Table, targetAfrBlend2Map, "Target AFR adder 2", 1
-		xyLabels = "RPM", "TPS"
+		xyLabels = "RPM", "Fueling Load"
 		xBins		= targetAfrBlends2_rpmBins, RPMValue
-		yBins		= targetAfrBlends2_loadBins, TPSValue
+		yBins		= targetAfrBlends2_loadBins, fuelingLoad
 		zBins		= targetAfrBlends2_table
 		gridOrient	= 250, 0, 340
 


### PR DESCRIPTION
at `firmware/controllers/algo/fuel/fuel_computer.cpp`
We are already using fuelingLoad as a parameter, so it's just a phrasing change in TS

```cpp
float FuelComputer::getTargetLambda(float rpm, float load) const {
	float target = interpolate3d(
		config->lambdaTable,
		config->lambdaLoadBins, load,
		config->lambdaRpmBins, rpm
	);

	// Add any blends if configured
	for (size_t i = 0; i < efi::size(config->targetAfrBlends); i++) {
		auto result = calculateBlend(config->targetAfrBlends[i], rpm, load);

		engine->outputChannels.targetAfrBlendParameter[i] = result.BlendParameter;
		engine->outputChannels.targetAfrBlendBias[i] = result.Bias;
		engine->outputChannels.targetAfrBlendOutput[i] = result.Value;

		target += result.Value;
	}

    return target;
}
```

related issue: #7170

TS Change:

prev:
![image](https://github.com/user-attachments/assets/211614c2-bbbf-403d-880a-2be55df2d7c9)


now:
![image](https://github.com/user-attachments/assets/9a152c53-5dfb-4c75-8d11-ce341f4d5186)
