### PR TITLE
detect and ignore doubled trigger edges [implement flag for disabling feature] see #4656

### DIFF
--- a/firmware/controllers/trigger/trigger_central.cpp
+++ b/firmware/controllers/trigger/trigger_central.cpp
@@ -721,7 +721,7 @@ bool TriggerCentral::isToothExpectedNow(efitick_t timestamp) {
 		if (Sensor::getOrZero(SensorType::Rpm) > 1000) {
 			// Now compute how close we are to the last tooth decoded
 			float angleSinceLastTooth = estimatedCurrentPhase.Value - lastToothPhase;
-			if (angleSinceLastTooth < 0.5f) {
+			if (angleSinceLastTooth < 0.5f && !engineConfiguration->doNotFilterTriggerEdgeNoise) {
 				// This tooth came impossibly early, ignore it
 				// This rejects things like doubled edges, for example:
 				//             |-| |----------------


### PR DESCRIPTION
I found this in the middle of night lurk, I guess it's the correct way to implement this flag that was unused, was added on: ee5c9db [2023]