### PR TITLE
-Not yet working for some reason- Gear position sensor for sequential gearboxes

### DIFF
--- a/firmware/controllers/algo/engine_configuration.cpp
+++ b/firmware/controllers/algo/engine_configuration.cpp
@@ -603,6 +603,11 @@ static void setDefaultEngineConfiguration() {
 	// https://github.com/rusefi/rusefi/issues/4030
 	engineConfiguration->mapErrorDetectionTooHigh = 410;
 
+	engineConfiguration->gearboxPosition.v1 = 0;
+	engineConfiguration->gearboxPosition.v2 = 5.0f;
+	engineConfiguration->gearboxPosition.value1 = 0;
+	engineConfiguration->gearboxPosition.value2 = 360.0f;
+
 	setLinearCurve(config->throttleEstimateEffectiveAreaBins, 0, 100);
 #endif // EFI_ENGINE_CONTROL
     #include "default_script.lua"

--- a/firmware/controllers/engine_controller.cpp
+++ b/firmware/controllers/engine_controller.cpp
@@ -61,6 +61,7 @@
 #include "adc_subscription.h"
 #include "gc_generic.h"
 #include "tuner_detector_utils.h"
+#include "gearbox_indicator.h"
 
 
 #if EFI_TUNER_STUDIO
@@ -508,6 +509,7 @@ void commonInitEngineController() {
 #endif
 
 	initSpeedometer();
+
 
 #if EFI_LTFT_CONTROL
 	initLtft();

--- a/firmware/controllers/gauges/gearbox_indicator.cpp
+++ b/firmware/controllers/gauges/gearbox_indicator.cpp
@@ -1,0 +1,13 @@
+#include "pch.h"
+
+#include "gearbox_indicator.h"
+
+static bool hasinitGearbox_Indicator = false;
+
+void Gearbox_IndicatorUpdate() {
+    float gearboxPosition = Sensor::get(SensorType::GearboxPositionSensor);
+}
+
+void initGearbox_Indicator() {
+    hasinitGearbox_Indicator = true;
+}

--- a/firmware/controllers/gauges/gearbox_indicator.h
+++ b/firmware/controllers/gauges/gearbox_indicator.h
@@ -1,0 +1,4 @@
+#pragma once
+
+void initGearbox_Indicator();
+void Gearbox_IndicatorUpdate();

--- a/firmware/controllers/sensors/sensor_type.h
+++ b/firmware/controllers/sensors/sensor_type.h
@@ -147,14 +147,16 @@ enum class SensorType : unsigned char {
 	LuaGauge7,
 	LuaGauge8,
 
-  IgnKeyVoltage,
+    IgnKeyVoltage,
 
-  DashOverrideRpm,
-  DashOverrideVehicleSpeed,
-  DashOverrideClt,
-  DashOverrideBatteryVoltage,
+    DashOverrideRpm,
+    DashOverrideVehicleSpeed,
+    DashOverrideClt,
+    DashOverrideBatteryVoltage,
 
-  AcPressure,
+    AcPressure,
+
+    GearboxPositionSensor,
 
 	AuxLinear1,
 	AuxLinear2,

--- a/firmware/init/init.h
+++ b/firmware/init/init.h
@@ -38,6 +38,7 @@ void initTurbochargerSpeedSensor();
 void initAuxSpeedSensors();
 void initInputShaftSpeedSensor();
 void initRangeSensors();
+void initGearboxPosition();
 
 // Sensor reconfiguration
 void deinitVbatt();
@@ -51,6 +52,7 @@ void deinitTurbochargerSpeedSensor();
 void deinitMap();
 void deinitAuxSpeedSensors();
 void deinitInputShaftSpeedSensor();
+void deinitGearboxPosition();
 
 void stopEgt(void);
 void startEgt(void);

--- a/firmware/init/init.mk
+++ b/firmware/init/init.mk
@@ -17,4 +17,5 @@ INIT_SRC_CPP =	$(PROJECT_DIR)/init/sensor/init_sensors.cpp \
 				$(PROJECT_DIR)/init/sensor/init_aux_speed_sensor.cpp \
 				$(PROJECT_DIR)/init/sensor/init_turbocharger_speed_sensor.cpp \
 				$(PROJECT_DIR)/init/sensor/init_input_shaft_speed_sensor.cpp \
-				$(PROJECT_DIR)/init/sensor/init_range.cpp
+				$(PROJECT_DIR)/init/sensor/init_range.cpp \
+				$(PROJECT_DIR)/init/sensor/init_gbps.cpp

--- a/firmware/init/sensor/init_gbps.cpp
+++ b/firmware/init/sensor/init_gbps.cpp
@@ -1,0 +1,42 @@
+#include "pch.h"
+
+#include "init.h"
+#include "adc_subscription.h"
+#include "functional_sensor.h"
+#include "linear_func.h"
+
+static LinearFunc gearboxposSensorFunc;
+static FunctionalSensor gearboxposSensor(SensorType::GearboxPositionSensor, /* timeout = */ MS2NT(50));
+
+static void initGearboxPosition(LinearFunc& func, FunctionalSensor& sensor, const linear_sensor_s& cfg, float bandwidth) {
+  auto channel = cfg.hwChannel;
+
+  // Only register if we have a sensor
+  if (!isAdcChannelValid(channel)) {
+    return;
+  }
+
+  float val1 = cfg.value1;
+  float val2 = cfg.value2;
+
+  // Limit to max given pressure - val1 or val2 could be larger
+  // (sensor may be backwards, high voltage = low pressure)
+  float greaterOutput = val1 > val2 ? val1 : val2;
+
+  // Allow slightly negative output (-5kpa) so as to not fail the sensor when engine is off
+  func.configure(cfg.v1, val1, cfg.v2, val2, /*minOutput*/ -5, greaterOutput);
+
+  sensor.setFunction(func);
+
+  AdcSubscription::SubscribeSensor(sensor, channel, bandwidth);
+
+  sensor.Register();
+}
+
+void initGearboxPosition() {
+  initGearboxPosition(gearboxposSensorFunc, gearboxposSensor, engineConfiguration->gearboxPosition, 10);
+}
+
+void deinitGearboxPosition() {
+  AdcSubscription::UnsubscribeSensor(gearboxposSensor, engineConfiguration->gearboxPosition.hwChannel);
+}

--- a/firmware/init/sensor/init_sensors.cpp
+++ b/firmware/init/sensor/init_sensors.cpp
@@ -104,6 +104,7 @@ static void sensorStartUpOrReconfiguration(bool isFirstTime) {
 	initRangeSensors();
 #endif
 	initFlexSensor(isFirstTime);
+	initGearboxPosition();
 }
 
 
@@ -131,7 +132,6 @@ void initNewSensors() {
 
 	// Init CLI functionality for sensors (mocking)
 	initSensorCli();
-
 #if defined(HARDWARE_CI) && !defined(HW_PROTEUS)
 	chThdSleepMilliseconds(100);
 
@@ -163,6 +163,7 @@ void stopSensors() {
 	deinitMap();
 	deinitInputShaftSpeedSensor();
 	stopEgt();
+	deinitGearboxPosition();
 }
 
 void reconfigureSensors() {

--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -1849,6 +1849,21 @@ uint8_t autoscale knockFuelTrim;Fuel trim when knock, max 30%;"%", 1, 0, 0, 30, 
 	can_wbo_type_e wboType1;
 	can_wbo_type_e wboType2;
 
+	linear_sensor_s gearboxPosition;
+	float gearboxHysteresis;Hysteresis of gearbox, meaning the range in angular position in which the gear is inserted correctly, MUST BE DIVIDED BY TWO;"degrees", 1, 0, 0, 360, 2
+	bit gearboxHasReverse;If the gearbox has reverse gear
+	float gearboxPositionReverse;Angular position in which the reverse gear is inserted, starting point for hysteresis;"degrees", 1, 0, 0, 360, 2
+	float gearboxPositionNeutral;Angular position in which the neutral gear is inserted, starting point for hysteresis;"degrees", 1, 0, 0, 360, 2
+	
+	float gearPosition1;Angular position in which the first gear is inserted, starting point for hysteresis;"degrees", 1, 0, 0, 360, 2
+	float gearPosition2;Angular position in which the second gear is inserted, starting point for hysteresis;"degrees", 1, 0, 0, 360, 2
+	float gearPosition3;Angular position in which the third gear is inserted, starting point for hysteresis;"degrees", 1, 0, 0, 360, 2
+	float gearPosition4;Angular position in which the fourth gear is inserted, starting point for hysteresis;"degrees", 1, 0, 0, 360, 2
+	float gearPosition5;Angular position in which the fifth gear is inserted, starting point for hysteresis;"degrees", 1, 0, 0, 360, 2
+	float gearPosition6;Angular position in which the sixth gear is inserted, starting point for hysteresis;"degrees", 1, 0, 0, 360, 2
+	float gearPosition7;Angular position in which the seventh gear is inserted, starting point for hysteresis;"degrees", 1, 0, 0, 360, 2
+	float gearPosition8;Angular position in which the eight gear is inserted, starting point for hysteresis;"degrees", 1, 0, 0, 360, 2
+
 ! historically 'unusedOftenChangesDuringFirmwareUpdate' was here - now that's just an anchor reminding where to insert new fields
 
 ! end of engine_configuration_s
@@ -2735,3 +2750,7 @@ end_struct
 #define ts_show_etb_min_max true
 ! who needs this feature when?!
 #define ts_show_disable_etb false
+
+#define GAUGE_NAME_GEARBOX_POSITION "Gearbox Position"
+#define GAUGE_NAME_GEARBOX_POSITION_UNITS "deg"
+#define ts_show_gearbox_position_sensor true

--- a/firmware/tunerstudio/tunerstudio.template.ini
+++ b/firmware/tunerstudio/tunerstudio.template.ini
@@ -1702,6 +1702,7 @@ gaugeCategory = Sensors - Extra 1
 	fuelTempGauge = fuelTemp, @@GAUGE_NAME_FUEL_TEMPERATURE@@, "C",	0,	100,	0,	0,	75,  100,	0,	0
 	fuelTankLevelGauge	= fuelTankLevel,"Fuel level",			"%",		0,		100,		10,	20,	100,	100,	1,	1
 	acPressureGauge		= acPressure,	@@GAUGE_NAME_AC_PRESSURE@@, "kPa", 0, 900, 0, 0, 900, 900, 0, 0
+	gearboxPositionGauge	= gearboxPosition,	@@GAUGE_NAME_GEARBOX_POSITION@@, "Deg", 0, 360, 0, 0, 360, 360, 1, 0
 	AuxL1Gauge		= auxLinear1,	@@GAUGE_NAME_AUX_LINEAR_1@@, "", -1000, 1000, -1000, -1000, 1000, 1000, 2, 2
 	AuxL2Gauge		= auxLinear2,	@@GAUGE_NAME_AUX_LINEAR_2@@, "", -1000, 1000, -1000, -1000, 1000, 1000, 2, 2
 	AuxL3Gauge		= auxLinear3,	@@GAUGE_NAME_AUX_LINEAR_3@@, "", -100, 100, -100, -100, 100, 100, 2, 2
@@ -1849,6 +1850,7 @@ gaugeCategory = Sensors - Raw
 	vssEdgeCounterGauge  = vssEdgeCounter, "Raw VSS",			"counter", 0, 5, 0, 0, 5, 5, 0, 0
 	issEdgeCounterGauge  = issEdgeCounter, "Raw ISS",			"counter", 0, 5, 0, 0, 5, 5, 0, 0
 	rawFlexFreqGauge = rawFlexFreq, "Raw Flex",			"Hz", 0, 5, 0, 0, 5, 5, 3, 0
+	rawGearboxPositionGauge = rawGearboxPosition, "Raw Gearbox Position Angle", "V", 0, 5, 0, 0, 5, 5, 0, 0
 
 gaugeCategory = Transmission
 	desiredGearGauge = tcuDesiredGear, @@GAUGE_NAME_DESIRED_GEAR@@, "gear", -1, 10, -1, -1, 10, 10, 0, 0@@if_show_tcu_gauges
@@ -2311,6 +2313,7 @@ menuDialog = main
 		groupChildMenu = speedSensor,				"Vehicle speed sensor"@@if_ts_show_vehicle_speed_sensor
 		groupChildMenu = ambientTempSensor,			"Ambient temp sensor", { 1 }, { uiMode == @@UiMode_FULL@@ || uiMode == @@UiMode_INSTALLATION@@ }
 		groupChildMenu = acPressureSensor,			"A/C Pressure"@@if_ts_show_air_conditioning
+		groupChildMenu = gearboxPositionSensor,			"Gearbox Position sensor"
 
 		# Base analog input settings
 		subMenu = analogInputSettings,		"Analog input settings", { 1 }, { uiMode == @@UiMode_FULL@@ || uiMode == @@UiMode_INSTALLATION@@ }@@if_ts_show_analog_input_settings
@@ -3748,6 +3751,35 @@ cmd_set_engine_type_default					= "@@TS_IO_TEST_COMMAND_char@@@@ts_command_e_TS_
 	dialog = acPressureSensor, "", border
 		panel = acPressureSensorSettings, West
 		panel = acPressureGauges, East
+
+	dialog = gearboxPositionSensorSettings, "Gearbox Position Sensor"
+		field = "Input",	    gearboxPosition.hwChannel
+		field = "Low voltage",	gearboxPosition_v1, {gearboxPosition.hwChannel != @@ADC_CHANNEL_NONE@@}
+		field = "Low value",	gearboxPosition_value1, {gearboxPosition.hwChannel != @@ADC_CHANNEL_NONE@@}
+		field = "High voltage",	gearboxPosition_v2, {gearboxPosition.hwChannel != @@ADC_CHANNEL_NONE@@}
+		field = "High value",	gearboxPosition_value2, {gearboxPosition.hwChannel != @@ADC_CHANNEL_NONE@@}
+		field = "Gearbox hysteresis",	gearboxHysteresis, {gearboxPosition.hwChannel != @@ADC_CHANNEL_NONE@@}
+		field = "Has reverse", gearboxHasReverse
+		field = "Reverse Degrees", gearboxPositionReverse {gearboxHasReverse == 1}
+		field = "Neutral Degrees", gearboxPositionNeutral
+		field = "Forward gear count", totalGearsCount
+		field = "1st gear Degrees", gearPosition1, { totalGearsCount >= 1 }
+		field = "2nd gear Degrees", gearPosition2, { totalGearsCount >= 2 }
+		field = "3rd gear Degrees", gearPosition3, { totalGearsCount >= 3 }
+		field = "4th gear Degrees", gearPosition4, { totalGearsCount >= 4 }
+		field = "5th gear Degrees", gearPosition5, { totalGearsCount >= 5 }
+		field = "6th gear Degrees", gearPosition6, { totalGearsCount >= 6 }
+		field = "7th gear Degrees", gearPosition7, { totalGearsCount >= 7 }
+		field = "8th gear Degrees", gearPosition8, { totalGearsCount >= 8 }
+
+	dialog = gearboxPositionGauges
+		gauge = gearboxPositionGauge
+		gauge = rawGearboxPositionGauge
+		gauge = detectedGearGauge
+
+	dialog = gearboxPositionSensor, "", border
+		panel = gearboxPositionSensorSettings, West
+		panel = gearboxPositionGauges, East
 
 	dialog = auxLinearSensor1, "Aux Linear Sensor #1"
 		field = "Input",	    auxLinear1_hwChannel


### PR DESCRIPTION
Addition of gear position sensor for sequential gearboxes, even for motorbike's gearboxes based on a 0-5V GPSwitch.

I've tried to add that sensor as a linear sensor, like the one of oil pressure, also tried to add a gauge, but was unsuccessfull at both, i'd love to receive feedback / critiques / suggestions