### PR TITLE
Lua heap and stm32f7 ram2

### DIFF
--- a/firmware/hw_layer/ports/stm32/stm32f7/STM32F7.ld
+++ b/firmware/hw_layer/ports/stm32/stm32f7/STM32F7.ld
@@ -102,7 +102,7 @@ REGION_ALIAS("DATA_RAM_LMA", flash0);
 REGION_ALIAS("BSS_RAM", ram0);
 
 /* RAM region to be used for the default heap.*/
-REGION_ALIAS("HEAP_RAM", ram3);
+REGION_ALIAS("HEAP_RAM", ram0);
 
 /* Stack rules inclusion.*/
 INCLUDE rules_stacks.ld

--- a/firmware/hw_layer/ports/stm32/stm32f7/STM32F7.ld
+++ b/firmware/hw_layer/ports/stm32/stm32f7/STM32F7.ld
@@ -48,7 +48,7 @@ MEMORY
     flash6 (rx) : org = 0x00000000, len = 0
     flash7 (rx) : org = 0x00000000, len = 0
     shared      : org = 0x20020000, len = _OpenBLT_Shared_Params_Size
-    ram0   (wx) : org = 0x20020000 + _OpenBLT_Shared_Params_Size, len = 384k - _OpenBLT_Shared_Params_Size      /* SRAM1 + SRAM2 */
+    ram0   (wx) : org = 0x20020000 + _OpenBLT_Shared_Params_Size, len = 368k - _OpenBLT_Shared_Params_Size      /* SRAM1 only, SRAM2 is used as no-cached area */
     ram1   (wx) : org = 0x20020000 + _OpenBLT_Shared_Params_Size, len = 368k - _OpenBLT_Shared_Params_Size      /* SRAM1 */
     ram2   (wx) : org = 0x2007C000, len = 16k       /* SRAM2 */
     ram3   (wx) : org = 0x20000000, len = 128k      /* DTCM-RAM */


### PR DESCRIPTION
1. ram2 is used as no-cached area. So exclude it from ram0. Keeping this are in two memory regions in ld file can cause overlap that will not detected by linker.

2. Also use unused ram from ram0 section for ChibiOS.

These increase amount of memory available for ChibiOS memcore and default heap. And thus to Lua
From:
```
2025-06-02_18_06_04_024: EngineState: Dedicated Lua memory heap usage: 20232 / 92000 bytes = 21.9%
2025-06-02_18_06_04_024: EngineState: Common ChibiOS heap: 0 bytes free
2025-06-02_18_06_04_024: EngineState: ChibiOS memcore: 52992 bytes free
```

To:
```
2025-06-02_17_25_36_509: EngineState: LUA script loaded successfully!
2025-06-02_17_25_36_509: EngineState: Dedicated Lua memory heap usage: 20232 / 92000 bytes = 21.9%
2025-06-02_17_25_36_510: EngineState: Common ChibiOS heap: 0 bytes free
2025-06-02_17_25_36_513: EngineState: ChibiOS memcore: 164912 bytes free

```

