### PR TITLE
setup_linux_environment.sh wont work on Ubuntu 24

### DIFF
--- a/firmware/setup_linux_environment.sh
+++ b/firmware/setup_linux_environment.sh
@@ -19,7 +19,7 @@ sudo apt-get update
 
 # install dependencies
 sudo bash misc/actions/ubuntu-install-tools.sh
-sudo apt-get install -y build-essential gcc gdb gcc-multilib make openjdk-11-jdk-headless xxd libncurses5 libncursesw5
+sudo apt-get install -y build-essential gcc gdb gcc-multilib make openjdk-11-jdk-headless xxd
 
 # delete any old tools, create a new folder, and go there
 rm -rf ~/.rusefi-tools


### PR DESCRIPTION
`libncurses5` and `libncursesw5` seems to be outdated and not present in the common Ubuntu 24.04 repository

Don't know who uses it, and most likely it can be simply removed.


```
$ sudo apt-get install -y build-essential gcc gdb gcc-multilib make openjdk-11-jdk-headless xxd libncurses5 libncursesw5
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
E: Unable to locate package libncurses5
E: Unable to locate package libncursesw5

```
