### PR TITLE
Updated tunerstudio.template.ini for rotary trigger

### DIFF
--- a/firmware/tunerstudio/tunerstudio.template.ini
+++ b/firmware/tunerstudio/tunerstudio.template.ini
@@ -5478,7 +5478,7 @@ dialog = tcuControls, "Transmission Settings"
 		field = "After cut timing ramp-in time", dfcoRetardRampInTime, {coastingFuelCutEnabled}
 
 	dialog = rotaryDialog, "Rotary"
-		field = "Enable Trailing Sparks", enableTrailingSparks
+		field = "Enable Trailing Sparks", enableTrailingSparks, { twoStroke == 1 }
 		field = "Trailing Pin 1",						trailingCoilPins1
 		field = "Trailing Pin 2",						trailingCoilPins2
 		field = "Trailing Pin 3",						trailingCoilPins3


### PR DESCRIPTION
edit for "Rotary" Should only be selectable when "Base engine-> Trigger->Strokes" is set to "Two" #6397