### PR TITLE
separate trigger offset from cam being on second phase see #7645

### DIFF
--- a/firmware/config/boards/hellen/hellen-honda-k/board_configuration.cpp
+++ b/firmware/config/boards/hellen/hellen-honda-k/board_configuration.cpp
@@ -88,7 +88,7 @@ void setBoardDefaultConfiguration() {
 	engineConfiguration->displayLogicLevelsInEngineSniffer = true;
 
 	engineConfiguration->camSyncOnSecondCrankRevolution = true;
-	engineConfiguration->globalTriggerAngleOffset = 360 + 303;
+	engineConfiguration->globalTriggerAngleOffset = 303;
 
 	engineConfiguration->enableSoftwareKnock = true;
 

--- a/firmware/config/engines/dodge_neon.cpp
+++ b/firmware/config/engines/dodge_neon.cpp
@@ -35,7 +35,7 @@ void setDodgeNeon1995EngineConfiguration() {
 
 	// set global_trigger_offset_angle 137
 	engineConfiguration->camSyncOnSecondCrankRevolution = true;
-	engineConfiguration->globalTriggerAngleOffset = 360 + 137;
+	engineConfiguration->globalTriggerAngleOffset = 137;
 
 	// set cranking_timing_angle 0
 	engineConfiguration->crankingTimingAngle = 0;

--- a/firmware/config/engines/gm_sbc.cpp
+++ b/firmware/config/engines/gm_sbc.cpp
@@ -141,7 +141,7 @@ void setGmSbc() {
 
 static void setGmEcotec3() {
   engineConfiguration->camSyncOnSecondCrankRevolution = true;
-  engineConfiguration->globalTriggerAngleOffset = 360 + 90; // todo: remove '360' once 'camSyncOnSecondCrankRevolution' actually works
+  engineConfiguration->globalTriggerAngleOffset = 90;
   engineConfiguration->vvtMode[0] = VVT_BOSCH_QUICK_START;
   engineConfiguration->lowPressureFuel.hwChannel = EFI_ADC_NONE;
   gmRailSensor();

--- a/firmware/config/engines/honda_k_dbc.cpp
+++ b/firmware/config/engines/honda_k_dbc.cpp
@@ -20,7 +20,7 @@ void setHondaK() {
 	engineConfiguration->trigger.type = trigger_type_e::TT_HONDA_K_CRANK_12_1;
 	engineConfiguration->camSyncOnSecondCrankRevolution = true;
 	int magic = 0; // note that offset and VVT are related
-	engineConfiguration->globalTriggerAngleOffset = 360 + 303 - magic;
+	engineConfiguration->globalTriggerAngleOffset = 303 - magic;
 
 	// VVT is here just single tooth? and we do not even use it!?
 	engineConfiguration->vvtMode[0] = VVT_HONDA_K_INTAKE;

--- a/firmware/config/engines/m111.cpp
+++ b/firmware/config/engines/m111.cpp
@@ -42,7 +42,7 @@ void setMercedesM111EngineConfiguration() {
 
     engineConfiguration->vvtMode[0] = VVT_SINGLE_TOOTH;
 	engineConfiguration->camSyncOnSecondCrankRevolution = true;
-	engineConfiguration->globalTriggerAngleOffset = 109 + 360; // please use a timing light?
+	engineConfiguration->globalTriggerAngleOffset = 109; // please use a timing light?
 
     // todo: i wonder if we have less custom curve for same sensor?
     setAtSensor(&engineConfiguration->iat, /*temp low*/0, 7400, /*temp mid*/22, 2180, /*temp high*/ 100, 180);

--- a/firmware/controllers/math/engine_math.h
+++ b/firmware/controllers/math/engine_math.h
@@ -40,8 +40,10 @@ void setSingleCoilDwell();
 // we combine trigger-defined triggerShape.tdcPosition with user-defined engineConfiguration->globalTriggerAngleOffset
 // expectation is that for well-known triggers engineConfiguration->globalTriggerAngleOffset would usually be zero
 // while for toothed wheels user would have to provide a value
+// If camSyncOnSecondCrankRevolution is active, 360° are added
 #define tdcPosition() \
-		(getTriggerCentral()->triggerShape.tdcPosition + engineConfiguration->globalTriggerAngleOffset)
+		(getTriggerCentral()->triggerShape.tdcPosition \
+   			+ ( engineConfiguration->camSyncOnSecondCrankRevolution ? engineConfiguration->globalTriggerAngleOffset + 360 : engineConfiguration->globalTriggerAngleOffset ))
 
 /** Gets phase offset for a particular cylinder's ID and number
  * For example on 4 cylinder engine with firing order 1-3-4-2, this


### PR DESCRIPTION
Also updated all the references to `globalTriggerAngleOffset` that were adding the 360°