### PR TITLE
clean more FORD_ASPIRE_1996 HW-CI tests

### DIFF
--- a/java_console/autotest/src/main/java/com/rusefi/EnduranceTestUtility.java
+++ b/java_console/autotest/src/main/java/com/rusefi/EnduranceTestUtility.java
@@ -26,7 +26,7 @@ public class EnduranceTestUtility {
             CommandQueue commandQueue = linkManager.getCommandQueue();
 
             for (int i = 0; i < count; i++) {
-                EcuTestHelper.currentEngineType = engine_type_e.FORD_ASPIRE_1996.ordinal();
+                EcuTestHelper.currentEngineType = engine_type_e.MINIMAL_PINS.ordinal();
                 sendBlockingCommand("set " + Integration.CMD_ENGINE_TYPE + " " + 3, Timeouts.SET_ENGINE_TIMEOUT, commandQueue);
                 sleepSeconds(2);
                 sendBlockingCommand(getEnableCommand("self_stimulation"), commandQueue);

--- a/java_console/autotest/src/main/java/com/rusefi/f4discovery/CommonFunctionalTest.java
+++ b/java_console/autotest/src/main/java/com/rusefi/f4discovery/CommonFunctionalTest.java
@@ -29,7 +29,7 @@ import static org.junit.Assert.assertTrue;
 public class CommonFunctionalTest extends RusefiTestBase {
     @Test
     public void testChangingIgnitionMode() {
-        ecu.setEngineType(engine_type_e.FORD_ASPIRE_1996);
+        ecu.setEngineType(engine_type_e.MINIMAL_PINS);
         ecu.changeRpm(2000);
 
         // First is wasted spark
@@ -109,7 +109,7 @@ public class CommonFunctionalTest extends RusefiTestBase {
 
     @Test
     public void testRevLimiter() {
-        ecu.setEngineType(engine_type_e.FORD_ASPIRE_1996);
+        ecu.setEngineType(engine_type_e.MINIMAL_PINS);
         ecu.changeRpm(2000);
 
         // Alpha-N mode so that we actually inject some fuel (without mocking tons of sensors)

--- a/java_console/autotest/src/main/java/com/rusefi/f4discovery/DiscoveryPwmHardwareTest.java
+++ b/java_console/autotest/src/main/java/com/rusefi/f4discovery/DiscoveryPwmHardwareTest.java
@@ -36,7 +36,7 @@ public class DiscoveryPwmHardwareTest extends RusefiTestBase {
 
     @Test
     public void scheduleBurnDoesNotAffectTriggerIssue2839() {
-        ecu.setEngineType(engine_type_e.FORD_ASPIRE_1996);
+        ecu.setEngineType(engine_type_e.MINIMAL_PINS);
         ecu.sendCommand(IoUtil.setTriggerType(com.rusefi.enums.trigger_type_e.TT_TOOTHED_WHEEL_60_2));
         ecu.sendCommand(getDisableCommand(Integration.CMD_SELF_STIMULATION));
         ecu.sendCommand(getEnableCommand(CMD_EXTERNAL_STIMULATION));


### PR DESCRIPTION
now using `MINIMAL_PINS`, related: #7964