### PR TITLE
fix MAP blending calculation in SpeedDensityAirmass::getPredictiveMap

### DIFF
--- a/firmware/controllers/algo/accel_enrichment.h
+++ b/firmware/controllers/algo/accel_enrichment.h
@@ -1,5 +1,5 @@
 /**
- * @file    accel_enrichment.h
+* @file    accel_enrichment.h
  * @brief   Acceleration enrichment calculator
  *
  * @date Apr 21, 2014
@@ -28,6 +28,9 @@ public:
 	TpsAccelEnrichment();
 
 	void onConfigurationChange(engine_configuration_s const* previousConfig) override;
+
+	// This function returns true ONCE per acceleration event.
+	bool isAccelEventTriggered();
 
 	int getMaxDeltaIndex();
 	float getMaxDelta();

--- a/firmware/controllers/algo/accel_enrichment.h
+++ b/firmware/controllers/algo/accel_enrichment.h
@@ -29,9 +29,6 @@ public:
 
 	void onConfigurationChange(engine_configuration_s const* previousConfig) override;
 
-	// This function returns true ONCE per acceleration event.
-	bool isAccelEventTriggered();
-
 	int getMaxDeltaIndex();
 	float getMaxDelta();
 

--- a/firmware/controllers/algo/airmass/speed_density_airmass.cpp
+++ b/firmware/controllers/algo/airmass/speed_density_airmass.cpp
@@ -65,7 +65,7 @@ float SpeedDensityAirmass::getPredictiveMap(float rpm, bool postState, float map
 	if (m_isMapPredictionActive) {
 		float blendFactor = elapsedTime / blendDuration;
 		// Linearly interpolate between the initial predicted and real values
-		effectiveMap = m_initialPredictedMap + (m_initialRealMap - m_initialPredictedMap) * blendFactor;
+		effectiveMap = m_initialPredictedMap - (m_initialPredictedMap - m_initialRealMap) * blendFactor;
 
 		if (mapSensor >= effectiveMap) {
 			m_isMapPredictionActive = false;


### PR DESCRIPTION
related/depends on https://github.com/rusefi/rusefi/pull/8237

only important change in this pr from:

`effectiveMap = m_initialPredictedMap + (m_initialRealMap - m_initialPredictedMap) * blendFactor;`

to:

`effectiveMap = m_initialPredictedMap - (m_initialPredictedMap - m_initialRealMap) * blendFactor;`

to obtain expected (this is what I understood, so maybe is wrong?): 

At 25% blend time: 85 - (85-65) * 0.25 = 80
At 50% blend time: 85 - (85-65) * 0.5 = 75
At 75% blend time: 85 - (85-65) * 0.75 = 70
