### PR TITLE
Celsius/ Fahrenheit handling on .ini generator

### DIFF
--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -50,7 +50,9 @@
 ! type name;comment;"units",scale,offset,min,max,number_of_digits
 ! hello;I like rusEFI;"ms",1,0,-10,10,2
 !
-!
+! for using temperature fields, you maybe want to use "SPECIAL_CASE_TEMPERATURE"
+! so we can auto-generate the TS conditional on the final ini, all the temperature-related fields, should be treated in celsius in the code,
+! they wel be represented on fahrenheit only on the TS interface
 !
 ! Q: what's the difference between 'engineConfiguration' and rest of the 'persistent_config_s'?
 ! A: 'engineConfiguration' portion has 'activeConfiguration' copy so that we can detect changes
@@ -1961,11 +1963,11 @@ custom lua_script_t @@LUA_SCRIPT_SIZE@@ string, ASCII, @OFFSET@, @@LUA_SCRIPT_SI
 lua_script_t luaScript;
 
 #define CLT_FUEL_CURVE_SIZE 16
-float[CLT_FUEL_CURVE_SIZE] cltFuelCorrBins;;"C", 1, 0, -100, @@CLT_UPPER_LIMIT@@, 2
+float[CLT_FUEL_CURVE_SIZE] cltFuelCorrBins;;"SPECIAL_CASE_TEMPERATURE", 1, 0, -100, @@CLT_UPPER_LIMIT@@, 2
 float[CLT_FUEL_CURVE_SIZE] cltFuelCorr;;"ratio", 1, 0, 0, 5, 2
 
 #define IAT_CURVE_SIZE 16
-float[IAT_CURVE_SIZE] iatFuelCorrBins;;"C", 1, 0, -100, @@CLT_UPPER_LIMIT@@, 2
+float[IAT_CURVE_SIZE] iatFuelCorrBins;;"SPECIAL_CASE_TEMPERATURE", 1, 0, -100, @@CLT_UPPER_LIMIT@@, 2
 float[IAT_CURVE_SIZE] iatFuelCorr;;"ratio", 1, 0, 0, 5, 2
 
 	float[CRANKING_CURVE_SIZE] crankingFuelCoef;;"ratio", 1, 0, 0, 50, 2

--- a/firmware/tunerstudio/tunerstudio.template.ini
+++ b/firmware/tunerstudio/tunerstudio.template.ini
@@ -562,6 +562,7 @@ page = 3
 		yBins		= mafDecoding
 		gauge		= rawMafGauge
 
+#if CELSIUS
 	curve = iatFuelCorrCurve, "Intake air temperature fuel Multiplier"
 	    topicHelp = "iatFuelCorrCurveHelp"
 		columnLabel = "Air Temp", "Multiplier"
@@ -570,12 +571,22 @@ page = 3
 		xBins		= iatFuelCorrBins, intake
 		yBins		= iatFuelCorr
 		gauge		= IATGauge
+#else
+	curve = iatFuelCorrCurve, "Intake air temperature fuel Multiplier"
+		topicHelp = "iatFuelCorrCurveHelp"
+		columnLabel = "Air Temp", "Multiplier"
+		xAxis		=  -40, 248, 9
+		yAxis		=  0,  2, 11
+		xBins		= iatFuelCorrBins, intake
+		yBins		= iatFuelCorr
+		gauge		= IATGauge
+#endif
 
 	curve = cltFuelCorrCurve, "Warmup fuel manual Multiplier"
 		columnLabel = "Coolant", "Multiplier"
 		xAxis		=  -40, 120, 9
 		yAxis		=  0,  3, 10
-		xBins		= cltFuelCorrBins, coolant
+		xBins		= cltFuelCorrBins, coolantTemperature
 		yBins		= cltFuelCorr
 		gauge		= CLTGauge
 

--- a/firmware/tunerstudio/tunerstudio.template.ini
+++ b/firmware/tunerstudio/tunerstudio.template.ini
@@ -244,6 +244,9 @@ page = 3
 	; this output channels are used on tables/curves, so we need to make a new output chanel and then override it here with the celsius conditional
 	coolantTemperature = { coolant }
 	intakeTemperature = { intake }
