### PR TITLE
update default_cranking.cpp now postCranking bins are auto-generated,…

### DIFF
--- a/firmware/controllers/algo/defaults/default_cranking.cpp
+++ b/firmware/controllers/algo/defaults/default_cranking.cpp
@@ -24,14 +24,8 @@ void setDefaultCranking() {
 	// After start enrichment
 #if !EFI_UNIT_TEST
 	// don't set this for unit tests, as it makes things more complicated to test
-	static const int16_t defaultPostCrankingCLTBins[] = {
-		-20, 0, 20, 40, 60, 80
-	};
-	static const uint16_t defaultPostCrankingDurationBins[] = {
-		0, 15, 35, 65, 100, 150
-	};
-	copyArray(config->postCrankingCLTBins, defaultPostCrankingCLTBins);
-	copyArray(config->postCrankingDurationBins, defaultPostCrankingDurationBins);
+	setLinearCurve(config->postCrankingCLTBins, /*from*/-20, /*to*/80, 20);
+	setLinearCurve(config->postCrankingDurationBins, /*from*/0, /*to*/150, 40);
 	setTable(config->postCrankingFactor, 1.2f);
 #endif
 

--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -1860,7 +1860,7 @@ uint8_t[TORQUE_CURVE_SIZE x TORQUE_CURVE_RPM_SIZE] autoscale torqueTable;;"Nm", 
 #define CRANKING_ENRICH_COUNT 6
 #define CRANKING_ENRICH_CLT_COUNT 6
 
-	float[CRANKING_ENRICH_COUNT x CRANKING_ENRICH_COUNT] postCrankingFactor;;"mult", 1, 0, 1, 3, 2
+	float[CRANKING_ENRICH_CLT_COUNT x CRANKING_ENRICH_COUNT] postCrankingFactor;;"mult", 1, 0, 1, 3, 2
 	uint16_t[CRANKING_ENRICH_COUNT] postCrankingDurationBins;;"count", 1, 0, 0, 64000, 0
 	int16_t[CRANKING_ENRICH_CLT_COUNT] postCrankingCLTBins;;"C", 1, 0, -100, @@CLT_UPPER_LIMIT@@, 0
 


### PR DESCRIPTION
… added test for X/Y axis

related pr: https://github.com/rusefi/rusefi/pull/8004