### PR TITLE
Std function drama

### DIFF
--- a/firmware/controllers/sensors/core/proxy_sensor.h
+++ b/firmware/controllers/sensors/core/proxy_sensor.h
@@ -1,7 +1,7 @@
 /**
  * @file    proxy_sensor.h
  * @brief A sensor to duplicate a sensor to an additional SensorType.
- * 
+ *
  * This was built for the use case of "driver throttle intent" where we care what the driver's
  * right foot is doing, but that might mean TPS (cable throttle) or pedal (electronic throttle).
  *
@@ -28,9 +28,18 @@ public:
 	    return proxied ? proxied->isRedundant() : false;
 	}
 
+	void setConverter(std::function<SensorResult(SensorResult)> p_converter) {
+		converter = p_converter;
+	}
+
 private:
+	std::function<SensorResult(SensorResult)> converter = [](SensorResult arg) {
+		return arg;
+	};
+
 	SensorResult get() const override {
-		return Sensor::get(m_proxiedSensor);
+		SensorResult proxiedValue = Sensor::get(m_proxiedSensor);
+		return converter(proxiedValue);
 	}
 
 	bool hasSensor() const override {

--- a/firmware/rusefi.cpp
+++ b/firmware/rusefi.cpp
@@ -322,3 +322,10 @@ void chDbgStackOverflowPanic(thread_t *otp) {
 #endif
 	chDbgPanic3(panicMessage, __FILE__, __LINE__);
 }
+
+namespace std {
+    void __throw_bad_function_call() {
+      // something to do with lack of libc++?
+      criticalError("invalid function called");
+    }
+}


### PR DESCRIPTION
problem one:
```
Compiling main.cpp
Linking build/rusefi.elf
lto-wrapper.exe: warning: Options to '-Xassembler' do not match: -alms=build/lst/gcc_version_check.lst, -alms=build/lst/crt1.lst, dropping all '-Xassembler' and '-Wa' options.
C:/Users/runneradmin/gcc-arm-none-eabi-14.2.1-win32-x64/bin/../lib/gcc/arm-none-eabi/14.2.1/../../../../arm-none-eabi/bin/ld.exe: warning: build/rusefi.elf has a LOAD segment with RWX permissions
C:/Users/runneradmin/gcc-arm-none-eabi-14.2.1-win32-x64/bin/../lib/gcc/arm-none-eabi/14.2.1/../../../../arm-none-eabi/bin/ld.exe: C:\Users\RUNNER~1\AppData\Local\Temp\ccIiYxft.ltrans5.ltrans.o: in function `ProxySensor::get() const':
C:/Users/runneradmin/gcc-arm-none-eabi-14.2.1-win32-x64/arm-none-eabi/include/c++/14.2.1/bits/std_function.h:590:(.text._ZNK11ProxySensor3getEv+0x2e): undefined reference to `std::__throw_bad_function_call()'
collect2.exe: error: ld returned 1 exit status
make: *** [ChibiOS/os/common/startup/ARMCMx/compilers/GCC/mk/rules.mk:221: build/rusefi.elf] Error 1
Error: Process completed with exit code 1.
```


problem two while trying to solve problem one:
```
rusefi.cpp:327:38: error: attributes are not allowed on a function-definition
  327 |     void __throw_bad_function_call() __attribute__ ((noreturn)) {
      |                                      ^~~~~~~~~~~~~
rusefi.cpp: In function 'void std::__throw_bad_function_call()':
rusefi.cpp:330:5: error: 'noreturn' function does return [-Werror]
  330 |     }
```
