### PR TITLE
RAM for Lua

### DIFF
--- a/firmware/controllers/lua/lua.cpp
+++ b/firmware/controllers/lua/lua.cpp
@@ -399,13 +399,14 @@ static LuaThread luaThread;
 
 void startLua() {
 #if defined(STM32F4) && !defined(EFI_IS_F42x)
+extern char __ram3_base__[];
+extern char __ram3_end__[];
 	// we need this on microRusEFI for sure
 	// definitely should NOT have this on Proteus
 	// on Hellen a bit of open question what's the best track
 	// cute hack: let's check at runtime if you are a lucky owner of microRusEFI with extra RAM and use that extra RAM for extra Lua
 	if (isStm32F42x()) {
-		char *buffer = (char *)0x20020000;
-		userHeap.reinit(buffer, 60000);
+		userHeap.reinit(__ram3_base__, __ram3_base__ - __ram3_end__);
 	}
 #endif // STM32F4
 

--- a/firmware/hw_layer/ports/stm32/stm32f4/STM32F4.ld
+++ b/firmware/hw_layer/ports/stm32/stm32f4/STM32F4.ld
@@ -51,7 +51,7 @@ MEMORY
     flash6  : org = 0x00000000, len = 0
     flash7  : org = 0x00000000, len = 0
     shared  : org = 0x20000000, len = _OpenBLT_Shared_Params_Size
-    ram0    : org = 0x20000000 + _OpenBLT_Shared_Params_Size, len = 128k + RAM3_SIZE - _OpenBLT_Shared_Params_Size /* SRAM1 + SRAM2 + SRAM3 (optionally) */
+    ram0    : org = 0x20000000 + _OpenBLT_Shared_Params_Size, len = 128k - _OpenBLT_Shared_Params_Size /* SRAM1 + SRAM2 */
     ram1    : org = 0x20000000 + _OpenBLT_Shared_Params_Size, len = 112k - _OpenBLT_Shared_Params_Size      /* SRAM1 */
     ram2    : org = 0x2001C000, len = 16k       /* SRAM2 */
     ram3    : org = 0x20020000, len = RAM3_SIZE /* SRAM3 note: this will be 0 size on F40x devices */

--- a/firmware/hw_layer/ports/stm32/stm32f4/STM32F4.ld
+++ b/firmware/hw_layer/ports/stm32/stm32f4/STM32F4.ld
@@ -20,11 +20,6 @@
  * bl section is where we link the rusefi bootloader
  */
 
-/* On devices with 256K RAM, use additional memory SRAM3. */
-/* STM32F40x do not have SRAM3 */
-/* STM32F42x and F46x have SRAM3 */
-RAM3_SIZE = DEFINED(STM32F4_HAS_SRAM3) ? 64k : 0;
-
 /* SDRAM */
 /* Only STM32F429I-Discovery has external SDRAM */
 SDRAM_SIZE = DEFINED(STM32_HAS_SDRAM) ? 8M : 0;
@@ -54,7 +49,10 @@ MEMORY
     ram0    : org = 0x20000000 + _OpenBLT_Shared_Params_Size, len = 128k - _OpenBLT_Shared_Params_Size /* SRAM1 + SRAM2 */
     ram1    : org = 0x20000000 + _OpenBLT_Shared_Params_Size, len = 112k - _OpenBLT_Shared_Params_Size      /* SRAM1 */
     ram2    : org = 0x2001C000, len = 16k       /* SRAM2 */
-    ram3    : org = 0x20020000, len = RAM3_SIZE /* SRAM3 note: this will be 0 size on F40x devices */
+    /* STM32F40x do not have SRAM3 */
+    /* STM32F42x and F46x have SRAM3 */
+    /* This region is hiden from linker, it is safe to have it 64k for all STM32F4xx */
+    ram3    : org = 0x20020000, len = 64k       /* SRAM3 note: this will be 0 size on F40x devices */
     ram4    : org = 0x10000000, len = 64k       /* CCM SRAM */
     ram5    : org = 0x40024000, len = 4k        /* BCKP SRAM */
     ram6    : org = 0x00000000, len = 0

--- a/firmware/hw_layer/ports/stm32/stm32f4/hw_ports.mk
+++ b/firmware/hw_layer/ports/stm32/stm32f4/hw_ports.mk
@@ -19,7 +19,6 @@ endif
 
 # STM32F42x has extra memory, so change some flags so we can use it.
 ifeq ($(IS_STM32F429),yes)
-	USE_OPT += -Wl,--defsym=STM32F4_HAS_SRAM3=1
 	DDEFS += -DSTM32F429xx -DSTM32F429_MCUCONF
 	DDEFS += -DEFI_IS_F42x
 else ifeq ($(IS_AT32F435),yes)


### PR DESCRIPTION
Hide RAM3 from linker script. FW will decide if it exist, and if so - give whole RAM3 to Lua heap.
So linker should not touch this memory.