### PR TITLE
ports: BKUP_RAM_NOINIT region for backuped data storing

### DIFF
--- a/firmware/hw_layer/ports/stm32/backup_ram.cpp
+++ b/firmware/hw_layer/ports/stm32/backup_ram.cpp
@@ -47,10 +47,10 @@ void backupRamFlush(void) {
 // STM32 only has 4k bytes of backup SRAM
 static_assert(sizeof(BackupSramData) <= 4096);
 
-extern BackupSramData __backup_sram_addr__;
+static BKUP_RAM_NOINIT BackupSramData backupSramData;
 
 BackupSramData* getBackupSram() {
-	return &__backup_sram_addr__;
+	return &backupSramData;
 }
 
 #endif

--- a/firmware/hw_layer/ports/stm32/stm32f4/STM32F4.ld
+++ b/firmware/hw_layer/ports/stm32/stm32f4/STM32F4.ld
@@ -113,6 +113,9 @@ REGION_ALIAS("HEAP_RAM", ram0);
 /* RAM region to be used for SDRAM segment.*/
 REGION_ALIAS("SDRAM_RAM", ram7);
 
+/* RAM region to be used for battery backuped data */
+REGION_ALIAS("BKUP_RAM", ram5);
+
 SECTIONS
 {
   /* Bootloader section */
@@ -137,6 +140,11 @@ SECTIONS
     _eshared = .;
     __shared_end__ = _eshared;
   } > shared
+
+  .bkup_ram_noinit (NOLOAD):
+  {
+    *(.bkup_ram_noinit)
+  } > BKUP_RAM
 }
 
 /* Generic rules inclusion.*/

--- a/firmware/hw_layer/ports/stm32/stm32f4/global_port.h
+++ b/firmware/hw_layer/ports/stm32/stm32f4/global_port.h
@@ -11,9 +11,11 @@
 #define CCM_OPTIONAL
 #define SDRAM_OPTIONAL
 #define NO_CACHE
+#define BKUP_RAM_NOINIT
 #else
 // CCM memory is 64k
 #define CCM_OPTIONAL __attribute__((section(".ram4")))
 #define SDRAM_OPTIONAL __attribute__((section(".ram7")))
 #define NO_CACHE	// F4 has no cache, do nothing
+#define BKUP_RAM_NOINIT __attribute__((section(".bkup_ram_noinit")))
 #endif

--- a/firmware/hw_layer/ports/stm32/stm32f7/STM32F7.ld
+++ b/firmware/hw_layer/ports/stm32/stm32f7/STM32F7.ld
@@ -117,6 +117,9 @@ REGION_ALIAS("NOCACHE_RAM", ram3);
 /* RAM region to be used for eth segment.*/
 REGION_ALIAS("ETH_RAM", ram3);
 
+/* RAM region to be used for battery backuped data */
+REGION_ALIAS("BKUP_RAM", ram5);
+
 SECTIONS
 {
     /* Special section for non cache-able areas.*/
@@ -154,6 +157,11 @@ SECTIONS
     _eshared = .;
     __shared_end__ = _eshared;
   } > shared
+
+  .bkup_ram_noinit (NOLOAD):
+  {
+    *(.bkup_ram_noinit)
+  } > BKUP_RAM
 }
 
 /* Code rules inclusion.*/

--- a/firmware/hw_layer/ports/stm32/stm32f7/STM32F746xG.ld
+++ b/firmware/hw_layer/ports/stm32/stm32f7/STM32F746xG.ld
@@ -102,6 +102,9 @@ REGION_ALIAS("NOCACHE_RAM", ram3);
 /* RAM region to be used for eth segment.*/
 REGION_ALIAS("ETH_RAM", ram3);
 
+/* RAM region to be used for battery backuped data */
+REGION_ALIAS("BKUP_RAM", ram5);
+
 SECTIONS
 {
     /* Special section for non cache-able areas.*/
@@ -125,6 +128,11 @@ SECTIONS
         . = ALIGN(4);
         __eth_end__ = .;
     } > ETH_RAM
+
+    .bkup_ram_noinit (NOLOAD):
+    {
+        *(.bkup_ram_noinit)
+    } > BKUP_RAM
 }
 
 /* Code rules inclusion.*/

--- a/firmware/hw_layer/ports/stm32/stm32f7/global_port.h
+++ b/firmware/hw_layer/ports/stm32/stm32f7/global_port.h
@@ -4,3 +4,5 @@
 #define SDRAM_OPTIONAL __attribute__((section(".ram7")))
 // SRAM2 is 16k and set to disable dcache
 #define NO_CACHE __attribute__((section(".ram2")))
+
+#define BKUP_RAM_NOINIT __attribute__((section(".bkup_ram_noinit")))

--- a/firmware/hw_layer/ports/stm32/stm32h7/STM32H743xI.ld
+++ b/firmware/hw_layer/ports/stm32/stm32h7/STM32H743xI.ld
@@ -116,6 +116,9 @@ REGION_ALIAS("NOCACHE_RAM", ram3);
 /* RAM region to be used for eth segment.*/
 REGION_ALIAS("ETH_RAM", ram3);
 
+/* RAM region to be used for battery backuped data */
+REGION_ALIAS("BKUP_RAM", ram7);
+
 SECTIONS
 {
     /* Special section for non cache-able areas.*/
@@ -139,6 +142,11 @@ SECTIONS
         . = ALIGN(4);
         __eth_end__ = .;
     } > ETH_RAM
+
+    .bkup_ram_noinit (NOLOAD):
+    {
+        *(.bkup_ram_noinit)
+    } > BKUP_RAM
 }
 
 /* Code rules inclusion.*/

--- a/firmware/hw_layer/ports/stm32/stm32h7/global_port.h
+++ b/firmware/hw_layer/ports/stm32/stm32h7/global_port.h
@@ -4,3 +4,5 @@
 #define SDRAM_OPTIONAL __attribute__((section(".ram8")))
 // SRAM3 is 32k and set to disable dcache
 #define NO_CACHE __attribute__((section(".ram3")))
+
+#define BKUP_RAM_NOINIT __attribute__((section(".bkup_ram_noinit")))


### PR DESCRIPTION
This defines new region for storing data that needs to maintain its state between powecycles and need no init.
Like fuel and ignition trims ans so on.
Previously one struct was manually put into backuped ram.
Now linker will take care and we can but data without uniting it to some mega-struct.