### PR TITLE
ADC: timer HW trigger

### DIFF
--- a/firmware/config/stm32f4ems/efifeatures.h
+++ b/firmware/config/stm32f4ems/efifeatures.h
@@ -438,9 +438,9 @@
 
 // TODO: switch to continuous ADC conversion for fast ADC?
 // NOTE: GPT mode triggers ADC convertion through IRQ
-//#define EFI_INTERNAL_FAST_ADC_GPT	&GPTD6
+#define EFI_INTERNAL_FAST_ADC_GPT	&GPTD6
 // NOTE: PWM mode triggers ADC convertion through hardware ADC trigger
-#define EFI_INTERNAL_FAST_ADC_PWM	&PWMD8
+//#define EFI_INTERNAL_FAST_ADC_PWM	&PWMD8
 
 #define EFI_SPI1_AF 5
 #define EFI_SPI2_AF 5

--- a/firmware/config/stm32f4ems/efifeatures.h
+++ b/firmware/config/stm32f4ems/efifeatures.h
@@ -436,8 +436,11 @@
 
 // todo: most of this should become configurable
 
-// todo: switch to continuous ADC conversion for fast ADC?
-#define EFI_INTERNAL_FAST_ADC_GPT	&GPTD6
+// TODO: switch to continuous ADC conversion for fast ADC?
+// NOTE: GPT mode triggers ADC convertion through IRQ
+//#define EFI_INTERNAL_FAST_ADC_GPT	&GPTD6
+// NOTE: PWM mode triggers ADC convertion through hardware ADC trigger
+#define EFI_INTERNAL_FAST_ADC_PWM	&PWMD8
 
 #define EFI_SPI1_AF 5
 #define EFI_SPI2_AF 5

--- a/firmware/console/binary/output_channels.txt
+++ b/firmware/console/binary/output_channels.txt
@@ -438,5 +438,7 @@ float mapFast
 
   uint8_t sd_error;
 
-	uint8_t[47 iterate] unusedAtTheEnd;;"",1, 0, 0, 0, 0
+	uint32_t fastAdcPeriod;
+
+	uint8_t[40 iterate] unusedAtTheEnd;;"",1, 0, 0, 0, 0
 end_struct

--- a/firmware/console/binary/output_channels.txt
+++ b/firmware/console/binary/output_channels.txt
@@ -439,6 +439,7 @@ float mapFast
   uint8_t sd_error;
 
 	uint32_t fastAdcPeriod;
+	uint32_t fastAdcConversionCount;
 
-	uint8_t[40 iterate] unusedAtTheEnd;;"",1, 0, 0, 0, 0
+	uint8_t[36 iterate] unusedAtTheEnd;;"",1, 0, 0, 0, 0
 end_struct

--- a/firmware/hw_layer/adc/AdcDevice.h
+++ b/firmware/hw_layer/adc/AdcDevice.h
@@ -39,7 +39,6 @@ public:
 	AdcToken getAdcChannelToken(adc_channel_e hwChannel);
 	int size() const;
 	void init(void);
-	uint32_t conversionCount = 0;
 
 private:
 	ADCDriver *adcp;

