### PR TITLE
Traction control ETB & spark tests

### DIFF
--- a/firmware/controllers/actuators/electronic_throttle.cpp
+++ b/firmware/controllers/actuators/electronic_throttle.cpp
@@ -333,7 +333,7 @@ expected<percent_t> EtbController::getSetpointEtb() {
 
   float vehicleSpeed = Sensor::getOrZero(SensorType::VehicleSpeed);
   float wheelSlip = Sensor::getOrZero(SensorType::WheelSlipRatio);
-  tcEtbDrop = tcEtbDropTable.getValue(wheelSlip, vehicleSpeed); // TODO: XY fliped here! getValue(float xColumn, float yRow)
+  tcEtbDrop = tcEtbDropTable.getValue(wheelSlip, vehicleSpeed);
 
 	// Apply any adjustment that this throttle alone needs
 	// Clamped to +-10 to prevent anything too wild

--- a/unit_tests/tests/actuators/test_etb.cpp
+++ b/unit_tests/tests/actuators/test_etb.cpp
@@ -904,13 +904,18 @@ TEST(etb, tractionControlEtbDrop) {
 	engineConfiguration->tractionControlEtbDrop[0][0] = -15;
 	engineConfiguration->tractionControlEtbDrop[0][1] = -15;
 
-	engineConfiguration->tractionControlEtbDrop[4][4] = +15;
-	engineConfiguration->tractionControlEtbDrop[5][5] = +15;
+	size_t lastYIndex = TRACTION_CONTROL_ETB_DROP_SLIP_SIZE - 1;
+	size_t lastXIndex = TRACTION_CONTROL_ETB_DROP_SPEED_SIZE - 1;
 
-	EXPECT_EQ(37, etb.getSetpoint().value_or(-1)); // should be 62
+	engineConfiguration->tractionControlEtbDrop[lastYIndex - 1][lastXIndex - 1] = 15;
+	engineConfiguration->tractionControlEtbDrop[lastYIndex][lastXIndex] = 15;
+
+	// we expect here that the first values are 37, and the last on the rigth side of the table are 62
+
+	EXPECT_EQ(37, etb.getSetpoint().value_or(-1));
 
 	Sensor::setMockValue(SensorType::VehicleSpeed, 120.0);
 	Sensor::setMockValue(SensorType::WheelSlipRatio, 1.2);
 
-	EXPECT_EQ(62, etb.getSetpoint().value_or(-1)); // should be 37
+	EXPECT_EQ(62, etb.getSetpoint().value_or(-1));
 }


### PR DESCRIPTION
* Traction control ETB is not fliped, updated the comment & test, both on firmware and TS we have correct X/Y axis (as defined on #6944 screenshot X => vehicle speed; Y => wheel slip)
* added test for tables on `Traction Control Timing drop` and `Traction Control Skip Ignition`
* newer test calculates the end of the table on compile time instated of fixed array length, to prevent more issues like: https://github.com/rusefi/rusefi/pull/7775

relevant TS template section:
```ini
table = tractionEtbTableTbl,  tractionEtb,  "Traction Control ETB drop",	1
    xBins		= tractionControlSpeedBins,  vehicleSpeedKph
    yBins		= tractionControlSlipBins,  wheelSlipRatio
    zBins		= tractionControlEtbDrop

table = tractionTimingTableTbl,  tractionEtb,  "Traction Control Timing drop",	1
    xBins		= tractionControlSpeedBins,  vehicleSpeedKph
    yBins		= tractionControlSlipBins,  wheelSlipRatio
    zBins		= tractionControlTimingDrop

table = tractionIgnitionSkipTableTbl,  tractionEtb,  "Traction Control Skip Ignition",	1
    xBins		= tractionControlSpeedBins,  vehicleSpeedKph
    yBins		= tractionControlSlipBins,  wheelSlipRatio
    zBins		= tractionControlIgnitionSkip

```

resolves: #6944