### PR TITLE
SD card: show formating indicator while formating

### DIFF
--- a/firmware/console/binary/output_channels.txt
+++ b/firmware/console/binary/output_channels.txt
@@ -43,7 +43,7 @@ bit triggerPageRefreshFlag
 bit hasFaultReportFile
 bit isAnalogFailure;Analog sensors supply failure
 bit isTuningNow
-! 1 unused bit left here
+bit sd_formating; SD: formating is in progress
 
 
 uint16_t RPMValue;@@GAUGE_NAME_RPM@@;"RPM",1, 0, 0, 8000, 0
@@ -436,5 +436,7 @@ float mapFast
 
   uint32_t mcuSerial;;"", 1, 0, 0, 4294967295, 0
 
-	uint8_t[48 iterate] unusedAtTheEnd;;"",1, 0, 0, 0, 0
+  uint8_t sd_error;
+
+	uint8_t[47 iterate] unusedAtTheEnd;;"",1, 0, 0, 0, 0
 end_struct

--- a/firmware/hw_layer/mmc_card.cpp
+++ b/firmware/hw_layer/mmc_card.cpp
@@ -685,21 +685,32 @@ static void sdLoggerStop(void)
 
 static bool sdFormat()
 {
+#if EFI_TUNER_STUDIO
+	engine->outputChannels.sd_formating = true;
+	engine->outputChannels.sd_error = 0;
+#endif
 	//FRESULT ret = f_mkfs("", nullptr, resources.formatBuff, sizeof(resources.formatBuff));
 	FRESULT ret = f_mkfs("", nullptr, resources.formatBuff, sizeof(resources.formatBuff));
 
 	if (ret) {
 		printError("format failed", ret);
 		warning(ObdCode::CUSTOM_ERR_SD_MOUNT_FAILED, "SD: format failed");
-		return false;
+		goto exit;
 	}
 	ret = f_setlabel(SD_CARD_LABEL);
 	if (ret) {
 		printError("setlabel failed", ret);
 		// this is not critical
+		ret = FR_OK;
 	}
 
-	return true;
+exit:
+#if EFI_TUNER_STUDIO
+	engine->outputChannels.sd_formating = false;
+	engine->outputChannels.sd_error = (uint8_t) ret;
+#endif
+
+	return (ret ? false : true);
 }
 
 static int sdModeSwitchToIdle(SD_MODE from)

--- a/firmware/tunerstudio/tunerstudio.template.ini
+++ b/firmware/tunerstudio/tunerstudio.template.ini
@@ -4539,6 +4539,11 @@ cmd_set_engine_type_default					= "@@TS_IO_TEST_COMMAND_char@@@@ts_command_e_TS_
 	indicatorPanel = sdCardStateIndicators, 2, { isSdCardEnabled }
 		indicator = { sd_logging_internal }, "No SD logging", "SD logging", white, black, green, black
 		indicator = { sd_msd }, "No SD USB", "SD USB",  white,  black,  green,  black
+		indicator =	{ sd_formating }, "No SD formating", "SD formating", white, black, green, black
+		indicator = { sd_error }, "No SD card error", "SD error", white, black, red, black
+
+	readoutPanel = sdCardErrorPanel
+		readout = sd_error, "FRESULT", "", 0, 20, 0, 0, 1, 1, 0, 0
 
 	indicatorPanel = sdCardErrorReportIndicators, 1, { isSdCardEnabled }
 		indicator = { hasFaultReportFile }, "No error reports", "Error report on SD", white, black, red, black
@@ -4554,6 +4559,7 @@ cmd_set_engine_type_default					= "@@TS_IO_TEST_COMMAND_char@@@@ts_command_e_TS_
 		panel = sdCardActivityIndicators
 		panel = sdCardLogging
 		panel = sdCardStateIndicators
+		panel = sdCardErrorPanel
 		panel = sdCardCommands
 		panel = sdReportCommands
 


### PR DESCRIPTION
Also show return values to user.

TODO: store all FatFS returned errors to sd_error
![Screenshot from 2025-04-14 15-21-11](https://github.com/user-attachments/assets/590ac5ea-01d2-4d66-a2f1-ad122a4d31a9)
