### PR TITLE
MC33810 SPKDUR support

### DIFF
--- a/firmware/config/boards/f407-discovery/board_configuration.cpp
+++ b/firmware/config/boards/f407-discovery/board_configuration.cpp
@@ -151,7 +151,10 @@ static const struct mc33810_config mc33810 = {
 	},
 	.en = {.port = GPIOA, .pad = 6}, // copy-paste with setMode code!
 	// TODO: pick from engineConfiguration->spi3sckPin or whatever SPI is used
-	.sck = {.port = GPIOB, .pad = 3}
+	.sck = {.port = GPIOB, .pad = 3},
+	.spkdur = Gpio::Unassigned,
+	.nomi = Gpio::Unassigned,
+	.maxi = Gpio::Unassigned
 };
 
     if (engineConfiguration->engineType == engine_type_e::FRANKENSO_TEST_33810) {

--- a/firmware/config/boards/hellen/hellen154hyundai_f7/board_configuration.cpp
+++ b/firmware/config/boards/hellen/hellen154hyundai_f7/board_configuration.cpp
@@ -177,7 +177,10 @@ static const struct mc33810_config mc33810 = {
 	},
 	.en = {.port = GPIOG, .pad = 9}, // H144_GP_IO4 hopefully
 	// TODO: pick from engineConfiguration->spi3sckPin or whatever SPI is used
-	.sck = {.port = GPIOC, .pad = 10}
+	.sck = {.port = GPIOC, .pad = 10},
+	.spkdur = Gpio::Unassigned,
+	.nomi = Gpio::Unassigned,
+	.maxi = Gpio::Unassigned
 };
 
 /*PUBLIC_API_WEAK*/ void boardInitHardware() {

--- a/firmware/config/boards/subaru_eg33/board_configuration.cpp
+++ b/firmware/config/boards/subaru_eg33/board_configuration.cpp
@@ -287,7 +287,11 @@ static const struct mc33810_config mc33810_odd = {
 	/* en shared between two chips */
 	.en = {.port = GPIOI, .pad = 7},
 	// TODO: pick from engineConfiguration->spi5sckPin or whatever SPI is used
-	.sck = {.port = GPIOF, .pad = 7}
+	.sck = {.port = GPIOF, .pad = 7},
+	/* TODO: */
+	.spkdur = Gpio::Unassigned,
+	.nomi = Gpio::Unassigned,
+	.maxi = Gpio::Unassigned
 };
 
 /* Schematic RefDef DA22 */
@@ -333,7 +337,11 @@ static const struct mc33810_config mc33810_even = {
 	/* en shared between two chips */
 	.en = {.port = nullptr, .pad = 0},
 	// TODO: pick from engineConfiguration->spi5sckPin or whatever SPI is used
-	.sck = {.port = GPIOF, .pad = 7}
+	.sck = {.port = GPIOF, .pad = 7},
+	/* TODO: */
+	.spkdur = Gpio::Unassigned,
+	.nomi = Gpio::Unassigned,
+	.maxi = Gpio::Unassigned
 };
 
 static void board_init_ext_gpios()

--- a/firmware/hw_layer/drivers/gpio/mc33810.h
+++ b/firmware/hw_layer/drivers/gpio/mc33810.h
@@ -16,8 +16,11 @@
 #include <hal.h>
 #include "rusefi_types.h"
 
-#define MC33810_OUTPUTS				8
-#define MC33810_DIRECT_OUTPUTS		8
+#define MC33810_INJ_OUTPUTS			4
+#define MC33810_IGN_OUTPUTS			4
+
+#define MC33810_OUTPUTS				(MC33810_INJ_OUTPUTS + MC33810_IGN_OUTPUTS)
+#define MC33810_DIRECT_OUTPUTS		MC33810_OUTPUTS
 
 /* TODO: add irq support */
 #define MC33810_POLL_INTERVAL_MS	100
@@ -46,6 +49,14 @@ struct mc33810_config {
 		ioportid_t		port;
 		uint_fast8_t	pad;
 	} sck;
+
+	/* TODO: fix mix of port+pad vs brain_pin_e */
+	/* Spark duration signal input, active low */
+	brain_pin_e			spkdur;
+	/* Nominal ignition coil current flag signal input */
+	brain_pin_e			nomi;
+	/* Maximum ignition coil current flag signal input */
+	brain_pin_e			maxi;
 };
 
 int mc33810_add(brain_pin_e base, unsigned int index, const mc33810_config *cfg);


### PR DESCRIPTION
No SPKDUR event after ignition pulse means misfire.
Duration of SPKDUR = duration of ignition spark.
Detect and measure duration of SPKDUR signal.
Of no SPKDUR detected - rise `PIN_OPEN` diagnostic code for this ignition output.

TODO: export spark duration to TS/logs.