### PR TITLE
7048 AEM vs RusEFI WBO

### DIFF
--- a/firmware/controllers/algo/rusefi_enums.h
+++ b/firmware/controllers/algo/rusefi_enums.h
@@ -676,10 +676,9 @@ typedef enum __attribute__ ((__packed__)) {
 } can_baudrate_e;
 
 typedef enum __attribute__ ((__packed__)) {
-	AUTODETECT = 0,
-	RUSEFI = 1,
-	AEM = 2,
-	DISABLED = 3
+	RUSEFI = 0,
+	AEM = 1,
+	DISABLED = 2
 } can_wbo_type_e;
 
 typedef enum __attribute__ ((__packed__)) {

--- a/firmware/controllers/algo/rusefi_enums.h
+++ b/firmware/controllers/algo/rusefi_enums.h
@@ -676,6 +676,13 @@ typedef enum __attribute__ ((__packed__)) {
 } can_baudrate_e;
 
 typedef enum __attribute__ ((__packed__)) {
+	AUTODETECT = 0,
+	RUSEFI = 1,
+	AEM = 2,
+	DISABLED = 3
+} can_wbo_type_e;
+
+typedef enum __attribute__ ((__packed__)) {
 	GPPWM_GreaterThan = 0,
 	GPPWM_LessThan = 1,
 } gppwm_compare_mode_e;

--- a/firmware/controllers/sensors/impl/AemXSeriesLambda.h
+++ b/firmware/controllers/sensors/impl/AemXSeriesLambda.h
@@ -34,12 +34,12 @@ protected:
 	void decodeRusefiDiag(const CANRxFrame& frame);
 
 private:
+	can_wbo_type_e sensorType() const;
 	bool isHeaterAllowed();
 
 	const uint8_t m_sensorIndex;
 	// raw fault code from sensor
 	uint8_t m_faultCode;
-	bool m_isAem;
 	bool m_isValid;
 	// Used for AEM sensor only
 	bool m_isFault;

--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -1080,7 +1080,7 @@ end_struct
 	uint16_t tps2SecondaryMin;;"ADC", 1, 0, 0, 1000, 0
 	uint16_t tps2SecondaryMax;;"ADC", 1, 0, 0, 1000, 0
 
-	bit widebandOnSecondBus,"2","1";Select which bus the wideband controller is attached to.
+	bit widebandOnSecondBus,"CAN2","CAN1";Select which bus the wideband controller is attached to.
 	bit fuelClosedLoopCorrectionEnabled;Enables lambda sensor closed loop feedback for fuelling.
 	bit alwaysWriteSdCard;Write SD card log even when powered by USB
 	bit knockDetectionUseDoubleFrequency,"second harmonic","first harmonic";Second harmonic (aka double) is usually quieter background noise

--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -1840,7 +1840,7 @@ uint8_t autoscale knockFuelTrim;Fuel trim when knock, max 30%;"%", 1, 0, 0, 30, 
 	float wastegatePositionOpenedVoltage;Voltage when the wastegate is fully open;"v", 1, 0, 0, 10, 2
 	float wastegatePositionClosedVoltage;Voltage when the wastegate is closed;"v", 1, 0, 0, 10, 2
 
-	#define can_wbo_type_e_enum "Autodetect", "RusEFI (onboard and external)", "AEM X-series", "Disabled/Analog"
+	#define can_wbo_type_e_enum "RusEFI", "AEM X-series", "Disabled/Analog"
 	custom can_wbo_type_e 2 bits, U08, @OFFSET@, [0:1], @@can_wbo_type_e_enum@@
 	can_wbo_type_e wboType1;
 	can_wbo_type_e wboType2;

--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -831,16 +831,18 @@ spi_device_e digitalPotentiometerSpiDevice;Digital Potentiometer is used by stoc
 	uint8_t autoscale lambdaProtectionMinRpm;;"RPM", 100, 0, 0, 25000, 0
 	uint8_t autoscale lambdaProtectionMinLoad;;"%", 10, 0, 0, @@MAP_UPPER_LIMIT@@, 0
 
-bit is_enabled_spi_1
-bit is_enabled_spi_2
+	! bit 0
+	bit is_enabled_spi_1
+	bit is_enabled_spi_2
 	bit is_enabled_spi_3
 	bit isSdCardEnabled;enable sd/disable sd
 	bit rusefiVerbose29b,"29 bit","11 bit";Use 11 bit (standard) or 29 bit (extended) IDs for rusEFI verbose CAN format.
 	bit rethrowHardFault
 	bit requireFootOnBrakeToCrank
 	bit verboseQuad
-	bit useStepperIdle;This setting should only be used if you have a stepper motor idle valve and a stepper motor driver installed.
 
+	! bit 8
+	bit useStepperIdle;This setting should only be used if you have a stepper motor idle valve and a stepper motor driver installed.
 	bit enabledStep1Limiter
 	bit lambdaProtectionEnable
 	bit verboseTLE8888
@@ -848,6 +850,8 @@ bit is_enabled_spi_2
 	bit externalRusEfiGdiModule
 	bit flipWboChannels
 	bit measureMapOnlyInOneCylinder;Useful for individual intakes
+
+	! bit 16
 	bit stepperForceParkingEveryRestart
 	bit isFasterEngineSpinUpEnabled;If enabled, try to fire the engine before a full engine cycle has been completed using RPM estimated from the last 90 degrees of engine rotation. As soon as the trigger syncs plus 90 degrees rotation, fuel and ignition events will occur. If disabled, worst case may require up to 4 full crank rotations before any events are scheduled.
 	bit coastingFuelCutEnabled;This setting disables fuel injection while the engine is in overrun, this is useful as a fuel saving measure and to prevent back firing.
@@ -856,13 +860,16 @@ bit is_enabled_spi_2
 	bit useIdleTimingPidControl
 	bit disableEtbWhenEngineStopped;Allows disabling the ETB when the engine is stopped. You may not like the power draw or PWM noise from the motor, so this lets you turn it off until it's necessary.
 	bit is_enabled_spi_4
+
+	! bit 24
 	bit pauseEtbControl;Disable the electronic throttle motor and DC idle motor for testing.\nThis mode is for testing ETB/DC idle position sensors, etc without actually driving the throttle.
 	bit tpsTpsPercentMode,"percent adder","ms adder"
 	bit verboseKLine
 	bit idleIncrementalPidCic
 	bit enableAemXSeries;AEM X-Series or rusEFI Wideband
 	bit modeledFlowIdle
-! 'unused32nd' is the 32nd bit here, you would need another bit region if more bits are desired
+	! bits 30, 31 are free to use
+	! 'unused32nd' is the 32nd bit here, you would need another bit region if more bits are desired
 
 	brain_input_pin_e[LOGIC_ANALYZER_CHANNEL_COUNT iterate] logicAnalyzerPins;
 	pin_output_mode_e mainRelayPinMode;

--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -1840,7 +1840,12 @@ uint8_t autoscale knockFuelTrim;Fuel trim when knock, max 30%;"%", 1, 0, 0, 30, 
 	float wastegatePositionOpenedVoltage;Voltage when the wastegate is fully open;"v", 1, 0, 0, 10, 2
 	float wastegatePositionClosedVoltage;Voltage when the wastegate is closed;"v", 1, 0, 0, 10, 2
 
-#define END_OF_CALIBRATION_PADDING 44
+	#define can_wbo_type_e_enum "Autodetect", "RusEFI (onboard and external)", "AEM X-series", "Disabled/Analog"
+	custom can_wbo_type_e 2 bits, U08, @OFFSET@, [0:1], @@can_wbo_type_e_enum@@
+	can_wbo_type_e wboType1;
+	can_wbo_type_e wboType2;
+
+#define END_OF_CALIBRATION_PADDING 40
 uint8_t[END_OF_CALIBRATION_PADDING] unusedOftenChangesDuringFirmwareUpdate;;"units", 1, 0, 0, 1, 0, noMsqSave
 
 ! end of engine_configuration_s

--- a/firmware/tunerstudio/tunerstudio.template.ini
+++ b/firmware/tunerstudio/tunerstudio.template.ini
@@ -3906,11 +3906,19 @@ cmd_set_engine_type_default					= "@@TS_IO_TEST_COMMAND_char@@@@ts_command_e_TS_
 		panel = uegoCan1Indicators
 		panel = uegoCan1IndicatorsExt
 
+	dialog = uegoCan0ConfigPanel
+		field = "UEGO type", wboType1
+
+	dialog = uegoCan1ConfigPanel
+		field = "UEGO type", wboType2
+
 	dialog = uegoCan0StatusPanel, "CAN UEGO 1", border
+		panel = uegoCan0ConfigPanel, North
 		panel = uegoCan0Gauges, West
 		panel = uegoCan0IndicatorPanel, East
 
 	dialog = uegoCan1StatusPanel, "CAN UEGO 2", border
+		panel = uegoCan1ConfigPanel, North
 		panel = uegoCan1IndicatorPanel, West
 		panel = uegoCan1Gauges, East
 

--- a/unit_tests/tests/controllers/can/test_can_wideband.cpp
+++ b/unit_tests/tests/controllers/can/test_can_wideband.cpp
@@ -11,9 +11,14 @@ TEST(CanWideband, AcceptFrameId0) {
 	frame.IDE = false;
 	frame.DLC = 8;
 
+	engineConfiguration->wboType1 = AEM;
+
 	// Check that the AEM format frame is accepted
 	frame.SID = 0x180;
 	EXPECT_TRUE(dut.acceptFrame(frame));
+
+	// Now switch to RusEFI
+	engineConfiguration->wboType1 = RUSEFI;
 
 	// Check that the rusEFI standard data is accepted
 	frame.SID = 0x190;
@@ -33,9 +38,14 @@ TEST(CanWideband, AcceptFrameId1) {
 	frame.IDE = false;
 	frame.DLC = 8;
 
+	engineConfiguration->wboType2 = AEM;
+
 	// Check that the AEM format frame is accepted
 	frame.SID = 0x181;
 	EXPECT_TRUE(dut.acceptFrame(frame));
+
+	// Now switch to RusEFI
+	engineConfiguration->wboType2 = RUSEFI;
 
 	// Check that the rusEFI standard data is accepted
 	frame.SID = 0x192;
@@ -131,6 +141,8 @@ TEST(CanWideband, DecodeValidAemFormat) {
   EngineTestHelper eth(engine_type_e::TEST_ENGINE);
 	AemXSeriesWideband dut(0, SensorType::Lambda1);
 	dut.Register();
+
+	engineConfiguration->wboType1 = AEM;
 
 	// check not set
 	EXPECT_FLOAT_EQ(-1, Sensor::get(SensorType::Lambda1).value_or(-1));


### PR DESCRIPTION
Now user can select witch type of WBO is used. So onboard RusEFI WBO can be ignored and external AEM can be used instead.
Autodetection is disabled. User should explicitly define used WBO.

Someone need to test this with AEM.
![Screenshot from 2025-05-19 16-01-33](https://github.com/user-attachments/assets/b77af727-87d3-4f60-917b-768d696e69aa)
