### PR TITLE
rewrite etb autocal to support main loop

### DIFF
--- a/firmware/controllers/actuators/electronic_throttle.h
+++ b/firmware/controllers/actuators/electronic_throttle.h
@@ -68,7 +68,7 @@ public:
 	virtual void setIdlePosition(percent_t pos) = 0;
 	virtual void setWastegatePosition(percent_t pos) = 0;
 	virtual void update() = 0;
-	virtual void autoCalibrateTps(bool reportToTs = true) = 0;
+	virtual void autoCalibrateTps(bool reportToTs = true) { (void)reportToTs; }
 	virtual bool isEtbMode() const = 0;
 
 	virtual const pid_state_s& getPidState() const = 0;

--- a/firmware/controllers/actuators/electronic_throttle_impl.h
+++ b/firmware/controllers/actuators/electronic_throttle_impl.h
@@ -62,9 +62,6 @@ public:
 	// Used to inspect the internal PID controller's state
 	const pid_state_s& getPidState() const override { return m_pid; };
 
-	// Use the throttle to automatically calibrate the relevant throttle position sensor(s).
-	void autoCalibrateTps(bool reportToTs = true) override;
-
 	// Override if this throttle needs special per-throttle adjustment (bank-to-bank trim, for example)
 	virtual percent_t getThrottleTrim(float /*rpm*/, percent_t /*targetPosition*/) const {
 		return 0;
@@ -81,11 +78,6 @@ public:
 	float prevOutput = 0;
 
 protected:
-	// This is set if an automatic TPS calibration should be run
-	bool m_isAutocal = false;
-	// Report calibated values to TS, if false - set directrly to config
-	bool m_isAutocalTs = true;
-
 	bool hadTpsError = false;
 	bool hadPpsError = false;
 


### PR DESCRIPTION
https://github.com/FOME-Tech/fome-fw/pull/514

While we are not running mega-loop this still improves things when running > 1 ETB/EWG. Second ETB/EWG is not blocked while another one doing its TPS calibration.

* rewrite etb autocal for main loop compat

* properly reset phase timer

* comment