### PR TITLE
Storage: async api

### DIFF
--- a/firmware/config/boards/at_start_f435/board_storage.cpp
+++ b/firmware/config/boards/at_start_f435/board_storage.cpp
@@ -25,10 +25,12 @@ const MFSConfig mfscfg1 = {
   .bank1_sectors    = 32U
 };
 
-void boardInitMfs()
+bool boardInitMfs()
 {
   /* Starting EFL driver.*/
   eflStart(&EFLD2, NULL);
+
+  return true;
 }
 
 const MFSConfig *boardGetMfsConfig()

--- a/firmware/config/boards/microrusefi/board_storage.cpp
+++ b/firmware/config/boards/microrusefi/board_storage.cpp
@@ -95,7 +95,7 @@ const MFSConfig mfsd_nor_config = {
 #endif
 };
 
-void boardInitMfs()
+bool boardInitMfs()
 {
 #if SNOR_SHARED_BUS == FALSE
 	spiStart(&EFI_FLASH_SDPID, &W25SpiCfg);
@@ -124,6 +124,8 @@ void boardInitMfs()
 	 */
 	snorObjectInit(&snor1, &snor1buf);
 	snorStart(&snor1, &W25FlashConfig);
+
+	return true;
 }
 
 const MFSConfig *boardGetMfsConfig()

--- a/firmware/config/boards/subaru_eg33/board_storage.cpp
+++ b/firmware/config/boards/subaru_eg33/board_storage.cpp
@@ -42,7 +42,7 @@ const MFSConfig mfsd_nor_config = {
 	.bank1_sectors	= 128U
 };
 
-void boardInitMfs()
+bool boardInitMfs()
 {
 #if SNOR_SHARED_BUS == FALSE
 	wspiStart(&WSPID1, &WSPIcfg1);
@@ -50,6 +50,8 @@ void boardInitMfs()
 	/* Initializing and starting snor1 driver.*/
 	snorObjectInit(&snor1, &snor1buf);
 	snorStart(&snor1, &snorcfg1);
+
+	return true;
 }
 
 const MFSConfig *boardGetMfsConfig()

--- a/firmware/controllers/storage.h
+++ b/firmware/controllers/storage.h
@@ -56,6 +56,7 @@ enum StorageItemId {
 // exported for unit tests only
 bool storageAllowWriteID(StorageItemId id);
 
+// read and write storate item. executed in caller context
 StorageStatus storageWrite(StorageItemId id, const uint8_t *ptr, size_t size);
 StorageStatus storageRead(StorageItemId id, uint8_t *ptr, size_t size);
 
@@ -65,6 +66,12 @@ bool storageReqestReadID(StorageItemId id);
 
 bool storageRegisterStorage(StorageType type, SettingStorageBase *storage);
 bool storageUnregisterStorage(StorageType type);
+
+bool storageIsStorageRegistered(StorageType type);
+
+// request storage manager to attach or deattach storage from its own context
+bool storagRequestRegisterStorage(StorageType id);
+bool storagRequestUnregisterStorage(StorageType id);
 
 /**
  * @return true if an persistentState write is pending

--- a/firmware/controllers/storage_mfs.cpp
+++ b/firmware/controllers/storage_mfs.cpp
@@ -119,11 +119,14 @@ static NO_CACHE mfs_nocache_buffer_t mfsbuf;
 
 static SettingStorageMFS storageMFS(&mfsd);
 
-extern void boardInitMfs(void);
+extern bool boardInitMfs(void);
 extern const MFSConfig *boardGetMfsConfig(void);
 
 bool initStorageMfs() {
-	boardInitMfs();
+	if (boardInitMfs() == false) {
+		return false;
+	}
+
 	const MFSConfig *mfsConfig = boardGetMfsConfig();
 
 	/* MFS */


### PR DESCRIPTION
Allow registering/deregistering storages from storage manager thread.
Allow boards to indicate that MFS storage is not ready (powered off on some Hellen boards).
Hellen boards: request MFS storage attach after aux power (used for SD and SPI flash) is enabled.