### PR TITLE
patch lcov since we don't have coverage reports since 2024-12-19

### DIFF
--- a/unit_tests/ci_gcov.sh
+++ b/unit_tests/ci_gcov.sh
@@ -32,7 +32,9 @@ echo -e "\nGenerating rusEFI unit test coverage"
 gcov *.c* > gcov.log 2>gcov.err
 
 echo -e "\nCollecting rusEFI unit test coverage"
-lcov --capture --directory . --output-file coverage.info
+#FIXME: we have some problem related to google test macro "TEST" and the ouput code on lcov
+# Currently we cannot obtain coverage on the tests themselves, but on the tests towards the code.
+lcov --ignore-errors mismatch --capture --directory . --output-file coverage.info
 
 echo -e "\nGenerating rusEFI unit test HTML"
 genhtml coverage.info --output-directory gcov


### PR DESCRIPTION
While creating the tests for closed_loop_idle.cpp I saw that we had lcov configured for the repository, and that the reports were uploaded to this URL:
https://rusefi.com/docs/unit_tests_coverage/index.html
but it has not been updated since December, searching in the CI, the pipeline always fails with an error similar to this:

```
geninfo: WARNING: ('mismatch') mismatched end line for _ZN29FunctionChain_TestSingle_Test8TestBodyEv at rusefi/unit_tests/tests/sensor/func_chain.cpp:25: 25 -> 40
	(use "geninfo --ignore-errors mismatch,mismatch ..." to suppress this warning)

``` 

With `--ignore-errors mismatch` we can patch until we find the exact error that causes it, which changes from file to file depending on the execution of the CI we look at.

now much nicer:
![image](https://github.com/user-attachments/assets/0a45a22d-34fe-4a05-ab48-676d62d7ffc1)