--- a/firmware/hw_layer/adc/adc_inputs.cpp
+++ b/firmware/hw_layer/adc/adc_inputs.cpp
@@ -118,7 +118,7 @@ static void printAdcChannedReport(const char *prefix, int internalIndex, adc_cha
 
 void printFullAdcReport(void) {
 #if EFI_USE_FAST_ADC
-	efiPrintf("fast %lu samples", fastAdc.conversionCount);
+	efiPrintf("fast %lu samples", engine->outputChannels.fastAdcConversionCount);
 
 	for (int internalIndex = 0; internalIndex < fastAdc.size(); internalIndex++) {
 		adc_channel_e hwChannel = fastAdc.getAdcChannelByInternalIndex(internalIndex);

--- a/firmware/hw_layer/adc/adc_inputs_onchip.cpp
+++ b/firmware/hw_layer/adc/adc_inputs_onchip.cpp
@@ -137,10 +137,18 @@ static volatile NO_CACHE adcsample_t fastAdcSampleBuf[ADC_BUF_DEPTH_FAST * ADC_M
 
 AdcDevice fastAdc(&ADC_FAST_DEVICE, &adcgrpcfgFast, fastAdcSampleBuf, ADC_BUF_DEPTH_FAST);
 
+static efitick_t lastTick = 0;
+
 static void fastAdcDoneCB(ADCDriver *adcp) {
 	// State may not be complete if we get a callback for "half done"
 	if (adcIsBufferComplete(adcp)) {
+		efitick_t nowTick = getTimeNowNt();
+		efitick_t diff = nowTick - lastTick;
+		lastTick = nowTick;
+
+		engine->outputChannels.fastAdcPeriod = (uint32_t)diff;
 		fastAdc.conversionCount++;
+
 		onFastAdcComplete(adcp->samples);
 	}
 }

--- a/firmware/hw_layer/adc/adc_inputs_onchip.cpp
+++ b/firmware/hw_layer/adc/adc_inputs_onchip.cpp
@@ -78,13 +78,25 @@ static void fastAdcDoneCB(ADCDriver *adcp);
 static void fastAdcErrorCB(ADCDriver *, adcerror_t err);
 
 static ADCConversionGroup adcgrpcfgFast = {
+#if defined(EFI_INTERNAL_FAST_ADC_PWM)
+	.circular			= TRUE,
+#elif defined (EFI_INTERNAL_FAST_ADC_GPT)
 	.circular			= FALSE,
+#endif
 	.num_channels		= 0,
 	.end_cb				= fastAdcDoneCB,
 	.error_cb			= fastAdcErrorCB,
 	/* HW dependent part.*/
 	.cr1				= 0,
+#if defined(EFI_INTERNAL_FAST_ADC_PWM)
+	/* HW start using TIM8 CC 1 event rising edge
+	 * See "External trigger for regular channels" for magic 13 number
+	 * NOTE: Currently only TIM8 in PWM mode is supported */
+	.cr2				= ADC_CR2_EXTEN_0 | (13 << ADC_CR2_EXTSEL_Pos),
+#elif defined (EFI_INTERNAL_FAST_ADC_GPT)
+	/* SW start through GPT callback and SW kick */
 	.cr2				= ADC_CR2_SWSTART,
+#endif
 		/**
 		 * here we configure all possible channels for fast mode. Some channels would not actually
          * be used hopefully that's fine to configure all possible channels.
@@ -140,7 +152,31 @@ static void fastAdcErrorCB(ADCDriver *, adcerror_t err) {
 	engine->outputChannels.fastAdcErrorCallbackCount++;
 }
 
-static void fastAdcTrigger(GPTDriver*) {
+#if defined(EFI_INTERNAL_FAST_ADC_PWM)
+
+static const PWMConfig pwmcfg = {
+	/* on each trigger event regular group of channels is converted,
+	 * to get whole buffer filled we need ADC_BUF_DEPTH_FAST trigger events */
+	.frequency = GPT_FREQ_FAST * ADC_BUF_DEPTH_FAST,
+	.period = GPT_PERIOD_FAST,
+	.callback = nullptr,
+	.channels = {
+		{PWM_OUTPUT_ACTIVE_HIGH, nullptr},
+		{PWM_OUTPUT_ACTIVE_HIGH, nullptr},
+		{PWM_OUTPUT_ACTIVE_HIGH, nullptr},
+		{PWM_OUTPUT_ACTIVE_HIGH, nullptr}
+	},
+	.cr2 = 0,
+#if STM32_PWM_USE_ADVANCED
+	.bdtr = 0,
+#endif
+	.dier = 0,
+};
+
+#elif defined (EFI_INTERNAL_FAST_ADC_GPT)
+
+static void fastAdcStartTrigger(GPTDriver*)
+{
 #if EFI_INTERNAL_ADC
 	/*
 	 * Starts an asynchronous ADC conversion operation, the conversion
@@ -153,10 +189,14 @@ static void fastAdcTrigger(GPTDriver*) {
 
 static const GPTConfig fast_adc_config = {
 	.frequency = GPT_FREQ_FAST,
-	.callback = fastAdcTrigger,
+	.callback = fastAdcStartTrigger,
 	.cr2 = 0,
 	.dier = 0,
 };
+
+#else
+	#error Please define EFI_INTERNAL_FAST_ADC_PWM or EFI_INTERNAL_FAST_ADC_GPT for Fast ADC
+#endif
 
 int AdcDevice::size() const {
 	return channelCount;
@@ -167,8 +207,15 @@ void AdcDevice::init(void) {
 	/* driver does this internally */
 	//hwConfig->sqr1 += ADC_SQR1_NUM_CH(size());
 
+#if defined(EFI_INTERNAL_FAST_ADC_PWM)
+	// Start the timer running
+	pwmStart(EFI_INTERNAL_FAST_ADC_PWM, &pwmcfg);
+	pwmEnableChannel(EFI_INTERNAL_FAST_ADC_PWM, 0, /* width */ 1);
+	adcStartConversion(adcp, hwConfig, (adcsample_t *)samples, depth);
+#elif defined (EFI_INTERNAL_FAST_ADC_GPT)
 	gptStart(EFI_INTERNAL_FAST_ADC_GPT, &fast_adc_config);
 	gptStartContinuous(EFI_INTERNAL_FAST_ADC_GPT, GPT_PERIOD_FAST);
+#endif
 }
 
 int AdcDevice::enableChannel(adc_channel_e hwChannel) {

--- a/firmware/hw_layer/adc/adc_inputs_onchip.cpp
+++ b/firmware/hw_layer/adc/adc_inputs_onchip.cpp
@@ -151,7 +151,7 @@ static void fastAdcTrigger(GPTDriver*) {
 #endif /* EFI_INTERNAL_ADC */
 }
 
-static GPTConfig fast_adc_config = {
+static const GPTConfig fast_adc_config = {
 	.frequency = GPT_FREQ_FAST,
 	.callback = fastAdcTrigger,
 	.cr2 = 0,

--- a/firmware/hw_layer/adc/adc_inputs_onchip.cpp
+++ b/firmware/hw_layer/adc/adc_inputs_onchip.cpp
@@ -207,14 +207,14 @@ int AdcDevice::enableChannel(adc_channel_e hwChannel) {
 void AdcDevice::startConversionI()
 {
 	chSysLockFromISR();
-	if ((ADC_FAST_DEVICE.state != ADC_READY) &&
-		(ADC_FAST_DEVICE.state != ADC_ERROR)) {
+	if ((ADC_FAST_DEVICE.state == ADC_READY) ||
+		(ADC_FAST_DEVICE.state == ADC_ERROR)) {
+		/* drop volatile type qualifier - this is safe */
+		adcStartConversionI(adcp, hwConfig, (adcsample_t *)samples, depth);
+	} else {
 		engine->outputChannels.fastAdcErrorsCount++;
 		// todo: when? why? criticalError("ADC fast not ready?");
 		// see notes at https://github.com/rusefi/rusefi/issues/6399
-	} else {
-		/* drop volatile type qualifier - this is safe */
-		adcStartConversionI(adcp, hwConfig, (adcsample_t *)samples, depth);
 	}
 	chSysUnlockFromISR();
 }

--- a/firmware/hw_layer/adc/adc_inputs_onchip.cpp
+++ b/firmware/hw_layer/adc/adc_inputs_onchip.cpp
@@ -147,7 +147,7 @@ static void fastAdcDoneCB(ADCDriver *adcp) {
 		lastTick = nowTick;
 
 		engine->outputChannels.fastAdcPeriod = (uint32_t)diff;
-		fastAdc.conversionCount++;
+		engine->outputChannels.fastAdcConversionCount++;
 
 		onFastAdcComplete(adcp->samples);
 	}

--- a/firmware/hw_layer/ports/at32/at32f4/cfg/mcuconf.h
+++ b/firmware/hw_layer/ports/at32/at32f4/cfg/mcuconf.h
@@ -293,7 +293,7 @@
 #define STM32_PWM_USE_TIM3                  TRUE
 #define STM32_PWM_USE_TIM4                  FALSE
 #define STM32_PWM_USE_TIM5                  TRUE
-#define STM32_PWM_USE_TIM8                  FALSE
+#define STM32_PWM_USE_TIM8                  TRUE
 #define STM32_PWM_USE_TIM9                  FALSE
 #define STM32_PWM_USE_TIM10                 FALSE
 #define STM32_PWM_USE_TIM11                 FALSE

--- a/firmware/hw_layer/ports/stm32/stm32_pwm.cpp
+++ b/firmware/hw_layer/ports/stm32/stm32_pwm.cpp
@@ -139,8 +139,8 @@ static expected<stm32_pwm_config> getConfigForPin(brain_pin_e pin) {
 #endif
 #if STM32_PWM_USE_TIM8
 
-	/* TIM8 is used for ADC trigger */
-#if 0
+	/* TIM8 may be used for ADC trigger */
+#ifndef EFI_INTERNAL_FAST_ADC_PWM
 #if !STM32_PWM_USE_TIM3
 	// If TIM3 is not used, put these pins on TIM8 instead..
 	// See https://github.com/rusefi/rusefi/issues/639

--- a/firmware/hw_layer/ports/stm32/stm32_pwm.cpp
+++ b/firmware/hw_layer/ports/stm32/stm32_pwm.cpp
@@ -139,6 +139,8 @@ static expected<stm32_pwm_config> getConfigForPin(brain_pin_e pin) {
 #endif
 #if STM32_PWM_USE_TIM8
 
+	/* TIM8 is used for ADC trigger */
+#if 0
 #if !STM32_PWM_USE_TIM3
 	// If TIM3 is not used, put these pins on TIM8 instead..
 	// See https://github.com/rusefi/rusefi/issues/639
@@ -150,6 +152,8 @@ static expected<stm32_pwm_config> getConfigForPin(brain_pin_e pin) {
 	case Gpio::C8:  return stm32_pwm_config{&PWMD8, 2, 3};
 	case Gpio::C9:  return stm32_pwm_config{&PWMD8, 3, 3};
 #endif
+#endif
+
 #if STM32_PWM_USE_TIM9
 	case Gpio::E5:  return stm32_pwm_config{&PWMD9, 0, 3};
 	case Gpio::E6:  return stm32_pwm_config{&PWMD9, 1, 3};


### PR DESCRIPTION
Now ADC is started by timer event without CPU intervention.
This removes 10.000 IRQ/sec.