### PR TITLE
WBO: setWidebandOffset() with hwIndex

### DIFF
--- a/firmware/controllers/bench_test.cpp
+++ b/firmware/controllers/bench_test.cpp
@@ -614,7 +614,7 @@ void executeTSCommand(uint16_t subsystem, uint16_t index) {
 		break;
 #if defined(EFI_WIDEBAND_FIRMWARE_UPDATE) && EFI_CAN_SUPPORT
 	case TS_WIDEBAND:
-		setWidebandOffset(index);
+		setWidebandOffset(0xff, index);
 		break;
 #endif // EFI_WIDEBAND_FIRMWARE_UPDATE && EFI_CAN_SUPPORT
 	case TS_BENCH_CATEGORY:
@@ -698,7 +698,7 @@ void initBenchTest() {
 
 #if EFI_WIDEBAND_FIRMWARE_UPDATE && EFI_CAN_SUPPORT
 	addConsoleAction("update_wideband", []() { widebandUpdatePending = true; });
-	addConsoleActionI("set_wideband_index", [](int index) { setWidebandOffset(index); });
+	addConsoleActionII("set_wideband_index", [](int hwIndex, int index) { setWidebandOffset(hwIndex, index); });
 #endif // EFI_WIDEBAND_FIRMWARE_UPDATE && EFI_CAN_SUPPORT
 
 	addConsoleAction(CMD_STARTER_BENCH, starterRelayBench);

--- a/firmware/controllers/can/rusefi_wideband.h
+++ b/firmware/controllers/can/rusefi_wideband.h
@@ -15,8 +15,9 @@ void handleWidebandCan(const CANRxFrame &frame);
 // Usually called from bench test task
 // Also do not call from ISR context
 
-// Set the CAN index offset of any attached wideband controller
-void setWidebandOffset(uint8_t index);
+// Set the CAN index offset of any (hwIndex = 0xff) or specific (hwIndex != 0xff) wideband controller
+// Addressing by hwIndex is supported by 2025 WBO FW
+void setWidebandOffset(uint8_t hwIndex, uint8_t index);
 
 #if EFI_WIDEBAND_FIRMWARE_UPDATE
 // Update the firmware on any connected wideband controller


### PR DESCRIPTION
If non-broadcast hwIndex is passed send extended WB_MSG_SET_INDEX CAN message with HW index in second byte. This type of packet is supported by 2025 WBO FW and allows to address individual WBO depending on its strap pins.