### PR TITLE
CanListener: pass CAN bus index to acceptFrame()

### DIFF
--- a/firmware/controllers/can/can_listener.h
+++ b/firmware/controllers/can/can_listener.h
@@ -16,8 +16,8 @@ public:
 	{
 	}
 
-	CanListener* processFrame(const CANRxFrame& frame, efitick_t nowNt) {
-		if (acceptFrame(frame)) {
+	CanListener* processFrame(const size_t busIndex, const CANRxFrame& frame, efitick_t nowNt) {
+		if (acceptFrame(busIndex, frame)) {
 			decodeFrame(frame, nowNt);
 		}
 
@@ -42,7 +42,10 @@ public:
 
 	// Return true if the provided frame should be accepted for processing by the listener.
 	// Override if you need more complex logic than comparing to a single ID.
-	virtual bool acceptFrame(const CANRxFrame& frame) const {
+	virtual bool acceptFrame(const size_t busIndex, const CANRxFrame& frame) const {
+		/* accept from all buses */
+		(void)busIndex;
+
 		return CAN_ID(frame) == m_id;
 	}
 

--- a/firmware/controllers/can/can_rx.cpp
+++ b/firmware/controllers/can/can_rx.cpp
@@ -56,7 +56,7 @@ struct CanListenerTailSentinel : public CanListener {
 	{
 	}
 
-	bool acceptFrame(const CANRxFrame&) const override {
+	bool acceptFrame(const size_t, const CANRxFrame&) const override {
 		return false;
 	}
 
@@ -68,12 +68,12 @@ struct CanListenerTailSentinel : public CanListener {
 static CanListenerTailSentinel tailSentinel;
 CanListener *canListeners_head = &tailSentinel;
 
-void serviceCanSubscribers(const CANRxFrame &frame, efitick_t nowNt) {
+void serviceCanSubscribers(const size_t busIndex, const CANRxFrame &frame, efitick_t nowNt) {
 	CanListener *current = canListeners_head;
 	size_t iterationValidationCounter = 0;
 
 	while (current) {
-		current = current->processFrame(frame, nowNt);
+		current = current->processFrame(busIndex, frame, nowNt);
 		if (iterationValidationCounter++ > 239) {
 		  criticalError("forever loop canListeners_head");
 		  return;
@@ -198,7 +198,7 @@ void processCanRxMessage(const size_t busIndex, const CANRxFrame &frame, efitick
 	boardProcessCanRxMessage(busIndex, frame, nowNt);
 
     // see AemXSeriesWideband as an example of CanSensorBase/CanListener
-	serviceCanSubscribers(frame, nowNt);
+	serviceCanSubscribers(busIndex, frame, nowNt);
 
 	// todo: convert to CanListener or not?
 	//Vss is configurable, should we handle it here:

--- a/firmware/controllers/can/can_rx.cpp
+++ b/firmware/controllers/can/can_rx.cpp
@@ -225,7 +225,7 @@ void processCanRxMessage(const size_t busIndex, const CANRxFrame &frame, efitick
 	}
 #endif // EFI_ENGINE_CONTROL
 
-	handleWidebandCan(frame);
+	handleWidebandCan(busIndex, frame);
 #if EFI_USE_OPENBLT
 #include "openblt/efi_blt_ids.h"
 	if ((CAN_SID(frame) == BOOT_COM_CAN_RX_MSG_ID) && (frame.DLC == 2)) {

--- a/firmware/controllers/can/rusefi_wideband.cpp
+++ b/firmware/controllers/can/rusefi_wideband.cpp
@@ -27,7 +27,12 @@ static size_t getWidebandBus() {
 
 static thread_t* waitingBootloaderThread = nullptr;
 
-void handleWidebandCan(const CANRxFrame& frame) {
+void handleWidebandCan(const size_t busIndex, const CANRxFrame& frame) {
+	// wrong bus
+	if (busIndex != getWidebandBus()) {
+		return;
+	}
+
 	// Bootloader acks with address 0x727573 aka ascii "rus"
 	if (CAN_EID(frame) != WB_ACK) {
 		return;

--- a/firmware/controllers/can/rusefi_wideband.cpp
+++ b/firmware/controllers/can/rusefi_wideband.cpp
@@ -19,7 +19,7 @@
 #include "wideband_firmware/for_rusefi/wideband_can.h"
 #pragma GCC diagnostic pop
 
-static size_t getWidebandBus() {
+size_t getWidebandBus() {
 	return engineConfiguration->widebandOnSecondBus ? 1 : 0;
 }
 

--- a/firmware/controllers/can/rusefi_wideband.h
+++ b/firmware/controllers/can/rusefi_wideband.h
@@ -3,6 +3,9 @@
 #pragma once
 #include "can.h"
 
+// Return index of CAN bus where WBO(s) live
+size_t getWidebandBus();
+
 // Send info to the wideband controller like battery voltage, heater enable bit, etc.
 void sendWidebandInfo();
 

--- a/firmware/controllers/can/rusefi_wideband.h
+++ b/firmware/controllers/can/rusefi_wideband.h
@@ -7,7 +7,7 @@
 void sendWidebandInfo();
 
 // Handles ack and pong responses from the wideband bootloader
-void handleWidebandCan(const CANRxFrame &frame);
+void handleWidebandCan(const size_t busIndex, const CANRxFrame &frame);
 
 // Pings wideband controller, reply includes protocol version and FW build date
 void pingWideband(uint8_t hwIndex);

--- a/firmware/controllers/sensors/impl/AemXSeriesLambda.cpp
+++ b/firmware/controllers/sensors/impl/AemXSeriesLambda.cpp
@@ -42,9 +42,11 @@ uint32_t AemXSeriesWideband::getAemCanId() const {
 }
 
 bool AemXSeriesWideband::acceptFrame(const size_t busIndex, const CANRxFrame& frame) const {
+#ifndef EFI_UNIT_TEST
 	if (busIndex != getWidebandBus()) {
 		return false;
 	}
+#endif
 
 	if (frame.DLC != 8) {
 		return false;

--- a/firmware/controllers/sensors/impl/AemXSeriesLambda.cpp
+++ b/firmware/controllers/sensors/impl/AemXSeriesLambda.cpp
@@ -4,6 +4,7 @@
 #if EFI_CAN_SUPPORT || EFI_UNIT_TEST
 #include "AemXSeriesLambda.h"
 #include "wideband_firmware/for_rusefi/wideband_can.h"
+#include "rusefi_wideband.h"
 
 static constexpr uint32_t aem_base    = 0x180;
 static constexpr uint32_t rusefi_base = WB_DATA_BASE_ADDR;
@@ -40,7 +41,11 @@ uint32_t AemXSeriesWideband::getAemCanId() const {
 	return aem_base + engineConfiguration->canWbo[m_sensorIndex].aemId;
 }
 
-bool AemXSeriesWideband::acceptFrame(const CANRxFrame& frame) const {
+bool AemXSeriesWideband::acceptFrame(const size_t busIndex, const CANRxFrame& frame) const {
+	if (busIndex != getWidebandBus()) {
+		return false;
+	}
+
 	if (frame.DLC != 8) {
 		return false;
 	}

--- a/firmware/controllers/sensors/impl/AemXSeriesLambda.h
+++ b/firmware/controllers/sensors/impl/AemXSeriesLambda.h
@@ -15,7 +15,7 @@ class AemXSeriesWideband : public CanSensorBase, public wideband_state_s {
 public:
 	AemXSeriesWideband(uint8_t sensorIndex, SensorType type);
 
-	bool acceptFrame(const CANRxFrame& frame) const override final;
+	bool acceptFrame(const size_t busIndex, const CANRxFrame& frame) const override final;
 
 	void refreshState(void);
 

--- a/firmware/hw_layer/drivers/gpio/can_gpio_msiobox.cpp
+++ b/firmware/hw_layer/drivers/gpio/can_gpio_msiobox.cpp
@@ -177,7 +177,7 @@ public:
 	}
 
 	CanListener* request() override;
-	bool acceptFrame(const CANRxFrame& frame) const override;
+	bool acceptFrame(const size_t busIndex, const CANRxFrame& frame) const override;
 
 	int init() override;
 	int config(uint32_t bus, uint32_t base, uint16_t period);
@@ -275,7 +275,9 @@ int MsIoBox::config(uint32_t bus, uint32_t base, uint16_t period)
 	return 0;
 }
 
-bool MsIoBox::acceptFrame(const CANRxFrame& frame) const {
+bool MsIoBox::acceptFrame(const size_t busIndex, const CANRxFrame& frame) const {
+	/* TODO: check busIndex! */
+
 	/* 11 bit only */
 	if (CAN_ISX(frame)) {
 		return false;

--- a/unit_tests/tests/controllers/can/test_can_rx.cpp
+++ b/unit_tests/tests/controllers/can/test_can_rx.cpp
@@ -10,7 +10,7 @@ public:
 	MockCanListener(uint32_t id) : CanListener(id) { }
 
 	MOCK_METHOD(void, decodeFrame, (const CANRxFrame& frame, efitick_t nowNt), (override));
-	MOCK_METHOD(bool, acceptFrame, (const CANRxFrame& frame), (const, override));
+	MOCK_METHOD(bool, acceptFrame, (const size_t busIndex, const CANRxFrame& frame), (const, override));
 };
 
 TEST(CanListener, FrameAccepted) {
@@ -19,12 +19,12 @@ TEST(CanListener, FrameAccepted) {
 	CANRxFrame frame;
 
 	// Accept should be called, returns true
-	EXPECT_CALL(dut, acceptFrame(_)).WillOnce(Return(true));
+	EXPECT_CALL(dut, acceptFrame(0, _)).WillOnce(Return(true));
 
 	// Because accept returns true, decode is called
 	EXPECT_CALL(dut, decodeFrame(_, 1234));
 
-	dut.processFrame(frame, 1234);
+	dut.processFrame(0, frame, 1234);
 }
 
 TEST(CanListener, FrameNotAccepted) {
@@ -33,9 +33,9 @@ TEST(CanListener, FrameNotAccepted) {
 	CANRxFrame frame;
 
 	// Accept should be called, returns false, so decode not called
-	EXPECT_CALL(dut, acceptFrame(_)).WillOnce(Return(false));
+	EXPECT_CALL(dut, acceptFrame(0, _)).WillOnce(Return(false));
 
-	dut.processFrame(frame, 1234);
+	dut.processFrame(0, frame, 1234);
 }
 
 struct CanListenerNoDecode : public CanListener {
@@ -52,7 +52,7 @@ TEST(CanListener, FrameAcceptedChecksId) {
 	frame.SID = 0x123;
 	frame.IDE = false;
 
-	EXPECT_TRUE(dut.acceptFrame(frame));
+	EXPECT_TRUE(dut.acceptFrame(0, frame));
 }
 
 TEST(CanListener, FrameNotAcceptedChecksId) {
@@ -63,5 +63,5 @@ TEST(CanListener, FrameNotAcceptedChecksId) {
 	frame.SID = 0x456;
 	frame.IDE = false;
 
-	EXPECT_FALSE(dut.acceptFrame(frame));
+	EXPECT_FALSE(dut.acceptFrame(0, frame));
 }


### PR DESCRIPTION
This allows listener to check CAN bus as well as CAN message ID.

This is needed for ECU with >= 2 CAN buses where same messages with different purpose may exist on different buses.