### PR TITLE
TS: pages support

### DIFF
--- a/firmware/console/binary/tunerstudio.h
+++ b/firmware/console/binary/tunerstudio.h
@@ -9,6 +9,10 @@
 #include "global.h"
 #include "tunerstudio_io.h"
 
+#define TS_PAGE_SETTINGS			0x0000
+// Issue TS zeroes LSB byte of pageIdentifier
+#define TS_PAGE_SCATTER_OFFSETS		0x0100
+
 typedef struct {
 	int queryCommandCounter;
 	int outputChannelsCommandCounter;

--- a/firmware/console/binary/tunerstudio_commands.cpp
+++ b/firmware/console/binary/tunerstudio_commands.cpp
@@ -10,14 +10,21 @@
 
 #if EFI_TUNER_STUDIO
 
-static constexpr size_t getTunerStudioPageSize() {
-	return TOTAL_CONFIG_SIZE;
+static constexpr size_t getTunerStudioPageSize(size_t page) {
+	switch (page) {
+	case TS_PAGE_SETTINGS:
+		return TOTAL_CONFIG_SIZE;
+	case TS_PAGE_SCATTER_OFFSETS:
+		return TS_SCATTER_PAGE_SIZE;
+	default:
+		return 0;
+	}
 }
 
 // Validate whether the specified offset and count would cause an overrun in the tune.
 // Returns true if an overrun would occur.
-bool validateOffsetCount(size_t offset, size_t count, TsChannelBase* tsChannel) {
-	size_t allowedSize = getTunerStudioPageSize();
+bool validateOffsetCount(size_t page, size_t offset, size_t count, TsChannelBase* tsChannel) {
+	size_t allowedSize = getTunerStudioPageSize(page);
 	if (offset + count > allowedSize) {
 		efiPrintf("TS: Project mismatch? Too much configuration requested %d+%d>%d", offset, count, allowedSize);
 		tunerStudioError(tsChannel, "ERROR: out of range");

--- a/firmware/console/binary/tunerstudio_commands.cpp
+++ b/firmware/console/binary/tunerstudio_commands.cpp
@@ -10,31 +10,6 @@
 
 #if EFI_TUNER_STUDIO
 
-static constexpr size_t getTunerStudioPageSize(size_t page) {
-	switch (page) {
-	case TS_PAGE_SETTINGS:
-		return TOTAL_CONFIG_SIZE;
-	case TS_PAGE_SCATTER_OFFSETS:
-		return TS_SCATTER_PAGE_SIZE;
-	default:
-		return 0;
-	}
-}
-
-// Validate whether the specified offset and count would cause an overrun in the tune.
-// Returns true if an overrun would occur.
-bool validateOffsetCount(size_t page, size_t offset, size_t count, TsChannelBase* tsChannel) {
-	size_t allowedSize = getTunerStudioPageSize(page);
-	if (offset + count > allowedSize) {
-		efiPrintf("TS: Project mismatch? Too much configuration requested %d+%d>%d", offset, count, allowedSize);
-		tunerStudioError(tsChannel, "ERROR: out of range");
-		sendErrorCode(tsChannel, TS_RESPONSE_OUT_OF_RANGE, "bad_offset");
-		return true;
-	}
-
-	return false;
-}
-
 static Timer channelsRequestTimer;
 
 int getSecondsSinceChannelsRequest() {


### PR DESCRIPTION
One more round of setting pages support.
Move all common code to helpers.
This should simplify adding new settings pages.
Someday we may want to divide big settings blob into chunks for each module and allocate separate page for each chunk.