### PR TITLE
ADC: knock

### DIFF
--- a/firmware/controllers/sensors/impl/software_knock.cpp
+++ b/firmware/controllers/sensors/impl/software_knock.cpp
@@ -54,7 +54,6 @@ void onStartKnockSampling(uint8_t cylinderNumber, float samplingSeconds, uint8_t
 
 	// Cancel if ADC isn't ready
 	if (!((KNOCK_ADC.state == ADC_READY) ||
-			(KNOCK_ADC.state == ADC_COMPLETE) ||
 			(KNOCK_ADC.state == ADC_ERROR))) {
 		return;
 	}

--- a/firmware/hw_layer/adc/adc_inputs_onchip.cpp
+++ b/firmware/hw_layer/adc/adc_inputs_onchip.cpp
@@ -208,7 +208,6 @@ void AdcDevice::startConversionI()
 {
 	chSysLockFromISR();
 	if ((ADC_FAST_DEVICE.state != ADC_READY) &&
-		(ADC_FAST_DEVICE.state != ADC_COMPLETE) &&
 		(ADC_FAST_DEVICE.state != ADC_ERROR)) {
 		engine->outputChannels.fastAdcErrorsCount++;
 		// todo: when? why? criticalError("ADC fast not ready?");

--- a/firmware/hw_layer/adc/adc_inputs_onchip.cpp
+++ b/firmware/hw_layer/adc/adc_inputs_onchip.cpp
@@ -127,7 +127,7 @@ AdcDevice fastAdc(&ADC_FAST_DEVICE, &adcgrpcfgFast, fastAdcSampleBuf, ADC_BUF_DE
 
 static void fastAdcDoneCB(ADCDriver *adcp) {
 	// State may not be complete if we get a callback for "half done"
-	if (adcp->state == ADC_COMPLETE) {
+	if (adcIsBufferComplete(adcp)) {
 		fastAdc.conversionCount++;
 		onFastAdcComplete(adcp->samples);
 	}

--- a/firmware/hw_layer/ports/stm32/stm32_adc_v2.cpp
+++ b/firmware/hw_layer/ports/stm32/stm32_adc_v2.cpp
@@ -238,7 +238,7 @@ adcsample_t getFastAdc(AdcToken token) {
 #ifdef EFI_SOFTWARE_KNOCK
 
 static void knockCompletionCallback(ADCDriver* adcp) {
-	if (adcp->state == ADC_COMPLETE) {
+	if (adcIsBufferComplete(adcp)) {
 		onKnockSamplingComplete();
 	}
 }

--- a/firmware/hw_layer/ports/stm32/stm32_adc_v4.cpp
+++ b/firmware/hw_layer/ports/stm32/stm32_adc_v4.cpp
@@ -63,7 +63,7 @@ adcsample_t* fastSampleBuffer;
 
 static void adc_callback(ADCDriver *adcp) {
 	// State may not be complete if we get a callback for "half done"
-	if (adcp->state == ADC_COMPLETE) {
+	if (adcIsBufferComplete(adcp)) {
 	  // here we invoke 'fast' from slow ADC due to https://github.com/rusefi/rusefi/issues/3301
 		onFastAdcComplete(adcp->samples);
 	}
@@ -200,7 +200,7 @@ static_assert((H7_KNOCK_OVERSAMPLE & (H7_KNOCK_OVERSAMPLE - 1)) == 0, "H7_ADC_OV
 static constexpr int H7_KNOCK_ADC_SHIFT_BITS = log2_int(H7_KNOCK_OVERSAMPLE);
 
 static void knockCompletionCallback(ADCDriver* adcp) {
-	if (adcp->state == ADC_COMPLETE) {
+	if (adcIsBufferComplete(adcp)) {
 		onKnockSamplingComplete();
 	}
 }


### PR DESCRIPTION
Starting new conversion until previous one is not handled cause assert and ChibiOS panic.
ADC_READY and ADC_ERROR are only allowed states to start new conversion.