### PR TITLE
Edits on Rotary menu for trailing sparks

### DIFF
--- a/firmware/tunerstudio/tunerstudio.template.ini
+++ b/firmware/tunerstudio/tunerstudio.template.ini
@@ -5479,10 +5479,10 @@ dialog = tcuControls, "Transmission Settings"
 
 	dialog = rotaryDialog, "Rotary"
 		field = "Enable Trailing Sparks", enableTrailingSparks, { twoStroke == 1 }
-		field = "Trailing Pin 1",						trailingCoilPins1
-		field = "Trailing Pin 2",						trailingCoilPins2
-		field = "Trailing Pin 3",						trailingCoilPins3
-		field = "Trailing Pin 4",						trailingCoilPins4
+		field = "Trailing Pin 1",						trailingCoilPins1, {enableTrailingSparks}
+		field = "Trailing Pin 2",						trailingCoilPins2, {enableTrailingSparks && cylindersCount >= 2}
+		field = "Trailing Pin 3",						trailingCoilPins3, {enableTrailingSparks && cylindersCount >= 3}
+		field = "Trailing Pin 4",						trailingCoilPins4, {enableTrailingSparks && cylindersCount >= 4}
 		panel = trailingSparkTable
 
 		@@BOARD_OPTIONS_FROM_FILE@@


### PR DESCRIPTION
- Show trailing spark fields only when trailing spark is enabled.
- Show trailing spark pins quantity based on "cylinder count".