### PR TITLE
fix: "map window averaging does not use crank angle" see #7869

### DIFF
--- a/firmware/controllers/modules/map_averaging/map_averaging.cpp
+++ b/firmware/controllers/modules/map_averaging/map_averaging.cpp
@@ -214,16 +214,18 @@ void MapAveragingModule::onEnginePhase(float /*rpm*/,
 			continue;
 		}
 
+		float angleOffset = samplingStart - currentPhase;
+		if (angleOffset < 0) {
+			angleOffset += getEngineState()->engineCycle;
+		}
+
 		// only if value is already prepared
 		int structIndex = getRevolutionCounter() % 2;
 
 		auto & mapAveraging = *engine->module<MapAveragingModule>();
 		mapSampler* s = &mapAveraging.samplers[i][structIndex];
 
-		// at the moment we schedule based on time prediction based on current RPM and angle
-		// we are loosing precision in case of changing RPM - the further away is the event the worse is precision
-		// todo: schedule this based on closest trigger event, same as ignition works
-		scheduleByAngle(&s->startTimer, edgeTimestamp, samplingStart,
+		scheduleByAngle(&s->startTimer, edgeTimestamp, angleOffset,
 				{ startMapAveraging, s });
 	}
 }

--- a/firmware/controllers/modules/map_averaging/map_averaging.cpp
+++ b/firmware/controllers/modules/map_averaging/map_averaging.cpp
@@ -217,14 +217,6 @@ void MapAveragingModule::onEnginePhase(float /*rpm*/,
 			continue;
 		}
 
-		angle_t samplingEnd = samplingStart + engine->engineState.mapAveragingDuration;
-
-		if (std::isnan(samplingEnd)) {
-			// todo: when would this happen?
-			warning(ObdCode::CUSTOM_ERR_6549, "no map angles");
-			return;
-		}
-
 		// only if value is already prepared
 		int structIndex = getRevolutionCounter() % 2;
 

--- a/firmware/controllers/modules/map_averaging/map_averaging.cpp
+++ b/firmware/controllers/modules/map_averaging/map_averaging.cpp
@@ -175,9 +175,6 @@ void MapAveragingModule::onFastCallback() {
 		angle_t start = interpolate2d(rpm, c->samplingAngleBins, c->samplingAngle);
 		efiAssertVoid(ObdCode::CUSTOM_ERR_MAP_START_ASSERT, !std::isnan(start), "start");
 
-		angle_t offsetAngle = engine->triggerCentral.triggerFormDetails.eventAngles[0];
-		efiAssertVoid(ObdCode::CUSTOM_ERR_MAP_AVG_OFFSET, !std::isnan(offsetAngle), "offsetAngle");
-
 		for (size_t i = 0; i < engineConfiguration->cylindersCount; i++) {
 			float cylinderStart = start + getPerCylinderFiringOrderOffset(i, getCylinderNumberAtIndex(i));
 			wrapAngle(cylinderStart, "cylinderStart", ObdCode::CUSTOM_ERR_6562);


### PR DESCRIPTION
related issue: #7869

now using `samplingStart - currentPhase` as map averager start

![image](https://github.com/user-attachments/assets/3541dc1c-4ef6-48b9-9adf-50dfad7bd18c)

detail on time active:
![image](https://github.com/user-attachments/assets/88381bd0-bab1-4d83-b810-e6918d80c43b)


log:
[2025-05-13_01.21.25.mlg.zip](https://github.com/user-attachments/files/20181120/2025-05-13_01.21.25.mlg.zip)

map averager configured as:
![image](https://github.com/user-attachments/assets/841b498a-ea8a-4741-a084-8bb0525a9dcb)
