### PR TITLE
CI coverage to assert that unit test build is incremental see #7748

### DIFF
--- a/.github/workflows/build-unit-tests.yaml
+++ b/.github/workflows/build-unit-tests.yaml
@@ -61,7 +61,7 @@ jobs:
       working-directory: ./unit_tests/
       run: |
         TIMEFORMAT=%R
-        time make -j4 COVERAGE=yes
+        timeout 30s make -j4 COVERAGE=yes
 
     - name: Run Tests
       working-directory: ./unit_tests/


### PR DESCRIPTION
The timeout command will throw an error code 127 if the second build takes more than 30 seconds.