### PR TITLE
intake/wb1-2 temperature imperial units support

### DIFF
--- a/firmware/integration/rusefi_config_shared.txt
+++ b/firmware/integration/rusefi_config_shared.txt
@@ -209,6 +209,7 @@
 #define UNITS_FAHRENHEIT "F"
 
 #define GAUGE_PRECISION_TEMPERATURE_C 1,1
+#define GAUGE_PRECISION_TEMPERATURE_F 1,2
 
 #define GAUGE_NAME_ADJUSTED_TIMING "Timing: ignition"
 #define GAUGE_NAME_TIMING_ADVANCE "Timing: base ignition"

--- a/firmware/tunerstudio/tunerstudio.template.ini
+++ b/firmware/tunerstudio/tunerstudio.template.ini
@@ -241,9 +241,17 @@ page = 3
 ; This is not officially documented in the .ini reference,
 ; but at the first occurrence of "#if CELSIUS", TS creates a settingGroup with the unit selector, which defaults to Fahrenheit.
 #if CELSIUS
+	; this output channels are used on tables/curves, so we need to make a new output chanel and then override it here with the celsius conditional
 	coolantTemperature = { coolant }
+	intakeTemperature = { intake }
 #else
+	intakeTemperature = { intake * 1.8 + 32 }
 	coolantTemperature = { coolant * 1.8 + 32 }
+
+	; note this output channels are not used on any table/curve, so we can simply add the "F" variants,
+	; and use it on the corresponding Gauge with the celsius conditional
+	wb1tempF = { wb1tempC * 1.8 + 32 }
+	wb2tempF = { wb1tempC * 1.8 + 32 }
 #endif
 
 [PcVariables]
@@ -1691,11 +1699,12 @@ gaugeCategory = Sensors - Basic
 
 #if CELSIUS
 	CLTGauge			= coolantTemperature,		@@GAUGE_LONG_NAME_CLT@@,		@@UNITS_CELSIUS@@,		-40,	140,	-15,		1,		95,	110,	@@GAUGE_PRECISION_TEMPERATURE_C@@
+	IATGauge			= intakeTemperature,		@@GAUGE_LONG_NAME_IAT@@,		@@UNITS_CELSIUS@@,		-40,	140,	-15,		1,		95,	110,	@@GAUGE_PRECISION_TEMPERATURE_C@@
 #else
-	CLTGauge			= coolantTemperature,		@@GAUGE_LONG_NAME_CLT@@,		@@UNITS_FAHRENHEIT@@,		-40,	284,	5,		33.8,		203,	230,	1,	2
+	CLTGauge			= coolantTemperature,		@@GAUGE_LONG_NAME_CLT@@,		@@UNITS_FAHRENHEIT@@,		-40,	284,	5,		33.8,		203,	230,	@@GAUGE_PRECISION_TEMPERATURE_F@@
+	IATGauge			= intakeTemperature,		@@GAUGE_NAME_IAT@@,				@@UNITS_FAHRENHEIT@@,		-40,	140,	-15,		1,		95,		110,	@@GAUGE_PRECISION_TEMPERATURE_F@@
 #endif
 
-	IATGauge			= intake,	@@GAUGE_LONG_NAME_IAT@@,		@@UNITS_CELSIUS@@,		-40,	140,	-15,		1,		95,	110,	@@GAUGE_PRECISION_TEMPERATURE_C@@
 	afr1Gauge			= AFRValue, @@GAUGE_NAME_AFR@@,			"",		10,	19.4,		12,	13,		15,	16,	2,	2
 	afr2Gauge			= AFRValue2, @@GAUGE_NAME_AFR2@@,		"",		10,	19.4,		12,	13,		15,	16,	2,	2
 	smoothedAfr1Gauge			= SmoothedAFRValue, @@SMOOTHED_GAUGE_NAME_AFR@@,			"",		10,	19.4,		12,	13,		15,	16,	2,	2
@@ -1755,11 +1764,19 @@ gaugeCategory = Sensors - O2
 	afr1Gauge			= AFRValue,           @@GAUGE_NAME_AFR@@,        "",        10,     19.4,        12,         13,         15,          16,     2,     2
 	afr2Gauge			= AFRValue2,          @@GAUGE_NAME_AFR2@@,       "",        10,     19.4,        12,         13,         15,          16,     2,     2
 	wb1heaterDuty		= wb1heaterDuty,      "WBO1: Heater Duty",       "%",      0.0,    100.0,       1.0,        3.0,         90,          95,     1,     1,		{ canWbo1_type == @@can_wbo_type_e_RUSEFI@@ }
+#if CELSIUS
 	wb1tempC			= wb1tempC,           "WBO1: Sensor t",          @@UNITS_CELSIUS@@,      500,     1050,       500,        650,        800,         950,     0,     0,		{ canWbo1_type == @@can_wbo_type_e_RUSEFI@@ }
+#else
+	wb1tempC			= wb1tempF,           "WBO1: Sensor t",          @@UNITS_FAHRENHEIT@@,      932,     1922,       932,       1202,      1472,         1742,     0,     0,		{ canWbo1_type == @@can_wbo_type_e_RUSEFI@@ }
+#endif
 	wb1nernstVoltage    = wb1nernstVoltage,   "WBO1: nernst V",          "V",     -0.2,      1.1,      0.35,       0.40,       0.50,        0.55,     3,     3,		{ canWbo1_type == @@can_wbo_type_e_RUSEFI@@ }
 	wb1esr				= wb1esr,             "WBO1: ESR",            "ohms",        0,      600,       200,        200,        350,         400,     0,     0,		{ canWbo1_type == @@can_wbo_type_e_RUSEFI@@ }
 	wb2heaterDuty		= wb2heaterDuty,      "WBO2: Heater Duty",       "%",      0.0,    100.0,       1.0,        3.0,         90,          95,     1,     1,		{ canWbo2_type == @@can_wbo_type_e_RUSEFI@@ }
+#if CELSIUS
 	wb2tempC			= wb2tempC,           "WBO2: Sensor t",          @@UNITS_CELSIUS@@,      500,     1050,       500,        650,        800,         950,     0,     0,		{ canWbo2_type == @@can_wbo_type_e_RUSEFI@@ }
+#else
+	wb2tempC			= wb2tempF,           "WBO2: Sensor t",          @@UNITS_FAHRENHEIT@@,      932,     1922,       932,       1202,      1472,         1742,     0,     0,		{ canWbo2_type == @@can_wbo_type_e_RUSEFI@@ }
+#endif
 	wb2nernstVoltage    = wb2nernstVoltage,   "WBO2: nernst V",          "V",     -0.2,      1.1,      0.35,       0.40,       0.50,        0.55,     3,     3,		{ canWbo2_type == @@can_wbo_type_e_RUSEFI@@ }
 	wb2esr				= wb2esr,             "WBO2: ESR",            "ohms",        0,      600,       200,        200,        350,         400,     0,     0,		{ canWbo2_type == @@can_wbo_type_e_RUSEFI@@ }
 


### PR DESCRIPTION
UI:
<img width="1460" height="783" alt="image" src="https://github.com/user-attachments/assets/f097a05b-501c-4117-a644-bf4d7809875b" />

more freedom :eagle: :eagle: :eagle: 

Some of these gauges are not used in any table/view, so I just added the temperature channels in F, instead of duplicating the existing one in C and then overriding it in F; as happens with the coolant/intake ones.

related #4788