### PR TITLE
gcov folder are inside "./unit_tests/gcov_working_area" not in "./unit_tests"

### DIFF
--- a/.github/workflows/build-unit-tests.yaml
+++ b/.github/workflows/build-unit-tests.yaml
@@ -95,7 +95,7 @@ jobs:
 
     - name: upload test coverage to remote server
       if: ${{ matrix.os != 'macos-latest' && github.event_name == 'push' && github.ref == 'refs/heads/master' }}
-      working-directory: ./unit_tests/
+      working-directory: ./unit_tests/gcov_working_area
       run: ./upload_coverage.sh
 
 


### PR DESCRIPTION
master failed on the upload to the remote server, this should fix that issue, sorry!
```
Run ./upload_coverage.sh

Uploading HTML
tar: gcov: Cannot open: No such file or directory
tar: Error is not recoverable: exiting now
Warning: Permanently added '***' (ED25519) to the list of known hosts.

Happy End.
``` 
