### PR TITLE
Revert change on trailing spark

### DIFF
--- a/firmware/tunerstudio/tunerstudio.template.ini
+++ b/firmware/tunerstudio/tunerstudio.template.ini
@@ -5479,10 +5479,10 @@ dialog = tcuControls, "Transmission Settings"
 
 	dialog = rotaryDialog, "Rotary"
 		field = "Enable Trailing Sparks", enableTrailingSparks, { twoStroke == 1 }
-		field = "Trailing Pin 1",						trailingCoilPins1
-		field = "Trailing Pin 2",						trailingCoilPins2
-		field = "Trailing Pin 3",						trailingCoilPins3
-		field = "Trailing Pin 4",						trailingCoilPins4
+		field = "Trailing Pin 1",						trailingCoilPins1, {enableTrailingSparks}
+		field = "Trailing Pin 2",						trailingCoilPins2, {enableTrailingSparks && cylindersCount >= 2}
+		field = "Trailing Pin 3",						trailingCoilPins3, {enableTrailingSparks && cylindersCount >= 3}
+		field = "Trailing Pin 4",						trailingCoilPins4, {enableTrailingSparks && cylindersCount >= 4}
 		panel = trailingSparkTable
 
 		@@BOARD_OPTIONS_FROM_FILE@@

--- a/firmware/tunerstudio/tunerstudio.template.ini
+++ b/firmware/tunerstudio/tunerstudio.template.ini
@@ -5478,7 +5478,7 @@ dialog = tcuControls, "Transmission Settings"
 		field = "After cut timing ramp-in time", dfcoRetardRampInTime, {coastingFuelCutEnabled}
 
 	dialog = rotaryDialog, "Rotary"
-		field = "Enable Trailing Sparks", enableTrailingSparks, { twoStroke == 1 }
+		field = "Enable Trailing Sparks", enableTrailingSparks
 		field = "Trailing Pin 1",						trailingCoilPins1, {enableTrailingSparks}
 		field = "Trailing Pin 2",						trailingCoilPins2, {enableTrailingSparks && cylindersCount >= 2}
 		field = "Trailing Pin 3",						trailingCoilPins3, {enableTrailingSparks && cylindersCount >= 3}

--- a/firmware/tunerstudio/tunerstudio.template.ini
+++ b/firmware/tunerstudio/tunerstudio.template.ini
@@ -5478,7 +5478,7 @@ dialog = tcuControls, "Transmission Settings"
 		field = "After cut timing ramp-in time", dfcoRetardRampInTime, {coastingFuelCutEnabled}
 
 	dialog = rotaryDialog, "Rotary"
-		field = "Enable Trailing Sparks", enableTrailingSparks
+		field = "Enable Trailing Sparks", enableTrailingSparks, { twoStroke == 1 }
 		field = "Trailing Pin 1",						trailingCoilPins1
 		field = "Trailing Pin 2",						trailingCoilPins2
 		field = "Trailing Pin 3",						trailingCoilPins3


### PR DESCRIPTION
Revert change on trailing spark enable, as trailing spark can also be used on four stroke, not only on rotary