### PR TITLE
refactoring: leverage EngineModule more often [ethernet_console] see #7572

### DIFF
--- a/firmware/console/console.mk
+++ b/firmware/console/console.mk
@@ -9,7 +9,6 @@ CONSOLE_SRC_CPP = $(CONSOLE_COMMON_SRC_CPP) \
 	$(PROJECT_DIR)/console/eficonsole.cpp \
 	$(PROJECT_DIR)/console/connector_uart_dma.cpp \
 	$(PROJECT_DIR)/console/binary_log/usb_console.cpp \
-	$(PROJECT_DIR)/console/binary_log/ethernet_console.cpp \
 	$(PROJECT_DIR)/console/wifi_console.cpp \
 
 

--- a/firmware/console/eficonsole.h
+++ b/firmware/console/eficonsole.h
@@ -7,11 +7,17 @@
  */
 
 #pragma once
+#include "engine_module.h"
 
 void initializeConsole();
 
 void startUsbConsole();
 void printUsbConnectorStats();
 
-void startEthernetConsole();
 void startWifiConsole();
+
+#if EFI_ETHERNET
+struct EthernetConsoleModule final : public EngineModule {
+    void initNoConfiguration();
+};
+#endif

--- a/firmware/controllers/modules/ethernet_console/ethernet_console.cpp
+++ b/firmware/controllers/modules/ethernet_console/ethernet_console.cpp
@@ -80,7 +80,7 @@ struct EthernetThread : public TunerstudioThread {
 
 static EthernetThread ethernetConsole;
 
-void startEthernetConsole() {
+void EthernetConsoleModule::initNoConfiguration() {
 	ethernetConsole.start();
 }
 

--- a/firmware/controllers/modules/ethernet_console/ethernet_console.mk
+++ b/firmware/controllers/modules/ethernet_console/ethernet_console.mk
@@ -1,0 +1,2 @@
+MODULES_CPPSRC += $(PROJECT_DIR)/controllers/modules/ethernet_console/ethernet_console.cpp
+MODULES_LIST += #if EFI_ETHERNET \n EthernetConsoleModule, \n #endif

--- a/firmware/controllers/modules/generated/modules_list_generated.h
+++ b/firmware/controllers/modules/generated/modules_list_generated.h
@@ -5,3 +5,7 @@ GearDetector,
 TripOdometer,
 FanControl1,FanControl2,
 MapAveragingModule,
+
+#if EFI_ETHERNET
+EthernetConsoleModule,
+#endif

--- a/firmware/controllers/modules/modules.mk
+++ b/firmware/controllers/modules/modules.mk
@@ -8,3 +8,4 @@ include $(PROJECT_DIR)/controllers/modules/gear_detector/gear_detector.mk
 include $(PROJECT_DIR)/controllers/modules/trip_odometer/trip_odometer.mk
 include $(PROJECT_DIR)/controllers/modules/fan_control/fan_control.mk
 include $(PROJECT_DIR)/controllers/modules/map_averaging/map_averaging.mk
+include $(PROJECT_DIR)/controllers/modules/ethernet_console/ethernet_console.mk

--- a/firmware/rusefi.cpp
+++ b/firmware/rusefi.cpp
@@ -213,9 +213,6 @@ void runRusEfi() {
   // at the moment that's always hellen board ID
 	detectBoardType();
 
-#if EFI_ETHERNET
-	startEthernetConsole();
-#endif
 
 #if EFI_USB_SERIAL
 	startUsbConsole();


### PR DESCRIPTION
last pr for resolve #7572, also first example of a optional module :D (ie, not all boards have eth, so the module is removed for those), also some form of progress to https://github.com/rusefi/rusefi/issues/7603 (_per-feature .txt and template.ini provisions_)