### PR TITLE
we definitely do not want to upload bundles with broken manifests

### DIFF
--- a/firmware/bin/check_manifest_in_jar.sh
+++ b/firmware/bin/check_manifest_in_jar.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+JAR_TO_CHECK=$1
+CHECK_MANIFEST_DIR=manifest_check
+MANIFEST_FILE_IN_JAR=META-INF/MANIFEST.MF
+
+rm -fr "$CHECK_MANIFEST_DIR"
+mkdir "$CHECK_MANIFEST_DIR"
+
+unzip "$JAR_TO_CHECK" "$MANIFEST_FILE_IN_JAR" -d "$CHECK_MANIFEST_DIR"
+
+EXIT_CODE=0
+
+if [[ "$JAR_TO_CHECK" == *_autoupdate.jar ]] || [[ "$JAR_TO_CHECK" == *_console.jar ]]; then
+  echo "Checking manifest in $JAR_TO_CHECK..."
+	if ! grep -q "Main-Class: " "$CHECK_MANIFEST_DIR/$MANIFEST_FILE_IN_JAR"; then
+		echo "ERROR: '$MANIFEST_FILE_IN_JAR' file in '$JAR_TO_CHECK' doesn't contain 'Main-Class' definition"
+		EXIT_CODE=1
+	fi
+fi
+
+rm -fr "$CHECK_MANIFEST_DIR"
+exit $EXIT_CODE

--- a/firmware/bin/check_manifests_in_bundle.sh
+++ b/firmware/bin/check_manifests_in_bundle.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+SCRIPT_DIR=$(realpath $(dirname "$0"))
+BUNDLE_TO_CHECK=$1
+CHECK_BUNDLE_DIR=bundle_check
+
+rm -fr "$CHECK_BUNDLE_DIR"
+mkdir "$CHECK_BUNDLE_DIR"
+
+unzip "$BUNDLE_TO_CHECK" -d "$CHECK_BUNDLE_DIR"
+
+EXIT_CODE=0
+if ! find "$CHECK_BUNDLE_DIR" -type f -name "*.jar" -print0 | xargs -n1 -0 "$SCRIPT_DIR/check_manifest_in_jar.sh"; then
+	echo "ERROR: some bundle .jar files have invalid minifest (for details see errors above)"
+	EXIT_CODE=1
+fi
+
+rm -fr "$CHECK_BUNDLE_DIR"
+exit $EXIT_CODE

--- a/firmware/bin/upload_bundle.sh
+++ b/firmware/bin/upload_bundle.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 USER=$1
 PASS=$2
 HOST=$3
@@ -36,6 +38,12 @@ if [ -n "${USER}" -a -n "$PASS" -a -n "${HOST}" ]; then
 
  FULL_BUNDLE_FILE="${WHITE_LABEL}_bundle_${BUNDLE_NAME}.zip"
  UPDATE_BUNDLE_FILE="${WHITE_LABEL}_bundle_${BUNDLE_NAME}_autoupdate.zip"
+
+ # Sometimes generated bundles have scanty manifests in .jar files.
+ # We don't know why it happens, but we definitely do not want to upload bundles with broken manifests.
+ CHECK_MANIFESTS_IN_BUNDLE_SCRIPT=$(realpath $(dirname "$0"))/check_manifests_in_bundle.sh
+ $CHECK_MANIFESTS_IN_BUNDLE_SCRIPT $FULL_BUNDLE_FILE
+ $CHECK_MANIFESTS_IN_BUNDLE_SCRIPT $UPDATE_BUNDLE_FILE
 
  RET=0
  if [ -n "${SUBFOLDER_TO_UPLOAD}" ]; then # subfolder to upload bundle is specified explicitly


### PR DESCRIPTION
 Sometimes generated bundles have scanty manifests in .jar files.
 We don't know why it happens, but we definitely do not want to upload bundles with broken manifests.
 only:uaefi