### PR TITLE
SD storage: delayed LTFT calibration load on SD card mount

### DIFF
--- a/firmware/console/status_loop.cpp
+++ b/firmware/console/status_loop.cpp
@@ -65,6 +65,7 @@
 #endif /* EFI_PROD_CODE */
 
 #if EFI_CONFIGURATION_STORAGE
+#include "storage.h"
 #include "flash_main.h"
 #endif
 

--- a/firmware/controllers/flash_main.h
+++ b/firmware/controllers/flash_main.h
@@ -18,12 +18,8 @@ void initFlash();
  * running so we postpone the write until the engine is stopped.
  */
 void writeToFlashNow();
+bool writeToFlashNowImpl();
 void setNeedToWriteConfiguration();
-
-/**
- * @return true if an flash write is pending
- */
-bool getNeedToWriteConfiguration();
 
 bool settingsLtftRequestWriteToFlash();
 

--- a/firmware/controllers/long_term_fuel_trim.cpp
+++ b/firmware/controllers/long_term_fuel_trim.cpp
@@ -219,7 +219,11 @@ void LongTermFuelTrim::reset() {
 }
 
 void LongTermFuelTrim::onSlowCallback() {
-	if ((ltftLearning) && (engine->rpmCalculator.getSecondsSinceEngineStart(getTimeNowNt()) > 1.0)) {
+	if ((ltftLearning) &&
+#if EFI_SHAFT_POSITION_INPUT
+		(engine->rpmCalculator.getSecondsSinceEngineStart(getTimeNowNt()) > 1.0) &&
+#endif
+		(1)) {
 		efiPrintf("LTFT: failed to load calibrations");
 		m_state->reset();
 		ltftLoadPending = false;

--- a/firmware/controllers/long_term_fuel_trim.h
+++ b/firmware/controllers/long_term_fuel_trim.h
@@ -23,6 +23,7 @@ public:
 	void init(LtftState *state);
 	void learn(ClosedLoopFuelResult clResult, float rpm, float fuelLoad);
 	ClosedLoopFuelResult getTrims(float rpm, float fuelLoad);
+	void load();
 	void store();
 	void reset();
 

--- a/firmware/controllers/long_term_fuel_trim_state.txt
+++ b/firmware/controllers/long_term_fuel_trim_state.txt
@@ -6,6 +6,7 @@ struct_no_prefix long_term_fuel_trim_state_s
 	bit ltftLearning;LTFT learning
 	bit ltftCorrecting;LTFT correcting
 	bit ltftSavePending;LTFT saving
+	bit ltftLoadPending;LTFT loading calibration
 
 	float[FT_BANK_COUNT iterate] ltftCorrection;LTFT: Bank; "%", 100, -1.0, 50, 150, 1
 end_struct

--- a/firmware/controllers/storage.cpp
+++ b/firmware/controllers/storage.cpp
@@ -9,7 +9,10 @@
 #include "pch.h"
 
 #include "storage.h"
+
+#if EFI_CONFIGURATION_STORAGE
 #include "mpu_util.h"
+#endif
 
 /* If any setting storage is exist or we are in unit test */
 #if EFI_CONFIGURATION_STORAGE || defined(EFI_UNIT_TEST)

--- a/firmware/controllers/storage.cpp
+++ b/firmware/controllers/storage.cpp
@@ -9,6 +9,7 @@
 #include "pch.h"
 
 #include "storage.h"
+#include "mpu_util.h"
 
 /* If any setting storage is exist or we are in unit test */
 #if EFI_CONFIGURATION_STORAGE || defined(EFI_UNIT_TEST)

--- a/firmware/controllers/storage.cpp
+++ b/firmware/controllers/storage.cpp
@@ -10,6 +10,39 @@
 
 #include "storage.h"
 
+/* If any setting storage is exist or we are in unit test */
+#if EFI_CONFIGURATION_STORAGE || defined(EFI_UNIT_TEST)
+bool storageAllowWriteID(StorageItemId id)
+{
+#if (EFI_STORAGE_INT_FLASH == TRUE) || defined(EFI_UNIT_TEST)
+	if ((id == EFI_SETTINGS_RECORD_ID) ||
+		(id == EFI_SETTINGS_BACKUP_RECORD_ID)) {
+		// special case, settings can be stored in internal flash
+
+		// writing internal flash can cause cpu freeze
+		// check if HW support flash writing while executing
+		if (mcuCanFlashWhileRunning()) {
+			return true;
+		}
+
+#if EFI_SHAFT_POSITION_INPUT
+		// MCU does not support write while executing, check if engine is stopped
+		if (engine->triggerCentral.directSelfStimulation || engine->rpmCalculator.isStopped()) {
+			return true;
+		} else {
+			// rusEfi usually runs on hardware which halts execution while writing to internal flash, so we
+			// postpone writes to until engine is stopped. Writes in case of self-stimulation are fine.
+			return false;
+		}
+#endif // EFI_SHAFT_POSITION_INPUT
+	}
+#endif // EFI_STORAGE_INT_FLASH
+
+	// TODO: we expect every other ID to be stored in external flash...
+	return true;
+}
+#endif // EFI_CONFIGURATION_STORAGE || defined(EFI_UNIT_TEST)
+
 /* If any setting storage is exist */
 #if EFI_CONFIGURATION_STORAGE
 
@@ -25,12 +58,51 @@
 #include "storage_sd.h"
 #endif
 
+#define STORAGE_MANAGER_POLL_INTERVAL_MS	100
+
 static constexpr size_t storagesCount = STORAGE_TOTAL;
 
 static SettingStorageBase *storages[storagesCount];
 
-static const char *storageTypeToName(StorageType type)
-{
+chibios_rt::Mailbox<msg_t, 16> storageManagerMb;
+
+#define MSG_CMD_WRITE		(0)
+// force settings save independently of mcuCanFlashWhileRunning()
+#define MSG_CMD_WRITE_NOW	(1)
+#define MSG_CMD_READ		(2)
+#define MSG_CMD_PING		(3)
+
+#define MSG_ID_MASK		0x1f
+
+static bool storageWriteID(uint32_t id) {
+	// Do the actual flash write operation for given ID
+	if (id == EFI_SETTINGS_RECORD_ID) {
+		return writeToFlashNowImpl();
+	} else if (id == EFI_LTFT_RECORD_ID) {
+		engine->module<LongTermFuelTrim>()->store();
+		return true;
+	} else {
+		efiPrintf("Requested to write unknown record id %ld", id);
+		// to clear pending bit
+		return true;
+	}
+	return true;
+}
+
+static bool storageReadID(uint32_t id) {
+	// Do actual read and call consumers callback
+
+	if (id == EFI_LTFT_RECORD_ID) {
+		engine->module<LongTermFuelTrim>()->load();
+		return true;
+	} else {
+		efiPrintf("Requested to read unknown record id %ld", id);
+		// to clear pending bit
+		return true;
+	}
+}
+
+static const char *storageTypeToName(StorageType type) {
 	switch (type) {
 	case STORAGE_INT_FLASH:
 		return "INT_FLASH";
@@ -51,8 +123,7 @@ static const char *storageTypeToName(StorageType type)
 	for (size_t i = 0; i < storagesCount; i++) \
 		if ((storage = storages[i]) != nullptr)
 
-bool storageIsIdAvailable(int id)
-{
+static bool storageIsIdAvailableForId(StorageItemId id) {
 	for_all_storages {
 		if ((storage->isReady()) && (storage->isIdSupported(id))) {
 			return true;
@@ -62,8 +133,7 @@ bool storageIsIdAvailable(int id)
 	return false;
 }
 
-StorageStatus storageWrite(int id, const uint8_t *ptr, size_t size)
-{
+StorageStatus storageWrite(StorageItemId id, const uint8_t *ptr, size_t size) {
 	bool success = false;
 	StorageStatus status = StorageStatus::NotSupported;
 
@@ -81,8 +151,7 @@ StorageStatus storageWrite(int id, const uint8_t *ptr, size_t size)
 	return (success ? StorageStatus::Ok : status);
 }
 
-StorageStatus storageRead(int id, uint8_t *ptr, size_t size)
-{
+StorageStatus storageRead(StorageItemId id, uint8_t *ptr, size_t size) {
 	bool success = false;
 	StorageStatus status = StorageStatus::NotSupported;
 
@@ -100,8 +169,23 @@ StorageStatus storageRead(int id, uint8_t *ptr, size_t size)
 	return (success ? StorageStatus::Ok : status);
 }
 
-bool storageRegisterStorage(StorageType type, SettingStorageBase *storage)
+static bool storageManagerSendCmd(uint32_t cmd, uint32_t arg)
 {
+	msg_t msg = ((cmd & 0xff) << 24) | (arg & 0x00ffffff);
+	// Note: we are not sure about caller context and using universal (but not optimal) chSysGetStatusAndLockX()
+	chibios_rt::CriticalSectionLocker csl;
+	return (storageManagerMb.postI(msg) == MSG_OK);
+}
+
+bool storageRequestWriteID(StorageItemId id, bool forced) {
+	return storageManagerSendCmd(forced ? MSG_CMD_WRITE_NOW : MSG_CMD_WRITE, (uint32_t)id);
+}
+
+bool storageReqestReadID(StorageItemId id) {
+	return storageManagerSendCmd(MSG_CMD_READ, (uint32_t)id);
+}
+
+bool storageRegisterStorage(StorageType type, SettingStorageBase *storage) {
 	if (type >= STORAGE_TOTAL) {
 		return false;
 	}
@@ -115,13 +199,12 @@ bool storageRegisterStorage(StorageType type, SettingStorageBase *storage)
 	storages[type] = storage;
 	efiPrintf("Storage %s registered", storageTypeToName(type));
 
-	/* TODO: notificate storage manager about newly added storage */
+	storageManagerSendCmd(MSG_CMD_PING, 0);
 
 	return true;
 }
 
-bool storageUnregisterStorage(StorageType type)
-{
+bool storageUnregisterStorage(StorageType type) {
 	if (type >= STORAGE_TOTAL) {
 		return false;
 	}
@@ -138,8 +221,88 @@ bool storageUnregisterStorage(StorageType type)
 	return true;
 }
 
-void initStorage()
-{
+static uint32_t pendingWrites = 0;
+static uint32_t pendingReads = 0;
+
+#if (EFI_STORAGE_MFS == TRUE) || (EFI_STORAGE_SD == TRUE)
+/* in case of MFS or SD card we need more stack */
+static THD_WORKING_AREA(storageManagerThreadStack, 3 * UTILITY_THREAD_STACK_SIZE);
+#else
+static THD_WORKING_AREA(storageManagerThreadStack, UTILITY_THREAD_STACK_SIZE);
+#endif
+
+static void storageManagerThread(void*) {
+	chRegSetThreadName("storage manger");
+
+	while (true) {
+		msg_t ret;
+		msg_t msg;
+
+		// Wait for a request to come in or timeout
+		ret = storageManagerMb.fetch(&msg, TIME_MS2I(STORAGE_MANAGER_POLL_INTERVAL_MS));
+		if (ret == MSG_OK) {
+			uint8_t cmd = (msg >> 24) & 0xff;
+			uint32_t id = msg & MSG_ID_MASK;
+
+			if (cmd == MSG_CMD_READ) {
+				pendingReads |= BIT(id);
+			} else if (cmd == MSG_CMD_WRITE) {
+				pendingWrites |= BIT(id);
+			} else if (cmd == MSG_CMD_WRITE_NOW) {
+				pendingWrites |= BIT(id);
+				// skip storageAllowWriteID() check
+				if (storageWriteID(id)) {
+					pendingWrites &= ~BIT(id);
+				}
+			} else if (cmd == MSG_CMD_PING) {
+				/* nop */
+			}
+		}
+
+		// check if we can read sone of pending IDs...
+		for (size_t i = 0; (i < EFI_STORAGE_TOTAL_ITEMS) && pendingReads; i++) {
+			if ((pendingReads & BIT(i)) == 0) {
+				continue;
+			}
+
+			StorageItemId id = (StorageItemId)i;
+			if (!storageIsIdAvailableForId(id)) {
+				continue;
+			}
+
+			if (storageReadID(id)) {
+				pendingReads &= ~BIT(id);
+			}
+		}
+
+		// check if we can write some of pendind IDs...
+		for (size_t i = 0; (i < EFI_STORAGE_TOTAL_ITEMS) && pendingWrites; i++) {
+			if ((pendingWrites & BIT(i)) == 0) {
+				continue;
+			}
+
+			StorageItemId id = (StorageItemId)i;
+			if (!storageIsIdAvailableForId(id)) {
+				continue;
+			}
+
+			if (!storageAllowWriteID(id)) {
+				continue;
+			}
+
+			if (storageWriteID(id)) {
+				pendingWrites &= ~BIT(id);
+			}
+		}
+	}
+}
+
+/* misc helpers */
+bool getNeedToWriteConfiguration() {
+	return (pendingWrites & BIT(EFI_SETTINGS_RECORD_ID)) != 0;
+}
+
+void initStorage() {
 #if EFI_STORAGE_INT_FLASH == TRUE
 	initStorageFlash();
 #endif // STORAGE_SD_CARD
@@ -154,6 +317,8 @@ void initStorage()
 	// restart the watchdog with the default timeout
 	startWatchdog();
 #endif // EFI_STORAGE_MFS
+
+	chThdCreateStatic(storageManagerThreadStack, sizeof(storageManagerThreadStack), PRIO_STORAGE_MANAGER, storageManagerThread, nullptr);
 }
 
 #endif // EFI_CONFIGURATION_STORAGE

--- a/firmware/controllers/storage.cpp
+++ b/firmware/controllers/storage.cpp
@@ -42,13 +42,24 @@ static SettingStorageBase *storages[storageCount];
 #define for_all_storages	SettingStorageBase* storage = nullptr; \
 	for (size_t i = 0; (i < storageCount) && ((storage = storages[i]) != nullptr); i++)
 
+bool storageIsIdAvailable(int id)
+{
+	for_all_storages {
+		if ((storage->isReady()) && (storage->isIdSupported(id))) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
 StorageStatus storageWrite(int id, const uint8_t *ptr, size_t size)
 {
 	bool success = false;
 	StorageStatus status = StorageStatus::NotSupported;
 
 	for_all_storages {
-		if (!storage->isIdSupported(id)) {
+		if ((!storage->isReady()) || (!storage->isIdSupported(id))) {
 			continue;
 		}
 
@@ -67,7 +78,7 @@ StorageStatus storageRead(int id, uint8_t *ptr, size_t size)
 	StorageStatus status = StorageStatus::NotSupported;
 
 	for_all_storages {
-		if (!storage->isIdSupported(id)) {
+		if ((!storage->isReady()) || (!storage->isIdSupported(id))) {
 			continue;
 		}
 

--- a/firmware/controllers/storage.h
+++ b/firmware/controllers/storage.h
@@ -53,11 +53,22 @@ enum StorageItemId {
 	EFI_STORAGE_TOTAL_ITEMS
 };
 
-bool storageIsIdAvailable(int id);
-StorageStatus storageWrite(int id, const uint8_t *ptr, size_t size);
-StorageStatus storageRead(int id, uint8_t *ptr, size_t size);
+// exported for unit tests only
+bool storageAllowWriteID(StorageItemId id);
+
+StorageStatus storageWrite(StorageItemId id, const uint8_t *ptr, size_t size);
+StorageStatus storageRead(StorageItemId id, uint8_t *ptr, size_t size);
+
+// request storage manager to read or write given ID from its own context when storage is ready
+bool storageRequestWriteID(StorageItemId id, bool forced);
+bool storageReqestReadID(StorageItemId id);
 
 bool storageRegisterStorage(StorageType type, SettingStorageBase *storage);
 bool storageUnregisterStorage(StorageType type);
+
+/**
+ * @return true if an persistentState write is pending
+ */
+bool getNeedToWriteConfiguration();
 
 void initStorage();

--- a/firmware/controllers/storage.h
+++ b/firmware/controllers/storage.h
@@ -34,11 +34,14 @@ public:
 	virtual StorageStatus format() = 0;
 };
 
-bool storageIsIdAvailable(int id);
-StorageStatus storageWrite(int id, const uint8_t *ptr, size_t size);
-StorageStatus storageRead(int id, uint8_t *ptr, size_t size);
+enum StorageType {
+	STORAGE_INT_FLASH = 0,
+	STORAGE_MFS_INT_FLASH = 1,
+	STORAGE_MFS_EXT_FLASH = 2,
+	STORAGE_SD_CARD = 3,
 
-void initStorage();
+	STORAGE_TOTAL
+};
 
 // IDs used as MFS record ids and internal RusEFI ids
 enum StorageItemId {
@@ -49,3 +52,12 @@ enum StorageItemId {
 
 	EFI_STORAGE_TOTAL_ITEMS
 };
+
+bool storageIsIdAvailable(int id);
+StorageStatus storageWrite(int id, const uint8_t *ptr, size_t size);
+StorageStatus storageRead(int id, uint8_t *ptr, size_t size);
+
+bool storageRegisterStorage(StorageType type, SettingStorageBase *storage);
+bool storageUnregisterStorage(StorageType type);
+
+void initStorage();

--- a/firmware/controllers/storage.h
+++ b/firmware/controllers/storage.h
@@ -22,12 +22,19 @@ enum class StorageStatus {
 
 class SettingStorageBase {
 public:
+	/* is storage ready? */
+	virtual bool isReady() = 0;
+	/* does storage able to srore given ID? */
 	virtual bool isIdSupported(size_t id) = 0;
+	/* store given ID */
 	virtual StorageStatus store(size_t id, const uint8_t *ptr, size_t size) = 0;
+	/* read given ID */
 	virtual StorageStatus read(size_t id, uint8_t *ptr, size_t size) = 0;
+	/* format/esare storage */
 	virtual StorageStatus format() = 0;
 };
 
+bool storageIsIdAvailable(int id);
 StorageStatus storageWrite(int id, const uint8_t *ptr, size_t size);
 StorageStatus storageRead(int id, uint8_t *ptr, size_t size);
 

--- a/firmware/controllers/storage_flash.cpp
+++ b/firmware/controllers/storage_flash.cpp
@@ -17,6 +17,7 @@
 
 class SettingStorageFlash : public SettingStorageBase {
 public:
+	bool isReady() override;
 	bool isIdSupported(size_t id) override;
 	StorageStatus store(size_t id, const uint8_t *ptr, size_t size) override;
 	StorageStatus read(size_t id, uint8_t *ptr, size_t size) override;
@@ -26,8 +27,7 @@ private:
 	flashaddr_t getIdAddress(size_t id);
 };
 
-flashaddr_t SettingStorageFlash::getIdAddress(size_t id)
-{
+flashaddr_t SettingStorageFlash::getIdAddress(size_t id) {
 	if (id == EFI_SETTINGS_RECORD_ID) {
 		return getFlashAddrFirstCopy();
 	} else if (id == EFI_SETTINGS_BACKUP_RECORD_ID) {
@@ -37,8 +37,11 @@ flashaddr_t SettingStorageFlash::getIdAddress(size_t id)
 	return 0;
 }
 
-bool SettingStorageFlash::isIdSupported(size_t id)
-{
+bool SettingStorageFlash::isReady() {
+	return true;
+}
+
+bool SettingStorageFlash::isIdSupported(size_t id) {
 	return (getIdAddress(id) != 0);
 }
 

--- a/firmware/controllers/storage_flash.cpp
+++ b/firmware/controllers/storage_flash.cpp
@@ -114,8 +114,8 @@ StorageStatus SettingStorageFlash::format() {
 
 static SettingStorageFlash storageFlash;
 
-SettingStorageBase *initStorageFlash() {
-	return &storageFlash;
+bool initStorageFlash() {
+	return storageRegisterStorage(STORAGE_INT_FLASH, &storageFlash);
 }
 
 #endif //EFI_STORAGE_SD

--- a/firmware/controllers/storage_flash.h
+++ b/firmware/controllers/storage_flash.h
@@ -8,4 +8,4 @@
 
 #pragma once
 
-SettingStorageBase *initStorageFlash();
+bool initStorageFlash();

--- a/firmware/controllers/storage_mfs.cpp
+++ b/firmware/controllers/storage_mfs.cpp
@@ -18,6 +18,7 @@
 
 class SettingStorageMFS : public SettingStorageBase {
 public:
+	bool isReady() override;
 	bool isIdSupported(size_t id) override;
 	StorageStatus store(size_t id, const uint8_t *ptr, size_t size) override;
 	StorageStatus read(size_t id, uint8_t *ptr, size_t size) override;
@@ -27,12 +28,17 @@ public:
 		m_drv = drv;
 	}
 
+	bool m_ready = false;
+
 private:
 	MFSDriver *m_drv;
 };
 
-bool SettingStorageMFS::isIdSupported(size_t id)
-{
+bool SettingStorageMFS::isReady(){
+	return m_ready;
+}
+
+bool SettingStorageMFS::isIdSupported(size_t id) {
 #if (EFI_STORAGE_INT_FLASH == TRUE)
 	// If internal flash storage is enabled - settings are stored in there
 	if ((id == EFI_SETTINGS_RECORD_ID) ||
@@ -129,6 +135,8 @@ SettingStorageBase *initStorageMfs() {
 	}
 
 	//addConsoleAction("erasestorage", eraseStorage);
+
+	storageMFS.m_ready = true;
 
 	return &storageMFS;
 }

--- a/firmware/controllers/storage_mfs.cpp
+++ b/firmware/controllers/storage_mfs.cpp
@@ -122,7 +122,7 @@ static SettingStorageMFS storageMFS(&mfsd);
 extern void boardInitMfs(void);
 extern const MFSConfig *boardGetMfsConfig(void);
 
-SettingStorageBase *initStorageMfs() {
+bool initStorageMfs() {
 	boardInitMfs();
 	const MFSConfig *mfsConfig = boardGetMfsConfig();
 
@@ -131,14 +131,14 @@ SettingStorageBase *initStorageMfs() {
 	mfs_error_t err = mfsStart(&mfsd, mfsConfig);
 	if (err < MFS_NO_ERROR) {
 		efiPrintf("MFS: storage failed to start: %d", err);
-		return nullptr;
+		return false;
 	}
 
 	//addConsoleAction("erasestorage", eraseStorage);
 
 	storageMFS.m_ready = true;
 
-	return &storageMFS;
+	return storageRegisterStorage(STORAGE_MFS_EXT_FLASH, &storageMFS);
 }
 
 #endif //EFI_STORAGE_MFS

--- a/firmware/controllers/storage_mfs.h
+++ b/firmware/controllers/storage_mfs.h
@@ -10,4 +10,4 @@
 
 #include "storage.h"
 
-SettingStorageBase *initStorageMfs();
+bool initStorageMfs();

--- a/firmware/controllers/storage_sd.cpp
+++ b/firmware/controllers/storage_sd.cpp
@@ -141,8 +141,12 @@ static NO_CACHE FIL fd;
 
 static SettingStorageSD storageSD(&fd);
 
-SettingStorageBase *initStorageSD() {
-	return &storageSD;
+bool initStorageSD() {
+	return storageRegisterStorage(STORAGE_SD_CARD, &storageSD);
+}
+
+bool deinitStorageSD() {
+	return storageUnregisterStorage(STORAGE_SD_CARD);
 }
 
 #endif //EFI_STORAGE_SD

--- a/firmware/controllers/storage_sd.cpp
+++ b/firmware/controllers/storage_sd.cpp
@@ -18,10 +18,12 @@
 #endif
 
 #include "ff.h"
+#include "mmc_card.h"
 #include "mmc_card_util.h"
 
 class SettingStorageSD : public SettingStorageBase {
 public:
+	bool isReady() override;
 	bool isIdSupported(size_t id) override;
 	StorageStatus store(size_t id, const uint8_t *ptr, size_t size) override;
 	StorageStatus read(size_t id, uint8_t *ptr, size_t size) override;
@@ -36,8 +38,7 @@ private:
 	FIL *m_fd;
 };
 
-const char *SettingStorageSD::getIdFileName(size_t id)
-{
+const char *SettingStorageSD::getIdFileName(size_t id) {
 	switch (id) {
 	case EFI_LTFT_RECORD_ID:
 		return "ltft.bin";
@@ -46,8 +47,11 @@ const char *SettingStorageSD::getIdFileName(size_t id)
 	}
 }
 
-bool SettingStorageSD::isIdSupported(size_t id)
-{
+bool SettingStorageSD::isReady() {
+	return (sdCardGetCurrentMode() == SD_MODE_ECU);
+}
+
+bool SettingStorageSD::isIdSupported(size_t id) {
 	return (getIdFileName(id) != nullptr);
 }
 

--- a/firmware/controllers/storage_sd.h
+++ b/firmware/controllers/storage_sd.h
@@ -8,4 +8,5 @@
 
 #pragma once
 
-SettingStorageBase *initStorageSD();
+bool initStorageSD();
+bool deinitStorageSD();

--- a/firmware/controllers/thread_priority.h
+++ b/firmware/controllers/thread_priority.h
@@ -49,7 +49,7 @@
 #define PRIO_BENCH_TEST (NORMALPRIO - 10)
 
 // These are intentionally low priority so they can't get in the way of anything else
-#define PRIO_FLASH_WRITE LOWPRIO + 20
+#define PRIO_STORAGE_MANAGER LOWPRIO + 20
 
 // USB mass storage
 #define MSD_THD_PRIO LOWPRIO + 20

--- a/firmware/hw_layer/mmc_card.cpp
+++ b/firmware/hw_layer/mmc_card.cpp
@@ -43,6 +43,10 @@ static bool sdLoggerReady = false;
 
 #include "rtc_helper.h"
 
+#if EFI_STORAGE_SD == TRUE
+#include "storage_sd.h"
+#endif // EFI_STORAGE_SD
+
 // TODO: do we need this additioal layer of buffering?
 // FIL structure already have buffer of FF_MAX_SS size
 // check if it is better to increase FF_MAX_SS and drop BufferedWriter?
@@ -571,6 +575,11 @@ static bool mountMmc() {
 		efiPrintf("MMC/SD mounted!");
 	}
 
+#if EFI_STORAGE_SD == TRUE
+	// notificate storage subsystem
+	initStorageSD();
+#endif // EFI_STORAGE_SD
+
 #if EFI_TUNER_STUDIO
 	engine->outputChannels.sd_logging_internal = ret;
 #endif
@@ -584,6 +593,12 @@ static bool mountMmc() {
  */
 static void unmountMmc() {
 	FRESULT ret;
+
+#if EFI_STORAGE_SD == TRUE
+	// notificate storage subsystem
+	deinitStorageSD();
+#endif // EFI_STORAGE_SD
+
 	// FATFS: Unregister work area prior to discard it
 	ret = f_unmount("");
 	if (ret != FR_OK) {

--- a/firmware/hw_layer/mmc_card.cpp
+++ b/firmware/hw_layer/mmc_card.cpp
@@ -566,13 +566,13 @@ static bool mountMmc() {
 
 		if (ret == false) {
 			sdStatus = SD_STATUS_MOUNT_FAILED;
-			efiPrintf("MMC/SD card mount failed!");
+			efiPrintf("SD card mount failed!");
 		}
 	}
 
 	if (ret) {
 		sdStatus = SD_STATUS_MOUNTED;
-		efiPrintf("MMC/SD mounted!");
+		efiPrintf("SD card mounted!");
 	}
 
 #if EFI_STORAGE_SD == TRUE
@@ -588,7 +588,7 @@ static bool mountMmc() {
 }
 
 /*
- * MMC card un-mount.
+ * SD card un-mount.
  * @return true if we had SD card alive
  */
 static void unmountMmc() {
@@ -615,12 +615,12 @@ static void unmountMmc() {
 #else // not EFI_PROD_CODE (simulator)
 
 bool initMmc() {
-	// Stub so the loop thinks the MMC is present
+	// Stub so the loop thinks the SD is present
 	return true;
 }
 
 bool mountMmc() {
-	// Stub so the loop thinks the MMC mounted OK
+	// Stub so the loop thinks the SD mounted OK
 	return true;
 }
 
@@ -874,7 +874,7 @@ static THD_WORKING_AREA(mmcThreadStack, 3 * UTILITY_THREAD_STACK_SIZE);		// MMC 
 static THD_FUNCTION(MMCmonThread, arg) {
 	(void)arg;
 
-	chRegSetThreadName("MMC Card Logger");
+	chRegSetThreadName("SD Card Logger");
 
 	while (!boardSdCardEnable()) {
 		// wait until board enables peripheral

--- a/unit_tests/tests/controllers/test_flash.cpp
+++ b/unit_tests/tests/controllers/test_flash.cpp
@@ -8,14 +8,13 @@
 
 #include "pch.h"
 #include "storage.h"
-#include "flash_main.h"
 #include "engine_test_helper.h"
 
 bool canFlashWhileRunning = true;
 
 bool mcuCanFlashWhileRunning() { return canFlashWhileRunning; }
 
-TEST(Flash, AllowWriteID) {
+TEST(Storage, AllowWriteID) {
     EngineTestHelper eth(engine_type_e::TEST_ENGINE);
     engine->rpmCalculator.setStopSpinning();
 
@@ -23,26 +22,26 @@ TEST(Flash, AllowWriteID) {
     engine->triggerCentral.directSelfStimulation = false;
     // Mock that MCU can flash while running
     canFlashWhileRunning = true;
-    EXPECT_TRUE(flashAllowWriteID(EFI_SETTINGS_RECORD_ID));
+    EXPECT_TRUE(storageAllowWriteID(EFI_SETTINGS_RECORD_ID));
 
     // Settings record with MCU that cannot flash while running,
     // but engine is in self-stimulation mode
     canFlashWhileRunning = false;
     engine->triggerCentral.directSelfStimulation = true;
-    EXPECT_TRUE(flashAllowWriteID(EFI_SETTINGS_RECORD_ID));
+    EXPECT_TRUE(storageAllowWriteID(EFI_SETTINGS_RECORD_ID));
 
     // Settings record with MCU that cannot flash while running,
     // engine not in self-stimulation but stopped
     engine->triggerCentral.directSelfStimulation = false;
     engine->rpmCalculator.setStopSpinning();
-    EXPECT_TRUE(flashAllowWriteID(EFI_SETTINGS_RECORD_ID));
+    EXPECT_TRUE(storageAllowWriteID(EFI_SETTINGS_RECORD_ID));
 
     // Settings record with MCU that cannot flash while running,
     // engine running (should not allow write)
     engine->rpmCalculator.setRpmValue(1000);
-    EXPECT_FALSE(flashAllowWriteID(EFI_SETTINGS_RECORD_ID));
+    EXPECT_FALSE(storageAllowWriteID(EFI_SETTINGS_RECORD_ID));
 
     // Non-settings record (should always allow write)
-    EXPECT_TRUE(flashAllowWriteID(EFI_LTFT_RECORD_ID));
-    EXPECT_TRUE(flashAllowWriteID(123)); // Some random ID
+    EXPECT_TRUE(storageAllowWriteID(EFI_LTFT_RECORD_ID));
+    EXPECT_TRUE(storageAllowWriteID((StorageItemId)123)); // Some random ID
 }


### PR DESCRIPTION
SD card takes some time to init. Initialization is done from separate thread after engine modules init is done.
We need way to notificate storage users that storage is ready and calibration can be loaded.
Implement such for LTFT.