### PR TITLE
TS UI: add etb1DutyCycle as Y OutputChannel on ETB bias curve

### DIFF
--- a/firmware/tunerstudio/tunerstudio.template.ini
+++ b/firmware/tunerstudio/tunerstudio.template.ini
@@ -593,7 +593,7 @@ enable2ndByteCanID = false
 		xAxis		=  0, 100, 11
 		yAxis		=  -40, 40, 9
 		xBins		= etbBiasBins, TPSValue
-		yBins		= etbBiasValues
+		yBins		= etbBiasValues, etb1DutyCycle
 		gauge		= TPSGauge
 
 	curve = ewgBiasCurve, "Electronic Wastegate Actuator Bias Curve"


### PR DESCRIPTION
This helps aiming when filling Bias table.
![Screenshot from 2025-04-20 11-55-25](https://github.com/user-attachments/assets/38e4b994-2cff-405d-86fe-a3b358e567e3)
