### PR TITLE
Lua: heap: fallback to ChibiOS defaul heap if userHeap is failed to allocate

### DIFF
--- a/firmware/controllers/lua/lua.cpp
+++ b/firmware/controllers/lua/lua.cpp
@@ -152,7 +152,7 @@ static void printLuaMemoryInfo() {
 	size_t chHeapFree = 0;
 	chHeapStatus(NULL, &chHeapFree, NULL);
 	efiPrintf("Common ChibiOS heap: %d bytes free", chHeapFree);
-	efiPrintf("ChibiOS memcore free size: %d", chCoreGetStatusX());
+	efiPrintf("ChibiOS memcore: %d bytes free", chCoreGetStatusX());
 }
 
 static void* myAlloc(void* /*ud*/, void* optr, size_t osize, size_t nsize) {


### PR DESCRIPTION
ChibiOS default heap uses RAM lefovers that were not allocated during compilation.
This modification allows use of all available RAM for Lua. No need to adjust  LUA_USER_HEAP.