### PR TITLE
blend Y falling only on GH action, test

### DIFF
--- a/.github/workflows/hardware-ci.yaml
+++ b/.github/workflows/hardware-ci.yaml
@@ -83,14 +83,13 @@ jobs:
     - name: Test/Identify Compiler
       run: arm-none-eabi-gcc -v
 
-    - name: Configuration Definition and Enum to String CI, without pushing new .jar
-      working-directory: ./java_tools
-      run: |
-        ./gradlew :config_definition:shadowJar :enum_to_string:shadowJar
-
-    - name: Generate All Configs
+    - name: Clean all before creating configs
       working-directory: ./firmware/
-      run: bash gen_config.sh
+      run: make clean
+
+    - name: Prebuid with default target # this should be re-build all the configs/livedata/etc
+      working-directory: ./firmware/
+      run: make
 
     - name: Build Firmware
 #      run: .github/workflows/hw-ci/build_for_hw_ci.sh config/boards/f407-discovery f407-discovery

--- a/.github/workflows/hw-ci/build_for_hw_ci.sh
+++ b/.github/workflows/hw-ci/build_for_hw_ci.sh
@@ -18,8 +18,8 @@ cd firmware
 export BOARD_META_PATH=$(bash bin/find_meta_info.sh ${HW_FOLDER} ${HW_TARGET})
 source config/boards/common_script_read_meta_env.inc "${BOARD_META_PATH}"
 
-echo "[build_for_hw_ci.sh] We aren't guaranteed a clean machine every time, so manually clean the output."
-make clean
+#echo "[build_for_hw_ci.sh] We aren't guaranteed a clean machine every time, so manually clean the output."
+#make clean
 
 export EXTRA_2_PARAMS=-DHARDWARE_CI
 

--- a/firmware/console/binary/output_channels.txt
+++ b/firmware/console/binary/output_channels.txt
@@ -314,10 +314,12 @@ int16_t rpmAcceleration;dRPM;"RPM acceleration/Rate of Change/ROC",1, 0, 0, 5, 2
 	int16_t[IGN_BLEND_COUNT iterate] autoscale ignBlendParameter;;"", 0.1, 0, -1000, 1000, 1
 	uint8_t[IGN_BLEND_COUNT iterate] autoscale ignBlendBias;;"%", 0.5, 0, 0, 100, 1
 	int16_t[IGN_BLEND_COUNT iterate] autoscale ignBlendOutput;;"deg", 0.01, 0, -300, 300, 2
+	int16_t[IGN_BLEND_COUNT iterate] autoscale ignBlendYAxis;;"", 0.1, 0, -1000, 1000, 1
 
 	int16_t[VE_BLEND_COUNT iterate] autoscale veBlendParameter;;"", 0.1, 0, -1000, 1000, 1
 	uint8_t[VE_BLEND_COUNT iterate] autoscale veBlendBias;;"%", 0.5, 0, 0, 100, 1
 	int16_t[VE_BLEND_COUNT iterate] autoscale veBlendOutput;;"%", 0.01, 0, -50, 50, 2
+	int16_t[VE_BLEND_COUNT iterate] autoscale veBlendYAxis;;"", 0.1, 0, -1000, 1000, 1
 
 	int16_t[BOOST_BLEND_COUNT iterate] autoscale boostOpenLoopBlendParameter;;"", 0.1, 0, -1000, 1000, 1
 	uint8_t[BOOST_BLEND_COUNT iterate] autoscale boostOpenLoopBlendBias;;"%", 0.5, 0, 0, 100, 1


### PR DESCRIPTION
ignore me, PR just for trigger HW-CI runs


The problem seems to be in the order in which we regenerate the configurations, we were first regenerating and then running make clean, so we ended up with the previous pre-regeneration state [if I'm not mistaken]