### PR TITLE
solve some errors on validateConfigOnStartUpOrBurn/setDefaultBaseEngine

### DIFF
--- a/firmware/controllers/algo/defaults/default_base_engine.cpp
+++ b/firmware/controllers/algo/defaults/default_base_engine.cpp
@@ -360,6 +360,10 @@ void setDefaultBaseEngine() {
 	engineConfiguration->minimumOilPressureTimeout = 0.5f;
 	setRpmTableBin(config->minimumOilPressureBins);
 	setRpmTableBin(config->maximumOilPressureBins);
+
+	engineConfiguration->mapExpAverageAlpha = 1;
+	engineConfiguration->alternator_iTermMax = 1000;
+	engineConfiguration->alternator_iTermMin = -1000;
 }
 
 void setPPSInputs(adc_channel_e pps1, adc_channel_e pps2) {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/25a7d14c-8e55-4ef3-a8d1-8cacff6aff3b)

We are missing a couple of defaults that can cause unwanted CRC errors. cc @ggurov for reporting it