### PR TITLE
FORD_ESCORT_GT remove preparation

### DIFF
--- a/unit_tests/tests/controllers/test_long_term_fuel_trim.cpp
+++ b/unit_tests/tests/controllers/test_long_term_fuel_trim.cpp
@@ -22,7 +22,7 @@
 
 TEST(LTFT, testLearning)
 {
-	EngineTestHelper eth(engine_type_e::FORD_ESCORT_GT);
+	EngineTestHelper eth(engine_type_e::TEST_ENGINE);
 
 	LtftState ltftState;
 	LongTermFuelTrim ltft;

--- a/unit_tests/tests/lua/test_lookup.cpp
+++ b/unit_tests/tests/lua/test_lookup.cpp
@@ -2,7 +2,7 @@
 #include "value_lookup.h"
 
 TEST(LuaBasic, configLookup) {
-	EngineTestHelper eth(engine_type_e::FORD_ESCORT_GT);
+	EngineTestHelper eth(engine_type_e::TEST_ENGINE);
 	{
 		const char * name = "ignitionDwellForCrankingMs";
 		setConfigValueByName(name, 1.6);

--- a/unit_tests/tests/test_engine_math.cpp
+++ b/unit_tests/tests/test_engine_math.cpp
@@ -12,10 +12,12 @@
 
 TEST(misc, testIgnitionPlanning) {
 	printf("*************************************************** testIgnitionPlanning\r\n");
-	EngineTestHelper eth(engine_type_e::FORD_ESCORT_GT);
+	EngineTestHelper eth(engine_type_e::TEST_ENGINE);
+	setTable(config->lambdaTable, 0.92f);
+	setupSimpleTestEngineWithMafAndTT_ONE_trigger(&eth);
 
 	engine->periodicFastCallback();
-	ASSERT_NEAR(13.5, engine->fuelComputer.targetAFR, EPS4D) << "testIgnitionPlanning_AFR";
+	ASSERT_NEAR(12.857, engine->fuelComputer.targetAFR, EPS4D) << "testIgnitionPlanning_AFR";
 
 	ASSERT_EQ(IM_BATCH, engineConfiguration->injectionMode);
 }
@@ -24,7 +26,8 @@ TEST(misc, testEngineMath) {
 	printf("*************************************************** testEngineMath\r\n");
 
 	// todo: let's see if we can make 'engine' unneeded in this test?
-	EngineTestHelper eth(engine_type_e::FORD_ESCORT_GT);
+	EngineTestHelper eth(engine_type_e::TEST_ENGINE);
+	setTable(config->lambdaTable, 0.92f);
 	setTable(config->veTable, 80);
 
     setCamOperationMode();
@@ -53,7 +56,7 @@ TEST(misc, testEngineMath) {
 	engineConfiguration->tChargeAirFlowMax = 153.6f;
 	// calc. some airMass given the engine displacement=1.839 and 4 cylinders (FORD_ESCORT_GT)
 	fuelComputer->sdAirMassInOneCylinder = SpeedDensityBase::getAirmassImpl(/*VE*/1.0f, /*MAP*/100.0f, /*tChargeK*/273.15f + 20.0f);
-	ASSERT_NEAR(0.5464f, fuelComputer->sdAirMassInOneCylinder, EPS4D);
+	ASSERT_NEAR(0.59418f, fuelComputer->sdAirMassInOneCylinder, EPS4D);
 
 	Sensor::setMockValue(SensorType::Clt, 90);
 	Sensor::setMockValue(SensorType::Iat, 20);
@@ -63,8 +66,8 @@ TEST(misc, testEngineMath) {
 
 	// calc. airFlow using airMass, and find tCharge
 	engine->periodicFastCallback();
-	ASSERT_NEAR(59.12f, engine->engineState.sd.tCharge, EPS4D);
-	ASSERT_NEAR(46.2747f/*kg/h*/, engine->engineState.airflowEstimate, EPS4D);
+	ASSERT_NEAR(57.0099f, engine->engineState.sd.tCharge, EPS3D);
+	ASSERT_NEAR(50.6476f/*kg/h*/, engine->engineState.airflowEstimate, EPS4D);
 }
 
 TEST(misc, testIgnitionMapGenerator) {

--- a/unit_tests/tests/trigger/test_cam_vvt_input.cpp
+++ b/unit_tests/tests/trigger/test_cam_vvt_input.cpp
@@ -75,8 +75,9 @@ TEST(trigger, testNoisyInput) {
 }
 
 TEST(trigger, testCamInput) {
-	// setting some weird engine
-	EngineTestHelper eth(engine_type_e::FORD_ESCORT_GT);
+	EngineTestHelper eth(engine_type_e::TEST_ENGINE);
+	engineConfiguration->globalTriggerAngleOffset = -37;
+	engineConfiguration->crankingTimingAngle = 3;
 	engineConfiguration->triggerInputPins[1] = Gpio::Unassigned;
 
 	// changing to 'ONE TOOTH' trigger on CRANK with CAM/VVT

--- a/unit_tests/tests/trigger/test_quad_cam.cpp
+++ b/unit_tests/tests/trigger/test_quad_cam.cpp
@@ -6,8 +6,9 @@
 #include "pch.h"
 
 TEST(trigger, testQuadCamInput) {
-	// setting some weird engine
-	EngineTestHelper eth(engine_type_e::FORD_ESCORT_GT);
+	EngineTestHelper eth(engine_type_e::TEST_ENGINE);
+	engineConfiguration->globalTriggerAngleOffset = -37;
+	engineConfiguration->crankingTimingAngle = 3;
 	engineConfiguration->triggerInputPins[1] = Gpio::Unassigned;
 	engineConfiguration->isFasterEngineSpinUpEnabled = false;
 	engineConfiguration->alwaysInstantRpm = true;


### PR DESCRIPTION
only updating test that uses `FORD_ESCORT_GT`, replaced for `TEST_ENGINE`