### PR TITLE
Luamemory command improvement

### DIFF
--- a/firmware/controllers/lua/lua.cpp
+++ b/firmware/controllers/lua/lua.cpp
@@ -124,7 +124,11 @@ static void printLuaMemoryInfo() {
 	auto heapSize = userHeap.size();
 	auto memoryUsed = userHeap.used();
 	float pct = 100.0f * memoryUsed / heapSize;
+	size_t chHeapFree = 0;
+	chHeapStatus(NULL, &chHeapFree, NULL);
 	efiPrintf("Lua memory heap usage: %d / %d bytes = %.1f%%", memoryUsed, heapSize, pct);
+	efiPrintf("Common ChibiOS heap: %d bytes free", chHeapFree);
+	efiPrintf("ChibiOS memcore free size: %d", chCoreGetStatusX());
 }
 
 static void* myAlloc(void* /*ud*/, void* ptr, size_t osize, size_t nsize) {

--- a/firmware/controllers/lua/lua.cpp
+++ b/firmware/controllers/lua/lua.cpp
@@ -24,7 +24,7 @@ static bool withErrorLoading = false;
 //#define LUA_HEAD_RAM_SECTION CCM_OPTIONAL
 //#endif
 
-static char luaUserHeap[LUA_USER_HEAP]
+CH_HEAP_AREA(luaUserHeap, LUA_USER_HEAP)
 #ifdef EFI_HAS_EXT_SDRAM
 SDRAM_OPTIONAL
 #endif
@@ -44,7 +44,7 @@ public:
 
 	size_t m_memoryUsed = 0;
 	size_t m_size;
-	char* m_buffer;
+	uint8_t* m_buffer;
 
 	void* alloc(size_t n) {
 		return chHeapAlloc(&m_heap, n);
@@ -56,12 +56,12 @@ public:
 
 public:
 	template<size_t TSize>
-	Heap(char (&buffer)[TSize])
+	Heap(uint8_t (&buffer)[TSize])
 	{
 		reinit(buffer, TSize);
 	}
 
-	void reinit(char *buffer, size_t size) {
+	void reinit(uint8_t *buffer, size_t size) {
 		criticalAssertVoid(m_memoryUsed == 0, "Too late to reinit Lua heap");
 
 		m_size = size;
@@ -413,8 +413,8 @@ void startLua() {
 	// on Hellen a bit of open question what's the best track
 	if (isStm32F42x()) {
 		// This is safe to use section base and end as we define ram3 for all F4 chips
-		extern char __ram3_base__[];
-		extern char __ram3_end__[];
+		extern uint8_t __ram3_base__[];
+		extern uint8_t __ram3_end__[];
 		userHeap.reinit(__ram3_base__, __ram3_end__ - __ram3_base__);
 	}
 #endif // !EFI_IS_F42x

--- a/firmware/controllers/lua/lua.cpp
+++ b/firmware/controllers/lua/lua.cpp
@@ -16,7 +16,8 @@ static bool withErrorLoading = false;
 #if EFI_PROD_CODE || EFI_SIMULATOR
 
 #ifndef LUA_USER_HEAP
-#define LUA_USER_HEAP 1
+// At least one heap_header_t should fit
+#define LUA_USER_HEAP 16
 #endif // LUA_USER_HEAP
 
 //#ifdef PERSISTENT_LOCATION_TODO


### PR DESCRIPTION
Now also shows ChibiOS heap and memcore statistic.
```
2025-06-01_10_04_21_403: EngineState: rx total/recent 0 0
2025-06-01_10_04_21_404: EngineState: luaCycle 22us including luaRxTime 9us
2025-06-01_10_04_21_404: EngineState: Lua memory heap usage: 16542 / 92000 bytes = 17.9%
2025-06-01_10_04_21_405: EngineState: Common ChibiOS heap: 0 bytes free
2025-06-01_10_04_21_406: EngineState: ChibiOS memcore free size: 52992
```
