### PR TITLE
LCOV => GCOVR migration

### DIFF
--- a/.github/workflows/build-unit-tests.yaml
+++ b/.github/workflows/build-unit-tests.yaml
@@ -30,6 +30,7 @@ jobs:
         sudo bash misc/actions/add-ubuntu-latest-apt-mirrors.sh
         sudo bash misc/actions/ubuntu-install-tools.sh
         sudo apt-get install python3-pip valgrind
+        pip install gcovr
 
     - name: Install required software (macos)
       if: ${{ matrix.os == 'macos-latest' }}

--- a/.github/workflows/build-unit-tests.yaml
+++ b/.github/workflows/build-unit-tests.yaml
@@ -29,7 +29,7 @@ jobs:
       run: |
         sudo bash misc/actions/add-ubuntu-latest-apt-mirrors.sh
         sudo bash misc/actions/ubuntu-install-tools.sh
-        sudo apt-get install lcov valgrind
+        sudo apt-get install python3-pip valgrind
 
     - name: Install required software (macos)
       if: ${{ matrix.os == 'macos-latest' }}

--- a/unit_tests/ci_gcov.sh
+++ b/unit_tests/ci_gcov.sh
@@ -8,27 +8,11 @@ rm -rf gcov_working_area
 
 mkdir gcov_working_area
 cd gcov_working_area
-
-echo "Looking for source code"
-find     ..                          -name *.c* >  source_files.txt
-find     ../../firmware/console/     -name *.c* >> source_files.txt
-find     ../../firmware/controllers/ -name *.c* >> source_files.txt
-
-wc -l source_files.txt
-
-xargs -L 1 -I {} cp {} . < source_files.txt
-
-cp ../build/obj/* .
+mkdir gcov
 
 echo -e "\nGenerating rusEFI unit test coverage"
-gcov *.c* > gcov.log 2>gcov.err
 
-echo -e "\nCollecting rusEFI unit test coverage"
-#FIXME: we have some problem related to google test macro "TEST" and the ouput code on lcov
-# todo gtest vs gcov https://github.com/rusefi/rusefi/issues/8129
-# Currently we cannot obtain coverage on the tests themselves, but on the tests towards the code.
-lcov --ignore-errors mismatch --capture --directory . --output-file coverage.info
-
-echo -e "\nGenerating rusEFI unit test HTML"
-genhtml coverage.info --output-directory gcov
-echo -e "\nGenerating rusEFI unit test HTML"
+# for debug use --html-details --html-single-page --verbose  to generate a single html
+gcovr --exclude-throw-branches --exclude-unreachable-branches --decisions \
+      --exclude '/.*/googletest/' \
+      -j4  -r ../.. --html-nested gcov/index.html


### PR DESCRIPTION
demo here:
https://fdsoftware.github.io/gcovr_demo/
visually are relative the same both, so not much to show, but gcovr introduces a new "decisions" instated of branches in the coverage:

<img width="881" height="124" alt="image" src="https://github.com/user-attachments/assets/ef6b5911-8cee-4f58-a4e8-8916d76eef70" />

fist are branches, second the decision
https://gcovr.com/en/stable/faq.html#why-does-c-code-have-so-many-uncovered-branches


decision are more readable than branches, see:

<img width="889" height="166" alt="image" src="https://github.com/user-attachments/assets/cb3217b5-3f9c-4fb2-8ab2-25fe66ce461b" />
vs:
<img width="831" height="148" alt="image" src="https://github.com/user-attachments/assets/9843a9e3-b610-49b1-8e21-7767fd020080" />


same file on LCOV:
<img width="924" height="938" alt="image" src="https://github.com/user-attachments/assets/7a9b9b30-a174-43b5-96b1-3d6614798de2" />

and on GCOVR:
<img width="1181" height="786" alt="image" src="https://github.com/user-attachments/assets/27c7dbf6-ab8d-47ae-a313-0272077e83c3" />


resolves: #8129

