### PR TITLE
Fix HW-CI .ini & fw signature

### DIFF
--- a/.github/workflows/hardware-ci.yaml
+++ b/.github/workflows/hardware-ci.yaml
@@ -136,6 +136,12 @@ jobs:
         name: rusefi_hw-ci-${{matrix.build-target}}.bin
         path: ./firmware/build/rusefi*.bin
 
+    - name: Upload .ini artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: rusefi_hw-ci-${{matrix.build-target}}.ini
+        path: ${{matrix.test-suite-ini}}    
+
     # This both compiles and runs HW CI tests
     # .github/workflows/hw-ci/run_hw_ci.sh com.rusefi.HwCiF4Discovery
     - name: Run Hardware CI

--- a/.github/workflows/hardware-ci.yaml
+++ b/.github/workflows/hardware-ci.yaml
@@ -9,6 +9,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+env:
+  AUTOMATION_REF: ${{github.ref_name}}
+
 jobs:
   hardware-ci:
     strategy:


### PR DESCRIPTION
we have a problem related to HW-CI and TS signatures:

to reproduce:
* download https://github.com/FDSoftware/rusefi/actions/runs/15635956765 .ini artifact
* see incorrect `signature	= "rusEFI .2025.06.13.stm32f767_nucleo.97654472"`
* download https://github.com/FDSoftware/rusefi/actions/runs/15637107791 .ini with fix:
* see now more nice: `signature	= "rusEFI fix_branch_name.2025.06.13.stm32f767_nucleo.97654472"`

