### PR TITLE
WBO: improvements

### DIFF
--- a/firmware/controllers/sensors/impl/AemXSeriesLambda.cpp
+++ b/firmware/controllers/sensors/impl/AemXSeriesLambda.cpp
@@ -158,9 +158,9 @@ bool AemXSeriesWideband::decodeAemXSeries(const CANRxFrame& frame, efitick_t now
 void AemXSeriesWideband::decodeRusefiStandard(const CANRxFrame& frame, efitick_t nowNt) {
 	auto data = reinterpret_cast<const wbo::StandardData*>(&frame.data8[0]);
 
-	if (data->Version != RUSEFI_WIDEBAND_VERSION) {
-		firmwareError(ObdCode::OBD_WB_FW_Mismatch, "Wideband controller index %d has wrong protocol version (0x%02x while 0x%02x expected), please update!",
-			m_sensorIndex, data->Version, RUSEFI_WIDEBAND_VERSION);
+	if (data->Version < RUSEFI_WIDEBAND_VERSION_MIN) {
+		firmwareError(ObdCode::OBD_WB_FW_Mismatch, "Wideband controller index %d has outdated protocol version (0x%02x while minimum 0x%02x expected), please update!",
+			m_sensorIndex, data->Version, RUSEFI_WIDEBAND_VERSION_MIN);
 		return;
 	}
 

--- a/firmware/controllers/sensors/impl/AemXSeriesLambda.cpp
+++ b/firmware/controllers/sensors/impl/AemXSeriesLambda.cpp
@@ -34,18 +34,18 @@ bool AemXSeriesWideband::acceptFrame(const CANRxFrame& frame) const {
 		return false;
 	}
 
-	uint32_t id = CAN_ID(frame);
-
-	if (type == RUSEFI) {
+	// RusEFI wideband uses standard CAN IDs
+	if ((!CAN_ISX(frame)) && (type == RUSEFI)) {
 		// 0th sensor is 0x190 and 0x191, 1st sensor is 0x192 and 0x193
 		uint32_t rusefiBaseId = rusefi_base + 2 * (engineConfiguration->flipWboChannels ? (1 - m_sensorIndex) : m_sensorIndex);
-		return ((id == rusefiBaseId) || (id == rusefiBaseId + 1));
+		return ((CAN_SID(frame) == rusefiBaseId) || (CAN_SID(frame) == rusefiBaseId + 1));
 	}
 
-	if (type == AEM) {
-		// 0th sensor is 0x180, 1st sensor is 0x181, etc
+	// AEM uses extended CAN ID
+	if ((CAN_ISX(frame)) && (type == AEM)) {
+		// 0th sensor is 0x00000180, 1st sensor is 0x00000181, etc
 		uint32_t aemXSeriesId = aem_base + m_sensorIndex;
-		return (id == aemXSeriesId);
+		return (CAN_EID(frame) == aemXSeriesId);
 	}
 
 	return false;

--- a/firmware/controllers/sensors/impl/AemXSeriesLambda.h
+++ b/firmware/controllers/sensors/impl/AemXSeriesLambda.h
@@ -10,6 +10,8 @@
 
 // todo: static_cast<uint8_t>(Fault::LegacyProtocol);
 
+#define RUSEFI_WIDEBAND_VERSION_MIN	0xA0
+
 class AemXSeriesWideband : public CanSensorBase, public wideband_state_s {
 public:
 	AemXSeriesWideband(uint8_t sensorIndex, SensorType type);


### PR DESCRIPTION
AEM uses extended CAN ID, while RusEFI uses standard CAN IDs. Check this in `AemXSeriesWideband::acceptFrame()`
Also we have bumped RusEFI wideband protocol version. But we are still backward compatible.