### PR TITLE
It is now possible to switch gcc/clang on local dev machine for unit tests builds with coverage

### DIFF
--- a/unit_tests/unit_test_rules.mk
+++ b/unit_tests/unit_test_rules.mk
@@ -124,7 +124,7 @@ ifeq ($(SANITIZE),yes)
 	ifeq ($(IS_MAC),yes)
 		USE_CPPOPT += -fsanitize=address
 	else
-		USE_CPPOPT += -fsanitize=address -fno-sanitize-recover=all
+		USE_CPPOPT += -fsanitize=address -fsanitize=bounds -fno-sanitize-recover=all
 	endif
 endif
 


### PR DESCRIPTION
Unit tests for Mac OS use mingw to get gcc available in env. However for Mac OS gcc from mingw is a placeholder for llvm/clang thus results of builds are different from pure gcc builds. Sometimes to look into those differences (at least to acquire warnings from clang that are not thrown from gcc) there is a need to build all with clang on local dev machine which is not Mac OS (i.e. on any recent Linux distro you get both gcc and clang). This change allows to run make with CC=clang option so all unit tests are built on your local machine with clang instead of gcc. This change handles coverage compile/linking options to satisfy differences between clang and gcc.