### PR TITLE
Testing engine configuration for state injection has a bug visible with recent compilers

### DIFF
--- a/unit_tests/tests/binary_log/test_bit_logger_field.cpp
+++ b/unit_tests/tests/binary_log/test_bit_logger_field.cpp
@@ -19,7 +19,7 @@ class BitLoggerFieldTest : public ::testing::Test {
 
         std::unique_ptr<output_channels_s> m_testOutputChannels;
         std::unique_ptr<LogField> m_logField;
-        std::array<char, 6> m_buffer;
+        std::array<uint8_t, 6> m_buffer{};
     };
 
     void BitLoggerFieldTest::SetUp() {
@@ -42,7 +42,7 @@ class BitLoggerFieldTest : public ::testing::Test {
     }
 
     void BitLoggerFieldTest::checkBitLoggerField(const bool expected, const char* const context) {
-        EXPECT_EQ(1, m_logField->writeData(m_buffer.data(), nullptr)) << context;
+        EXPECT_EQ(1, m_logField->writeData(reinterpret_cast<char*>(m_buffer.data()), nullptr)) << context;
         EXPECT_THAT(m_buffer, ::testing::ElementsAre((expected ? 0x01 : 0x00), 0xAA, 0xAA, 0xAA, 0xAA, 0xAA));
     }
 

--- a/unit_tests/tests/util/test_engine_configuration.cpp
+++ b/unit_tests/tests/util/test_engine_configuration.cpp
@@ -335,6 +335,16 @@ void TestEngineConfiguration::configureInjectorBattLagCorr(const std::optional<B
     if (battLagCorr.has_value()) {
         copyTable(engineConfiguration->injector.battLagCorrTable, battLagCorr.value());
     } else {
+        // This whole thing is wrong as you can not access std::optional which was found to be empty.
+        // On top of that this method is called after explicitly setting test config with test curve data
+        // (TEST_PRIMARY_INJECTOR_BATT_LAG_CORR_CURVE) with curve filled by 5.6f
+        // But then it is compared against default config table with very different data from firmware defaults
+        // in file engine_configuration_defaults.h (INJECTOR_BATT_LAG_CURR)
+        // { 4.240f, 2.483f, 1.739f, 1.501f, 1.308f, 1.149f, 0.964f, 0.913f },
+        // { 3.084f, 1.641f, 1.149f, 1.194f, 0.992f, 0.759f, 0.637f, 0.603f },
+        // Seems like it was covered by some std::optional+gtest bug...
+        return;
+
         EXPECT_EQ(
             battLagCorr->size(),
             std::size(engineConfiguration->injector.battLagCorrTable)
@@ -392,6 +402,16 @@ void TestEngineConfiguration::configureInjectorSecondaryBattLagCorr(const std::o
             );
         }
     } else {
+        // This whole thing is wrong as you can not access std::optional which was found to be empty.
+        // On top of that this method is called after explicitly setting test config with test curve data
+        // (TEST_SECONDARY_INJECTOR_DEAD_TIME) with curve filled by 7.8f
+        // But then it is compared against default config table with very different data from firmware defaults
+        // in file engine_configuration_defaults.h (INJECTOR_SECONDARY_BATT_LAG_CURR)
+        // { 4.240f, 2.483f, 1.739f, 1.501f, 1.308f, 1.149f, 0.964f, 0.913f },
+        // { 3.084f, 1.641f, 1.149f, 1.194f, 0.992f, 0.759f, 0.637f, 0.603f },
+        // Seems like it was covered by some std::optional+gtest bug...
+        return;
+
         EXPECT_EQ(
             battLagCorr->size(),
             std::size(engineConfiguration->injector.battLagCorrTable)


### PR DESCRIPTION
Test TestEngineConfiguration has an error at:

void TestEngineConfiguration::configureInjectorBattLagCorr(const std::optional<BattLagCorrTable> battLagCorr)...

and same error for secondary injection.

Error is in accessing std::optional internals right after checking there is nothing inside. Older compilers seem to jump over google test macro covered code after such access thus passing over like nothing was done at all. 

The solution so far is to let copy happen if value is present and do nothing if not.

Changes were made by @kifir23917 last time. Maybe he can take a look what was the intent as currently it is not clear what this code was supposed to do if there was no table passed.

I added a comment to the code:

// This whole thing is wrong as you can not access std::optional which was found to be empty.
// On top of that this method is called after explicitly setting test config with test curve data
// (TEST_PRIMARY_INJECTOR_BATT_LAG_CORR_CURVE) with curve filled by 5.6f
// But then it is compared against default config table with very different data from firmware defaults
// in file engine_configuration_defaults.h (INJECTOR_BATT_LAG_CURR)
// { 4.240f, 2.483f, 1.739f, 1.501f, 1.308f, 1.149f, 0.964f, 0.913f },
// { 3.084f, 1.641f, 1.149f, 1.194f, 0.992f, 0.759f, 0.637f, 0.603f },
// Seems like it was hidden by some std::optional+gtest bug...

Newer compilers will fail execution on attempt to access empty std::optional (which is correct behavior)