### PR TITLE
efi_gpio: do not efiPrintf() from critical section

### DIFF
--- a/firmware/controllers/system/efi_gpio.cpp
+++ b/firmware/controllers/system/efi_gpio.cpp
@@ -799,6 +799,8 @@ void OutputPin::initPin(const char *msg, brain_pin_e p_brainPin, pin_output_mode
 }
 
 void OutputPin::deInit() {
+	efiPrintf("unregistering %s", hwPortname(brainPin));
+
 	// Unregister under lock - we don't want other threads mucking with the pin while we're trying to turn it off
 	chibios_rt::CriticalSectionLocker csl;
 
@@ -810,8 +812,6 @@ void OutputPin::deInit() {
 #if (BOARD_EXT_GPIOCHIPS > 0)
 	ext = false;
 #endif // (BOARD_EXT_GPIOCHIPS > 0)
-
-	efiPrintf("unregistering %s", hwPortname(brainPin));
 
 #if EFI_GPIO_HARDWARE && EFI_PROD_CODE
 	efiSetPadUnused(brainPin);


### PR DESCRIPTION
efiPrintfInternal() has it's own critical section inside. Nesting critical sections is not allowed in ChibiOS and cause "SV#4" halt on ChibiOS 21.11.x.
See _dbg_check_lock() and _dbg_enter_lock().
Not clear why we did not see this fault on currect ChibiOS...

Breakpoint 1, chSysHalt (reason=0x56791e40 "SV#4") at ../firmware/ChibiOS/os/rt/src/chsys.c:209 209	void chSysHalt(const char *reason) {
(gdb) bt
 0  chSysHalt (reason=0x56791e40 "SV#4") at ../firmware/ChibiOS/os/rt/src/chsys.c:209
 1  0x56584c68 in __dbg_check_lock () at ../firmware/ChibiOS/os/rt/src/chdebug.c:159
 2  0x56584a08 in chSysLock () at ../firmware/ChibiOS/os/rt/include/chsys.h:411
 3  chSysGetStatusAndLockX () at ../firmware/ChibiOS/os/rt/src/chsys.c:431
 4  0x566e0338 in chibios_rt::CriticalSectionLocker::CriticalSectionLocker (this=0x568fae00 <primaryChannelThread+18880>) at ../firmware/ChibiOS/os/various/cpp_wrappers/ch.hpp:389
 5  priv::efiPrintfInternal (format=<optimized out>) at ../firmware/util/loggingcentral.cpp:194
 6  0x566da3ec in OutputPin::deInit (this=<optimized out>) at ../firmware/controllers/system/efi_gpio.cpp:814
 7  0x56718b33 in stopVvtControlPins () at ../firmware/controllers/actuators/vvt.cpp:188
 8  0x566d1192 in stopHardware () at ../firmware/hw_layer/hardware.cpp:470
 9  0x566d11f6 in applyNewHardwareSettings () at ../firmware/hw_layer/hardware.cpp:333
 10 0x5669204a in incrementGlobalConfigurationVersion (msg=<optimized out>) at ../firmware/controllers/algo/engine_configuration.cpp:140
 11 0x566f1983 in disableTriggerStimulator () at ../firmware/controllers/trigger/trigger_emulator_algo.cpp:228
 12 0x5671fb03 in enableOrDisable (param=param@entry=0x56918188 <handleBuffer+8> "self_stimulation", isEnabled=isEnabled@entry=false) at ../firmware/controllers/settings.cpp:425
 13 0x5671fb6d in disable (param=0x56918188 <handleBuffer+8> "self_stimulation") at ../firmware/controllers/settings.cpp:446
 14 0x566e176b in handleActionWithParameter (current=<optimized out>, argv=<optimized out>, argc=<optimized out>) at ../firmware/util/cli_registry.cpp:310
 15 0x566e2a60 in handleConsoleLineInternal (commandLine=commandLine@entry=0x568fb54d <primaryChannel+13> "disable self_stimulation") at ../firmware/util/cli_registry.cpp:499
 16 0x566e2b8d in handleConsoleLine (line=0x568fb54d <primaryChannel+13> "disable self_stimulation") at ../firmware/util/cli_registry.cpp:521
 17 0x566cf6a4 in TunerStudio::handleExecuteCommand (this=0x568aa840 <tsInstance>, tsChannel=0x568fb540 <primaryChannel>, data=0x568fb54d <primaryChannel+13> "disable self_stimulation", incomingPacketSize=24)
    at ../firmware/console/binary/tunerstudio.cpp:790
 18 0x566cfa31 in TunerStudio::handleCrcCommand (this=<optimized out>, tsChannel=<optimized out>, data=0x568fb54d <primaryChannel+13> "disable self_stimulation", incomingPacketSize=<optimized out>)
    at ../firmware/console/binary/tunerstudio.cpp:853
 19 0x566d09af in tsProcessOne (tsChannel=tsChannel@entry=0x568fb540 <primaryChannel>) at ../firmware/console/binary/tunerstudio.cpp:716
 20 0x566d0b5c in TunerstudioThread::ThreadTask (this=0x568f6440 <primaryChannelThread>) at ../firmware/console/binary/tunerstudio.cpp:736
 21 0x566c8f3a in ThreadController<4152>::main (this=0x568f6440 <primaryChannelThread>) at ../firmware/controllers/system/thread_controller.h:33
 22 0x56768ef3 in chibios_rt::_thd_start (arg=0x568f6440 <primaryChannelThread>) at ../firmware/ChibiOS/os/various/cpp_wrappers/ch.cpp:41
 23 0x5658f572 in _port_thread_start (pf=0x56768e9d <chibios_rt::_thd_start(void*)>, p=0x568f6440 <primaryChannelThread>) at ../firmware/ChibiOS/os/common/ports/SIMIA32/chcore.c:118
 24 0x00000000 in ?? ()