### PR TITLE
Storage: do not stuck for 5..7 second on starts if MFS enabled

### DIFF
--- a/firmware/controllers/long_term_fuel_trim.cpp
+++ b/firmware/controllers/long_term_fuel_trim.cpp
@@ -219,9 +219,10 @@ void LongTermFuelTrim::reset() {
 }
 
 void LongTermFuelTrim::onSlowCallback() {
+	// we can wait some time for LTFT to be loaded from storage...
 	if ((ltftLearning) &&
 #if EFI_SHAFT_POSITION_INPUT
-		(engine->rpmCalculator.getSecondsSinceEngineStart(getTimeNowNt()) > 1.0) &&
+		(engine->rpmCalculator.getSecondsSinceEngineStart(getTimeNowNt()) > 5.0) &&
 #endif
 		(1)) {
 		efiPrintf("LTFT: failed to load calibrations");

--- a/firmware/hw_layer/ports/mpu_watchdog.h
+++ b/firmware/hw_layer/ports/mpu_watchdog.h
@@ -18,7 +18,8 @@
 #define WATCHDOG_TIMEOUT_MS (5 * WATCHDOG_RESET_MS)
 // 5 secs should be enough to wait until 
 #define WATCHDOG_FLASH_TIMEOUT_MS 5000
-
+// MFS startup time in case of garbage collection can take a loooot of time
+#define WATCHDOG_MFS_START_TIMEOUT_MS 7000
 
 // we use 'int' for compatibility with addConsoleActionI()
 // can be called multiple times to change the timeout

--- a/firmware/hw_layer/ports/stm32/use_higher_level_flash_api.mk
+++ b/firmware/hw_layer/ports/stm32/use_higher_level_flash_api.mk
@@ -1,8 +1,6 @@
 # this header is relevant both for modern driver to access internal flash, and for external flash persistence
 # see also 'HAL_USE_EFL' in case of internal flash
 
-# do not use legacy implementation to persist calibrations
-DDEFS += -DEFI_STORAGE_INT_FLASH=FALSE
 # use higher level API instead
 DDEFS += -DEFI_STORAGE_MFS=TRUE
 # Are we going to store something else but settings?

--- a/simulator/simulator/sim_watchdog.h
+++ b/simulator/simulator/sim_watchdog.h
@@ -18,6 +18,8 @@
 #define WATCHDOG_TIMEOUT_MS (3 * WATCHDOG_RESET_MS)
 // 5 secs should be enough to wait until
 #define WATCHDOG_FLASH_TIMEOUT_MS 5000
+// MFS startup time in case of garbage collection can take a loooot of time
+#define WATCHDOG_MFS_START_TIMEOUT_MS 7000
 
 
 // we use 'int' for compatibility with addConsoleActionI()


### PR DESCRIPTION
In both internal flash and MFS are enabled we can skip MFS initialization during startup. persistentState is loaded from internal flash.
MFS is used for LTFT and it can wait.