### PR TITLE
initial .iaexclude/.aiignore files

### DIFF
--- a/.aiexclude
+++ b/.aiexclude
@@ -1,0 +1,13 @@
+firmware/ChibiOS/
+firmware/ChibiOS-Contrib/
+hardware/
+state/
+logs/
+doxygen/
+android/
+misc/
+simulator/generated/
+simulator/build/
+**/.dep/
+firmware/libfirmware/
+firmware/tunerstudio/generated/

--- a/.aiignore
+++ b/.aiignore
@@ -1,0 +1,13 @@
+firmware/ChibiOS/
+firmware/ChibiOS-Contrib/
+hardware/
+state/
+logs/
+doxygen/
+android/
+misc/
+simulator/generated/
+simulator/build/
+**/.dep/
+firmware/libfirmware/
+firmware/tunerstudio/generated/


### PR DESCRIPTION
part of https://github.com/rusefi/rusefi/issues/8227 :
> any gemini-robots.txt helpful files to black-list chibi and gtest folders?

notes:
CLion/jetbrains/junie/etc uses `.aiignore` file
Gemini/ Gemini plugin for CLion uses `.aiexclude` file

more info on:
https://cloud.google.com/gemini/docs/codeassist/create-aiexclude-file#vs-code
https://www.jetbrains.com/help/junie/aiignore.html