### PR TITLE
7840 burn brokes TS on Proteus F7

### DIFF
--- a/firmware/config/boards/proteus/prepend_proteus_f7.txt
+++ b/firmware/config/boards/proteus/prepend_proteus_f7.txt
@@ -1,4 +1,4 @@
-#define LUA_SCRIPT_SIZE 64000
+#define LUA_SCRIPT_SIZE 48000
 
 ! huge buffer for happier remote TCP/IP connector - see also 'blockingFactorOverride' in console source code
 #define CUSTOM_TS_BUFFER_SIZE 32000

--- a/firmware/console/binary/tunerstudio.cpp
+++ b/firmware/console/binary/tunerstudio.cpp
@@ -92,6 +92,9 @@
 
 #if EFI_TUNER_STUDIO
 
+// We have TS protocol limitation: offset within one settings page is uin16_t type.
+static_assert(sizeof(*config) <= 65536);
+
 static void printErrorCounters() {
 	efiPrintf("TunerStudio size=%d / total=%d / errors=%d / H=%d / O=%d / P=%d / B=%d",
 			sizeof(engine->outputChannels), tsState.totalCounter, tsState.errorCounter, tsState.queryCommandCounter,
@@ -154,6 +157,8 @@ void tunerStudioDebug(TsChannelBase* tsChannel, const char *msg) {
 }
 
 uint8_t* getWorkingPageAddr() {
+	// TODO: why engineConfiguration, not config
+	// TS has access to whole persistent_config_s
 	return (uint8_t*)engineConfiguration;
 }
 


### PR DESCRIPTION
We have 64K offset limitation for one settings page. Try not to cross this boundary.
https://github.com/rusefi/rusefi/issues/7840