### PR TITLE
RE WBO: individually addressed set CAN index commands and UI

### DIFF
--- a/firmware/console/binary/output_channels.txt
+++ b/firmware/console/binary/output_channels.txt
@@ -401,7 +401,7 @@ float mapFast
 	uint8_t autoscale injectorDutyCycleStage2;@@GAUGE_NAME_FUEL_INJ_DUTY_STAGE_2@@;"%",{1/2}, 0, 0, 0, 0
 	uint8_t rawFlexFreq
 
-	uint8_t unusedWasAdc
+	uint8_t canReWidebandCmdStatus
 	uint8_t deviceUid
 	uint16_t mc33810spiErrorCounter
 

--- a/firmware/controllers/algo/engine_types.h
+++ b/firmware/controllers/algo/engine_types.h
@@ -313,6 +313,7 @@ typedef enum {
 	TS_SET_ENGINE_TYPE = 30,
 	TS_SET_DEFAULT_ENGINE = 31,
 	TS_LUA_OUTPUT_CATEGORY = 32,
+	TS_WIDEBAND_SET_IDX_BY_ID = 33,
 } ts_command_e;
 
 typedef enum {

--- a/firmware/controllers/algo/rusefi_enums.h
+++ b/firmware/controllers/algo/rusefi_enums.h
@@ -683,6 +683,13 @@ typedef enum __attribute__ ((__packed__)) {
 } can_wbo_type_e;
 
 typedef enum __attribute__ ((__packed__)) {
+	WBO_RE_IDLE	= 0,
+	WBO_RE_DONE = 1,
+	WBO_RE_BUSY = 2,
+	WBO_RE_FAILED = 3
+} can_wbo_re_status_e;
+
+typedef enum __attribute__ ((__packed__)) {
 	GPPWM_GreaterThan = 0,
 	GPPWM_LessThan = 1,
 } gppwm_compare_mode_e;

--- a/firmware/controllers/bench_test.cpp
+++ b/firmware/controllers/bench_test.cpp
@@ -612,11 +612,11 @@ void executeTSCommand(uint16_t subsystem, uint16_t index) {
 	case TS_X14:
 		handleCommandX14(index);
 		break;
-#if defined(EFI_WIDEBAND_FIRMWARE_UPDATE) && EFI_CAN_SUPPORT
+#if EFI_CAN_SUPPORT
 	case TS_WIDEBAND:
 		setWidebandOffset(0xff, index);
 		break;
-#endif // EFI_WIDEBAND_FIRMWARE_UPDATE && EFI_CAN_SUPPORT
+#endif // EFI_CAN_SUPPORT
 	case TS_BENCH_CATEGORY:
 		handleBenchCategory(index);
 		break;
@@ -696,10 +696,12 @@ void initBenchTest() {
 
 	addConsoleAction("mainrelaybench", mainRelayBench);
 
-#if EFI_WIDEBAND_FIRMWARE_UPDATE && EFI_CAN_SUPPORT
+#if EFI_CAN_SUPPORT
+#if EFI_WIDEBAND_FIRMWARE_UPDATE
 	addConsoleAction("update_wideband", []() { widebandUpdatePending = true; });
+#endif // EFI_WIDEBAND_FIRMWARE_UPDATE
 	addConsoleActionII("set_wideband_index", [](int hwIndex, int index) { setWidebandOffset(hwIndex, index); });
-#endif // EFI_WIDEBAND_FIRMWARE_UPDATE && EFI_CAN_SUPPORT
+#endif // EFI_CAN_SUPPORT
 
 	addConsoleAction(CMD_STARTER_BENCH, starterRelayBench);
 	addConsoleAction(CMD_MIL_BENCH, milBench);

--- a/firmware/controllers/bench_test.cpp
+++ b/firmware/controllers/bench_test.cpp
@@ -616,6 +616,17 @@ void executeTSCommand(uint16_t subsystem, uint16_t index) {
 	case TS_WIDEBAND:
 		setWidebandOffset(0xff, index);
 		break;
+	case TS_WIDEBAND_SET_IDX_BY_ID:
+		{
+			uint8_t hwIndex = index >> 8;
+			uint8_t canIndex = index & 0xff;
+
+			// Hack until we fix canReWidebandHwIndex and set "Broadcast" to 0xff
+			// TODO:
+			hwIndex = hwIndex < 8 ? hwIndex : 0xff;
+			setWidebandOffset(hwIndex, canIndex);
+		}
+		break;
 #endif // EFI_CAN_SUPPORT
 	case TS_BENCH_CATEGORY:
 		handleBenchCategory(index);

--- a/firmware/controllers/can/rusefi_wideband.cpp
+++ b/firmware/controllers/can/rusefi_wideband.cpp
@@ -115,6 +115,7 @@ void sendWidebandInfo() {
 
 void updateWidebandFirmware() {
 	size_t bus = getWidebandBus();
+	size_t totalSize = sizeof(build_wideband_image_bin);
 
 	setStatus(WBO_RE_BUSY);
 
@@ -141,7 +142,7 @@ void updateWidebandFirmware() {
 		if (!waitAck()) {
 			efiPrintf("Wideband Update ERROR: Expected ACK from entry to bootloader, didn't get one.");
 			setStatus(WBO_RE_FAILED);
-			return;
+			goto exit;
 		}
 
 		// Let the controller reboot (and show blinky lights for a second before the update begins)
@@ -160,10 +161,8 @@ void updateWidebandFirmware() {
 	if (!waitAck()) {
 		efiPrintf("Wideband Update ERROR: Expected ACK from flash erase command, didn't get one.");
 		setStatus(WBO_RE_FAILED);
-		return;
+		goto exit;
 	}
-
-	size_t totalSize = sizeof(build_wideband_image_bin);
 
 	efiPrintf("Wideband Update: Flash erased! Sending %d bytes...", totalSize);
 
@@ -177,7 +176,7 @@ void updateWidebandFirmware() {
 		if (!waitAck()) {
 			efiPrintf("Wideband Update ERROR: Expected ACK from data write, didn't get one.");
 			setStatus(WBO_RE_FAILED);
-			return;
+			goto exit;
 		}
 	}
 
@@ -193,6 +192,7 @@ void updateWidebandFirmware() {
 
 	setStatus(WBO_RE_DONE);
 
+exit:
 	waitingBootloaderThread = nullptr;
 }
 

--- a/firmware/controllers/can/rusefi_wideband.cpp
+++ b/firmware/controllers/can/rusefi_wideband.cpp
@@ -87,7 +87,7 @@ void setWidebandOffset(uint8_t hwIndex, uint8_t index) {
 	}
 
 	if (!waitAck()) {
-		criticalError("Wideband index set failed: no controller detected!");
+		efiPrintf("Wideband index set failed: no controller detected!");
 		setStatus(WBO_RE_FAILED);
 	} else {
 		setStatus(WBO_RE_DONE);

--- a/firmware/tunerstudio/tunerstudio.template.ini
+++ b/firmware/tunerstudio/tunerstudio.template.ini
@@ -266,6 +266,8 @@ enable2ndByteCanID = false
 	outputDiagErrorList = bits, U08, [0:3], "Not used", "No error", "Open Load", "Short to Gnd", "Short to Battery", "Overload", "Driver Overtemp", "Driver disabled", "Unknown"
 
 	canReWidebandCmdStatusList = bits, U08, [0:7], "Idle", "Done", "Busy", "Failed"
+	canReWidebandHwIndex = bits, U08, [0:7], 0="Idx 0", 1="Idx 1", 2="Idx 2", 3="Idx 3", 4="Idx 4", 5="Idx 5", 6="Idx 6", 7="Idx7", 255="Broadcast"
+	canReWidebandCanId = bits, U08, [0:7], 0="CAN0 0x190/191", 1="CAN1 0x192/193", 2="CAN2 0x194/195", 3="CAN3 0x195/196"
 @@BOARD_PC_VARIABLES_FROM_FILE@@
 
 [ConstantsExtensions]
@@ -2541,6 +2543,8 @@ cmd_burn_without_flash		= "@@TS_IO_TEST_COMMAND_char@@@@ts_command_e_TS_X14_16_h
 
 cmd_set_wideband_idx_0		= "@@TS_IO_TEST_COMMAND_char@@@@ts_command_e_TS_WIDEBAND_16_hex@@\x00\x00"
 cmd_set_wideband_idx_1		= "@@TS_IO_TEST_COMMAND_char@@@@ts_command_e_TS_WIDEBAND_16_hex@@\x00\x01"
+
+cmd_set_wideband_idx_by_id	= "@@TS_IO_TEST_COMMAND_char@@@@ts_command_e_TS_WIDEBAND_SET_IDX_BY_ID_16_hex@@\$canReWidebandHwIndex\$canReWidebandCanId"
 
 cmd_stop_engine				= "@@TS_IO_TEST_COMMAND_char@@\x00\x79\x00\x00"
 
@@ -5266,11 +5270,17 @@ dialog = tcuControls, "Transmission Settings"
 		commandButton = "Set Index 0",	cmd_set_wideband_idx_0@@if_ts_show_wbo_canbus_set_index
 		commandButton = "Set Index 1",	cmd_set_wideband_idx_1@@if_ts_show_wbo_canbus_set_index
 
+	dialog = canReWidebandNewTools, "New FW"
+		field = "Target device HW ID", canReWidebandHwIndex
+		field = "Required CAN ID", canReWidebandCanId
+		commandButton = "Set Index", cmd_set_wideband_idx_by_id@@if_ts_show_wbo_canbus_set_index
+
 	indicatorPanel = canReWidebandIndicators
 		indicator = { canReWidebandCmdStatus > 1 }, { bitStringValue(canReWidebandCmdStatusList, canReWidebandCmdStatus) }, { bitStringValue(canReWidebandCmdStatusList, canReWidebandCmdStatus) }, green, black, red, black
 
 	dialog = canReWidebandTools, "rusEFI Wideband Tools"
 		panel = canReWidebandLegacyTools
+		panel = canReWidebandNewTools
 		panel = canReWidebandIndicators
 
 	dialog = engineTypeDialog, "Popular vehicles"

--- a/firmware/tunerstudio/tunerstudio.template.ini
+++ b/firmware/tunerstudio/tunerstudio.template.ini
@@ -266,8 +266,8 @@ enable2ndByteCanID = false
 	outputDiagErrorList = bits, U08, [0:3], "Not used", "No error", "Open Load", "Short to Gnd", "Short to Battery", "Overload", "Driver Overtemp", "Driver disabled", "Unknown"
 
 	canReWidebandCmdStatusList = bits, U08, [0:7], "Idle", "Done", "Busy", "Failed"
-	canReWidebandHwIndex = bits, U08, [0:7], 0="Idx 0", 1="Idx 1", 2="Idx 2", 3="Idx 3", 4="Idx 4", 5="Idx 5", 6="Idx 6", 7="Idx7", 255="Broadcast"
-	canReWidebandCanId = bits, U08, [0:7], 0="CAN0 0x190/191", 1="CAN1 0x192/193", 2="CAN2 0x194/195", 3="CAN3 0x195/196"
+	canReWidebandHwIndex = bits, U08, [0:3], "Idx 0", "Idx 1", "Idx 2", "Idx 3", "Idx 4", "Idx 5", "Idx 6", "Idx 7", "Broadcast", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID"
+	canReWidebandCanId = bits, U08, [0:1], "CAN0 0x190/191", "CAN1 0x192/193", "CAN2 0x194/195", "CAN3 0x195/196"
 @@BOARD_PC_VARIABLES_FROM_FILE@@
 
 [ConstantsExtensions]

--- a/firmware/tunerstudio/tunerstudio.template.ini
+++ b/firmware/tunerstudio/tunerstudio.template.ini
@@ -264,6 +264,8 @@ enable2ndByteCanID = false
 	etbCutCodeList = bits, U08, [0:7], "None", "engine stopped", "TPS error", "PPS error", "TPS noise", "Autotune", "Lua", "TPS Calib", "N/A", "Redundancy", "PPS noise", "Jam"
 
 	outputDiagErrorList = bits, U08, [0:3], "Not used", "No error", "Open Load", "Short to Gnd", "Short to Battery", "Overload", "Driver Overtemp", "Driver disabled", "Unknown"
+
+	canReWidebandCmdStatusList = bits, U08, [0:7], "Idle", "Done", "Busy", "Failed"
 @@BOARD_PC_VARIABLES_FROM_FILE@@
 
 [ConstantsExtensions]
@@ -2332,7 +2334,7 @@ menuDialog = main
 		# O2 sensor(s)
 		subMenu = egoSettings,				@@egoSettings_NAME@@, { 1 }, { uiMode == @@UiMode_FULL@@ || uiMode == @@UiMode_INSTALLATION@@ }
 		subMenu = analogEgoSettings,		"Analog O2 sensor", { 1 }, { uiMode == @@UiMode_FULL@@ || uiMode == @@UiMode_INSTALLATION@@ }@@if_ts_show_analog_o2
-		subMenu = widebandConfig,			"rusEFI Wideband Controller", 0, { canReadEnabled && canWriteEnabled }@@if_ts_show_can_wbo
+		subMenu = canReWidebandTools,		"rusEFI Wideband Tools", 0, { canReadEnabled && canWriteEnabled }@@if_ts_show_can_wbo
 		subMenu = std_separator
 
 		subMenu = idleValvePosDialog,		"ETB-style Idle valve position sensor", { etbFunctions1 == @@dc_function_e_DC_IdleValve@@ || etbFunctions2 == @@dc_function_e_DC_IdleValve@@ }, { 1 }
@@ -5256,13 +5258,20 @@ dialog = tcuControls, "Transmission Settings"
 		panel = injTest_l
 		panel = injTest_r
 
-	dialog = widebandConfig, "rusEFI Wideband Config"
+	dialog = canReWidebandLegacyTools, "Legacy FW"
 		field = "!Please connect exactly one wideband controller before pressing these buttons!"
 		commandButton = "Update Firmware", cmd_wideband_firmare_update
 		field = "!These buttons will set ALL connected controllers to the specified index."@@if_ts_show_wbo_canbus_set_index
 		field = "!Disconnect all controllers you don't want to set!"@@if_ts_show_wbo_canbus_set_index
 		commandButton = "Set Index 0",	cmd_set_wideband_idx_0@@if_ts_show_wbo_canbus_set_index
 		commandButton = "Set Index 1",	cmd_set_wideband_idx_1@@if_ts_show_wbo_canbus_set_index
+
+	indicatorPanel = canReWidebandIndicators
+		indicator = { canReWidebandCmdStatus > 1 }, { bitStringValue(canReWidebandCmdStatusList, canReWidebandCmdStatus) }, { bitStringValue(canReWidebandCmdStatusList, canReWidebandCmdStatus) }, green, black, red, black
+
+	dialog = canReWidebandTools, "rusEFI Wideband Tools"
+		panel = canReWidebandLegacyTools
+		panel = canReWidebandIndicators
 
 	dialog = engineTypeDialog, "Popular vehicles"
 		field = "!These buttons send a command to rusEFI controller to apply preset values"


### PR DESCRIPTION
New UI with dropdowns fully replaces "Set Index 0" and "Set Index 1". Someday we should remove these buttons.
![Screenshot from 2025-05-23 11-31-19](https://github.com/user-attachments/assets/3548de3f-dce1-424d-960f-92d1d23a0640)
