### PR TITLE
refactoring: leverage EngineModule more often see #7572

### DIFF
--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -257,6 +257,7 @@ endif
 
 include $(PROJECT_DIR)/hw_layer/mass_storage/mass_storage.mk
 include $(PROJECT_DIR)/common.mk
+include $(PROJECT_DIR)/controllers/modules/modules.mk
 
 ifeq ($(USE_OPENBLT),yes)
   # Reserve start of flash for OpenBLT
@@ -308,6 +309,7 @@ CPPSRC = \
   $(HW_LAYER_DRIVERS_CPP) \
   $(CONSOLE_SRC_CPP) \
   $(RUSEFI_LIB_CPP) \
+  $(MODULES_CPPSRC) \
   rusefi.cpp \
   main.cpp
 
@@ -343,6 +345,7 @@ INCDIR += \
   $(PCH_DIR) \
   $(BOARDINC) \
   $(ALLINC) \
+  $(MODULES_INC) \
   $(TESTINC) \
   $(CHIBIOS)/os/various \
   $(RUSEFI_LIB_INC) \

--- a/firmware/bootloader/Makefile
+++ b/firmware/bootloader/Makefile
@@ -198,6 +198,7 @@ CPPSRC = $(ALLCPPSRC) \
 	$(PROJECT_DIR)/util/efilib.cpp \
 	$(PROJECT_DIR)/hw_layer/pin_repository.cpp \
 	$(RUSEFI_LIB_CPP) \
+	$(MODULES_CPPSRC) \
 	$(PROJECT_DIR)/bootloader/openblt_chibios/openblt_chibios.cpp \
 	$(PROJECT_DIR)/bootloader/openblt_chibios/openblt_flash.cpp \
 	$(PROJECT_DIR)/bootloader/openblt_chibios/openblt_usb.cpp \
@@ -234,6 +235,7 @@ ASMXSRC = $(STARTUPASM) $(PORTASM) $(OSALASM) \
 INCDIR += $(ALLINC) \
 	$(PCH_DIR) \
 	.. \
+	$(MODULES_INC) \
 	$(BOARDINC) \
 	$(CHIBIOS)/os/various \
 	$(CHIBIOS)/os/ex/ST \

--- a/firmware/controllers/algo/engine.cpp
+++ b/firmware/controllers/algo/engine.cpp
@@ -26,7 +26,6 @@
 #include "idle_thread.h"
 #include "idle_hardware.h"
 #include "gppwm.h"
-#include "tachometer.h"
 #include "speedometer.h"
 #include "dynoview.h"
 #include "boost_control.h"

--- a/firmware/controllers/algo/engine.h
+++ b/firmware/controllers/algo/engine.h
@@ -61,9 +61,12 @@
 #include "trip_odometer.h"
 #include "long_term_fuel_trim.h"
 #include "electronic_throttle_generated.h"
-#include "tachometer.h"
 
 #include <functional>
+
+#ifndef EFI_BOOTLOADER
+#include "engine_modules_generated.h"
+#endif
 
 #ifndef EFI_UNIT_TEST
 #error EFI_UNIT_TEST must be defined!
@@ -183,7 +186,9 @@ public:
 #if EFI_LTFT_CONTROL
 		LongTermFuelTrim,
 #endif
-		TachometerModule,
+
+#include "modules_list_generated.h"
+
 		EngineModule // dummy placeholder so the previous entries can all have commas
 		> engineModules;
 

--- a/firmware/controllers/controllers.mk
+++ b/firmware/controllers/controllers.mk
@@ -25,7 +25,6 @@ CONTROLLERS_SRC_CPP = \
 	$(CONTROLLERS_DIR)/actuators/gppwm_channel_reader.cpp \
 	$(CONTROLLERS_DIR)/actuators/gppwm/gppwm_channel.cpp \
 	$(CONTROLLERS_DIR)/actuators/gppwm/gppwm.cpp \
-	$(CONTROLLERS_DIR)/modules/tachometer/tachometer.cpp \
 	$(CONTROLLERS_DIR)/gauges/speedometer.cpp \
 	$(CONTROLLERS_DIR)/gauges/malfunction_indicator.cpp \
 	$(CONTROLLERS_DIR)/system/timer/single_timer_executor.cpp \
@@ -89,7 +88,6 @@ CONTROLLERS_INC=\
 	$(CONTROLLERS_DIR)/trigger \
 	$(CONTROLLERS_DIR)/can \
 	$(CONTROLLERS_DIR)/core \
-	$(CONTROLLERS_DIR)/modules/tachometer \
 	$(CONTROLLERS_DIR)/gauges \
 	$(CONTROLLERS_DIR)/math \
 	$(CONTROLLERS_DIR)/generated \

--- a/firmware/controllers/engine_controller.cpp
+++ b/firmware/controllers/engine_controller.cpp
@@ -51,7 +51,6 @@
 #include "vvt.h"
 #include "boost_control.h"
 #include "launch_control.h"
