### PR TITLE
unit_tests: binary_logging: 1B is too much for this hack

### DIFF
--- a/firmware/console/binary_log/binary_logging.cpp
+++ b/firmware/console/binary_log/binary_logging.cpp
@@ -123,7 +123,7 @@ static size_t writeSdBlock(Writer& outBuffer) {
 	for (size_t fieldIndex = 0; fieldIndex < efi::size(fields); fieldIndex++) {
 		#if EFI_UNIT_TEST
 			// dark magic: most elements of log_fields_generated.h were const-evaluated against 'nullptr' engine, let's add it!
-			void *offset = fields[fieldIndex].needsEngineOffsetHack() ? engine : nullptr;
+			void *offset = fields[fieldIndex].needsEngineOffsetHack(sizeof(*engine)) ? engine : nullptr;
 		#else
 			void *offset = nullptr;
 		#endif

--- a/firmware/console/binary_log/log_field.h
+++ b/firmware/console/binary_log/log_field.h
@@ -90,9 +90,9 @@ public:
 	size_t writeData(char* buffer, void *offset) const;
 
 #if EFI_UNIT_TEST
-  bool needsEngineOffsetHack() const {
+  bool needsEngineOffsetHack(size_t size) const {
     // low addresses are offsets without engine reference
-    return (intptr_t)m_addr < 1'000'000'000;
+    return (intptr_t)m_addr < size;
   }
 #endif
 


### PR DESCRIPTION
Lets use actual engine object size