### PR TITLE
defect around pt2001 timeout to trigger warning for pump #7776

### DIFF
--- a/firmware/controllers/limp_manager.cpp
+++ b/firmware/controllers/limp_manager.cpp
@@ -225,12 +225,14 @@ void LimpManager::updateState(float rpm, efitick_t nowNt) {
 #if EFI_HPFP
 	{
 		// HPFP Fuel cut
-		angle_t finalHpfpPumpAngle = engine->module<HpfpController>().unmock().m_deadangle + static_cast<angle_t>(engineConfiguration->hpfpActivationAngle);
-		float finalHpfpPumpTime = static_cast<float>(finalHpfpPumpAngle) * engine->rpmCalculator.oneDegreeUs;
+		angle_t m_deadangle = engine->module<HpfpController>().unmock().m_deadangle;
+		angle_t finalHpfpPumpAngle = m_deadangle + static_cast<angle_t>(engineConfiguration->hpfpActivationAngle);
+		float finalHpfpPumpTimeMs = US2MS(static_cast<float>(finalHpfpPumpAngle) * engine->rpmCalculator.oneDegreeUs);
 
-		if(isGdiEngine() && finalHpfpPumpTime > MS2US(engineConfiguration->mc33_hpfp_max_hold)) {
+		if (engineConfiguration->tempPumpLimitCheck && isGdiEngine() && finalHpfpPumpTimeMs > engineConfiguration->mc33_hpfp_max_hold) {
 			allowFuel.clear(ClearReason::GdiPumpLimit);
-			warning(ObdCode::CUSTOM_TOO_LONG_FUEL_INJECTION, "Injection HPFP pump time excess PT2001 limits time: %.4f", finalHpfpPumpTime);
+			warning(ObdCode::CUSTOM_TOO_LONG_FUEL_INJECTION, "Injection HPFP pump time excess PT2001 limits time: %.4fms", finalHpfpPumpTimeMs);
+			efiPrintf("%f %f %f", m_deadangle, (float)engineConfiguration->hpfpActivationAngle, engine->rpmCalculator.oneDegreeUs);
 		}
 	}
 #endif

--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -525,7 +525,7 @@ bit useTLE8888_cranking_hack;
 bit kickStartCranking
 bit useSeparateIdleTablesForCrankingTaper;This uses separate ignition timing and VE tables not only for idle conditions, also during the postcranking-to-idle taper transition (See also afterCrankingIACtaperDuration).
 bit launchControlEnabled;
-bit unusedBitHere
+bit tempPumpLimitCheck
 bit antiLagEnabled;
 bit useRunningMathForCranking,"Fuel Map","Fixed";For cranking either use the specified fixed base fuel mass, or use the normal running math (VE table).
 bit displayLogicLevelsInEngineSniffer;Shall we display real life signal or just the part consumed by trigger decoder.\nApplies to both trigger and cam/vvt input.

--- a/firmware/tunerstudio/tunerstudio.template.ini
+++ b/firmware/tunerstudio/tunerstudio.template.ini
@@ -5595,6 +5595,7 @@ dialog = tcuControls, "Transmission Settings"
 		field = "Valve Pin Mode", hpfpValvePinMode, {hpfpCamLobes != 0}
 		commandButton = "Bench Test HPFP Valve", cmd_test_hpfp_valve
 	field = "Valve peak current", mc33_hpfp_i_peak, {hpfpCamLobes != 0}
+	field = tempPumpLimitCheck, tempPumpLimitCheck
 	field = "Valve hold current", mc33_hpfp_i_hold, {hpfpCamLobes != 0}
 	field = "Valve hold off time", mc33_hpfp_i_hold_off, {hpfpCamLobes != 0}
 	field = "Valve maximum duration", mc33_hpfp_max_hold, {hpfpCamLobes != 0}

--- a/java_console/ui/src/main/java/com/rusefi/maintenance/DfuFlasher.java
+++ b/java_console/ui/src/main/java/com/rusefi/maintenance/DfuFlasher.java
@@ -1,6 +1,5 @@
 package com.rusefi.maintenance;
 
-import com.devexperts.logging.Logging;
 import com.rusefi.FileLog;
 import com.rusefi.Launcher;
 import com.rusefi.SerialPortScanner;
@@ -26,14 +25,13 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static com.devexperts.logging.Logging.getLogging;
 import static com.rusefi.core.FindFileHelper.INPUT_FILES_PATH;
 
 /**
  * @see StLinkFlasher
  */
 public class DfuFlasher {
-    private static final Logging log = getLogging(DfuFlasher.class);
+    //private static final Logging log = getLogging(DfuFlasher.class);
 
     public static final String BOOTLOADER_BIN_FILE = INPUT_FILES_PATH + "/" + "openblt.bin";
     private static final String DFU_CMD_TOOL_LOCATION = Launcher.TOOLS_PATH + File.separator + "STM32_Programmer_CLI/bin";
@@ -234,7 +232,7 @@ public class DfuFlasher {
     }
 
     public static boolean detectSTM32BootloaderDriverState(UpdateOperationCallbacks callbacks) {
-        return MaintenanceUtil.detectDevice(callbacks, WMIC_DFU_QUERY_COMMAND, "ConfigManagerErrorCode=0");
+        return MaintenanceUtil.detectDevice(callbacks, WMIC_DFU_QUERY_COMMAND, "ConfigManagerErrorCode=0", true);
     }
 
     private static void appendWindowsVersion(UpdateOperationCallbacks callbacks) {

--- a/java_console/ui/src/main/java/com/rusefi/maintenance/MaintenanceUtil.java
+++ b/java_console/ui/src/main/java/com/rusefi/maintenance/MaintenanceUtil.java
@@ -9,31 +9,32 @@ import java.io.File;
 import static com.devexperts.logging.Logging.getLogging;
 
 public class MaintenanceUtil {
-    private static final Logging log = getLogging(DfuFlasher.class);
+    private static final Logging log = getLogging(MaintenanceUtil.class);
 
     private static final String WMIC_PCAN_QUERY_COMMAND = "wmic path win32_pnpentity where \"Caption like '%PCAN-USB%'\" get Caption,ConfigManagerErrorCode /format:list";
 
-    static boolean detectDevice(UpdateOperationCallbacks callbacks, String queryCommand, String pattern) {
+    static boolean detectDevice(UpdateOperationCallbacks callbacks, String queryCommand, String pattern, boolean valueInCaseOfError) {
         long now = System.currentTimeMillis();
         StringBuffer output = new StringBuffer();
         StringBuffer error = new StringBuffer();
         try {
             ExecHelper.executeCommand(queryCommand, callbacks, output, error, null);
         } catch (ErrorExecutingCommand e) {
+            log.error("Error: " + e);
             callbacks.logLine("IOError: " + e);
             // let's assume DFU is present just to give user more options
-            return true;
+            return valueInCaseOfError;
         }
         callbacks.logLine(output.toString());
         callbacks.logLine(error.toString());
         long cost = System.currentTimeMillis() - now;
-        log.info("DFU lookup cost " + cost + "ms");
+        log.info("detectDevice lookup cost " + cost + "ms");
         log.info(queryCommand + " says " + output);
         return output.toString().contains(pattern);
     }
 
     public static boolean detectPcan(UpdateOperationCallbacks wnd) {
-        return detectDevice(wnd, WMIC_PCAN_QUERY_COMMAND, "PCAN");
+        return detectDevice(wnd, WMIC_PCAN_QUERY_COMMAND, "PCAN", false);
     }
 
     public static long getBinaryModificationTimestamp() {

--- a/java_console/ui/src/main/java/com/rusefi/maintenance/StLinkFlasher.java
+++ b/java_console/ui/src/main/java/com/rusefi/maintenance/StLinkFlasher.java
@@ -74,7 +74,7 @@ public class StLinkFlasher {
     }
 
     public static boolean detectStLink(UpdateOperationCallbacks wnd) {
-        return MaintenanceUtil.detectDevice(wnd, WMIC_STLINK_QUERY_COMMAND, "STLink");
+        return MaintenanceUtil.detectDevice(wnd, WMIC_STLINK_QUERY_COMMAND, "STLink", false);
     }
 
     @NotNull

--- a/simulator/generated/simulator_tune.msq
+++ b/simulator/generated/simulator_tune.msq
@@ -4007,6 +4007,7 @@ end</constant>
         <constant name="tcuUpshiftButtonPin">"NONE"</constant>
         <constant name="tcuUpshiftButtonPinMode">"DEFAULT"</constant>
         <constant digits="0" name="technicalDebt7738" units="">0.0</constant>
+        <constant name="tempPumpLimitCheck">"false"</constant>
         <constant cols="1" digits="0" name="throttle2TrimRpmBins" rows="6">
          0.0
          0.0
@@ -4413,7 +4414,6 @@ end</constant>
         <constant name="unused1320_28">"false"</constant>
         <constant name="unused920_1testChange">"false"</constant>
         <constant digits="0" name="unusedafterCrankingIACtaperDuration" units="">0.0</constant>
-        <constant name="unusedBitHere">"false"</constant>
         <constant digits="0" name="unusedcrankingIACposition" units="">0.0</constant>
         <constant name="unusedFancy10">"false"</constant>
         <constant name="unusedFancy11">"false"</constant>
@@ -4990,7 +4990,7 @@ end</constant>
 </constant>
         <constant name="yesUnderstandLocking">"no"</constant>
     </page>
-    <versionInfo firmwareInfo="20250424" nPages="1" signature="rusEFI master.2025.04.24.f407-discovery.1559754547" version="5.0"/>
+    <versionInfo firmwareInfo="20250424" nPages="1" signature="rusEFI master.2025.04.24.f407-discovery.3676123804" version="5.0"/>
     <bibliography author="rusEFI 20250424" writeDate="date"/>
     <settings/>
     <userComments/>

--- a/simulator/generated/simulator_tune_BMW_M52.msq
+++ b/simulator/generated/simulator_tune_BMW_M52.msq
@@ -4007,6 +4007,7 @@ end</constant>
         <constant name="tcuUpshiftButtonPin">"NONE"</constant>
         <constant name="tcuUpshiftButtonPinMode">"DEFAULT"</constant>
         <constant digits="0" name="technicalDebt7738" units="">0.0</constant>
+        <constant name="tempPumpLimitCheck">"false"</constant>
         <constant cols="1" digits="0" name="throttle2TrimRpmBins" rows="6">
          0.0
          0.0
@@ -4413,7 +4414,6 @@ end</constant>
         <constant name="unused1320_28">"false"</constant>
         <constant name="unused920_1testChange">"false"</constant>
         <constant digits="0" name="unusedafterCrankingIACtaperDuration" units="">0.0</constant>
-        <constant name="unusedBitHere">"false"</constant>
         <constant digits="0" name="unusedcrankingIACposition" units="">0.0</constant>
         <constant name="unusedFancy10">"false"</constant>
         <constant name="unusedFancy11">"false"</constant>
@@ -4990,7 +4990,7 @@ end</constant>
 </constant>
         <constant name="yesUnderstandLocking">"no"</constant>
     </page>
-    <versionInfo firmwareInfo="20250424" nPages="1" signature="rusEFI master.2025.04.24.f407-discovery.1559754547" version="5.0"/>
+    <versionInfo firmwareInfo="20250424" nPages="1" signature="rusEFI master.2025.04.24.f407-discovery.3676123804" version="5.0"/>
     <bibliography author="rusEFI 20250424" writeDate="date"/>
     <settings/>
     <userComments/>

--- a/simulator/generated/simulator_tune_HELLEN_121_NISSAN_6_CYL.msq
+++ b/simulator/generated/simulator_tune_HELLEN_121_NISSAN_6_CYL.msq
@@ -4171,6 +4171,7 @@ canRxAdd(IN_35D, onCanRxAc)</constant>
         <constant name="tcuUpshiftButtonPin">"NONE"</constant>
         <constant name="tcuUpshiftButtonPinMode">"DEFAULT"</constant>
         <constant digits="0" name="technicalDebt7738" units="">0.0</constant>
+        <constant name="tempPumpLimitCheck">"false"</constant>
         <constant cols="1" digits="0" name="throttle2TrimRpmBins" rows="6">
          0.0
          0.0
@@ -4577,7 +4578,6 @@ canRxAdd(IN_35D, onCanRxAc)</constant>
         <constant name="unused1320_28">"false"</constant>
         <constant name="unused920_1testChange">"false"</constant>
         <constant digits="0" name="unusedafterCrankingIACtaperDuration" units="">0.0</constant>
-        <constant name="unusedBitHere">"false"</constant>
         <constant digits="0" name="unusedcrankingIACposition" units="">0.0</constant>
         <constant name="unusedFancy10">"false"</constant>
         <constant name="unusedFancy11">"false"</constant>
@@ -5154,7 +5154,7 @@ canRxAdd(IN_35D, onCanRxAc)</constant>
 </constant>
         <constant name="yesUnderstandLocking">"no"</constant>
     </page>
-    <versionInfo firmwareInfo="20250424" nPages="1" signature="rusEFI master.2025.04.24.f407-discovery.1559754547" version="5.0"/>
+    <versionInfo firmwareInfo="20250424" nPages="1" signature="rusEFI master.2025.04.24.f407-discovery.3676123804" version="5.0"/>
     <bibliography author="rusEFI 20250424" writeDate="date"/>
     <settings/>
     <userComments/>

--- a/simulator/generated/simulator_tune_HELLEN_154_HYUNDAI_COUPE_BK1.msq
+++ b/simulator/generated/simulator_tune_HELLEN_154_HYUNDAI_COUPE_BK1.msq
@@ -4056,6 +4056,7 @@ end</constant>
         <constant name="tcuUpshiftButtonPin">"NONE"</constant>
         <constant name="tcuUpshiftButtonPinMode">"DEFAULT"</constant>
         <constant digits="0" name="technicalDebt7738" units="">0.0</constant>
+        <constant name="tempPumpLimitCheck">"false"</constant>
         <constant cols="1" digits="0" name="throttle2TrimRpmBins" rows="6">
          0.0
          0.0
@@ -4462,7 +4463,6 @@ end</constant>
         <constant name="unused1320_28">"false"</constant>
         <constant name="unused920_1testChange">"false"</constant>
         <constant digits="0" name="unusedafterCrankingIACtaperDuration" units="">0.0</constant>
-        <constant name="unusedBitHere">"false"</constant>
         <constant digits="0" name="unusedcrankingIACposition" units="">0.0</constant>
         <constant name="unusedFancy10">"false"</constant>
         <constant name="unusedFancy11">"false"</constant>
@@ -5039,7 +5039,7 @@ end</constant>
 </constant>
         <constant name="yesUnderstandLocking">"no"</constant>
     </page>
-    <versionInfo firmwareInfo="20250424" nPages="1" signature="rusEFI master.2025.04.24.f407-discovery.1559754547" version="5.0"/>
+    <versionInfo firmwareInfo="20250424" nPages="1" signature="rusEFI master.2025.04.24.f407-discovery.3676123804" version="5.0"/>
     <bibliography author="rusEFI 20250424" writeDate="date"/>
     <settings/>
     <userComments/>

--- a/simulator/generated/simulator_tune_HELLEN_154_HYUNDAI_COUPE_BK2.msq
+++ b/simulator/generated/simulator_tune_HELLEN_154_HYUNDAI_COUPE_BK2.msq
@@ -4056,6 +4056,7 @@ end</constant>
         <constant name="tcuUpshiftButtonPin">"NONE"</constant>
         <constant name="tcuUpshiftButtonPinMode">"DEFAULT"</constant>
         <constant digits="0" name="technicalDebt7738" units="">0.0</constant>
+        <constant name="tempPumpLimitCheck">"false"</constant>
         <constant cols="1" digits="0" name="throttle2TrimRpmBins" rows="6">
          0.0
          0.0
@@ -4462,7 +4463,6 @@ end</constant>
         <constant name="unused1320_28">"false"</constant>
         <constant name="unused920_1testChange">"false"</constant>
         <constant digits="0" name="unusedafterCrankingIACtaperDuration" units="">0.0</constant>
-        <constant name="unusedBitHere">"false"</constant>
         <constant digits="0" name="unusedcrankingIACposition" units="">0.0</constant>
         <constant name="unusedFancy10">"false"</constant>
         <constant name="unusedFancy11">"false"</constant>
@@ -5039,7 +5039,7 @@ end</constant>
 </constant>
         <constant name="yesUnderstandLocking">"no"</constant>
     </page>
-    <versionInfo firmwareInfo="20250424" nPages="1" signature="rusEFI master.2025.04.24.f407-discovery.1559754547" version="5.0"/>
+    <versionInfo firmwareInfo="20250424" nPages="1" signature="rusEFI master.2025.04.24.f407-discovery.3676123804" version="5.0"/>
     <bibliography author="rusEFI 20250424" writeDate="date"/>
     <settings/>
     <userComments/>

--- a/simulator/generated/simulator_tune_HONDA_K.msq
+++ b/simulator/generated/simulator_tune_HONDA_K.msq
@@ -4009,6 +4009,7 @@ end</constant>
         <constant name="tcuUpshiftButtonPin">"NONE"</constant>
         <constant name="tcuUpshiftButtonPinMode">"DEFAULT"</constant>
         <constant digits="0" name="technicalDebt7738" units="">0.0</constant>
+        <constant name="tempPumpLimitCheck">"false"</constant>
         <constant cols="1" digits="0" name="throttle2TrimRpmBins" rows="6">
          0.0
          0.0
@@ -4415,7 +4416,6 @@ end</constant>
         <constant name="unused1320_28">"false"</constant>
         <constant name="unused920_1testChange">"false"</constant>
         <constant digits="0" name="unusedafterCrankingIACtaperDuration" units="">0.0</constant>
-        <constant name="unusedBitHere">"false"</constant>
         <constant digits="0" name="unusedcrankingIACposition" units="">0.0</constant>
         <constant name="unusedFancy10">"false"</constant>
         <constant name="unusedFancy11">"false"</constant>
@@ -4992,7 +4992,7 @@ end</constant>
 </constant>
         <constant name="yesUnderstandLocking">"no"</constant>
     </page>
-    <versionInfo firmwareInfo="20250424" nPages="1" signature="rusEFI master.2025.04.24.f407-discovery.1559754547" version="5.0"/>
+    <versionInfo firmwareInfo="20250424" nPages="1" signature="rusEFI master.2025.04.24.f407-discovery.3676123804" version="5.0"/>
     <bibliography author="rusEFI 20250424" writeDate="date"/>
     <settings/>
     <userComments/>

--- a/simulator/generated/simulator_tune_HONDA_OBD1.msq
+++ b/simulator/generated/simulator_tune_HONDA_OBD1.msq
@@ -4008,6 +4008,7 @@ end</constant>
         <constant name="tcuUpshiftButtonPin">"NONE"</constant>
         <constant name="tcuUpshiftButtonPinMode">"DEFAULT"</constant>
         <constant digits="0" name="technicalDebt7738" units="">0.0</constant>
+        <constant name="tempPumpLimitCheck">"false"</constant>
         <constant cols="1" digits="0" name="throttle2TrimRpmBins" rows="6">
          0.0
          0.0
@@ -4414,7 +4415,6 @@ end</constant>
         <constant name="unused1320_28">"false"</constant>
         <constant name="unused920_1testChange">"false"</constant>
         <constant digits="0" name="unusedafterCrankingIACtaperDuration" units="">0.0</constant>
-        <constant name="unusedBitHere">"false"</constant>
         <constant digits="0" name="unusedcrankingIACposition" units="">0.0</constant>
         <constant name="unusedFancy10">"false"</constant>
         <constant name="unusedFancy11">"false"</constant>
@@ -4991,7 +4991,7 @@ end</constant>
 </constant>
         <constant name="yesUnderstandLocking">"no"</constant>
     </page>
-    <versionInfo firmwareInfo="20250424" nPages="1" signature="rusEFI master.2025.04.24.f407-discovery.1559754547" version="5.0"/>
+    <versionInfo firmwareInfo="20250424" nPages="1" signature="rusEFI master.2025.04.24.f407-discovery.3676123804" version="5.0"/>
     <bibliography author="rusEFI 20250424" writeDate="date"/>
     <settings/>
     <userComments/>

--- a/simulator/generated/simulator_tune_HYUNDAI_PB.msq
+++ b/simulator/generated/simulator_tune_HYUNDAI_PB.msq
@@ -4099,6 +4099,7 @@ end</constant>
         <constant name="tcuUpshiftButtonPin">"NONE"</constant>
         <constant name="tcuUpshiftButtonPinMode">"DEFAULT"</constant>
         <constant digits="0" name="technicalDebt7738" units="">0.0</constant>
+        <constant name="tempPumpLimitCheck">"false"</constant>
         <constant cols="1" digits="0" name="throttle2TrimRpmBins" rows="6">
          0.0
          0.0
@@ -4505,7 +4506,6 @@ end</constant>
         <constant name="unused1320_28">"false"</constant>
         <constant name="unused920_1testChange">"false"</constant>
         <constant digits="0" name="unusedafterCrankingIACtaperDuration" units="">0.0</constant>
-        <constant name="unusedBitHere">"false"</constant>
         <constant digits="0" name="unusedcrankingIACposition" units="">0.0</constant>
         <constant name="unusedFancy10">"false"</constant>
         <constant name="unusedFancy11">"false"</constant>
@@ -5082,7 +5082,7 @@ end</constant>
 </constant>
         <constant name="yesUnderstandLocking">"no"</constant>
     </page>
-    <versionInfo firmwareInfo="20250424" nPages="1" signature="rusEFI master.2025.04.24.f407-discovery.1559754547" version="5.0"/>
+    <versionInfo firmwareInfo="20250424" nPages="1" signature="rusEFI master.2025.04.24.f407-discovery.3676123804" version="5.0"/>
     <bibliography author="rusEFI 20250424" writeDate="date"/>
     <settings/>
     <userComments/>

--- a/simulator/generated/simulator_tune_MAVERICK_X3.msq
+++ b/simulator/generated/simulator_tune_MAVERICK_X3.msq
@@ -4006,6 +4006,7 @@ end</constant>
         <constant name="tcuUpshiftButtonPin">"NONE"</constant>
         <constant name="tcuUpshiftButtonPinMode">"DEFAULT"</constant>
         <constant digits="0" name="technicalDebt7738" units="">0.0</constant>
+        <constant name="tempPumpLimitCheck">"false"</constant>
         <constant cols="1" digits="0" name="throttle2TrimRpmBins" rows="6">
          0.0
          0.0
@@ -4412,7 +4413,6 @@ end</constant>
         <constant name="unused1320_28">"false"</constant>
         <constant name="unused920_1testChange">"false"</constant>
         <constant digits="0" name="unusedafterCrankingIACtaperDuration" units="">0.0</constant>
-        <constant name="unusedBitHere">"false"</constant>
         <constant digits="0" name="unusedcrankingIACposition" units="">0.0</constant>
         <constant name="unusedFancy10">"false"</constant>
         <constant name="unusedFancy11">"false"</constant>
@@ -4989,7 +4989,7 @@ end</constant>
 </constant>
         <constant name="yesUnderstandLocking">"no"</constant>
     </page>
-    <versionInfo firmwareInfo="20250424" nPages="1" signature="rusEFI master.2025.04.24.f407-discovery.1559754547" version="5.0"/>
+    <versionInfo firmwareInfo="20250424" nPages="1" signature="rusEFI master.2025.04.24.f407-discovery.3676123804" version="5.0"/>
     <bibliography author="rusEFI 20250424" writeDate="date"/>
     <settings/>
     <userComments/>

--- a/simulator/generated/simulator_tune_MAZDA_MIATA_NA6.msq
+++ b/simulator/generated/simulator_tune_MAZDA_MIATA_NA6.msq
@@ -4009,6 +4009,7 @@ end</constant>
         <constant name="tcuUpshiftButtonPin">"NONE"</constant>
         <constant name="tcuUpshiftButtonPinMode">"DEFAULT"</constant>
         <constant digits="0" name="technicalDebt7738" units="">0.0</constant>
+        <constant name="tempPumpLimitCheck">"false"</constant>
         <constant cols="1" digits="0" name="throttle2TrimRpmBins" rows="6">
          0.0
          0.0
@@ -4415,7 +4416,6 @@ end</constant>
         <constant name="unused1320_28">"false"</constant>
         <constant name="unused920_1testChange">"false"</constant>
         <constant digits="0" name="unusedafterCrankingIACtaperDuration" units="">0.0</constant>
-        <constant name="unusedBitHere">"false"</constant>
         <constant digits="0" name="unusedcrankingIACposition" units="">0.0</constant>
         <constant name="unusedFancy10">"false"</constant>
         <constant name="unusedFancy11">"false"</constant>
@@ -4992,7 +4992,7 @@ end</constant>
 </constant>
         <constant name="yesUnderstandLocking">"no"</constant>
     </page>
-    <versionInfo firmwareInfo="20250424" nPages="1" signature="rusEFI master.2025.04.24.f407-discovery.1559754547" version="5.0"/>
+    <versionInfo firmwareInfo="20250424" nPages="1" signature="rusEFI master.2025.04.24.f407-discovery.3676123804" version="5.0"/>
     <bibliography author="rusEFI 20250424" writeDate="date"/>
     <settings/>
     <userComments/>

--- a/simulator/generated/simulator_tune_MAZDA_MIATA_NA94.msq
+++ b/simulator/generated/simulator_tune_MAZDA_MIATA_NA94.msq
@@ -4009,6 +4009,7 @@ end</constant>
         <constant name="tcuUpshiftButtonPin">"NONE"</constant>
         <constant name="tcuUpshiftButtonPinMode">"DEFAULT"</constant>
         <constant digits="0" name="technicalDebt7738" units="">0.0</constant>
+        <constant name="tempPumpLimitCheck">"false"</constant>
         <constant cols="1" digits="0" name="throttle2TrimRpmBins" rows="6">
          0.0
          0.0
@@ -4415,7 +4416,6 @@ end</constant>
         <constant name="unused1320_28">"false"</constant>
         <constant name="unused920_1testChange">"false"</constant>
         <constant digits="0" name="unusedafterCrankingIACtaperDuration" units="">0.0</constant>
-        <constant name="unusedBitHere">"false"</constant>
         <constant digits="0" name="unusedcrankingIACposition" units="">0.0</constant>
         <constant name="unusedFancy10">"false"</constant>
         <constant name="unusedFancy11">"false"</constant>
@@ -4992,7 +4992,7 @@ end</constant>
 </constant>
         <constant name="yesUnderstandLocking">"no"</constant>
     </page>
-    <versionInfo firmwareInfo="20250424" nPages="1" signature="rusEFI master.2025.04.24.f407-discovery.1559754547" version="5.0"/>
+    <versionInfo firmwareInfo="20250424" nPages="1" signature="rusEFI master.2025.04.24.f407-discovery.3676123804" version="5.0"/>
     <bibliography author="rusEFI 20250424" writeDate="date"/>
     <settings/>
     <userComments/>

--- a/simulator/generated/simulator_tune_MAZDA_MIATA_NA96.msq
+++ b/simulator/generated/simulator_tune_MAZDA_MIATA_NA96.msq
@@ -4009,6 +4009,7 @@ end</constant>
         <constant name="tcuUpshiftButtonPin">"NONE"</constant>
         <constant name="tcuUpshiftButtonPinMode">"DEFAULT"</constant>
         <constant digits="0" name="technicalDebt7738" units="">0.0</constant>
+        <constant name="tempPumpLimitCheck">"false"</constant>
         <constant cols="1" digits="0" name="throttle2TrimRpmBins" rows="6">
          0.0
          0.0
@@ -4415,7 +4416,6 @@ end</constant>
         <constant name="unused1320_28">"false"</constant>
         <constant name="unused920_1testChange">"false"</constant>
         <constant digits="0" name="unusedafterCrankingIACtaperDuration" units="">0.0</constant>
-        <constant name="unusedBitHere">"false"</constant>
         <constant digits="0" name="unusedcrankingIACposition" units="">0.0</constant>
         <constant name="unusedFancy10">"false"</constant>
         <constant name="unusedFancy11">"false"</constant>
@@ -4992,7 +4992,7 @@ end</constant>
 </constant>
         <constant name="yesUnderstandLocking">"no"</constant>
     </page>
-    <versionInfo firmwareInfo="20250424" nPages="1" signature="rusEFI master.2025.04.24.f407-discovery.1559754547" version="5.0"/>
+    <versionInfo firmwareInfo="20250424" nPages="1" signature="rusEFI master.2025.04.24.f407-discovery.3676123804" version="5.0"/>
     <bibliography author="rusEFI 20250424" writeDate="date"/>
     <settings/>
     <userComments/>

--- a/simulator/generated/simulator_tune_MAZDA_MIATA_NB1.msq
+++ b/simulator/generated/simulator_tune_MAZDA_MIATA_NB1.msq
@@ -4009,6 +4009,7 @@ end</constant>
         <constant name="tcuUpshiftButtonPin">"NONE"</constant>
         <constant name="tcuUpshiftButtonPinMode">"DEFAULT"</constant>
         <constant digits="0" name="technicalDebt7738" units="">0.0</constant>
+        <constant name="tempPumpLimitCheck">"false"</constant>
         <constant cols="1" digits="0" name="throttle2TrimRpmBins" rows="6">
          0.0
          0.0
@@ -4415,7 +4416,6 @@ end</constant>
         <constant name="unused1320_28">"false"</constant>
         <constant name="unused920_1testChange">"false"</constant>
         <constant digits="0" name="unusedafterCrankingIACtaperDuration" units="">0.0</constant>
-        <constant name="unusedBitHere">"false"</constant>
         <constant digits="0" name="unusedcrankingIACposition" units="">0.0</constant>
         <constant name="unusedFancy10">"false"</constant>
         <constant name="unusedFancy11">"false"</constant>
@@ -4992,7 +4992,7 @@ end</constant>
 </constant>
         <constant name="yesUnderstandLocking">"no"</constant>
     </page>
-    <versionInfo firmwareInfo="20250424" nPages="1" signature="rusEFI master.2025.04.24.f407-discovery.1559754547" version="5.0"/>
+    <versionInfo firmwareInfo="20250424" nPages="1" signature="rusEFI master.2025.04.24.f407-discovery.3676123804" version="5.0"/>
     <bibliography author="rusEFI 20250424" writeDate="date"/>
     <settings/>
     <userComments/>

--- a/simulator/generated/simulator_tune_MAZDA_MIATA_NB2.msq
+++ b/simulator/generated/simulator_tune_MAZDA_MIATA_NB2.msq
@@ -4009,6 +4009,7 @@ end</constant>
         <constant name="tcuUpshiftButtonPin">"NONE"</constant>
         <constant name="tcuUpshiftButtonPinMode">"DEFAULT"</constant>
         <constant digits="0" name="technicalDebt7738" units="">0.0</constant>
+        <constant name="tempPumpLimitCheck">"false"</constant>
         <constant cols="1" digits="0" name="throttle2TrimRpmBins" rows="6">
          0.0
          0.0
@@ -4415,7 +4416,6 @@ end</constant>
         <constant name="unused1320_28">"false"</constant>
         <constant name="unused920_1testChange">"false"</constant>
         <constant digits="0" name="unusedafterCrankingIACtaperDuration" units="">0.0</constant>
-        <constant name="unusedBitHere">"false"</constant>
         <constant digits="0" name="unusedcrankingIACposition" units="">0.0</constant>
         <constant name="unusedFancy10">"false"</constant>
         <constant name="unusedFancy11">"false"</constant>
@@ -4993,7 +4993,7 @@ end</constant>
 </constant>
         <constant name="yesUnderstandLocking">"no"</constant>
     </page>
-    <versionInfo firmwareInfo="20250424" nPages="1" signature="rusEFI master.2025.04.24.f407-discovery.1559754547" version="5.0"/>
+    <versionInfo firmwareInfo="20250424" nPages="1" signature="rusEFI master.2025.04.24.f407-discovery.3676123804" version="5.0"/>
     <bibliography author="rusEFI 20250424" writeDate="date"/>
     <settings/>
     <userComments/>

--- a/simulator/generated/simulator_tune_MERCEDES_M111.msq
+++ b/simulator/generated/simulator_tune_MERCEDES_M111.msq
@@ -4009,6 +4009,7 @@ end</constant>
         <constant name="tcuUpshiftButtonPin">"NONE"</constant>
         <constant name="tcuUpshiftButtonPinMode">"DEFAULT"</constant>
         <constant digits="0" name="technicalDebt7738" units="">0.0</constant>
+        <constant name="tempPumpLimitCheck">"false"</constant>
         <constant cols="1" digits="0" name="throttle2TrimRpmBins" rows="6">
          0.0
          0.0
@@ -4415,7 +4416,6 @@ end</constant>
         <constant name="unused1320_28">"false"</constant>
         <constant name="unused920_1testChange">"false"</constant>
         <constant digits="0" name="unusedafterCrankingIACtaperDuration" units="">0.0</constant>
-        <constant name="unusedBitHere">"false"</constant>
         <constant digits="0" name="unusedcrankingIACposition" units="">0.0</constant>
         <constant name="unusedFancy10">"false"</constant>
         <constant name="unusedFancy11">"false"</constant>
@@ -4992,7 +4992,7 @@ end</constant>
 </constant>
         <constant name="yesUnderstandLocking">"no"</constant>
     </page>
-    <versionInfo firmwareInfo="20250424" nPages="1" signature="rusEFI master.2025.04.24.f407-discovery.1559754547" version="5.0"/>
+    <versionInfo firmwareInfo="20250424" nPages="1" signature="rusEFI master.2025.04.24.f407-discovery.3676123804" version="5.0"/>
     <bibliography author="rusEFI 20250424" writeDate="date"/>
     <settings/>
     <userComments/>

--- a/simulator/generated/simulator_tune_POLARIS_RZR.msq
+++ b/simulator/generated/simulator_tune_POLARIS_RZR.msq
@@ -4006,6 +4006,7 @@ end</constant>
         <constant name="tcuUpshiftButtonPin">"NONE"</constant>
         <constant name="tcuUpshiftButtonPinMode">"DEFAULT"</constant>
         <constant digits="0" name="technicalDebt7738" units="">0.0</constant>
+        <constant name="tempPumpLimitCheck">"false"</constant>
         <constant cols="1" digits="0" name="throttle2TrimRpmBins" rows="6">
          0.0
          0.0
@@ -4412,7 +4413,6 @@ end</constant>
         <constant name="unused1320_28">"false"</constant>
         <constant name="unused920_1testChange">"false"</constant>
         <constant digits="0" name="unusedafterCrankingIACtaperDuration" units="">0.0</constant>
-        <constant name="unusedBitHere">"false"</constant>
         <constant digits="0" name="unusedcrankingIACposition" units="">0.0</constant>
         <constant name="unusedFancy10">"false"</constant>
         <constant name="unusedFancy11">"false"</constant>
@@ -4989,7 +4989,7 @@ end</constant>
 </constant>
         <constant name="yesUnderstandLocking">"no"</constant>
     </page>
-    <versionInfo firmwareInfo="20250424" nPages="1" signature="rusEFI master.2025.04.24.f407-discovery.1559754547" version="5.0"/>
+    <versionInfo firmwareInfo="20250424" nPages="1" signature="rusEFI master.2025.04.24.f407-discovery.3676123804" version="5.0"/>
     <bibliography author="rusEFI 20250424" writeDate="date"/>
     <settings/>
     <userComments/>

--- a/unit_tests/tests/test_limp.cpp
+++ b/unit_tests/tests/test_limp.cpp
@@ -440,6 +440,7 @@ TEST(limp, hpfpFuelCut) {
 	engineConfiguration->hpfpCam = HPFP_CAM_NONE;
 	engineConfiguration->hpfpCamLobes = 4;
 	engine->rpmCalculator.setRpmValue(1000);
+	engineConfiguration->tempPumpLimitCheck = true;
 
 	// mock & configure HPFP controller
 	Mockhpfp hpfp;


### PR DESCRIPTION
test for https://github.com/rusefi/rusefi/commit/f512a9729fa9c7bcdca8bf1e84d41a676d7d2a28 are red, the test needs the new flag `tempPumpLimitCheck` on true