### PR TITLE
ramp target as you enter idle

### DIFF
--- a/firmware/controllers/actuators/idle_thread.cpp
+++ b/firmware/controllers/actuators/idle_thread.cpp
@@ -40,12 +40,15 @@ IIdleController::TargetInfo IdleController::getTargetRpm(float clt) {
  	float exitRpm = target + 1.5 * rpmUpperLimit;
  
  	// Ramp the target down from the transition RPM to normal over a few seconds
- 	float timeSinceIdleEntry = m_timeInIdlePhase.getElapsedSeconds();
- 	target += interpolateClampedWithValidation(
- 		0, rpmUpperLimit,
- 		3, 0,
- 		timeSinceIdleEntry
- 	);
+  if (engineConfiguration->idleReturnTargetRamp) {
+ 		// Ramp the target down from the transition RPM to normal over a few seconds
+ 		float timeSinceIdleEntry = m_timeInIdlePhase.getElapsedSeconds();
+ 		target += interpolateClamped(
+ 			0, rpmUpperLimit,
+ 			3, 0,
+ 			timeSinceIdleEntry
+ 		);
+ 	}
 
  	idleTarget = target;
  	return { target, entryRpm, exitRpm };

--- a/firmware/controllers/actuators/idle_thread.cpp
+++ b/firmware/controllers/actuators/idle_thread.cpp
@@ -33,8 +33,17 @@ IIdleController::TargetInfo IdleController::getTargetRpm(float clt) {
 	targetRpmAc = engine->module<AcController>().unmock().acButtonState ? engineConfiguration->acIdleRpmTarget : 0;
 
 	float target = (targetRpmByClt < targetRpmAc) ? targetRpmAc : targetRpmByClt;
- 	float entryRpm = target + engineConfiguration->idlePidRpmUpperLimit;
+	float rpmUpperLimit = engineConfiguration->idlePidRpmUpperLimit;
+ 	float entryRpm = target + rpmUpperLimit;
  
+ 	// Ramp the target down from the transition RPM to normal over a few seconds
+ 	float timeSinceIdleEntry = m_timeInIdlePhase.getElapsedSeconds();
+ 	target += interpolateClampedWithValidation(
+ 		0, rpmUpperLimit,
+ 		3, 0,
+ 		timeSinceIdleEntry
+ 	);
+
  	idleTarget = target;
  	return { target, entryRpm };
 }
@@ -334,6 +343,12 @@ float IdleController::getIdlePosition(float rpm) {
 		// Determine what operation phase we're in - idling or not
 		float vehicleSpeed = Sensor::getOrZero(SensorType::VehicleSpeed);
 		auto phase = determinePhase(rpm, targetRpm, tps, vehicleSpeed, crankingTaper);
+
+    if (phase != m_lastPhase && phase == Phase::Idling) {
+        // Just entered idle, reset timer
+ 		    m_timeInIdlePhase.reset();
+ 	  }
+
 		m_lastPhase = phase;
 
 		finishIdleTestIfNeeded();

--- a/firmware/controllers/actuators/idle_thread.cpp
+++ b/firmware/controllers/actuators/idle_thread.cpp
@@ -35,6 +35,9 @@ IIdleController::TargetInfo IdleController::getTargetRpm(float clt) {
 	float target = (targetRpmByClt < targetRpmAc) ? targetRpmAc : targetRpmByClt;
 	float rpmUpperLimit = engineConfiguration->idlePidRpmUpperLimit;
  	float entryRpm = target + rpmUpperLimit;
+  
+  // Higher exit than entry to add some hysteresis to avoid bouncing around upper threshold
+ 	float exitRpm = target + 1.5 * rpmUpperLimit;
  
  	// Ramp the target down from the transition RPM to normal over a few seconds
  	float timeSinceIdleEntry = m_timeInIdlePhase.getElapsedSeconds();
@@ -45,7 +48,7 @@ IIdleController::TargetInfo IdleController::getTargetRpm(float clt) {
  	);
 
  	idleTarget = target;
- 	return { target, entryRpm };
+ 	return { target, entryRpm, exitRpm };
 }
 
 IIdleController::Phase IdleController::determinePhase(float rpm, IIdleController::TargetInfo targetRpm, SensorResult tps, float vss, float crankingTaperFraction) {
@@ -67,8 +70,13 @@ IIdleController::Phase IdleController::determinePhase(float rpm, IIdleController
 
 	// If rpm too high (but throttle not pressed), we're coasting
 	// ALSO, if still in the cranking taper, disable coasting
-	looksLikeCoasting = rpm > targetRpm.IdleEntryRpm;
-	looksLikeCrankToIdle = crankingTaperFraction < 1;
+  if (rpm > targetRpm.IdleExitRpm) {
+ 		looksLikeCoasting = true;
+ 	} else if (rpm < targetRpm.IdleEntryRpm) {
+ 		looksLikeCoasting = false;
+ 	}
+ 
+ 	looksLikeCrankToIdle = crankingTaperFraction < 1;
 	if (looksLikeCoasting && !looksLikeCrankToIdle) {
 		return Phase::Coasting;
 	}

--- a/firmware/controllers/actuators/idle_thread.h
+++ b/firmware/controllers/actuators/idle_thread.h
@@ -29,9 +29,12 @@ struct IIdleController {
  
  		// If below this speed, enter idle
  		float IdleEntryRpm;
+    
+    // If above this speed, exit idle
+ 		float IdleExitRpm;
  
  		bool operator==(const TargetInfo& other) const {
- 			return ClosedLoopTarget == other.ClosedLoopTarget && IdleEntryRpm == other.IdleEntryRpm;
+        return ClosedLoopTarget == other.ClosedLoopTarget && IdleEntryRpm == other.IdleEntryRpm && IdleExitRpm == other.IdleExitRpm;
  		}
  	};
  

--- a/firmware/controllers/actuators/idle_thread.h
+++ b/firmware/controllers/actuators/idle_thread.h
@@ -23,8 +23,20 @@ struct IIdleController {
 		Running,	// On throttle
 	};
 
-	virtual Phase determinePhase(float rpm, float targetRpm, SensorResult tps, float vss, float crankingTaperFraction) = 0;
-	virtual int getTargetRpm(float clt) = 0;
+		struct TargetInfo {
+ 		// Target speed for closed loop control
+ 		float ClosedLoopTarget;
+ 
+ 		// If below this speed, enter idle
+ 		float IdleEntryRpm;
+ 
+ 		bool operator==(const TargetInfo& other) const {
+ 			return ClosedLoopTarget == other.ClosedLoopTarget && IdleEntryRpm == other.IdleEntryRpm;
+ 		}
+ 	};
+ 
+ 	virtual Phase determinePhase(float rpm, TargetInfo targetRpm, SensorResult tps, float vss, float crankingTaperFraction) = 0;
+ 	virtual TargetInfo getTargetRpm(float clt) = 0;
 	virtual float getCrankingOpenLoop(float clt) const = 0;
 	virtual float getRunningOpenLoop(IIdleController::Phase phase, float rpm, float clt, SensorResult tps) = 0;
 	virtual float getOpenLoop(Phase phase, float rpm, float clt, SensorResult tps, float crankingTaperFraction) = 0;
@@ -44,10 +56,10 @@ public:
 	float getIdlePosition(float rpm);
 
 	// TARGET DETERMINATION
-	int getTargetRpm(float clt) override;
+	TargetInfo getTargetRpm(float clt) override;
 
 	// PHASE DETERMINATION: what is the driver trying to do right now?
-	Phase determinePhase(float rpm, float targetRpm, SensorResult tps, float vss, float crankingTaperFraction) override;
+	Phase determinePhase(float rpm, TargetInfo targetRpm, SensorResult tps, float vss, float crankingTaperFraction) override;
 	float getCrankingTaperFraction() const override;
 
 	// OPEN LOOP CORRECTIONS

--- a/firmware/controllers/actuators/idle_thread.h
+++ b/firmware/controllers/actuators/idle_thread.h
@@ -109,6 +109,8 @@ private:
 	// used by "soft" idle entry
 	float m_crankTaperEndTime = 0.0f;
 	float m_idleTimingSoftEntryEndTime = 0.0f;
+  
+  Timer m_timeInIdlePhase;
 
 	// This is stored by getClosedLoop and used in case we want to "do nothing"
 	float m_lastAutomaticPosition = 0;

--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -961,7 +961,7 @@ custom maf_sensor_type_e 1 bits, S08, @OFFSET@, [0:1], @@maf_sensor_type_e_enum@
 	custom vehicle_info_t @@VEHICLE_INFO_SIZE@@ string, ASCII, @OFFSET@, @@VEHICLE_INFO_SIZE@@
 	custom gppwm_note_t @@GPPWM_NOTE_SIZE@@ string, ASCII, @OFFSET@, @@GPPWM_NOTE_SIZE@@
 
-	bit unused920_0
+	bit idleReturnTargetRamp
 	bit unused920_1
 	bit useHbridgesToDriveIdleStepper;If enabled we use two H-bridges to drive stepper idle air valve
 	bit multisparkEnable

--- a/firmware/tunerstudio/tunerstudio.template.ini
+++ b/firmware/tunerstudio/tunerstudio.template.ini
@@ -5364,6 +5364,7 @@ dialog = tcuControls, "Transmission Settings"
 		field = "BRZ/FRS/GT86 pedal",							allowIdenticalPps
 		field = "Artificial Misfire",						artificialTestMisfire
 		field = "Always use instant RPM",				alwaysInstantRpm
+		field = "Idle return target ramp",				idleReturnTargetRamp
 		field = vinNumber,										vinNumber
 		field = turbochargerFilter,							turbochargerFilter
 		field = auxFrequencyFilter,							auxFrequencyFilter

--- a/unit_tests/mocks.h
+++ b/unit_tests/mocks.h
@@ -127,8 +127,8 @@ public:
 	MockIdleController();
 	virtual ~MockIdleController();
 
-	MOCK_METHOD(IIdleController::Phase, determinePhase, (float rpm, float targetRpm, SensorResult tps, float vss, float crankingTaperFraction), (override));
-	MOCK_METHOD(int, getTargetRpm, (float clt), (override));
+  MOCK_METHOD(IIdleController::Phase, determinePhase, (float rpm, IIdleController::TargetInfo targetRpm, SensorResult tps, float vss, float crankingTaperFraction), (override));
+ 	MOCK_METHOD(IIdleController::TargetInfo, getTargetRpm, (float clt), (override));
 	MOCK_METHOD(float, getCrankingOpenLoop, (float clt), (const, override));
 	MOCK_METHOD(float, getRunningOpenLoop, (IIdleController::Phase phase, float rpm, float clt, SensorResult tps), (override));
 	MOCK_METHOD(float, getOpenLoop, (IIdleController::Phase phase, float rpm, float clt, SensorResult tps, float crankingTaperFraction), (override));

--- a/unit_tests/tests/test_idle_controller.cpp
+++ b/unit_tests/tests/test_idle_controller.cpp
@@ -60,12 +60,12 @@ TEST(idle_v2, testTargetRpm) {
 	}
 
 	engineConfiguration->idlePidRpmUpperLimit = 50;
- 	EXPECT_EQ((TgtInfo{100, 150}), dut.getTargetRpm(10));
- 	EXPECT_EQ((TgtInfo{500, 550}), dut.getTargetRpm(50));
+	EXPECT_EQ((TgtInfo{100, 150, 175}), dut.getTargetRpm(10));
+ 	EXPECT_EQ((TgtInfo{500, 550, 575}), dut.getTargetRpm(50));
  
  	engineConfiguration->idlePidRpmUpperLimit = 73;
- 	EXPECT_EQ((TgtInfo{100, 173}), dut.getTargetRpm(10));
- 	EXPECT_EQ((TgtInfo{500, 573}), dut.getTargetRpm(50));
+	EXPECT_EQ((TgtInfo{100, 173, 209.5}), dut.getTargetRpm(10));
+ 	EXPECT_EQ((TgtInfo{500, 573, 609.5}), dut.getTargetRpm(50));
 }
 
 TEST(idle_v2, testDeterminePhase) {
@@ -84,6 +84,7 @@ TEST(idle_v2, testDeterminePhase) {
  
  	// Idling threshold is 1000 + 100 rpm
  	targetInfo.IdleEntryRpm = 1000 + 100;
+  targetInfo.IdleExitRpm = 1000 + 100;
 
 	// First test stopped engine
 	engine->rpmCalculator.setRpmValue(0);
@@ -426,7 +427,7 @@ TEST(idle_v2, IntegrationManual) {
 	Sensor::setMockValue(SensorType::Clt, expectedClt);
 	Sensor::setMockValue(SensorType::VehicleSpeed, 15.0);
 
-  TgtInfo target{1000, 1100};
+  TgtInfo target{1000, 1100, 1100};
 
 	// Target of 1000 rpm
 	EXPECT_CALL(dut, getTargetRpm(expectedClt))
@@ -461,7 +462,7 @@ TEST(idle_v2, IntegrationAutomatic) {
 	Sensor::setMockValue(SensorType::Clt, expectedClt);
 	Sensor::setMockValue(SensorType::VehicleSpeed, 15.0);
   
-  TgtInfo target{1000, 1100};
+  TgtInfo target{1000, 1100, 1100};
 
 	// Target of 1000 rpm
 	EXPECT_CALL(dut, getTargetRpm(expectedClt))
@@ -498,7 +499,7 @@ TEST(idle_v2, IntegrationClamping) {
 	Sensor::setMockValue(SensorType::DriverThrottleIntent, expectedTps.Value);
 	Sensor::setMockValue(SensorType::Clt, expectedClt);
 	Sensor::setMockValue(SensorType::VehicleSpeed, 15.0);
-  TgtInfo target{1000, 1100};
+  TgtInfo target{1000, 1100, 1100};
 
 	// Target of 1000 rpm
 	EXPECT_CALL(dut, getTargetRpm(expectedClt))


### PR DESCRIPTION
https://github.com/FOME-Tech/fome-fw/commit/dd67fa58e79183425c38d1f9c516fa3da59581f4 => added comment about diff on `targetRpmAc`
https://github.com/FOME-Tech/fome-fw/commit/1934761cea3c3758dcb48e93c9cb0a1c8a77c73a => change from `interpolateClamped` to `interpolateClampedWithValidation`
https://github.com/FOME-Tech/fome-fw/commit/e2796b2f11273cec397c6f64af7e6f6e482624a7 => as is
https://github.com/FOME-Tech/fome-fw/commit/404bf5c188055ac3acf838219c018d9efd988092 => as is

related issue: #7598