### PR TITLE
ADCv2: irq-driven continuoes conversion in background

### DIFF
--- a/firmware/config/stm32f4ems/efifeatures.h
+++ b/firmware/config/stm32f4ems/efifeatures.h
@@ -436,6 +436,10 @@
 // NOTE: PWM mode triggers ADC convertion through hardware ADC trigger
 //#define EFI_INTERNAL_FAST_ADC_PWM	&PWMD8
 
+// Continuously run internal ADC in background for all channels
+// Do averaging in thread with no sync with convertion end
+#define EFI_INTERNAL_SLOW_ADC_BACKGROUND	TRUE
+
 #define EFI_SPI1_AF 5
 #define EFI_SPI2_AF 5
 #define EFI_SPI3_AF 6

--- a/firmware/hw_layer/adc/adc_inputs.cpp
+++ b/firmware/hw_layer/adc/adc_inputs.cpp
@@ -54,6 +54,8 @@ int analogGetDiagnostic()
 
 extern AdcDevice fastAdc;
 
+/* TODO: Drop NO_CACHE for F4 and F7 couse with ADCv2 driver CPU does averaging and CPU stores result to this array */
+/* TODO: store summ of samples is this array and divide on oversample factor only when converting to float - this will increase accuracity */
 static volatile NO_CACHE adcsample_t slowAdcSamples[SLOW_ADC_CHANNEL_COUNT];
 
 static uint32_t slowAdcConversionCount = 0;

--- a/firmware/hw_layer/adc/adc_inputs.h
+++ b/firmware/hw_layer/adc/adc_inputs.h
@@ -61,11 +61,11 @@ int analogGetDiagnostic();
 
 /*
  * We have 1 / (GPT_FREQ_FAST / GPT_PERIOD_FAST) to finish conversion = 100 uS
- * With ADC_SAMPLING_FAST = 28 ADC clock @ 21 MHz (F4) -> one channel conversion takes 1.33(3) uS
+ * With ADC_SAMPLING_FAST = 28 ADC clock @ 21 MHz (F4)
+ * One channel conversion takes 28 + 12 = 40 clocks
+ * One channel conversion takes 1 / 21`000`000 * 40 = 1.904 uS
  * Oversampling is ADC_BUF_DEPTH_FAST = 4
- * We can do up-to 100 / (1.33(3) * 4) = 18.75 channels conversions
- * So we can enable ALL channels for fast ADC.
- * This will increase bus load with more DMA transfers, but who cares?
+ * We can do up-to 100 / (1.904 * 4) = 13.125 channels conversions
  */
 
 #endif /* GPT_FREQ_FAST GPT_PERIOD_FAST */

--- a/firmware/hw_layer/ports/stm32/stm32_adc_v2.cpp
+++ b/firmware/hw_layer/ports/stm32/stm32_adc_v2.cpp
@@ -116,10 +116,18 @@ float getMcuTemperature() {
 }
 
 // See https://github.com/rusefi/rusefi/issues/976 for discussion on these values
+// ...  there is no reason to use a longer sampling time than 56 cycles with the current clock ...
 #ifndef ADC_SAMPLING_SLOW
 #define ADC_SAMPLING_SLOW ADC_SAMPLE_56
 #endif
 // see also ADC_SAMPLING_FAST in adc_inputs.cpp
+// ADC clock is 21MHz on F4 and 27MHz on F7
+// We want 500 Hz refresh rate for 16 (32) channels + MCU temperature
+// 21 MHz / 500 = 42000 clocks for all channels including oversampling
+// We want SLOW_ADC_OVERSAMPLE
+// 42000 / 8 / 16 = 328.125 clocks / channel
+// 42000 / 8 / 32 = 164 clocks / channel
+// This ^ does not include additional MCU temperatur conversions
 
 // Slow ADC has 16 channels we can sample, or 32 if ADC mux mode is enabled.
 constexpr size_t adcChannelCount = 16;

--- a/firmware/hw_layer/ports/stm32/stm32_adc_v2.cpp
+++ b/firmware/hw_layer/ports/stm32/stm32_adc_v2.cpp
@@ -225,7 +225,7 @@ static void slowAdcEndCB(ADCDriver *adcp) {
 }
 #endif
 
-static bool readBatch(adcsample_t* convertedSamples, adcsample_t* b, size_t start) {
+static bool readBatch(adcsample_t* convertedSamples, adcsample_t* b) {
 #if (EFI_INTERNAL_SLOW_ADC_BACKGROUND == FALSE)
 	msg_t result = adcConvert(&ADCD1, &convGroupSlow, b, SLOW_ADC_OVERSAMPLE);
 
@@ -245,7 +245,7 @@ static bool readBatch(adcsample_t* convertedSamples, adcsample_t* b, size_t star
 		}
 
 		adcsample_t value = static_cast<adcsample_t>(sum / SLOW_ADC_OVERSAMPLE);
-		convertedSamples[start + i] = value;
+		convertedSamples[i] = value;
 	}
 
 	return true;
@@ -254,14 +254,14 @@ static bool readBatch(adcsample_t* convertedSamples, adcsample_t* b, size_t star
 bool readSlowAnalogInputs(adcsample_t* convertedSamples) {
 	bool result = true;
 
-	result &= readBatch(convertedSamples, (adcsample_t *)slowSampleBuffer, 0);
+	result &= readBatch(convertedSamples, (adcsample_t *)slowSampleBuffer);
 
 #ifdef ADC_MUX_PIN
 	#if (EFI_INTERNAL_SLOW_ADC_BACKGROUND == FALSE)
 		muxControl.setValue(1, /*force*/true);
 	#endif
 		// read the second batch, starting where we left off
-		result &= readBatch(convertedSamples, (adcsample_t *)slowSampleBufferMuxed, adcChannelCount);
+		result &= readBatch(&convertedSamples[adcChannelCount], (adcsample_t *)slowSampleBufferMuxed);
 	#if (EFI_INTERNAL_SLOW_ADC_BACKGROUND == FALSE)
 		muxControl.setValue(0, /*force*/true);
 	#endif

--- a/firmware/hw_layer/ports/stm32/stm32_adc_v2.cpp
+++ b/firmware/hw_layer/ports/stm32/stm32_adc_v2.cpp
@@ -196,8 +196,6 @@ static slowAdcState_t slowAdcState = convertPrimary;
 static void slowAdcEndCB(ADCDriver *adcp) {
 	if (adcIsBufferComplete(adcp)) {
 		chSysLockFromISR();
-		// Stop ADC to reset DMA and internal state machine to avoid spurious DMA request
-		//adcStopConversionI(adcp);
 		// Switch state to ready to allow starting new conversion from here
 		adcp->state = ADC_READY;
 		// get next state


### PR DESCRIPTION
If `EFI_INTERNAL_SLOW_ADC_BACKGROUND` is enabled slowAdc is continually restarted from `end_cb` conversion end callback.
`readSlowAnalogInputs` is not longer wait for conversion end, it just picks fresh `SLOW_ADC_OVERSAMPLE` samples and does averaging.