+	; this are used in the 3D table axis
+	cltHighXaxis = { 120 }
+	iattHighXaxis = { 120 }
 #else
 	intakeTemperature = { intake * 1.8 + 32 }
 	coolantTemperature = { coolant * 1.8 + 32 }
@@ -252,6 +255,9 @@ page = 3
 	; and use it on the corresponding Gauge with the celsius conditional
 	wb1tempF = { wb1tempC * 1.8 + 32 }
 	wb2tempF = { wb1tempC * 1.8 + 32 }
+
+	cltHighXaxis = { 248 }
+	iatHighXaxis = { 248 }
 #endif
 
 [PcVariables]
@@ -562,29 +568,18 @@ page = 3
 		yBins		= mafDecoding
 		gauge		= rawMafGauge
 
-#if CELSIUS
 	curve = iatFuelCorrCurve, "Intake air temperature fuel Multiplier"
 	    topicHelp = "iatFuelCorrCurveHelp"
 		columnLabel = "Air Temp", "Multiplier"
-		xAxis		=  -40, 120, 9
+		xAxis		=  -40, { iatHighXaxis }, 9
 		yAxis		=  0,  2, 11
-		xBins		= iatFuelCorrBins, intake
+		xBins		= iatFuelCorrBins, intakeTemperature
 		yBins		= iatFuelCorr
 		gauge		= IATGauge
-#else
-	curve = iatFuelCorrCurve, "Intake air temperature fuel Multiplier"
-		topicHelp = "iatFuelCorrCurveHelp"
-		columnLabel = "Air Temp", "Multiplier"
-		xAxis		=  -40, 248, 9
-		yAxis		=  0,  2, 11
-		xBins		= iatFuelCorrBins, intake
-		yBins		= iatFuelCorr
-		gauge		= IATGauge
-#endif
 
 	curve = cltFuelCorrCurve, "Warmup fuel manual Multiplier"
 		columnLabel = "Coolant", "Multiplier"
-		xAxis		=  -40, 120, 9
+		xAxis		=  -40, { cltHighXaxis }, 9
 		yAxis		=  0,  3, 10
 		xBins		= cltFuelCorrBins, coolantTemperature
 		yBins		= cltFuelCorr

--- a/firmware/tunerstudio/tunerstudio.template.ini
+++ b/firmware/tunerstudio/tunerstudio.template.ini
@@ -246,7 +246,7 @@ page = 3
 	intakeTemperature = { intake }
 	; this are used in the 3D table axis
 	cltHighXaxis = { 120 }
-	iattHighXaxis = { 120 }
+	iatHighXaxis = { 120 }
 #else
 	intakeTemperature = { intake * 1.8 + 32 }
 	coolantTemperature = { coolant * 1.8 + 32 }

