### PR TITLE
second units for injector flow #7502

### DIFF
--- a/firmware/tunerstudio/tunerstudio.template.ini
+++ b/firmware/tunerstudio/tunerstudio.template.ini
@@ -35,6 +35,9 @@ enable2ndByteCanID = false
 ;  settingGroup = connectivityProfile, "Protocol Profile"
 ;    settingOption = CONN_SLOW, "Slower / Wireless"
 ;    settingOption = CONN_FAST, "High Speed / USB"
+	settingGroup = fuel_flow_units, "Fuel flow unit"
+	settingOption = fuel_flow_unit_default, "g/s (grams per second)"
+	settingOption = fuel_flow_unit_pound, "lb/h (pound per hour)"
 
 [MegaTune]
  ; https://rusefi.com/forum/viewtopic.php?p=36201#p36201
@@ -216,6 +219,8 @@ enable2ndByteCanID = false
 	egoCorrectionForVeAnalyze = { 100 + fuelPidCorrection1 }
 
 	wbo0_hasFault = { enableAemXSeries && ((wb1faultCode >= 3) && (wb1faultCode != 7)) }
+
+	fuelFlowRateLbh = { fuelFlowRate / 7.56 }
 
 [PcVariables]
 	fuelUnits = bits, U08, [0:2], "kPa", "MAF", "%TPS", "Lua"
@@ -1697,10 +1702,14 @@ gaugeCategory = Fueling
 	fuelPidCorrectionGauge2= fuelPidCorrection2,		@@GAUGE_NAME_FUEL_TRIM_2@@,		"%",		-10,	10,	-8, -5, 5, 8,	3, 1
 	fuelingLoadGauge = fuelingLoad, @@GAUGE_NAME_FUEL_LOAD@@, "%", 0, 300, 0, 0, 300, 300, 1, 1
 	totalFuelConsumptionGauge = totalFuelConsumption, @@GAUGE_NAME_FUEL_CONSUMPTION@@, "g", 0, 10000, 0, 0, 10000, 10000, 0, 0
-	fuelFlowRateGauge = fuelFlowRate, @@GAUGE_NAME_FUEL_FLOW@@, "g/s", 0, 50, 0, 0, 50, 50, 2, 0
 	targetLambdaGauge = targetLambda,"fuel: target lambda", "",		10,	19.4,		12,	13,		15,	16,	2,	2
 	currentTargetAfrGauge = targetAFR,"fuel: target AFR", "",		0.65,	1.2,		0.7,	0.75,		1.1,	1.15,	3,	2
 	fuelPressureCorrectionReferenceGauge  = pressureCorrectionReference,	@@GAUGE_NAME_FUEL_CORRECTION_REFERENCE_PRESSURE@@, "kPa", 0, 1000, 0, 0, 1000, 1000, 0, 0
+
+	#if fuel_flow_unit_default
+		fuelFlowRateGauge = fuelFlowRate, @@GAUGE_NAME_FUEL_FLOW@@, "g/s", 0, 50, 0, 0, 50, 50, 2, 0
+	#elif fuel_flow_unit_pound
+		fuelFlowRateGauge = fuelFlowRateLbh, @@GAUGE_NAME_FUEL_FLOW@@, "lb/h", 0, 100, 0, 0, 100, 100, 2, 0
 
 gaugeCategory = Throttle Body (incl. ETB)
 	pedalPositionGauge = throttlePedalPosition, @@GAUGE_NAME_THROTTLE_PEDAL@@,		"%",	-20,	120,		-10,	-5,	105,	110,	1,	1


### PR DESCRIPTION
added pound per hour as unit, keeping gram/sec as default

![image](https://github.com/user-attachments/assets/0cc18fab-7795-4a71-b80d-4bc6f0d545d2)
![image](https://github.com/user-attachments/assets/b41cb3f3-3b9b-4ffe-bd7b-367c9f407b6e)
