### PR TITLE
fix "can assign o2 input to a duplicate channel" see #7755

### DIFF
--- a/firmware/config/boards/f407-discovery/board_configuration.cpp
+++ b/firmware/config/boards/f407-discovery/board_configuration.cpp
@@ -112,7 +112,8 @@ void setBoardDefaultConfiguration() {
 	engineConfiguration->map.sensor.hwChannel = EFI_ADC_4;
 	engineConfiguration->clt.adcChannel = EFI_ADC_6;
 	engineConfiguration->iat.adcChannel = EFI_ADC_7;
-	engineConfiguration->afr.hwChannel = EFI_ADC_14;
+	engineConfiguration->afr.hwChannel = EFI_ADC_NONE;
+	engineConfiguration->afr.hwChannel2 = EFI_ADC_NONE;
 
 	engineConfiguration->accelerometerSpiDevice = SPI_DEVICE_1;
 

--- a/firmware/init/sensor/init_sensors.cpp
+++ b/firmware/init/sensor/init_sensors.cpp
@@ -42,11 +42,15 @@ void deInitIfValid(const char* msg, adc_channel_e channel) {
 }
 
 static void initOldAnalogInputs() {
+	initIfValid("AFR#1", engineConfiguration->afr.hwChannel);
+	initIfValid("AFR#2", engineConfiguration->afr.hwChannel2);
 	initIfValid("AUXF#1", engineConfiguration->auxFastSensor1_adcChannel);
 }
 
 static void deInitOldAnalogInputs() {
 	deInitIfValid("AUXF#1", activeConfiguration.auxFastSensor1_adcChannel);
+	deInitIfValid("AFR#1", engineConfiguration->afr.hwChannel);
+	deInitIfValid("AFR#2", engineConfiguration->afr.hwChannel2);
 }
 
 static void initAuxDigital() {


### PR DESCRIPTION
revert change:
https://github.com/rusefi/rusefi/pull/7723/files#diff-0e17bc54b82926e37cdea7b81c5c81924373b9369885a7fe45be05ce9389f5bf

`- initIfValid("AFR", engineConfiguration->afr.hwChannel);`

from pr #7723

resolves #7755 