### PR TITLE
WBO: get FW version command and UI

### DIFF
--- a/firmware/console/binary/output_channels.txt
+++ b/firmware/console/binary/output_channels.txt
@@ -443,6 +443,11 @@ float mapFast
 	uint16_t fastAdcPeriod;ECU: Fast ADC period;"ticks", 1, 0, 0, 1000, 0
 	uint16_t fastAdcConversionCount;ECU: Fast ADC conversions;"N", 1, 0, 0, 65535, 0
 
+	uint8_t canReWidebandVersion;
+	uint8_t canReWidebandFwDay
+	uint8_t canReWidebandFwMon
+	uint8_t canReWidebandFwYear
+
 bit isMapAveraging
-	uint8_t[36 iterate] unusedAtTheEnd;;"",1, 0, 0, 0, 0
+	uint8_t[32 iterate] unusedAtTheEnd;;"",1, 0, 0, 0, 0
 end_struct

--- a/firmware/controllers/algo/engine_types.h
+++ b/firmware/controllers/algo/engine_types.h
@@ -314,6 +314,7 @@ typedef enum {
 	TS_SET_DEFAULT_ENGINE = 31,
 	TS_LUA_OUTPUT_CATEGORY = 32,
 	TS_WIDEBAND_SET_IDX_BY_ID = 33,
+	TS_WIDEBAND_PING_BY_ID = 34,
 } ts_command_e;
 
 typedef enum {

--- a/firmware/controllers/bench_test.cpp
+++ b/firmware/controllers/bench_test.cpp
@@ -627,6 +627,9 @@ void executeTSCommand(uint16_t subsystem, uint16_t index) {
 			setWidebandOffset(hwIndex, canIndex);
 		}
 		break;
+	case TS_WIDEBAND_PING_BY_ID:
+		pingWideband(index >> 8);
+		break;
 #endif // EFI_CAN_SUPPORT
 	case TS_BENCH_CATEGORY:
 		handleBenchCategory(index);

--- a/firmware/controllers/can/rusefi_wideband.h
+++ b/firmware/controllers/can/rusefi_wideband.h
@@ -9,6 +9,9 @@ void sendWidebandInfo();
 // Handles ack and pong responses from the wideband bootloader
 void handleWidebandCan(const CANRxFrame &frame);
 
+// Pings wideband controller, reply includes protocol version and FW build date
+void pingWideband(uint8_t hwIndex);
+
 // WARNING:
 // Two following functions can block thread execution while waiting for ACK from WBO
 // Do not call from critical tasks!

--- a/firmware/tunerstudio/tunerstudio.template.ini
+++ b/firmware/tunerstudio/tunerstudio.template.ini
@@ -2546,6 +2546,8 @@ cmd_set_wideband_idx_1		= "@@TS_IO_TEST_COMMAND_char@@@@ts_command_e_TS_WIDEBAND
 
 cmd_set_wideband_idx_by_id	= "@@TS_IO_TEST_COMMAND_char@@@@ts_command_e_TS_WIDEBAND_SET_IDX_BY_ID_16_hex@@\$canReWidebandHwIndex\$canReWidebandCanId"
 
+cmd_set_wideband_ping_by_id	= "@@TS_IO_TEST_COMMAND_char@@@@ts_command_e_TS_WIDEBAND_PING_BY_ID_16_hex@@\$canReWidebandHwIndex\x00"
+
 cmd_stop_engine				= "@@TS_IO_TEST_COMMAND_char@@\x00\x79\x00\x00"
 
 ; reboot ECU
@@ -5270,10 +5272,20 @@ dialog = tcuControls, "Transmission Settings"
 		commandButton = "Set Index 0",	cmd_set_wideband_idx_0@@if_ts_show_wbo_canbus_set_index
 		commandButton = "Set Index 1",	cmd_set_wideband_idx_1@@if_ts_show_wbo_canbus_set_index
 
+	readoutPanel = canReWidebandBuildDate, 4, { 1 }
+		readout = canReWidebandVersion, "Version", "", 150, 255, 159, 160, 162, 162, 0, 0
+		readout = canReWidebandFwDay, "Day", "", 0, 32, 1, 1, 31, 31, 0, 0
+		readout = canReWidebandFwMon, "Month", "", 0, 13, 1, 1, 12, 12, 0, 0
+		readout = canReWidebandFwYear, "Year", "", 19, 51, 20, 20, 50, 50, 0, 0
+
 	dialog = canReWidebandNewTools, "New FW"
 		field = "Target device HW ID", canReWidebandHwIndex
+		field = ""
 		field = "Required CAN ID", canReWidebandCanId
 		commandButton = "Set Index", cmd_set_wideband_idx_by_id@@if_ts_show_wbo_canbus_set_index
+		commandButton = "Ping/Get FW version", cmd_set_wideband_ping_by_id
+		field = "FW version and build date:"
+		panel = canReWidebandBuildDate
 
 	indicatorPanel = canReWidebandIndicators
 		indicator = { canReWidebandCmdStatus > 1 }, { bitStringValue(canReWidebandCmdStatusList, canReWidebandCmdStatus) }, { bitStringValue(canReWidebandCmdStatusList, canReWidebandCmdStatus) }, green, black, red, black


### PR DESCRIPTION
This consumes 4 bytes in outputChannels/livedata. But I do not know better way.
![Screenshot from 2025-05-23 18-47-26](https://github.com/user-attachments/assets/abfa3896-7420-4153-bed8-0a9e24dc8007)
