### PR TITLE
Fix "SmoothedAFRValue and SmoothedAFRValue2 always zero with CAN WBOs"

### DIFF
--- a/firmware/controllers/sensors/impl/AemXSeriesLambda.h
+++ b/firmware/controllers/sensors/impl/AemXSeriesLambda.h
@@ -19,6 +19,8 @@ public:
 
 	void refreshState(void);
 
+	void refreshSmoothedLambda(float lambda);
+
 protected:
 	// Dispatches to one of the three decoders below
 	void decodeFrame(const CANRxFrame& frame, efitick_t nowNt) override;
@@ -45,4 +47,6 @@ private:
 	bool m_isFault;
 	// Last valid packed received, for wbo::Fault::CanSilent state
 	efitick_t m_lastUpdate = 0;
+	// Lambda1 / Lambda2 / etc
+	SensorType m_type;
 };

--- a/firmware/controllers/sensors/impl/ego.cpp
+++ b/firmware/controllers/sensors/impl/ego.cpp
@@ -10,13 +10,12 @@
  *
  */
 #include "pch.h"
-#include "exp_average.h"
 
 StoredValueSensor smoothedLambda1Sensor(SensorType::SmoothedLambda1, MS2NT(500));
 StoredValueSensor smoothedLambda2Sensor(SensorType::SmoothedLambda2, MS2NT(500));
 
-static ExpAverage expAverageLambda1;
-static ExpAverage expAverageLambda2;
+ExpAverage expAverageLambda1;
+ExpAverage expAverageLambda2;
 
 #include "cyclic_buffer.h"
 

--- a/firmware/controllers/sensors/impl/ego.h
+++ b/firmware/controllers/sensors/impl/ego.h
@@ -12,6 +12,7 @@
 #include "global.h"
 #include "stored_value_sensor.h"
 #include "engine_configuration.h"
+#include "exp_average.h"
 
 float getAfr(SensorType type);
 bool hasAfrSensor();
@@ -19,3 +20,6 @@ void setEgoSensor(ego_sensor_e type);
 
 extern StoredValueSensor smoothedLambda1Sensor;
 extern StoredValueSensor smoothedLambda2Sensor;
+
+extern ExpAverage expAverageLambda1;
+extern ExpAverage expAverageLambda2;

--- a/firmware/init/sensor/init_lambda.cpp
+++ b/firmware/init/sensor/init_lambda.cpp
@@ -50,6 +50,9 @@ const wideband_state_s* getLiveData(size_t idx) {
 }
 
 void initLambda() {
+  	// first we register the smoothed sensors for the early return on the can wbo case
+	smoothedLambda1Sensor.Register();
+	smoothedLambda2Sensor.Register();
 
 #if EFI_CAN_SUPPORT
 	if (engineConfiguration->enableAemXSeries) {
@@ -78,6 +81,4 @@ void initLambda() {
 	if (isAdcChannelValid(engineConfiguration->afr.hwChannel2) || isUnitTest) {
 	  lambdaSensor2.Register();
   }
-	smoothedLambda1Sensor.Register();
-	smoothedLambda2Sensor.Register();
 }

--- a/unit_tests/tests/controllers/can/test_can_wideband.cpp
+++ b/unit_tests/tests/controllers/can/test_can_wideband.cpp
@@ -135,6 +135,8 @@ TEST(CanWideband,DecodeAemXSeriesSensorFault){
 TEST(CanWideband,DecodeAemXSeriesValidLambda){
 	AemXSeriesWidebandWrapper wbo(0, SensorType::Lambda1);
 	EngineTestHelper eth(engine_type_e::TEST_ENGINE);
+	// we dont call initLambda on the tests init code. so we need to register this sensor on the test
+	smoothedLambda1Sensor.Register();
 
 	engineConfiguration->canWbo[0].type = AEM;
 
@@ -163,6 +165,7 @@ TEST(CanWideband,DecodeAemXSeriesValidLambda){
 	wbo.decodeAemXSeries(frame, getTimeNowNt());
 
 	EXPECT_FLOAT_EQ(1.2032f, Sensor::get(SensorType::Lambda1).value_or(-1));
+	EXPECT_FLOAT_EQ(1.2032f, Sensor::get(SensorType::SmoothedLambda1).value_or(-1));
 	Sensor::resetRegistry();
 }
 
@@ -227,6 +230,8 @@ TEST(CanWideband, DecodeRusefiStandard)
 {
 	AemXSeriesWideband dut(0, SensorType::Lambda1);
 	EngineTestHelper eth(engine_type_e::TEST_ENGINE);
+	// we dont call initLambda on the tests init code. so we need to register this sensor on the test
+	smoothedLambda1Sensor.Register();
 
 	engineConfiguration->canWbo[0].type = RUSEFI;
 
@@ -276,6 +281,7 @@ TEST(CanWideband, DecodeRusefiStandard)
 	dut.processFrame(frame, getTimeNowNt());
 	dut.processFrame(diagFrame, getTimeNowNt());
 	EXPECT_FLOAT_EQ(0.7f, Sensor::get(SensorType::Lambda1).value_or(-1));
+	EXPECT_FLOAT_EQ(0.7f, Sensor::get(SensorType::SmoothedLambda1).value_or(-1));
 
 	// Check that temperature updates
 	EXPECT_EQ(dut.tempC, 1234);


### PR DESCRIPTION
resolves: #8149
depends on: #8154 