### PR TITLE
fix test_vvt.cpp tests for disable-vvt-close-to-zero

### DIFF
--- a/firmware/controllers/actuators/vvt.cpp
+++ b/firmware/controllers/actuators/vvt.cpp
@@ -55,6 +55,16 @@ void VvtController::onConfigurationChange(engine_configuration_s const * previou
 	}
 }
 
+static bool shouldInvertVvt(int camIndex) {
+	// grumble grumble, can't do an array of bits in c++
+	switch (camIndex) {
+		case 0: return engineConfiguration->invertVvtControlIntake;
+		case 1: return engineConfiguration->invertVvtControlExhaust;
+	}
+
+	return false;
+}
+
 expected<angle_t> VvtController::observePlant() {
 #if EFI_SHAFT_POSITION_INPUT
 	return engine->triggerCentral.getVVTPosition(m_bank, m_cam);
@@ -82,6 +92,22 @@ expected<angle_t> VvtController::getSetpoint() {
 	engine->outputChannels.vvtTargets[index] = target;
 #endif
 
+	// If the target is very near the rest position, disable control entirely
+	// Couple reasons for this:
+	// - Avoid integrator windup from trying to jam the cam against the stop
+	// - Many VVT implementations don't like being controlled near the stop,
+	//       as this can cause problems with the lock pin jamming.
+	bool allowCamControl;
+	if (shouldInvertVvt(m_cam)) {
+		allowCamControl = m_targetHysteresis.test(target < -3, target > -1);
+	} else {
+		allowCamControl = m_targetHysteresis.test(target > 3, target < 1);
+	}
+
+	if (!allowCamControl) {
+		return unexpected;
+	}
+
 	vvtTarget = target;
 
 	return target;
@@ -91,16 +117,6 @@ expected<percent_t> VvtController::getOpenLoop(angle_t target) {
 	// TODO: could we do VVT open loop?
 	UNUSED(target);
 	return 0;
-}
-
-static bool shouldInvertVvt(int camIndex) {
-	// grumble grumble, can't do an array of bits in c++
-	switch (camIndex) {
-		case 0: return engineConfiguration->invertVvtControlIntake;
-		case 1: return engineConfiguration->invertVvtControlExhaust;
-	}
-
-	return false;
 }
 
 expected<percent_t> VvtController::getClosedLoop(angle_t target, angle_t observation) {

--- a/firmware/controllers/actuators/vvt.cpp
+++ b/firmware/controllers/actuators/vvt.cpp
@@ -32,6 +32,7 @@ void VvtController::init(const ValueProvider3D* targetMap, IPwm* pwm) {
 
 	m_targetMap = targetMap;
 	m_pwm = pwm;
+	m_targetHysteresis = Hysteresis();
 }
 
 void VvtController::onFastCallback() {

--- a/firmware/controllers/actuators/vvt.h
+++ b/firmware/controllers/actuators/vvt.h
@@ -60,6 +60,7 @@ private:
 	bool m_isCltWarmEnough = false;
 
 	const ValueProvider3D* m_targetMap = nullptr;
+	Hysteresis m_targetHysteresis;
 	IPwm* m_pwm = nullptr;
 };
 

--- a/unit_tests/tests/actuators/test_vvt.cpp
+++ b/unit_tests/tests/actuators/test_vvt.cpp
@@ -48,11 +48,22 @@ struct FakeMap : public ValueProvider3D {
 
 TEST(VVT, SetpointHysteresisAdvancingCam) {
 	EngineTestHelper eth(engine_type_e::TEST_ENGINE);
+	Sensor::setMockValue(SensorType::Clt, 70); // m_isCltWarmEnough
+	// m_isRpmHighEnough
+	engine->rpmCalculator.setRpmValue(1500);
+	engineConfiguration->vvtControlMinRpm = 500;
+	// m_engineRunningLongEnough
+	advanceTimeUs(0.8e6);
+	engineConfiguration->vvtActivationDelayMs = 5;
 
 	FakeMap targetMap;
+	MockPwm pwm;
 
-	VvtController dut(0, 0, 0);
-	dut.init(&targetMap, nullptr);
+	VvtController dut(0);
+	dut.init(&targetMap, &pwm);
+
+	// update m_engineRunningLongEnough / m_isRpmHighEnough flags
+	dut.onFastCallback();
 
 	// 0 position returns unexpected
 	targetMap.setpoint = 0;
@@ -77,13 +88,24 @@ TEST(VVT, SetpointHysteresisAdvancingCam) {
 
 TEST(VVT, SetpointHysteresisRetardingCam) {
 	EngineTestHelper eth(engine_type_e::TEST_ENGINE);
+	Sensor::setMockValue(SensorType::Clt, 70); // m_isCltWarmEnough
+	// m_isRpmHighEnough
+	engine->rpmCalculator.setRpmValue(1500);
+	engineConfiguration->vvtControlMinRpm = 500;
+	// m_engineRunningLongEnough
+	advanceTimeUs(0.8e6);
+	engineConfiguration->vvtActivationDelayMs = 5;
 
 	engineConfiguration->invertVvtControlIntake = true;
 
 	FakeMap targetMap;
+	MockPwm pwm;
 
-	VvtController dut(0, 0, 0);
-	dut.init(&targetMap, nullptr);
+	VvtController dut(0);
+	dut.init(&targetMap, &pwm);
+
+	// update m_engineRunningLongEnough / m_isRpmHighEnough flags
+	dut.onFastCallback();
 
 	// 0 position returns unexpected
 	targetMap.setpoint = 0;

--- a/unit_tests/tests/actuators/test_vvt.cpp
+++ b/unit_tests/tests/actuators/test_vvt.cpp
@@ -55,6 +55,8 @@ TEST(VVT, SetpointHysteresisAdvancingCam) {
 	// m_engineRunningLongEnough
 	advanceTimeUs(0.8e6);
 	engineConfiguration->vvtActivationDelayMs = 5;
+	engineConfiguration->invertVvtControlIntake = false;
+	engineConfiguration->invertVvtControlExhaust = false;
 
 	FakeMap targetMap;
 	MockPwm pwm;
@@ -97,6 +99,7 @@ TEST(VVT, SetpointHysteresisRetardingCam) {
 	engineConfiguration->vvtActivationDelayMs = 5;
 
 	engineConfiguration->invertVvtControlIntake = true;
+	engineConfiguration->invertVvtControlExhaust = false;
 
 	FakeMap targetMap;
 	MockPwm pwm;


### PR DESCRIPTION
we need `m_engineRunningLongEnough` / `m_isRpmHighEnough` flags on true before trying to get vvt target with `getSetpoint`