### PR TITLE
TS UI: improve ETB calibration dialogs

### DIFF
--- a/firmware/tunerstudio/tunerstudio.template.ini
+++ b/firmware/tunerstudio/tunerstudio.template.ini
@@ -5087,20 +5087,34 @@ dialog = tcuControls, "Transmission Settings"
 		panel = etbIndicatorPanel
 ;		commandButton = "Reset ETB", cmd_etb_reset
 
-	dialog = etbAutotune, "Sensor/PID autotune"
+	dialog = etbTps1Calib, "ETB 1 TPS sensor calibration"
 		field = "First step: calibrate TPS and hit 'Burn'"
-		field = "should first OPEN, then CLOSE"
+		field = "Should first OPEN, then CLOSE"
+		field = "!Please check with your eyes that throttle first OPENS and then CLOSES"
+		field = "!If order is reversed swap ETB+/ETB- wires"
 		commandButton = "Auto Calibrate ETB 1", cmd_etb_auto_calibrate,   {hasIgnitionVoltage && (etbFunctions1 == @@dc_function_e_DC_Throttle1@@ || etbFunctions2 == @@dc_function_e_DC_Throttle1@@) && tps1_1AdcChannel != @@ADC_CHANNEL_NONE@@ && calibrationMode == @@TsCalMode_None@@}
 		commandButton = "Fast Auto Calibrate ETB 1", cmd_etb_auto_calibrate_fast,   { hasIgnitionVoltage && (etbFunctions1 == @@dc_function_e_DC_Throttle1@@ || etbFunctions2 == @@dc_function_e_DC_Throttle1@@) && tps1_1AdcChannel != @@ADC_CHANNEL_NONE@@ && calibrationMode == @@TsCalMode_None@@}
+
+	dialog = etbTps2Calib, "ETB 2 TPS sensor calibration"
+		field = "First step: calibrate TPS and hit 'Burn'"
+		field = "Should first OPEN, then CLOSE"
+		field = "!Please check with your eyes that throttle first OPENS and then CLOSES"
+		field = "!If order is reversed swap ETB+/ETB- wires"
 		commandButton = "Auto Calibrate ETB 2", cmd_etb_auto_calibrate_2, {hasIgnitionVoltage && (etbFunctions1 == @@dc_function_e_DC_Throttle2@@ || etbFunctions2 == @@dc_function_e_DC_Throttle2@@) && tps2_1AdcChannel != @@ADC_CHANNEL_NONE@@ && calibrationMode == @@TsCalMode_None@@}@@if_ts_show_tps2
 		commandButton = "Fast Auto Calibrate ETB 2", cmd_etb_auto_calibrate_2_fast, { hasIgnitionVoltage && (etbFunctions1 == @@dc_function_e_DC_Throttle2@@ || etbFunctions2 == @@dc_function_e_DC_Throttle2@@) && tps2_1AdcChannel != @@ADC_CHANNEL_NONE@@ && calibrationMode == @@TsCalMode_None@@}@@if_ts_show_tps2
-		field = "Second step"
+
+	dialog = etbAutotune, "Sensor/PID autotune"
+		field = "Second step: calibrate PID"
+		field = "Run PID calibration for 10..15 seconds and press Stop"
+		field = "Autotune executed for ETB 1 only, values applied for all ETBs"
 		commandButton = "Start ETB PID Autotune", cmd_etb_autotune,       {hasIgnitionVoltage && (etbFunctions1 == @@dc_function_e_DC_Throttle1@@ || etbFunctions1 == @@dc_function_e_DC_Throttle2@@ || etbFunctions2 == @@dc_function_e_DC_Throttle1@@ || etbFunctions2 == @@dc_function_e_DC_Throttle2@@) && calibrationMode = @@TsCalMode_None@@}
 		commandButton = "Stop ETB PID Autotune",  cmd_etb_autotune_stop,  {hasIgnitionVoltage && (etbFunctions1 == @@dc_function_e_DC_Throttle1@@ || etbFunctions1 == @@dc_function_e_DC_Throttle2@@ || etbFunctions2 == @@dc_function_e_DC_Throttle1@@ || etbFunctions2 == @@dc_function_e_DC_Throttle2@@) && calibrationMode >= @@TsCalMode_EtbKp@@ && calibrationMode <= @@TsCalMode_EtbKd@@}
 
 	dialog = etbDialogRight
-		panel = etbPidDialog, { etbFunctions1 == @@dc_function_e_DC_Throttle1@@ || etbFunctions1 == @@dc_function_e_DC_Throttle2@@ || etbFunctions2 == @@dc_function_e_DC_Throttle1@@ || etbFunctions2 == @@dc_function_e_DC_Throttle2@@ }
-		panel = etbAutotune,  { etbFunctions1 == @@dc_function_e_DC_Throttle1@@ || etbFunctions1 == @@dc_function_e_DC_Throttle2@@ || etbFunctions2 == @@dc_function_e_DC_Throttle1@@ || etbFunctions2 == @@dc_function_e_DC_Throttle2@@ }
+		panel = etbPidDialog, Center, { etbFunctions1 == @@dc_function_e_DC_Throttle1@@ || etbFunctions1 == @@dc_function_e_DC_Throttle2@@ || etbFunctions2 == @@dc_function_e_DC_Throttle1@@ || etbFunctions2 == @@dc_function_e_DC_Throttle2@@ }
+		panel = etbTps1Calib, Center, { etbFunctions1 == @@dc_function_e_DC_Throttle1@@ || etbFunctions2 == @@dc_function_e_DC_Throttle1@@ }
+		panel = etbTps2Calib, Center, { etbFunctions1 == @@dc_function_e_DC_Throttle2@@ || etbFunctions2 == @@dc_function_e_DC_Throttle2@@ }
+		panel = etbAutotune,  Center, { etbFunctions1 == @@dc_function_e_DC_Throttle1@@ || etbFunctions1 == @@dc_function_e_DC_Throttle2@@ || etbFunctions2 == @@dc_function_e_DC_Throttle1@@ || etbFunctions2 == @@dc_function_e_DC_Throttle2@@ }
 
 	dialog = etbDialog, "Electronic Throttle Body", border
 		topicHelp = "etbHelp"


### PR DESCRIPTION
Users usually ignore instructions. Lets see if they can see RED warning.
From:
![Screenshot from 2025-05-01 12-06-43](https://github.com/user-attachments/assets/90a6f439-af23-457a-bb09-01df886f7487)
To:
![Screenshot from 2025-05-01 12-37-47](https://github.com/user-attachments/assets/877c7491-64bc-42ef-8ff6-c476f84540db)
