### PR TITLE
periodic thread controller: be more real-time

### DIFF
--- a/firmware/controllers/system/periodic_thread_controller.h
+++ b/firmware/controllers/system/periodic_thread_controller.h
@@ -56,8 +56,8 @@ private:
     {
         OnStarted();
 
+        systime_t prev = chVTGetSystemTime();
         while(!chThdShouldTerminateX()) {
-            systime_t before = chVTGetSystemTime();
             efitick_t nowNt = getTimeNowNt();
 
 			{
@@ -72,7 +72,7 @@ private:
             // If the work takes 1ms, and we wait 2ms (1 / 500hz), we actually
             // get a loop at 333 hz.  We need to wait until 2ms after we START
             // doing work, so the loop runs at a predictable 500hz.
-            chThdSleepUntilWindowed(before, before + m_period);
+            prev = chThdSleepUntilWindowed(prev, chTimeAddX(prev, m_period));
         }
 
 		criticalError("Thread died: %s", this->m_name);

--- a/unit_tests/chibios-mock/mock-threads.h
+++ b/unit_tests/chibios-mock/mock-threads.h
@@ -5,6 +5,7 @@
 typedef void (*tfunc_t)(void *p);
 typedef int tprio_t;
 typedef uint32_t systime_t;
+typedef uint32_t sysinterval_t;
 
 class thread_t {
 public:
@@ -21,6 +22,10 @@ systime_t chThdSleepUntilWindowed(systime_t prev, systime_t next);
 
 thread_t *chThdCreateStatic(void *wsp, size_t size,
                             tprio_t prio, tfunc_t pf, void *arg);
+static inline systime_t chTimeAddX(systime_t systime,
+                                   sysinterval_t interval) {
+  return systime + (systime_t)interval;
+}
 
 #define PAL_MODE_OUTPUT_PUSHPULL 0
 


### PR DESCRIPTION
Use previous execution timestamp instead of chVTGetSystemTime()
Use chTimeAddX() helper

From this:
![Screenshot from 2025-04-29 14-09-16](https://github.com/user-attachments/assets/fccb03e4-185c-4d76-aab3-4beadf858961)
To this:
![Screenshot from 2025-04-29 14-02-49](https://github.com/user-attachments/assets/4b9a2894-8088-4e66-89b2-d805136308f5)
Average execution period (last PID dT) is closer to 2.0 mS with this fix.

See https://www.chibios.org/dokuwiki/doku.php?id=chibios:documentation:books:rt:kernel_threading "Fixed Intervals 3"

Somehow also relate to main loop https://github.com/rusefi/rusefi/issues/7760