### PR TITLE
prep: new board override system for boardInitHardware/boardInitHardwareExtra see #8249

### DIFF
--- a/firmware/config/boards/nucleo_f429/board_configuration.cpp
+++ b/firmware/config/boards/nucleo_f429/board_configuration.cpp
@@ -1,4 +1,5 @@
 #include "pch.h"
+#include "board_overrides.h"
 
 // PB14 is error LED, configured in board.mk
 // Board only has 3 LEDs, so no warning LED

--- a/firmware/config/boards/nucleo_f429/board_configuration.cpp
+++ b/firmware/config/boards/nucleo_f429/board_configuration.cpp
@@ -16,7 +16,7 @@ Gpio getWarningLedPin() {
 	return Gpio::Unassigned;
 }
 
-void preHalInit() {
+void nucleo_f429_preHalInit() {
 	efiSetPadMode("Ethernet",  Gpio::A1, PAL_MODE_ALTERNATE(0xb));
 	efiSetPadMode("Ethernet",  Gpio::A2, PAL_MODE_ALTERNATE(0xb));
 	efiSetPadMode("Ethernet",  Gpio::A7, PAL_MODE_ALTERNATE(0xb));
@@ -29,4 +29,8 @@ void preHalInit() {
 
 	efiSetPadMode("Ethernet", Gpio::G11, PAL_MODE_ALTERNATE(0xb));
 	efiSetPadMode("Ethernet", Gpio::G13, PAL_MODE_ALTERNATE(0xb));
+}
+
+void setup_custom_board_overrides() {
+	custom_board_preHalInit = nucleo_f429_preHalInit;
 }

--- a/firmware/config/boards/nucleo_h743/board_configuration.cpp
+++ b/firmware/config/boards/nucleo_h743/board_configuration.cpp
@@ -1,4 +1,5 @@
 #include "pch.h"
+#include "board_overrides.h"
 
 // PB14 is error LED, configured in board.mk
 // Board only has 3 LEDs, so no warning LED

--- a/firmware/config/boards/nucleo_h743/board_configuration.cpp
+++ b/firmware/config/boards/nucleo_h743/board_configuration.cpp
@@ -15,7 +15,7 @@ Gpio getWarningLedPin() {
 	return Gpio::Unassigned;
 }
 
-void preHalInit() {
+void nucleo_h743_preHalInit() {
 	efiSetPadMode("Ethernet",  Gpio::A1, PAL_MODE_ALTERNATE(0xb));
 	efiSetPadMode("Ethernet",  Gpio::A2, PAL_MODE_ALTERNATE(0xb));
 	efiSetPadMode("Ethernet",  Gpio::A7, PAL_MODE_ALTERNATE(0xb));
@@ -28,4 +28,8 @@ void preHalInit() {
 
 	efiSetPadMode("Ethernet", Gpio::G11, PAL_MODE_ALTERNATE(0xb));
 	efiSetPadMode("Ethernet", Gpio::G13, PAL_MODE_ALTERNATE(0xb));
+}
+
+void setup_custom_board_overrides() {
+	custom_board_preHalInit = nucleo_h743_preHalInit;
 }

--- a/firmware/console/eficonsole.cpp
+++ b/firmware/console/eficonsole.cpp
@@ -27,6 +27,9 @@
 #include "eficonsole.h"
 #include "console_io.h"
 #include "mpu_util.h"
+#include "board_overrides.h"
+
+std::optional<setup_custom_board_overrides_type> custom_board_boardSayHello;
 
 #if defined(STM32F4) || defined(STM32F7) || defined(STM32H7)
 static void printUid() {
@@ -61,6 +64,7 @@ static void sayHello() {
 #endif
 
   boardSayHello();
+  call_board_override(custom_board_boardSayHello);
 
 #if EFI_PROD_CODE && ENABLE_AUTO_DETECT_HSE
 	extern float hseFrequencyMhz;

--- a/firmware/hw_layer/board_overrides.h
+++ b/firmware/hw_layer/board_overrides.h
@@ -34,7 +34,7 @@ using setup_custom_board_overrides_type = void (*)();
  * Allows boards to perform custom initialization before HAL is initialized
  * Example: special pin setup or hardware initialization needed before HAL
  */
-// extern std::optional<setup_custom_board_overrides_type> custom_board_preHalInit;
+extern std::optional<setup_custom_board_overrides_type> custom_board_preHalInit;
 
 extern std::optional<setup_custom_board_overrides_type> custom_board_boardSayHello;
 

--- a/firmware/hw_layer/board_overrides.h
+++ b/firmware/hw_layer/board_overrides.h
@@ -1,0 +1,47 @@
+/*
+ * @file board_overrides.h
+ * @brief Board-specific override mechanism
+ *
+ * This header provides a centralized way to define and manage board-specific overrides.
+ * Custom boards can implement their own specialized behavior by overriding these function pointers.
+ *
+ * Usage Example:
+ *
+ * 1. Define your custom function:
+ *    void myBoardCustomHello() {
+ *        // Your custom implementation
+ *    }
+ *
+ * 2. Set up the override in your board_configuration.cpp:
+ *    void setup_custom_board_overrides() {
+ *        custom_board_boardSayHello = myBoardCustomHello;
+ *    }
+ *
+ *
+ * @date: jul 09, 2025
+ * @author FDSoftware
+ */
+
+#pragma once
+#include <functional>
+#include <optional>
+
+using setup_custom_board_overrides_type = void (*)();
+
+/**
+ * @brief Pre-HAL initialization override point
+ * Allows boards to perform custom initialization before HAL is initialized
+ * Example: special pin setup or hardware initialization needed before HAL
+ */
+// extern std::optional<setup_custom_board_overrides_type> custom_board_preHalInit;
+
+extern std::optional<setup_custom_board_overrides_type> custom_board_boardSayHello;
+
+/**
+ * This function checks if an override is present and calls it if available.
+ */
+static inline void call_board_override(std::optional<setup_custom_board_overrides_type> board_override){
+    if (board_override.has_value()) {
+        std::invoke(board_override.value());
+    }
+}

--- a/firmware/hw_layer/board_overrides.h
+++ b/firmware/hw_layer/board_overrides.h
@@ -26,6 +26,7 @@
 #include <functional>
 #include <optional>
 
+// function with no parameters and returning void
 using setup_custom_board_overrides_type = void (*)();
 
 /**

--- a/firmware/hw_layer/board_overrides.h
+++ b/firmware/hw_layer/board_overrides.h
@@ -32,7 +32,6 @@ using setup_custom_board_overrides_type = void (*)();
 /**
  * @brief Pre-HAL initialization override point
  * Allows boards to perform custom initialization before HAL is initialized
- * Example: special pin setup or hardware initialization needed before HAL
  */
 extern std::optional<setup_custom_board_overrides_type> custom_board_preHalInit;
 

--- a/firmware/main.cpp
+++ b/firmware/main.cpp
@@ -21,13 +21,13 @@
 PUBLIC_API_WEAK void setup_custom_board_overrides() {
 }
 
-// std::optional<setup_custom_board_overrides_type> custom_board_preHalInit;
+std::optional<setup_custom_board_overrides_type> custom_board_preHalInit;
 
 int main(void) {
 	setup_custom_board_overrides();
 	// Maybe your board needs to do something special before HAL init
 	preHalInit();
-	// call_board_override(custom_board_preHalInit);
+	call_board_override(custom_board_preHalInit);
 
 	/*
 	 * ChibiOS/RT initialization

--- a/firmware/main.cpp
+++ b/firmware/main.cpp
@@ -13,10 +13,21 @@
 
 #include "rusefi.h"
 #include "mpu_util.h"
+#include "board_overrides.h"
+
+// this function is used to link all the posibles overrides of the bord, is one of the first func call, before any hw init!
+// use ONLY for the setup of the overrides!!
+// note: this function is weak until we migrate all the other func & boards, make required after the migration!
+PUBLIC_API_WEAK_SOMETHING_WEIRD static inline void setup_custom_board_overrides() {
+}
+
+// std::optional<setup_custom_board_overrides_type> custom_board_preHalInit;
 
 int main(void) {
+	setup_custom_board_overrides();
 	// Maybe your board needs to do something special before HAL init
 	preHalInit();
+	// call_board_override(custom_board_preHalInit);
 
 	/*
 	 * ChibiOS/RT initialization

--- a/firmware/main.cpp
+++ b/firmware/main.cpp
@@ -18,7 +18,7 @@
 // this function is used to link all the posibles overrides of the bord, is one of the first func call, before any hw init!
 // use ONLY for the setup of the overrides!!
 // note: this function is weak until we migrate all the other func & boards, make required after the migration!
-PUBLIC_API_WEAK_SOMETHING_WEIRD static inline void setup_custom_board_overrides() {
+PUBLIC_API_WEAK void setup_custom_board_overrides() {
 }
 
 // std::optional<setup_custom_board_overrides_type> custom_board_preHalInit;

--- a/simulator/main.cpp
+++ b/simulator/main.cpp
@@ -24,6 +24,8 @@
 #include <fstream>
 #include <sstream>
 
+#include "board_overrides.h"
+
 #define CONSOLE_WA_SIZE     THD_WORKING_AREA_SIZE(4096)
 
 bool main_loop_started = false;
@@ -137,12 +139,21 @@ bool verboseMode = true;
 
 static virtual_timer_t exitTimer;
 
+// board override demo:
+static inline void myCustomHello(){
+	efiPrintf("custom board hello from simulator");
+}
+
+void setup_custom_board_overrides(){
+	custom_board_boardSayHello = myCustomHello;
+}
+
 /*------------------------------------------------------------------------*
  * Simulator main.                                                        *
  *------------------------------------------------------------------------*/
 int main(int argc, char** argv) {
 	setbuf(stdout, NULL);
-
+	setup_custom_board_overrides();
 	/*
 	 * System initializations.
 	 * - HAL initialization, this also initializes the configured device drivers


### PR DESCRIPTION
I thought about taking advantage of the fact that we are using more c20, we have std::invoke available to be able to invoke functions without having to write a cast

result:
```
[0us]efiPrintfInternal:msg`*** rusEFI LLC (c) 2012-2024. All rights reserved.`
[0us]efiPrintfInternal:msg`*** rusEFI v20250709@1140675965 now=0`
[0us]efiPrintfInternal:msg`*** Chibios Kernel:       7.0.5`
[0us]efiPrintfInternal:msg`*** Compiled:     Jul  9 2025 - 18:26:56`
[0us]efiPrintfInternal:msg`*** COMPILER=14.2.1 20240912 (Red Hat 14.2.1-3)`
[0us]efiPrintfInternal:msg`custom board hello from simulator`
``` 


If we need to invoke a custom board function or a default one, we can also add something like

```c++
std::invoke(custom_board_boardSayHello.value_or(default_board_boardSayHello));
```
related: #8249