### PR TITLE
cranking iac taper duration should be a curve see #7670

### DIFF
--- a/firmware/config/engines/hyundai.cpp
+++ b/firmware/config/engines/hyundai.cpp
@@ -299,7 +299,7 @@ static void commonGenesisCoupe() {
     // default 50.0
 	setArrayValues(config->cltCrankingCorr, 70);
     // default 200.0
-    engineConfiguration->afterCrankingIACtaperDuration = 100;
+    setArrayValues(config->afterCrankingIACtaperDuration, 100);
     // default 0.0
     engineConfiguration->tpsAccelLookback = 0.3;
     // default 40.0

--- a/firmware/config/engines/mazda/mazda_miata_na8.cpp
+++ b/firmware/config/engines/mazda/mazda_miata_na8.cpp
@@ -42,7 +42,7 @@ void setMazdaMiata96() {
 	engineConfiguration->wwaeTau = 0.1;
 	setTable(config->alternatorVoltageTargetTable, 14.2);
 	setArrayValues(config->cltCrankingCorr, 36);
-	engineConfiguration->afterCrankingIACtaperDuration = 189;
+	setArrayValues(config->afterCrankingIACtaperDuration, 189);
 
 	engineConfiguration->crankingTimingAngle = 6;
 	engineConfiguration->ignitionDwellForCrankingMs = 4;

--- a/firmware/config/engines/mazda/mazda_miata_vvt.cpp
+++ b/firmware/config/engines/mazda/mazda_miata_vvt.cpp
@@ -267,7 +267,7 @@ static void setCommonMazdaNB() {
 	engineConfiguration->cranking.baseFuel = 27.5; // this value for return-less NB miata fuel system, higher pressure
 	engineConfiguration->cranking.rpm = 400;
 	setArrayValues(config->cltCrankingCorr, 60);
-	engineConfiguration->afterCrankingIACtaperDuration = 250;
+	setArrayValues(config->afterCrankingIACtaperDuration, 250);
 
 	// Idle
 	engineConfiguration->idleMode = IM_AUTO;

--- a/firmware/controllers/actuators/idle_thread.cpp
+++ b/firmware/controllers/actuators/idle_thread.cpp
@@ -107,8 +107,9 @@ IIdleController::Phase IdleController::determinePhase(float rpm, IIdleController
 	return Phase::Idling;
 }
 
-float IdleController::getCrankingTaperFraction() const {
-	return (float)engine->rpmCalculator.getRevolutionCounterSinceStart() / engineConfiguration->afterCrankingIACtaperDuration;
+float IdleController::getCrankingTaperFraction(float clt) const {
+  	float taperDuration = interpolate2d(clt, config->afterCrankingIACtaperDurationBins, config->afterCrankingIACtaperDuration);
+	return (float)engine->rpmCalculator.getRevolutionCounterSinceStart() / taperDuration;
 }
 
 float IdleController::getCrankingOpenLoop(float clt) const {
@@ -356,7 +357,7 @@ float IdleController::getIdlePosition(float rpm) {
 		m_lastTargetRpm = targetRpm.ClosedLoopTarget;
 
 		// Determine cranking taper (modeled flow does no taper of open loop)
-		float crankingTaper = useModeledFlow ? 1 : getCrankingTaperFraction();
+		float crankingTaper = useModeledFlow ? 1 : getCrankingTaperFraction(clt);
 
 		// Determine what operation phase we're in - idling or not
 		float vehicleSpeed = Sensor::getOrZero(SensorType::VehicleSpeed);

--- a/firmware/controllers/actuators/idle_thread.h
+++ b/firmware/controllers/actuators/idle_thread.h
@@ -46,7 +46,7 @@ struct IIdleController {
 	virtual float getRunningOpenLoop(IIdleController::Phase phase, float rpm, float clt, SensorResult tps) = 0;
 	virtual float getOpenLoop(Phase phase, float rpm, float clt, SensorResult tps, float crankingTaperFraction) = 0;
 	virtual float getClosedLoop(Phase phase, float tps, float rpm, float target) = 0;
-	virtual float getCrankingTaperFraction() const = 0;
+	virtual float getCrankingTaperFraction(float clt) const = 0;
 	virtual bool isIdlingOrTaper() const = 0;
 	virtual float getIdleTimingAdjustment(float rpm) = 0;
 };
@@ -65,7 +65,7 @@ public:
 
 	// PHASE DETERMINATION: what is the driver trying to do right now?
 	Phase determinePhase(float rpm, TargetInfo targetRpm, SensorResult tps, float vss, float crankingTaperFraction) override;
-	float getCrankingTaperFraction() const override;
+	float getCrankingTaperFraction(float clt) const override;
 
 	// OPEN LOOP CORRECTIONS
 	percent_t getCrankingOpenLoop(float clt) const override;

--- a/firmware/controllers/algo/defaults/default_cranking.cpp
+++ b/firmware/controllers/algo/defaults/default_cranking.cpp
@@ -17,7 +17,8 @@ void setDefaultCranking() {
 	// IAC
 	setArrayValues(config->cltCrankingCorr, 50);
 	// should be 100 once tune is better
-	engineConfiguration->afterCrankingIACtaperDuration = 200;
+	setArrayValues(config->afterCrankingIACtaperDuration, 200);
+	setLinearCurve(config->afterCrankingIACtaperDurationBins, CLT_CURVE_RANGE_FROM, 100, 1);
 
 	engineConfiguration->isFasterEngineSpinUpEnabled = true;
 

--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -96,7 +96,7 @@
 ! This is the version of the data stored in flash configuration
 ! Any time an incompatible change is made to the configuration format stored in flash,
 ! update this string to the current date!
-#define FLASH_DATA_VERSION 250330
+#define FLASH_DATA_VERSION 250403
 
 ! all the sub-structures are going to be nested within the primary structure, that's
 ! needed to get a proper TunerStudio file
@@ -150,6 +150,7 @@ struct_no_prefix engine_configuration_s
 #define CLT_LIMITER_CURVE_SIZE 4
 #define CRANKING_CLT_IDLE_CURVE_SIZE 8
 #define CLT_CRANKING_CURVE_SIZE 8
+#define CLT_CRANKING_TAPER_CURVE_SIZE 6
 #define CRANKING_CYCLE_CLT_SIZE 4
 #define IDLE_ADVANCE_CURVE_SIZE 8
 #define CRANKING_ADVANCE_CURVE_SIZE 4
@@ -1233,7 +1234,7 @@ int16_t tps2Max;Full throttle#2. tpsMax value as 10 bit ADC value. Not Voltage!\
 	bit enableKnockSpectrogram,"yes","no";"Available via TS Plugin see https://rusefi.com/s/knock"
 	bit enableKnockSpectrogramFilter
 
-	int16_t afterCrankingIACtaperDuration;This is the duration in cycles that the IAC will take to reach its normal idle position, it can be used to hold the idle higher for a few seconds after cranking to improve startup.\nShould be 100 once tune is better;"cycles", 1, 0, 0, 5000, 0
+	int16_t unusedafterCrankingIACtaperDuration;;"", 1, 0, 0, 5000, 0
 	int16_t iacByTpsTaper;This value is an added for base idle value. Idle Value added when coasting and transitioning into idle.;"percent", 1, 0, 0, 500, 0
 
 	Gpio accelerometerCsPin;
@@ -1905,6 +1906,9 @@ uint8_t[PEDAL_TO_TPS_SIZE] autoscale pedalToTpsRpmBins;;"RPM", 100, 0, 0, 25000,
 
 float[CLT_CRANKING_CURVE_SIZE] cltCrankingCorrBins;CLT-based cranking position % for simple manual idle controller;"C", 1, 0, -100, @@CLT_UPPER_LIMIT@@, 2
 float[CLT_CRANKING_CURVE_SIZE] cltCrankingCorr    ;CLT-based cranking position % for simple manual idle controller;"percent", 1, 0, 0, 100, 2
+
+float[CLT_CRANKING_TAPER_CURVE_SIZE] afterCrankingIACtaperDurationBins;;"C", 1, 0, -100, @@CLT_UPPER_LIMIT@@, 2
+uint16_t[CLT_CRANKING_TAPER_CURVE_SIZE] afterCrankingIACtaperDuration;This is the duration in cycles that the IAC will take to reach its normal idle position, it can be used to hold the idle higher for a few seconds after cranking to improve startup.\nShould be 100 once tune is better;"cycles", 1, 0, 0, 500, 1
 
 uint8_t[IDLE_ADVANCE_CURVE_SIZE] autoscale idleAdvanceBins;Optional timing advance table for Idle (see useSeparateAdvanceForIdle);"RPM", 50, 0, 0, 12000, 0
 float[IDLE_ADVANCE_CURVE_SIZE] idleAdvance    ;Optional timing advance table for Idle (see useSeparateAdvanceForIdle);"deg", 1, 0, -20, 90, 1

--- a/firmware/tunerstudio/tunerstudio.template.ini
+++ b/firmware/tunerstudio/tunerstudio.template.ini
@@ -621,6 +621,14 @@ enable2ndByteCanID = false
 		yBins		= cltCrankingCorr
 		gauge		= CLTGauge
 
+	curve = afterCrankingIACtaperCurve, "Idle valve Crank-to-Run Taper"
+		columnLabel = "Coolant", "cyles"
+		xAxis		= -40, 120, 7
+		yAxis		=  0,  500, 11
+		xBins		= afterCrankingIACtaperDurationBins, coolant
+		yBins		= afterCrankingIACtaperDuration
+		gauge		= CLTGauge
+
 	curve = cltIdleRPMCurve, "Idle Target RPM"
 		columnLabel = "Coolant", "RPM"
 		xAxis		= -40, 120, 9
@@ -2142,6 +2150,7 @@ menuDialog = main
 		subMenu = cltIdleRPMCurve,			"Target RPM"
 		subMenu = cltIdleTable,				"Base Idle Valve Position"
 		subMenu = cltCrankingCurveDialog,			"Cranking Idle Valve Curve", 1, { uiMode == @@UiMode_FULL@@ || uiMode == @@UiMode_INSTALLATION@@ }
+		subMenu = afterCrankingIACtaperDurationDialog, "Idle Valve Crank-to-Run Taper"
 		subMenu = std_separator
 		subMenu = idleTimingPidCorrDialog,	"Closed-loop idle timing"
 		subMenu = iacPidMultTbl,			"IAC PID multiplier", 0, {idleMode == 0 && useIacPidMultTable == 1}
@@ -2566,6 +2575,9 @@ cmd_set_engine_type_default					= "@@TS_IO_TEST_COMMAND_char@@@@ts_command_e_TS_
   dialog = cltCrankingCurveDialog
     field = "ETB idle maximum angle",				etbIdleThrottleRange
     panel = cltCrankingCurve
+
+	dialog = afterCrankingIACtaperDurationDialog
+		panel = afterCrankingIACtaperCurve
 
 	dialog = tChargeSettings, "Estimated cylinder air temperature"
 		panel = tChargeGeneralSettings
@@ -4652,9 +4664,6 @@ cmd_set_engine_type_default					= "@@TS_IO_TEST_COMMAND_char@@@@ts_command_e_TS_
 		field = "Injection mode",						crankingInjectionMode
 		field = "Fuel Source For Cranking",				useRunningMathForCranking@@if_ts_show_useRunningMathForCranking
 		field = "Base fuel mass",				cranking_baseFuel, {useRunningMathForCranking == 0}
-
-	dialog = crankingIAC, "Idle air valve"
-		field = "After cranking IAC taper duration",afterCrankingIACtaperDuration
 
 	dialog = crankingIgnition, "Ignition"
 		field = "Timing Advance mode",	useSeparateAdvanceForCranking

--- a/unit_tests/mocks.h
+++ b/unit_tests/mocks.h
@@ -133,7 +133,7 @@ public:
 	MOCK_METHOD(float, getRunningOpenLoop, (IIdleController::Phase phase, float rpm, float clt, SensorResult tps), (override));
 	MOCK_METHOD(float, getOpenLoop, (IIdleController::Phase phase, float rpm, float clt, SensorResult tps, float crankingTaperFraction), (override));
 	MOCK_METHOD(float, getClosedLoop, (IIdleController::Phase phase, float tps, float rpm, float target), (override));
-	MOCK_METHOD(float, getCrankingTaperFraction, (), (const, override));
+	MOCK_METHOD(float, getCrankingTaperFraction, (float clt), (const, override));
 	MOCK_METHOD(bool, isIdlingOrTaper, (), (const, override));
 	MOCK_METHOD(float, getIdleTimingAdjustment, (float rpm), (override));
 };


### PR DESCRIPTION
resolves #7670 
UI:
![image](https://github.com/user-attachments/assets/71bd203e-56e4-4e2d-a990-739f962c4b75)

also new max 500 cycles ==> at 1500 rpm == 20s (5000 cycles was the original max value and seems too exaggerated)