### PR TITLE
logicdata_csv_reader: generate more detailed msl log

### DIFF
--- a/unit_tests/test-framework/logicdata_csv_reader.h
+++ b/unit_tests/test-framework/logicdata_csv_reader.h
@@ -32,6 +32,7 @@ public:
 	bool flipOnRead = false;
 	bool flipVvtOnRead = false;
 	int readingOffset = 0;
+	double lastTimeStamp = 0.0;
 
 	int lineIndex() const {
 		return m_lineIndex;


### PR DESCRIPTION
logicdata_csv_reader is driven by timestamps from csv file. Trigger csv files have big gaps in time. Same timestamp gaps are observed in output msl file.
This cause most of 'logic' signals look like saw toohs. Filling gaps with same data with constant rate improves msl logs and it looks more like real log with high refresh rate.

From this:
<img width="1919" height="912" alt="Screenshot from 2025-07-22 00-04-37" src="https://github.com/user-attachments/assets/6f933356-b88c-4b5e-a462-926b85aa7a18" />
To this:
<img width="1920" height="917" alt="Screenshot from 2025-07-22 00-10-46" src="https://github.com/user-attachments/assets/893ce43d-3f81-48f0-9311-315a171806d2" />
