### PR TITLE
update deprecated java on java_tools/java_console

### DIFF
--- a/java_console/io/src/main/java/com/rusefi/binaryprotocol/BinaryProtocol.java
+++ b/java_console/io/src/main/java/com/rusefi/binaryprotocol/BinaryProtocol.java
@@ -353,7 +353,7 @@ public class BinaryProtocol {
                     (ConnectionAndMeta.saveSettingsToFile() ? BinaryProtocolLocalCache.CONFIGURATION_RUSEFI_BINARY : null),
                     BinaryProtocolLocalCache.CONFIGURATION_RUSEFI_XML
                 );
-            } catch (Exception e) {
+            } catch (IOException | JAXBException e) {
                 log.error("Ignoring " + e);
             }
         }

--- a/java_console/io/src/main/java/com/rusefi/tools/online/HttpUtil.java
+++ b/java_console/io/src/main/java/com/rusefi/tools/online/HttpUtil.java
@@ -5,7 +5,7 @@ import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
-import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.params.HttpConnectionParams;
 import org.apache.http.params.HttpParams;
 import org.apache.http.util.EntityUtils;
@@ -45,7 +45,7 @@ public class HttpUtil {
     }
 
     public static String executeGet(String url) throws IOException {
-        HttpClient httpclient = new DefaultHttpClient();
+        HttpClient httpclient = HttpClientBuilder.create().build();
         HttpParams httpParameters = httpclient.getParams();
 //        HttpConnectionParams.setConnectionTimeout(httpParameters, CONNECTION_TIMEOUT);
 //        HttpConnectionParams.setSoTimeout(httpParameters, WAIT_RESPONSE_TIMEOUT);

--- a/java_console/io/src/testFixtures/java/com/rusefi/proxy/client/LocalApplicationProxy.java
+++ b/java_console/io/src/testFixtures/java/com/rusefi/proxy/client/LocalApplicationProxy.java
@@ -24,7 +24,7 @@ import org.apache.http.NameValuePair;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.entity.UrlEncodedFormEntity;
 import org.apache.http.client.methods.HttpPost;
-import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.message.BasicNameValuePair;
 
 import java.io.Closeable;
@@ -68,7 +68,7 @@ public class LocalApplicationProxy implements Closeable {
 
         httpPost.setEntity(entity);
 
-        HttpClient httpclient = new DefaultHttpClient();
+        HttpClient httpclient = HttpClientBuilder.create().build();;
         return httpclient.execute(httpPost);
     }
 

--- a/java_console/shared_ui/src/main/java/com/rusefi/tools/online/Online.java
+++ b/java_console/shared_ui/src/main/java/com/rusefi/tools/online/Online.java
@@ -12,7 +12,7 @@ import org.apache.http.concurrent.FutureCallback;
 import org.apache.http.entity.mime.MultipartEntity;
 import org.apache.http.entity.mime.content.FileBody;
 import org.apache.http.entity.mime.content.StringBody;
-import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
 import org.jetbrains.annotations.Nullable;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
@@ -33,7 +33,7 @@ public class Online {
      * blocking call for http file upload
      */
     public static UploadResult upload(File fileName, String authTokenValue) {
-        HttpClient httpclient = new DefaultHttpClient();
+        HttpClient httpclient = HttpClientBuilder.create().build();
         HttpPost httpPost = new HttpPost(url);
 
         String responseString;


### PR DESCRIPTION
still WIP
notes:
The instability problem seems to be related to the current HTTP client, since it never terminates connections after use; the new method does so automatically, see: [CloseableHttpClient](https://hc.apache.org/httpcomponents-client-4.5.x/current/httpclient/apidocs/org/apache/http/impl/client/CloseableHttpClient.html).
 I still have exceptions related to writing the .xml file, which seems to be related to an error caused by not having a TS signature on `java_console/inifile/src/main/java/com/rusefi/tune/xml/VersionInfo.java` func "validate".