--- a/java_tools/configuration_definition_base/src/main/java/com/rusefi/output/TsOutput.java
+++ b/java_tools/configuration_definition_base/src/main/java/com/rusefi/output/TsOutput.java
@@ -28,6 +28,13 @@ public class TsOutput {
     private final boolean isConstantsSection;
     private final StringBuilder tsHeader = new StringBuilder();
     private final TreeSet<String> usedNames = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
+    private final String celsiusConditionalStart = "#if CELSIUS" + EOL;
+    private final String celsiusConditionalElse = "#else" + EOL;
+    private final String celsiusConditionalEnd = "#endif" + EOL;
+    private final String temperatureCelsiusUnit = quote("C");
+    private final String temperatureFahrenheitUnit = quote("F");
+    private final String temperatureToFahrenheitScale = "{ 9 / 5 }";
+    private final String temperatureToFahrenheitTranslate = "17.77777";
 
     public TsOutput(boolean longForm) {
         this.isConstantsSection = longForm;
@@ -100,6 +107,7 @@ public class TsOutput {
 				ConfigField next = it.next;
 				int bitIndex = it.bitState.get();
 				String nameWithPrefix = prefix + variableNamePrefix + configField.getName();
+				String originalUnits = configField.getUnits();
                 ConfigStructure cs = configField.getStructureType();
 
                 /**
@@ -148,6 +156,21 @@ public class TsOutput {
                     return it.adjustSize(tsPosition);
                 }
 
+                 // if the units are SPECIAL_CASE_TEMPERATURE, we are going to deal with a temperature-based config
+                // so we need to edit the unit first on C degree, and then on F degree, also the TS conditional is added here
+                if (originalUnits.startsWith("SPECIAL_CASE_TEMPERATURE")) {
+                    // first the Celsius case, and save the index after writing the field
+                    configField.setTsInfo(formatTemperatureTsInfo(configField.getTsInfo(), false));
+                    tsHeader.append(celsiusConditionalStart);
+                    int newIndex = writeFieldJob(nameWithPrefix, configField, next, tsPosition, bitIndex, nameWithPrefix, cs);
+                    tsHeader.append(celsiusConditionalElse);
+                    // now the fahrenheit case:
+                    configField.setTsInfo(formatTemperatureTsInfo(configField.getTsInfo(), true));
+                    writeFieldJob(nameWithPrefix, configField, next, tsPosition, bitIndex, nameWithPrefix, cs);
+                    tsHeader.append(celsiusConditionalEnd);
+                    return newIndex;
+                }
+
 				return writeFieldJob(nameWithPrefix, configField, next, tsPosition, bitIndex, nameWithPrefix, cs);
 			}
 		};
@@ -157,6 +180,32 @@ public class TsOutput {
             tsHeader.append("; total TS size = " + structureStartingTsPosition + EOL);
         }
         return structureStartingTsPosition;
+    }
+
+    private double celsiusToFahrenheit(double celsius){
+        return celsius * 1.8 + 32;
+    }
+
+    private String formatTemperatureTsInfo(String tsInfo, boolean isFahrenheit){
+        if (tsInfo == null || tsInfo.trim().isEmpty()) {
+            // this case is handle by handleTsInfo, so we return a empty string
+            return "";
+        }
+        String[] fields = tokenizeWithBraces(tsInfo);
+
+         if (isFahrenheit){
+            // override scale/translate & units, convert min-max
+            fields[0] = temperatureFahrenheitUnit;
+            fields[1] = temperatureToFahrenheitScale;
+            fields[2] = temperatureToFahrenheitTranslate;
+            fields[3] = String.valueOf( celsiusToFahrenheit( IniField.parseDouble(fields[3]) ) ); // min
+            fields[4] = String.valueOf( celsiusToFahrenheit( IniField.parseDouble(fields[4]) ) ); // max
+         } else {
+            // override units
+            fields[0] = temperatureCelsiusUnit;
+         }
+
+          return tokensToString(fields);
     }
 
     private String handleTsInfo(ConfigField configField, String tsInfo, int multiplierIndex) {


### PR DESCRIPTION
new rusefi_config.txt syntax is: 

`float[IAT_CURVE_SIZE] iatFuelCorrBins;;"SPECIAL_CASE_TEMPERATURE", 1, 0, -100, @@CLT_UPPER_LIMIT@@, 2`

Instated of: 
`float[IAT_CURVE_SIZE] iatFuelCorrBins;;"C", 1, 0, -100, @@CLT_UPPER_LIMIT@@, 2`

note the new `SPECIAL_CASE_TEMPERATURE` unit to determine if we are dealing with temperature units

new generated .ini should be like this:

```
#if CELSIUS
iatFuelCorrBins = array, F32, 13740, [16], "C", 1, 0, -100, 250, 2
#else
iatFuelCorrBins = array, F32, 13740, [16], "F", 1.8,17.77777,-148.0,482.0, 2
#endif
``` 

~draft since needs more comments to explain how it works, and I'm afraid I've committed too many sins in this PR (fixed with the last force-push, now i split all in more small commits)~

also maybe `SPECIAL_CASE_TEMPERATURE` not the best name for this?


related #607 ; #4788

UI: 
<img width="1274" height="661" alt="image" src="https://github.com/user-attachments/assets/49af6574-38f2-4d15-9f39-4053d8b084df" />


diff vs previus .ini:

<img width="1831" height="296" alt="image" src="https://github.com/user-attachments/assets/12c40594-9da8-4176-b84b-1ed6297560e5" />
