### PR TITLE
CAN WBO: implement its own timeout

### DIFF
--- a/firmware/controllers/sensors/impl/AemXSeriesLambda.cpp
+++ b/firmware/controllers/sensors/impl/AemXSeriesLambda.cpp
@@ -6,12 +6,14 @@
 
 static constexpr uint32_t aem_base    = 0x180;
 static constexpr uint32_t rusefi_base = WB_DATA_BASE_ADDR;
+// sensor transmits at 100hz, allow a frame to be missed
+static constexpr efidur_t sensor_timeout = MS2NT(3 * WBO_TX_PERIOD_MS);
 
 AemXSeriesWideband::AemXSeriesWideband(uint8_t sensorIndex, SensorType type)
 	: CanSensorBase(
 		0,	// ID passed here doesn't matter since we override acceptFrame
 		type,
-		MS2NT(3 * WBO_TX_PERIOD_MS)	// sensor transmits at 100hz, allow a frame to be missed
+		sensor_timeout
 	)
 	, m_sensorIndex(sensorIndex)
 {
@@ -71,16 +73,7 @@ bool AemXSeriesWideband::isHeaterAllowed() {
 void AemXSeriesWideband::refreshState() {
 	can_wbo_type_e type = sensorType();
 
-	if ((type == RUSEFI) && (!isHeaterAllowed())) {
-		faultCode = static_cast<uint8_t>(wbo::Fault::NotAllowed);
-		isValid = false;
-		// Do not check for any errors while heater is not allowed
-		return;
-	}
-
-	// Communication timeout is priority error code
-	auto value = get();
-	if ((!value) && (value.Code == UnexpectedCode::Timeout)) {
+	if (getTimeNowNt() - sensor_timeout > m_lastUpdate) {
 		faultCode = static_cast<uint8_t>(wbo::Fault::CanSilent);
 		isValid = false;
 		return;
@@ -88,6 +81,13 @@ void AemXSeriesWideband::refreshState() {
 
 	if (type == RUSEFI) {
 		// This is RE WBO
+		if (!isHeaterAllowed()) {
+			faultCode = static_cast<uint8_t>(wbo::Fault::NotAllowed);
+			isValid = false;
+			// Do not check for any errors while heater is not allowed
+			return;
+		}
+
 		isValid = m_afrIsValid;
 		if (m_faultCode != static_cast<uint8_t>(wbo::Fault::None)) {
 			// Report error code from WBO
@@ -123,6 +123,7 @@ void AemXSeriesWideband::refreshState() {
 }
 
 void AemXSeriesWideband::decodeFrame(const CANRxFrame& frame, efitick_t nowNt) {
+	bool accepted = false;
 	// accept frame has already guaranteed that this message belongs to us
 	// We just have to check if it's AEM or rusEFI
 	if (sensorType() == RUSEFI){
@@ -134,10 +135,14 @@ void AemXSeriesWideband::decodeFrame(const CANRxFrame& frame, efitick_t nowNt) {
 			decodeRusefiDiag(frame);
 		} else {
 			// low bit not set, this is standard frame
-			decodeRusefiStandard(frame, nowNt);
+			accepted = decodeRusefiStandard(frame, nowNt);
 		}
 	} else /* if (sensorType() == AEM) */ {
-		decodeAemXSeries(frame, nowNt);
+		accepted = decodeAemXSeries(frame, nowNt);
+	}
+
+	if (accepted) {
+		m_lastUpdate = nowNt;
 	}
 
 	// Do refresh on each CAN packet
@@ -170,21 +175,21 @@ bool AemXSeriesWideband::decodeAemXSeries(const CANRxFrame& frame, efitick_t now
 	return true;
 }
 
-void AemXSeriesWideband::decodeRusefiStandard(const CANRxFrame& frame, efitick_t nowNt) {
+bool AemXSeriesWideband::decodeRusefiStandard(const CANRxFrame& frame, efitick_t nowNt) {
 	auto data = reinterpret_cast<const wbo::StandardData*>(&frame.data8[0]);
 
 	if (data->Version > RUSEFI_WIDEBAND_VERSION) {
 		firmwareError(ObdCode::OBD_WB_FW_Mismatch, "Wideband controller index %d has newer protocol version (0x%02x while 0x%02x supported), please update ECU FW!",
 			m_sensorIndex, data->Version, RUSEFI_WIDEBAND_VERSION);
 		fwUnsupported = true;
-		return;
+		return false;
 	}
 
 	if (data->Version < RUSEFI_WIDEBAND_VERSION_MIN) {
 		firmwareError(ObdCode::OBD_WB_FW_Mismatch, "Wideband controller index %d has outdated protocol version (0x%02x while minimum 0x%02x expected), please update WBO!",
 			m_sensorIndex, data->Version, RUSEFI_WIDEBAND_VERSION_MIN);
 		fwUnsupported = true;
-		return;
+		return false;
 	}
 
 	fwUnsupported = false;
@@ -198,10 +203,11 @@ void AemXSeriesWideband::decodeRusefiStandard(const CANRxFrame& frame, efitick_t
 
 	if (!m_afrIsValid) {
 		invalidate();
-		return;
+	} else {
+		setValidValue(lambda, nowNt);
 	}
 
-	setValidValue(lambda, nowNt);
+	return true;
 }
 
 void AemXSeriesWideband::decodeRusefiDiag(const CANRxFrame& frame) {

--- a/firmware/controllers/sensors/impl/AemXSeriesLambda.h
+++ b/firmware/controllers/sensors/impl/AemXSeriesLambda.h
@@ -27,7 +27,7 @@ protected:
 	bool decodeAemXSeries(const CANRxFrame& frame, efitick_t nowNt);
 
 	// Decode rusEFI custom format
-	void decodeRusefiStandard(const CANRxFrame& frame, efitick_t nowNt);
+	bool decodeRusefiStandard(const CANRxFrame& frame, efitick_t nowNt);
 	void decodeRusefiDiag(const CANRxFrame& frame);
 
 private:
@@ -43,4 +43,6 @@ private:
 	bool m_afrIsValid;
 	// Used for AEM sensor only
 	bool m_isFault;
+	// Last valid packed received, for wbo::Fault::CanSilent state
+	efitick_t m_lastUpdate = 0;
 };


### PR DESCRIPTION
Using timeout from StoredValueSensor is not correct as it is not updated on invalidate() call.