### PR TITLE
only:now we check `battLagCorrTable` only when `VBAT_INJECTOR_CURVE_P…

### DIFF
--- a/unit_tests/tests/util/test_engine_configuration.cpp
+++ b/unit_tests/tests/util/test_engine_configuration.cpp
@@ -341,10 +341,12 @@ void TestEngineConfiguration::configureInjectorBattLagCorr(const std::optional<B
             );
         }
     } else {
+#if (VBAT_INJECTOR_CURVE_PRESSURE_SIZE == 2) && (VBAT_INJECTOR_CURVE_SIZE == 8)
         EXPECT_THAT(
             engineConfiguration->injector.battLagCorrTable[0],
             testing::ElementsAreArray(engine_configuration_defaults::INJECTOR_BATT_LAG_CURR[0])
         );
+#endif //(VBAT_INJECTOR_CURVE_PRESSURE_SIZE == 2) && (VBAT_INJECTOR_CURVE_SIZE == 8)
     }
 }
 void TestEngineConfiguration::configureFuelReferencePressure(const std::optional<float> fuelReferencePressure) {
@@ -392,10 +394,12 @@ void TestEngineConfiguration::configureInjectorSecondaryBattLagCorr(const std::o
             );
         }
     } else {
+#if (VBAT_INJECTOR_CURVE_PRESSURE_SIZE == 2) && (VBAT_INJECTOR_CURVE_SIZE == 8)
        EXPECT_THAT(
             engineConfiguration->injectorSecondary.battLagCorrTable[0],
             testing::ElementsAreArray(engine_configuration_defaults::INJECTOR_SECONDARY_BATT_LAG_CURR[0])
         );
+#endif //(VBAT_INJECTOR_CURVE_PRESSURE_SIZE == 2) && (VBAT_INJECTOR_CURVE_SIZE == 8)
     }
 }
 


### PR DESCRIPTION
…RESSURE_SIZE` is 2 and `VBAT_INJECTOR_CURVE_SIZE` is 8 because otherwise function `setBosch02880155868` doesn't init `battLagCorrTable`