### PR TITLE
defect around pt2001 timeout to trigger warning for pump see #7776

### DIFF
--- a/firmware/controllers/limp_manager.cpp
+++ b/firmware/controllers/limp_manager.cpp
@@ -225,14 +225,15 @@ void LimpManager::updateState(float rpm, efitick_t nowNt) {
 #if EFI_HPFP
 	{
 		// HPFP Fuel cut
-		angle_t m_deadangle = engine->module<HpfpController>().unmock().m_deadangle;
-		angle_t finalHpfpPumpAngle = m_deadangle + static_cast<angle_t>(engineConfiguration->hpfpActivationAngle);
+		angle_t m_deadangle = engine->module<HpfpController>()->m_deadangle;
+		angle_t m_requested_pump = engine->module<HpfpController>()->m_requested_pump;
+		angle_t finalHpfpPumpAngle = m_deadangle + m_requested_pump;
 		float finalHpfpPumpTimeMs = US2MS(static_cast<float>(finalHpfpPumpAngle) * engine->rpmCalculator.oneDegreeUs);
 
 		if (engineConfiguration->tempPumpLimitCheck && isGdiEngine() && finalHpfpPumpTimeMs > engineConfiguration->mc33_hpfp_max_hold) {
 			allowFuel.clear(ClearReason::GdiPumpLimit);
 			warning(ObdCode::CUSTOM_TOO_LONG_FUEL_INJECTION, "Injection HPFP pump time excess PT2001 limits time: %.4fms", finalHpfpPumpTimeMs);
-			efiPrintf("%f %f %f", m_deadangle, (float)engineConfiguration->hpfpActivationAngle, engine->rpmCalculator.oneDegreeUs);
+			efiPrintf("%f %f %f", static_cast<float>(m_deadangle), static_cast<float>(finalHpfpPumpAngle), engine->rpmCalculator.oneDegreeUs);
 		}
 	}
 #endif


### PR DESCRIPTION
* ~LimpManager is now mockeable~ now at https://github.com/rusefi/rusefi/pull/7784
* GdiPumpLimit case now uses `m_requested_pump`
* refactor of test & fix false positive (the previous test wasn't actually working correctly, the `finalHpfpPumpAngletime`  was 0! and the test didn't notice)

related issue: #7776