-#include "tachometer.h"
 #include "speedometer.h"
 #include "gppwm.h"
 #include "date_stamp.h"
@@ -502,7 +501,10 @@ void commonInitEngineController() {
 	initAuxValves();
 #endif /* EFI_AUX_VALVES */
 
+#ifdef MODULE_TACHOMETER
 	engine->module<TachometerModule>()->init();
+#endif
+
 	initSpeedometer();
 
 #if EFI_LTFT_CONTROL

--- a/firmware/controllers/modules/generated/engine_modules_generated.h
+++ b/firmware/controllers/modules/generated/engine_modules_generated.h
@@ -1,0 +1,2 @@
+// TODO: generate me with a util! (read MODULES_INCLUDE var)
+#include "tachometer.h"

--- a/firmware/controllers/modules/generated/modules_list_generated.h
+++ b/firmware/controllers/modules/generated/modules_list_generated.h
@@ -1,0 +1,2 @@
+// TODO: generate me with a util! (read MODULES_LIST var)
+TachometerModule,

--- a/firmware/controllers/modules/modules.mk
+++ b/firmware/controllers/modules/modules.mk
@@ -1,0 +1,5 @@
+# auto-gen files
+MODULES_INC += $(PROJECT_DIR)/controllers/modules/generated
+
+# user defined modules
+include $(PROJECT_DIR)/controllers/modules/tachometer/tachometer.mk

--- a/firmware/controllers/modules/tachometer/tachometer.mk
+++ b/firmware/controllers/modules/tachometer/tachometer.mk
@@ -1,0 +1,7 @@
+MODULES_INC += $(PROJECT_DIR)/controllers/modules/tachometer
+MODULES_CPPSRC += $(PROJECT_DIR)/controllers/modules/tachometer/tachometer.cpp
+MODULES_INCLUDE += \#include "tachometer.h"\n
+MODULES_LIST += TachometerModule,
+
+# this define needs to be used in any file where the module is used (ie to not generate a compile error when we deactivate this module)
+DDEFS += -DMODULE_TACHOMETER

--- a/simulator/Makefile
+++ b/simulator/Makefile
@@ -174,7 +174,7 @@ endif
 include $(PROJECT_DIR)/console/binary/tunerstudio.mk
 include $(PROJECT_DIR)/console/console.mk
 include $(PROJECT_DIR)/common.mk
-
+include $(PROJECT_DIR)/controllers/modules/modules.mk
 
 # C sources that can be compiled in ARM or THUMB mode depending on the global
 # setting.
@@ -197,6 +197,7 @@ CPPSRC = $(ALLCPPSRC) \
   simulator/system/signal_executor_sleep.cpp \
   simulator/boards.cpp \
   $(TEST_SRC_CPP) \
+  $(MODULES_CPPSRC) \
   $(RUSEFI_LIB_CPP) \
   main.cpp
 
@@ -216,6 +217,7 @@ endif
 INCDIR += . \
   $(PCH_DIR) \
   $(ALLINC) \
+  $(MODULES_INC) \
   $(CHIBIOS)/os/various/cpp_wrappers \
   $(PROJECT_DIR)/hw_layer/drivers/can \
   ${CHIBIOS}/os/various \

--- a/unit_tests/Makefile
+++ b/unit_tests/Makefile
@@ -24,6 +24,7 @@ include $(UNIT_TESTS_DIR)/test.mk
 include $(UNIT_TESTS_DIR)/tests/tests.mk
 include $(PROJECT_DIR)/../unit_tests/tests/util/test_util.mk
 include $(PROJECT_DIR)/common.mk
+include $(PROJECT_DIR)/controllers/modules/modules.mk
 
 ifneq ("$(wildcard $(BOARD_DIR)/board_unit_tests.mk)","")
   # could depend on BOARDS_DIR
@@ -57,6 +58,7 @@ CPPSRC += $(ALLCPPSRC) \
 	$(PROJECT_DIR)/../unit_tests/mocks.cpp \
 	$(RUSEFI_LIB)/mock/lib-time-mocks.cpp \
 	$(RUSEFI_LIB_CPP) \
+	$(MODULES_CPPSRC) \
 	$(RUSEFI_LIB_CPP_TEST) \
 
 INCDIR += \
@@ -64,6 +66,7 @@ INCDIR += \
 	$(BOARDINC) \
 	$(UNIT_TESTS_DIR) \
 	$(ALLINC) \
+	$(MODULES_INC) \
 	$(PROJECT_DIR)/config/boards/hellen \
 	$(FRAMEWORK_INC) \
 	$(UNIT_TESTS_DIR)/test_data_structures \


### PR DESCRIPTION
Updated the makefiles, removed unused references to `tachometer.h`

now windows safe :D