### PR TITLE
Update tunerstudio.template.ini

### DIFF
--- a/firmware/tunerstudio/tunerstudio.template.ini
+++ b/firmware/tunerstudio/tunerstudio.template.ini
@@ -5478,7 +5478,7 @@ dialog = tcuControls, "Transmission Settings"
 		field = "After cut timing ramp-in time", dfcoRetardRampInTime, {coastingFuelCutEnabled}
 
 	dialog = rotaryDialog, "Rotary"
-		field = "Enable Trailing Sparks", enableTrailingSparks, { twoStroke == 1 }
+		field = "Enable Trailing Sparks", enableTrailingSparks
 		field = "Trailing Pin 1",						trailingCoilPins1, {enableTrailingSparks}
 		field = "Trailing Pin 2",						trailingCoilPins2, {enableTrailingSparks && cylindersCount >= 2}
 		field = "Trailing Pin 3",						trailingCoilPins3, {enableTrailingSparks && cylindersCount >= 3}


### PR DESCRIPTION
- Revert edit on tunerstudio.template.ini regarding the possibility of enabling trailing spark as it can be used both in two stroke (for rotary) and four stroke for twin spark reciprocating ICE