### PR TITLE
Simulator won't compile with newer GCC versions #6650

### DIFF
--- a/simulator/simulator/can/hal_can_lld.cpp
+++ b/simulator/simulator/can/hal_can_lld.cpp
@@ -149,7 +149,7 @@ void can_lld_stop(CANDriver *canp) {
 
 #if !EFI_SIM_IS_WINDOWS
 	// Remove from the "interrupt handler" list
-	std::remove(instances.begin(), instances.end(), canp);
+	(void)std::remove(instances.begin(), instances.end(), canp);
 
 	// Close the socket.
 	close(canp->sock);


### PR DESCRIPTION
works ok now with:
`gcc versión 14.2.1 20240912 (Red Hat 14.2.1-3) (GCC) `

resolves #6650