### PR TITLE
Minor: mute compiler warnings during unittests building

### DIFF
--- a/firmware/controllers/lua/lua_hooks.cpp
+++ b/firmware/controllers/lua/lua_hooks.cpp
@@ -68,6 +68,8 @@ static int lua_readpin(lua_State* l) {
 		int physicalValue = palReadPad(getHwPort("read", pin), getHwPin("read", pin));
 		lua_pushinteger(l, physicalValue);
 	}
+#else
+    UNUSED(l);
 #endif
 	return 1;
 }
@@ -364,6 +366,7 @@ bool getAuxDigital(int index) {
 #if EFI_PROD_CODE
     return efiReadPin(engineConfiguration->luaDigitalInputPins[index]);
 #else
+    UNUSED(index);
     return false;
 #endif
 }
@@ -630,7 +633,9 @@ int lua_canRxAddMask(lua_State* l) {
 }
 #endif // EFI_CAN_SUPPORT
 
-PUBLIC_API_WEAK void boardConfigureLuaHooks(lua_State* lState) { }
+PUBLIC_API_WEAK void boardConfigureLuaHooks(lua_State* lState) {
+    UNUSED(lState);
+}
 
 static tinymt32_t tinymt;
 
@@ -837,7 +842,7 @@ extern int luaCommandCounters[LUA_BUTTON_COUNT];
 		return 0;
 	});
 
-	lua_register(lState, "enableCanRxWorkaround", [](lua_State* l) {
+	lua_register(lState, "enableCanRxWorkaround", [](lua_State*) {
 		// that's about global_can_data
 		engineConfiguration->luaCanRxWorkaround = true;
 		return 0;
@@ -851,7 +856,7 @@ extern int luaCommandCounters[LUA_BUTTON_COUNT];
 		return 1;
 	});
 #endif // EFI_CAN_SUPPORT
-	lua_register(lState, "disableExtendedCanBroadcast", [](lua_State* l) {
+	lua_register(lState, "disableExtendedCanBroadcast", [](lua_State*) {
 		// that's about global_can_data
 		engineConfiguration->enableExtendedCanBroadcast = false;
 		return 0;
@@ -1072,7 +1077,7 @@ extern int luaCommandCounters[LUA_BUTTON_COUNT];
 		}
 		return 0;
 	});
-	lua_register(lState, CMD_BURNCONFIG, [](lua_State* l) {
+	lua_register(lState, CMD_BURNCONFIG, [](lua_State*) {
 	  requestBurn();
 		return 0;
 	});

--- a/unit_tests/test-framework/engine_test_helper.cpp
+++ b/unit_tests/test-framework/engine_test_helper.cpp
@@ -442,7 +442,7 @@ bool EngineTestHelper::assertEventExistsAtEnginePhase(const char *msg, action_s 
 	//std::cout << "executor->size():              " << executor->size() << std::endl;
 	//std::cout << "expected_action.getCallback():  0x" << std::hex << reinterpret_cast<size_t>(action_expected.getCallback()) << "; name: " << action_expected.getCallbackName() << std::endl;
 
-	for (size_t i = 0; i < executor->size(); i++) {
+	for (int i = 0; i < executor->size(); i++) {
 		auto event = executor->getForUnitTest(i);
 		assert(event != nullptr);
 

--- a/unit_tests/tests/binary_log/test_bit_logger_field.cpp
+++ b/unit_tests/tests/binary_log/test_bit_logger_field.cpp
@@ -42,7 +42,7 @@ class BitLoggerFieldTest : public ::testing::Test {
     }
 
     void BitLoggerFieldTest::checkBitLoggerField(const bool expected, const char* const context) {
-        EXPECT_EQ(1, m_logField->writeData(m_buffer.data(), nullptr)) << context;
+        EXPECT_EQ(1u, m_logField->writeData(m_buffer.data(), nullptr)) << context;
         EXPECT_THAT(m_buffer, ::testing::ElementsAre((expected ? 0x01 : 0x00), 0xAA, 0xAA, 0xAA, 0xAA, 0xAA));
     }
 

--- a/unit_tests/tests/ignition_injection/test_fuel_map.cpp
+++ b/unit_tests/tests/ignition_injection/test_fuel_map.cpp
@@ -141,7 +141,7 @@ TEST(misc, testAngleResolver) {
 
 	ASSERT_EQ(4, ts->getTriggerWaveformSynchPointIndex());
 
-	ASSERT_EQ( 10,  ts->getSize()) << "shape size";
+	ASSERT_EQ( 10u,  ts->getSize()) << "shape size";
 
 	TriggerWaveform t;
 	configureFordAspireTriggerWaveform(&t);

--- a/unit_tests/tests/ignition_injection/test_fuel_math.cpp
+++ b/unit_tests/tests/ignition_injection/test_fuel_math.cpp
@@ -226,7 +226,7 @@ TEST(FuelMath, testDifferentInjectionModes) {
 	setInjectionMode((int)IM_SINGLE_POINT);
 	engine->periodicFastCallback();
 	EXPECT_FLOAT_EQ( 40,  engine->engineState.injectionDuration) << "injection while IM_SINGLE_POINT";
-	EXPECT_EQ( 0, eth.recentWarnings()->getCount()) << "warningCounter#testDifferentInjectionModes";
+	EXPECT_EQ( 0u, eth.recentWarnings()->getCount()) << "warningCounter#testDifferentInjectionModes";
 }
 #endif //FUEL_RPM_COUNT == 16
 

--- a/unit_tests/tests/ignition_injection/test_multispark.cpp
+++ b/unit_tests/tests/ignition_injection/test_multispark.cpp
@@ -10,14 +10,14 @@
 TEST(Multispark, DefaultConfiguration) {
 	EngineTestHelper eth(engine_type_e::TEST_ENGINE);
 
-	EXPECT_EQ(0, getMultiSparkCount(0    ));
-	EXPECT_EQ(0, getMultiSparkCount(100  ));
-	EXPECT_EQ(0, getMultiSparkCount(200  ));
-	EXPECT_EQ(0, getMultiSparkCount(500  ));
-	EXPECT_EQ(0, getMultiSparkCount(1000  ));
-	EXPECT_EQ(0, getMultiSparkCount(2000  ));
-	EXPECT_EQ(0, getMultiSparkCount(5000  ));
-	EXPECT_EQ(0, getMultiSparkCount(50000 ));
+	EXPECT_EQ(0u, getMultiSparkCount(0    ));
+	EXPECT_EQ(0u, getMultiSparkCount(100  ));
+	EXPECT_EQ(0u, getMultiSparkCount(200  ));
+	EXPECT_EQ(0u, getMultiSparkCount(500  ));
+	EXPECT_EQ(0u, getMultiSparkCount(1000  ));
+	EXPECT_EQ(0u, getMultiSparkCount(2000  ));
+	EXPECT_EQ(0u, getMultiSparkCount(5000  ));
+	EXPECT_EQ(0u, getMultiSparkCount(50000 ));
 }
 
 static void multisparkCfg() {
@@ -43,21 +43,21 @@ TEST(Multispark, EnabledNoMaxRpm) {
 	// Practically no RPM limit
 	engineConfiguration->multisparkMaxRpm = 12500;
 
-	EXPECT_EQ(0,  getMultiSparkCount(0    ));
-	EXPECT_EQ(10, getMultiSparkCount(150  ));
-	EXPECT_EQ(10, getMultiSparkCount(250  ));
-	EXPECT_EQ(4,  getMultiSparkCount(550  ));
-	EXPECT_EQ(3,  getMultiSparkCount(800  ));
-	EXPECT_EQ(2,  getMultiSparkCount(900  ));
-	EXPECT_EQ(1,  getMultiSparkCount(1500  ));
+	EXPECT_EQ(0u,  getMultiSparkCount(0    ));
+	EXPECT_EQ(10u, getMultiSparkCount(150  ));
+	EXPECT_EQ(10u, getMultiSparkCount(250  ));
+	EXPECT_EQ(4u,  getMultiSparkCount(550  ));
+	EXPECT_EQ(3u,  getMultiSparkCount(800  ));
+	EXPECT_EQ(2u,  getMultiSparkCount(900  ));
+	EXPECT_EQ(1u,  getMultiSparkCount(1500  ));
 
 	// 2500 is the threshold where we should get zero
-	EXPECT_EQ(1,  getMultiSparkCount(2499  ));
-	EXPECT_EQ(0,  getMultiSparkCount(2501  ));
+	EXPECT_EQ(1u,  getMultiSparkCount(2499  ));
+	EXPECT_EQ(0u,  getMultiSparkCount(2501  ));
 
-	EXPECT_EQ(0,  getMultiSparkCount(5000  ));
+	EXPECT_EQ(0u,  getMultiSparkCount(5000  ));
 
-	EXPECT_EQ(0,  getMultiSparkCount(50000 ));
+	EXPECT_EQ(0u,  getMultiSparkCount(50000 ));
 }
 
 TEST(Multispark, RpmLimit) {
@@ -68,6 +68,6 @@ TEST(Multispark, RpmLimit) {
 	// Disable at 800 rpm
 	engineConfiguration->multisparkMaxRpm = 800;
 
-	EXPECT_EQ(3, getMultiSparkCount(795));
-	EXPECT_EQ(0, getMultiSparkCount(805));
+	EXPECT_EQ(3u, getMultiSparkCount(795));
+	EXPECT_EQ(0u, getMultiSparkCount(805));
 }

--- a/unit_tests/tests/sent/test_sent.cpp
+++ b/unit_tests/tests/sent/test_sent.cpp
@@ -97,7 +97,7 @@ TEST(sent, testFordIdle) {
 	ASSERT_TRUE(lineCount > 100);
 	#if SENT_STATISTIC_COUNTERS
 		sent_channel_stat &statistic = channel.statistic;
-		ASSERT_EQ(statistic.RestartCnt, 0);
+		ASSERT_EQ(statistic.RestartCnt, 0u);
 	#endif
 }
 
@@ -110,7 +110,7 @@ TEST(sent, testFordClosed) {
 	#if SENT_STATISTIC_COUNTERS
 		sent_channel_stat &statistic = channel.statistic;
 		/* TODO: bad captured data or real problem? */
-		ASSERT_TRUE(statistic.RestartCnt <= 1);
+		ASSERT_TRUE(statistic.RestartCnt <= 1u);
 	#endif
 }
 
@@ -123,7 +123,7 @@ TEST(sent, testOpelIdle) {
 	#if SENT_STATISTIC_COUNTERS
 		sent_channel_stat &statistic = channel.statistic;
 		/* TODO: bad captured data or real problem? */
-		ASSERT_TRUE(statistic.RestartCnt <= 1);
+		ASSERT_TRUE(statistic.RestartCnt <= 1u);
 	#endif
 }
 
@@ -136,7 +136,7 @@ TEST(sent, testOpelMove) {
 	#if SENT_STATISTIC_COUNTERS
 		sent_channel_stat &statistic = channel.statistic;
 		/* TODO: bad captured data or real problem? */
-		ASSERT_TRUE(statistic.RestartCnt <= 1);
+		ASSERT_TRUE(statistic.RestartCnt <= 1u);
 	#endif
 }
 
@@ -148,7 +148,7 @@ TEST(sent, testFuelPressure) {
    	ASSERT_FALSE(isError);
 	#if SENT_STATISTIC_COUNTERS
 		sent_channel_stat &statistic = channel.statistic;
-		ASSERT_TRUE(statistic.RestartCnt == 0);
+		ASSERT_TRUE(statistic.RestartCnt == 0u);
 		/* TODO: add more checks? Check data? */
 	#endif
 }
@@ -162,7 +162,7 @@ TEST(sent, testVagMap) {
 	#if SENT_STATISTIC_COUNTERS
 		sent_channel_stat &statistic = channel.statistic;
 		/* TODO: bad captured data or real problem? */
-		ASSERT_TRUE(statistic.RestartCnt <= 1);
+		ASSERT_TRUE(statistic.RestartCnt <= 1u);
 	#endif
 }
 

--- a/unit_tests/tests/test_binary_log.cpp
+++ b/unit_tests/tests/test_binary_log.cpp
@@ -58,7 +58,7 @@ TEST(BinaryLogField, Value) {
 	memset(buffer, 0xAA, sizeof(buffer));
 
 	// Should write 4 bytes
-	EXPECT_EQ(4, lf.writeData(buffer, nullptr));
+	EXPECT_EQ(4u, lf.writeData(buffer, nullptr));
 
 	// Check that big endian data was written, and bytes after weren't touched
 	EXPECT_THAT(buffer, ElementsAre(0x00, 0xbc, 0x61, 0x4e, 0xAA, 0xAA));

--- a/unit_tests/tests/test_cpp_memory_layout.cpp
+++ b/unit_tests/tests/test_cpp_memory_layout.cpp
@@ -60,7 +60,7 @@ TEST(CppMemoryLayout, VirtualStruct) {
 
 	// '4' in case of 32 bit target
 	// '8' in case of 64 bit target
-	int MAGIC_VTABLE_SIZE = sizeof(void*);
+	size_t MAGIC_VTABLE_SIZE = sizeof(void*);
 
 	// validate field initializers just for fun
 	ASSERT_EQ(540, c.field0);
@@ -91,14 +91,14 @@ TEST(CppMemoryLayout, PlainExtraFieldsStruct) {
 	// parent fields go first
 	memcpy(&destimationInt, &c, 4);
 	ASSERT_EQ(540, destimationInt);
-	ASSERT_EQ(0, (uintptr_t)&c.field0 - (uintptr_t)&c);
+	ASSERT_EQ(0u, (uintptr_t)&c.field0 - (uintptr_t)&c);
 }
 
 TEST(CppMemoryLayout, structSize) {
-	ASSERT_EQ(1, sizeof(adc_channel_e)) << "adc_channel_e enum size";
-	ASSERT_EQ(1, sizeof(pin_input_mode_e)) << "pin_input_mode_e enum size";
-	ASSERT_EQ(1, sizeof(pin_output_mode_e)) << "pin_output_mode_e enum size";
-	ASSERT_EQ(2, sizeof(brain_pin_e)) << "brain_pin_e enum size";
-	ASSERT_EQ(12, sizeof(air_pressure_sensor_config_s));
-	ASSERT_EQ(TOTAL_CONFIG_SIZE, sizeof(persistent_config_s));
+	ASSERT_EQ(1u, sizeof(adc_channel_e)) << "adc_channel_e enum size";
+	ASSERT_EQ(1u, sizeof(pin_input_mode_e)) << "pin_input_mode_e enum size";
+	ASSERT_EQ(1u, sizeof(pin_output_mode_e)) << "pin_output_mode_e enum size";
+	ASSERT_EQ(2u, sizeof(brain_pin_e)) << "brain_pin_e enum size";
+	ASSERT_EQ(12u, sizeof(air_pressure_sensor_config_s));
+	ASSERT_EQ(size_t(TOTAL_CONFIG_SIZE), sizeof(persistent_config_s));
 }

--- a/unit_tests/tests/test_gear_detector.cpp
+++ b/unit_tests/tests/test_gear_detector.cpp
@@ -77,18 +77,18 @@ TEST(GearDetector, DetermineGearSingleSpeed) {
 	dut.onConfigurationChange(nullptr);
 
 	// Super high ratios indicate clutch slip or idling in neutral or something
-	EXPECT_EQ(0, dut.determineGearFromRatio(100));
-	EXPECT_EQ(0, dut.determineGearFromRatio(4));
+	EXPECT_EQ(0u, dut.determineGearFromRatio(100));
+	EXPECT_EQ(0u, dut.determineGearFromRatio(4));
 
 	// Check exactly on the gear
-	EXPECT_EQ(1, dut.determineGearFromRatio(2));
+	EXPECT_EQ(1u, dut.determineGearFromRatio(2));
 
 	// Check near the gear
-	EXPECT_EQ(1, dut.determineGearFromRatio(2.1));
-	EXPECT_EQ(1, dut.determineGearFromRatio(1.9));
+	EXPECT_EQ(1u, dut.determineGearFromRatio(2.1));
+	EXPECT_EQ(1u, dut.determineGearFromRatio(1.9));
 
 	// Extremely low ratio suggests stopped engine at speed?
-	EXPECT_EQ(0, dut.determineGearFromRatio(1.0));
+	EXPECT_EQ(0u, dut.determineGearFromRatio(1.0));
 }
 
 TEST(GearDetector, DetermineGear5Speed) {
@@ -105,34 +105,34 @@ TEST(GearDetector, DetermineGear5Speed) {
 	dut.onConfigurationChange(nullptr);
 
 	// Super high ratios indicate clutch slip or idling in neutral or something
-	EXPECT_EQ(0, dut.determineGearFromRatio(100));
-	EXPECT_EQ(0, dut.determineGearFromRatio(6));
+	EXPECT_EQ(0u, dut.determineGearFromRatio(100));
+	EXPECT_EQ(0u, dut.determineGearFromRatio(6));
 
 	// Check exactly on gears
-	EXPECT_EQ(1, dut.determineGearFromRatio(3.35));
-	EXPECT_EQ(2, dut.determineGearFromRatio(1.99));
-	EXPECT_EQ(3, dut.determineGearFromRatio(1.33));
-	EXPECT_EQ(4, dut.determineGearFromRatio(1.00));
-	EXPECT_EQ(5, dut.determineGearFromRatio(0.72));
+	EXPECT_EQ(1u, dut.determineGearFromRatio(3.35));
+	EXPECT_EQ(2u, dut.determineGearFromRatio(1.99));
+	EXPECT_EQ(3u, dut.determineGearFromRatio(1.33));
+	EXPECT_EQ(4u, dut.determineGearFromRatio(1.00));
+	EXPECT_EQ(5u, dut.determineGearFromRatio(0.72));
 
 	// Check near each gear
-	EXPECT_EQ(1, dut.determineGearFromRatio(3.45));
-	EXPECT_EQ(1, dut.determineGearFromRatio(3.25));
+	EXPECT_EQ(1u, dut.determineGearFromRatio(3.45));
+	EXPECT_EQ(1u, dut.determineGearFromRatio(3.25));
 
-	EXPECT_EQ(2, dut.determineGearFromRatio(2.2));
-	EXPECT_EQ(2, dut.determineGearFromRatio(1.8));
+	EXPECT_EQ(2u, dut.determineGearFromRatio(2.2));
+	EXPECT_EQ(2u, dut.determineGearFromRatio(1.8));
 
-	EXPECT_EQ(3, dut.determineGearFromRatio(1.45));
-	EXPECT_EQ(3, dut.determineGearFromRatio(1.25));
+	EXPECT_EQ(3u, dut.determineGearFromRatio(1.45));
+	EXPECT_EQ(3u, dut.determineGearFromRatio(1.25));
 
-	EXPECT_EQ(4, dut.determineGearFromRatio(1.1));
-	EXPECT_EQ(4, dut.determineGearFromRatio(0.9));
+	EXPECT_EQ(4u, dut.determineGearFromRatio(1.1));
+	EXPECT_EQ(4u, dut.determineGearFromRatio(0.9));
 
-	EXPECT_EQ(5, dut.determineGearFromRatio(0.8));
-	EXPECT_EQ(5, dut.determineGearFromRatio(0.6));
+	EXPECT_EQ(5u, dut.determineGearFromRatio(0.8));
+	EXPECT_EQ(5u, dut.determineGearFromRatio(0.6));
 
 	// Extremely low ratio suggests stopped engine at speed?
-	EXPECT_EQ(0, dut.determineGearFromRatio(0.1));
+	EXPECT_EQ(0u, dut.determineGearFromRatio(0.1));
 }
 
 TEST(GearDetector, MiataNb6Speed) {
@@ -151,16 +151,16 @@ TEST(GearDetector, MiataNb6Speed) {
 
 	dut.onConfigurationChange(nullptr);
 
-	EXPECT_EQ(0, dut.determineGearFromRatio(5.85));
-	EXPECT_EQ(1, dut.determineGearFromRatio(5.51));
+	EXPECT_EQ(0u, dut.determineGearFromRatio(5.85));
+	EXPECT_EQ(1u, dut.determineGearFromRatio(5.51));
 
 	// Check exactly on gears
-	EXPECT_EQ(1, dut.determineGearFromRatio(3.76));
-	EXPECT_EQ(2, dut.determineGearFromRatio(2.27));
-	EXPECT_EQ(3, dut.determineGearFromRatio(1.65));
-	EXPECT_EQ(4, dut.determineGearFromRatio(1.26));
-	EXPECT_EQ(5, dut.determineGearFromRatio(1.00));
-	EXPECT_EQ(6, dut.determineGearFromRatio(0.84));
+	EXPECT_EQ(1u, dut.determineGearFromRatio(3.76));
+	EXPECT_EQ(2u, dut.determineGearFromRatio(2.27));
+	EXPECT_EQ(3u, dut.determineGearFromRatio(1.65));
+	EXPECT_EQ(4u, dut.determineGearFromRatio(1.26));
+	EXPECT_EQ(5u, dut.determineGearFromRatio(1.00));
+	EXPECT_EQ(6u, dut.determineGearFromRatio(0.84));
 }
 
 TEST(GearDetector, DetermineGear8Speed) {
@@ -181,25 +181,25 @@ TEST(GearDetector, DetermineGear8Speed) {
 	dut.onConfigurationChange(nullptr);
 
 	// Super high ratios indicate clutch slip or idling in neutral or something
-	EXPECT_EQ(0, dut.determineGearFromRatio(100));
-	EXPECT_EQ(0, dut.determineGearFromRatio(8));
+	EXPECT_EQ(0u, dut.determineGearFromRatio(100));
+	EXPECT_EQ(0u, dut.determineGearFromRatio(8));
 
 	// Check exactly on gears - only test the ends, the middle works
-	EXPECT_EQ(1, dut.determineGearFromRatio(4.69));
-	EXPECT_EQ(2, dut.determineGearFromRatio(3.13));
+	EXPECT_EQ(1u, dut.determineGearFromRatio(4.69));
+	EXPECT_EQ(2u, dut.determineGearFromRatio(3.13));
 
-	EXPECT_EQ(7, dut.determineGearFromRatio(0.84));
-	EXPECT_EQ(8, dut.determineGearFromRatio(0.67));
+	EXPECT_EQ(7u, dut.determineGearFromRatio(0.84));
+	EXPECT_EQ(8u, dut.determineGearFromRatio(0.67));
 
 	// Check near each gear - only test the ends, the middle works
-	EXPECT_EQ(1, dut.determineGearFromRatio(4.75));
-	EXPECT_EQ(1, dut.determineGearFromRatio(4.3));
+	EXPECT_EQ(1u, dut.determineGearFromRatio(4.75));
+	EXPECT_EQ(1u, dut.determineGearFromRatio(4.3));
 
-	EXPECT_EQ(8, dut.determineGearFromRatio(0.71));
-	EXPECT_EQ(8, dut.determineGearFromRatio(0.6));
+	EXPECT_EQ(8u, dut.determineGearFromRatio(0.71));
+	EXPECT_EQ(8u, dut.determineGearFromRatio(0.6));
 
 	// Extremely low ratio suggests stopped engine at speed?
-	EXPECT_EQ(0, dut.determineGearFromRatio(0.1));
+	EXPECT_EQ(0u, dut.determineGearFromRatio(0.1));
 }
 
 TEST(GearDetector, ParameterValidation) {

--- a/unit_tests/tests/test_hpfp_integrated.cpp
+++ b/unit_tests/tests/test_hpfp_integrated.cpp
@@ -8,9 +8,9 @@
 #include "pch.h"
 using ::testing::_;
 
-static size_t hpfpTotalToggle = 0;
+static int hpfpTotalToggle = 0;
 
-static void assertToggleCounterExtra(EngineTestHelper *eth, size_t extra, const char *msg) {
+static void assertToggleCounterExtra(EngineTestHelper *eth, int extra, const char *msg) {
 	eth->smartFireTriggerEvents2(/*count*/4, /*delay*/ 16);
 	ASSERT_EQ(hpfpTotalToggle + extra, enginePins.hpfpValve.pinToggleCounter) << msg;
 	hpfpTotalToggle += extra;

--- a/unit_tests/tests/test_stft.cpp
+++ b/unit_tests/tests/test_stft.cpp
@@ -56,24 +56,24 @@ TEST(ClosedLoopFuel, CellSelection) {
 	cfg.maxOverrunLoad = 30;
 
 	// Test idle
-	EXPECT_EQ(0, computeStftBin(1000, 10, cfg));
-	EXPECT_EQ(0, computeStftBin(1000, 50, cfg));
-	EXPECT_EQ(0, computeStftBin(1000, 90, cfg));
+	EXPECT_EQ(0u, computeStftBin(1000, 10, cfg));
+	EXPECT_EQ(0u, computeStftBin(1000, 50, cfg));
+	EXPECT_EQ(0u, computeStftBin(1000, 90, cfg));
 
 	// Test overrun
-	EXPECT_EQ(1, computeStftBin(2000, 10, cfg));
-	EXPECT_EQ(1, computeStftBin(4000, 10, cfg));
-	EXPECT_EQ(1, computeStftBin(10000, 10, cfg));
+	EXPECT_EQ(1u, computeStftBin(2000, 10, cfg));
+	EXPECT_EQ(1u, computeStftBin(4000, 10, cfg));
+	EXPECT_EQ(1u, computeStftBin(10000, 10, cfg));
 
 	// Test load
-	EXPECT_EQ(2, computeStftBin(2000, 90, cfg));
-	EXPECT_EQ(2, computeStftBin(4000, 90, cfg));
-	EXPECT_EQ(2, computeStftBin(10000, 90, cfg));
+	EXPECT_EQ(2u, computeStftBin(2000, 90, cfg));
+	EXPECT_EQ(2u, computeStftBin(4000, 90, cfg));
+	EXPECT_EQ(2u, computeStftBin(10000, 90, cfg));
 
 	// Main cell
-	EXPECT_EQ(3, computeStftBin(2000, 50, cfg));
-	EXPECT_EQ(3, computeStftBin(4000, 50, cfg));
-	EXPECT_EQ(3, computeStftBin(10000, 50, cfg));
+	EXPECT_EQ(3u, computeStftBin(2000, 50, cfg));
+	EXPECT_EQ(3u, computeStftBin(4000, 50, cfg));
+	EXPECT_EQ(3u, computeStftBin(10000, 50, cfg));
 }
 
 TEST(ClosedLoopFuel, afrLimits) {

--- a/unit_tests/tests/test_trip_odometer.cpp
+++ b/unit_tests/tests/test_trip_odometer.cpp
@@ -4,32 +4,32 @@ TEST(TripOdometer, TestLargePulses) {
 	TripOdometer dut;
 
 	// Initial consumption should be zero
-	EXPECT_EQ(0, dut.getConsumedGrams());
+	EXPECT_EQ(0u, dut.getConsumedGrams());
 
 	dut.consumeFuel(100, 0);
-	EXPECT_EQ(100, dut.getConsumedGrams());
+	EXPECT_EQ(100u, dut.getConsumedGrams());
 
 	dut.consumeFuel(100, 0);
-	EXPECT_EQ(200, dut.getConsumedGrams());
+	EXPECT_EQ(200u, dut.getConsumedGrams());
 }
 
 TEST(TripOdometer, TestSmallPulses) {
 	TripOdometer dut;
 
 	// Initial consumption should be zero
-	EXPECT_EQ(0, dut.getConsumedGrams());
+	EXPECT_EQ(0u, dut.getConsumedGrams());
 
 	dut.consumeFuel(0.6, 0);
-	EXPECT_EQ(0, dut.getConsumedGrams());
+	EXPECT_EQ(0u, dut.getConsumedGrams());
 
 	dut.consumeFuel(0.6, 0);
-	EXPECT_EQ(1, dut.getConsumedGrams());
+	EXPECT_EQ(1u, dut.getConsumedGrams());
 
 	for (int i = 0; i < 6; i++) {
 		dut.consumeFuel(0.6, 0);
 	}
 
-	EXPECT_EQ(4, dut.getConsumedGrams());
+	EXPECT_EQ(4u, dut.getConsumedGrams());
 	dut.consumeFuel(0.6, 0);
-	EXPECT_EQ(5, dut.getConsumedGrams());
+	EXPECT_EQ(5u, dut.getConsumedGrams());
 }

--- a/unit_tests/tests/test_util.cpp
+++ b/unit_tests/tests/test_util.cpp
@@ -250,12 +250,12 @@ TEST(misc, testGpsParser) {
 	ASSERT_NEAR(11.2, GPSdata.speed, EPS3D) << "3 speed";
 //	ASSERT_EQ( 0,  GPSdata.altitude) << "3 altitude";  // GPRMC not overwrite altitude
 	ASSERT_EQ( 0,  GPSdata.course) << "3 course";
-	ASSERT_EQ( 2006,  GPSdata.time.year + 1900) << "3 GPS yy";
-	ASSERT_EQ( 12,  GPSdata.time.month) << "3 GPS mm";
-	ASSERT_EQ( 26,  GPSdata.time.day) << "3 GPS dd";
-	ASSERT_EQ( 11,  GPSdata.time.hour) << "3 GPS hh";
-	ASSERT_EQ( 16,  GPSdata.time.minute) << "3 GPS mm";
-	ASSERT_EQ( 9,  GPSdata.time.second) << "3 GPS ss";
+	ASSERT_EQ( 2006u,  GPSdata.time.year + 1900u) << "3 GPS yy";
+	ASSERT_EQ( 12u,  GPSdata.time.month) << "3 GPS mm";
+	ASSERT_EQ( 26u,  GPSdata.time.day) << "3 GPS dd";
+	ASSERT_EQ( 11u,  GPSdata.time.hour) << "3 GPS hh";
+	ASSERT_EQ( 16u,  GPSdata.time.minute) << "3 GPS mm";
+	ASSERT_EQ( 9u,  GPSdata.time.second) << "3 GPS ss";
 
 	// check again first one
 	// we need to pass a mutable string, not a constant because the parser would be modifying the string

--- a/unit_tests/tests/trigger/test_cam_vvt_input.cpp
+++ b/unit_tests/tests/trigger/test_cam_vvt_input.cpp
@@ -18,7 +18,7 @@ TEST(trigger, testNoStartUpWarningsNoSynchronizationTrigger) {
 
 	eth.fireTriggerEvents2(/*count*/10, /*duration*/50);
 	ASSERT_EQ(1200,  round(Sensor::getOrZero(SensorType::Rpm))) << "testNoStartUpWarnings RPM";
-	ASSERT_EQ( 0,  getRecentWarnings()->getCount()) << "warningCounter#testNoStartUpWarningsNoSynchronizationTrigger";
+	ASSERT_EQ( 0u,  getRecentWarnings()->getCount()) << "warningCounter#testNoStartUpWarningsNoSynchronizationTrigger";
 }
 
 TEST(trigger, testNoStartUpWarnings) {
@@ -37,7 +37,7 @@ TEST(trigger, testNoStartUpWarnings) {
 	}
 
 	ASSERT_EQ(400,  round(Sensor::getOrZero(SensorType::Rpm))) << "testNoStartUpWarnings RPM";
-	ASSERT_EQ( 0,  getRecentWarnings()->getCount()) << "warningCounter#testNoStartUpWarnings";
+	ASSERT_EQ( 0u,  getRecentWarnings()->getCount()) << "warningCounter#testNoStartUpWarnings";
 	// now let's post something unneeded
 	eth.fireRise(50);
 	eth.fireFall(50);
@@ -51,7 +51,7 @@ TEST(trigger, testNoStartUpWarnings) {
 		eth.fireRise(50);
 		eth.fireFall(150);
 	}
-	EXPECT_EQ( 1,  getRecentWarnings()->getCount()) << "warningCounter#testNoStartUpWarnings CUSTOM_SYNC_COUNT_MISMATCH expected";
+	EXPECT_EQ( 1u,  getRecentWarnings()->getCount()) << "warningCounter#testNoStartUpWarnings CUSTOM_SYNC_COUNT_MISMATCH expected";
 	EXPECT_EQ(ObdCode::CUSTOM_PRIMARY_TOO_MANY_TEETH, getRecentWarnings()->get(0).Code);
 }
 
@@ -70,7 +70,7 @@ TEST(trigger, testNoisyInput) {
 	eth.firePrimaryTriggerFall();
 	ASSERT_EQ(0, Sensor::getOrZero(SensorType::Rpm));
 
-	EXPECT_EQ(1, getRecentWarnings()->getCount());
+	EXPECT_EQ(1u, getRecentWarnings()->getCount());
 	EXPECT_EQ(ObdCode::CUSTOM_PRIMARY_NOT_ENOUGH_TEETH, getRecentWarnings()->get(0).Code);
 }
 
@@ -95,7 +95,7 @@ TEST(trigger, testCamInput) {
 	}
 
 	ASSERT_EQ(1200,  round(Sensor::getOrZero(SensorType::Rpm)));
-	ASSERT_EQ(0,  getRecentWarnings()->getCount()) << "warningCounter#testCamInput";
+	ASSERT_EQ(0u,  getRecentWarnings()->getCount()) << "warningCounter#testCamInput";
 
 	for (int i = 0; i < 600;i++) {
 		eth.fireRise(25);
@@ -103,7 +103,7 @@ TEST(trigger, testCamInput) {
 	}
 
 	// asserting that lack of camshaft signal would be detecting
-	ASSERT_EQ(1,  getRecentWarnings()->getCount()) << "warningCounter#testCamInput #2";
+	ASSERT_EQ(1u,  getRecentWarnings()->getCount()) << "warningCounter#testCamInput #2";
 	ASSERT_EQ(ObdCode::OBD_Camshaft_Position_Sensor_Circuit_Range_Performance, getRecentWarnings()->get(0).Code) << "@0";
 	getRecentWarnings()->clear();
 
@@ -125,7 +125,7 @@ TEST(trigger, testCamInput) {
 	}
 
 	// asserting that error code has cleared
-	ASSERT_EQ(0, getRecentWarnings()->getCount()) << "warningCounter#testCamInput #3";
+	ASSERT_EQ(0u, getRecentWarnings()->getCount()) << "warningCounter#testCamInput #3";
 	EXPECT_NEAR_M3(71, engine->triggerCentral.getVVTPosition(0, 0));
 }
 

--- a/unit_tests/tests/trigger/test_coil.cpp
+++ b/unit_tests/tests/trigger/test_coil.cpp
@@ -19,24 +19,24 @@ static void prepareToScheduleOverdwellSparkDown(EngineTestHelper& eth) {
 	engineConfiguration->isIgnitionEnabled = true;
 	engineConfiguration->isInjectionEnabled = false;
 
-	ASSERT_EQ( 0,  getRecentWarnings()->getCount()) << "warningCounter#0";
+	ASSERT_EQ( 0u,  getRecentWarnings()->getCount()) << "warningCounter#0";
 
 	eth.smartFireRise(20);
-	ASSERT_EQ( 0,  engine->triggerCentral.triggerState.currentCycle.current_index) << "ci#0";
+	ASSERT_EQ( 0u,  engine->triggerCentral.triggerState.currentCycle.current_index) << "ci#0";
 
 	eth.smartFireFall(20);
-	ASSERT_EQ( 1,  engine->triggerCentral.triggerState.currentCycle.current_index) << "ci#1";
+	ASSERT_EQ( 1u,  engine->triggerCentral.triggerState.currentCycle.current_index) << "ci#1";
 
 	eth.smartFireRise(20);
-	ASSERT_EQ( 0,  engine->triggerCentral.triggerState.currentCycle.current_index) << "ci#2";
+	ASSERT_EQ( 0u,  engine->triggerCentral.triggerState.currentCycle.current_index) << "ci#2";
 
 	eth.smartFireFall(20);
-	ASSERT_EQ( 1,  engine->triggerCentral.triggerState.currentCycle.current_index) << "ci#3";
+	ASSERT_EQ( 1u,  engine->triggerCentral.triggerState.currentCycle.current_index) << "ci#3";
 
 	eth.smartFireRise(20);
 
 	eth.smartFireFall(20);
-	ASSERT_EQ( 1,  eth.engine.triggerCentral.triggerState.currentCycle.current_index) << "ci#5";
+	ASSERT_EQ( 1u,  eth.engine.triggerCentral.triggerState.currentCycle.current_index) << "ci#5";
 
 	ASSERT_EQ(3000, Sensor::getOrZero(SensorType::Rpm));
 
@@ -69,7 +69,7 @@ TEST(coil, testOverdwellProtection) {
 	ASSERT_STREQ("Coil 1", testOutputName.c_str()) << "Unexpected test output name";
 
 	std::optional<efitick_t> turnSparkPinHighStartChargingTimestamp;
-	std::optional<int> testSparkCounter;
+	std::optional<uint32_t> testSparkCounter;
 	engine->onScheduleTurnSparkPinHighStartCharging =
 		[&](const IgnitionEvent& event, efitick_t, angle_t, efitick_t chargeTime) -> void {
 			if (testOutputName == event.outputs[0]->getName()) {

--- a/unit_tests/tests/trigger/test_nissan_vq_vvt.cpp
+++ b/unit_tests/tests/trigger/test_nissan_vq_vvt.cpp
@@ -143,5 +143,5 @@ TEST(nissan, vq_vvt) {
 	ASSERT_NEAR(34, tc->vvtPosition[0][0], EPS2D);
 	ASSERT_NEAR(34, tc->vvtPosition[1][0], EPS2D);
 
-	EXPECT_EQ(0, eth.recentWarnings()->getCount());
+	EXPECT_EQ(0u, eth.recentWarnings()->getCount());
 }

--- a/unit_tests/tests/trigger/test_real_4b11.cpp
+++ b/unit_tests/tests/trigger/test_real_4b11.cpp
@@ -28,7 +28,7 @@ TEST(real4b11, running) {
 		reader.assertFirstRpm(1436, 30);
 	}
 
-	ASSERT_EQ(0, eth.recentWarnings()->getCount());
+	ASSERT_EQ(0u, eth.recentWarnings()->getCount());
 }
 
 TEST(real4b11, runningDoubledEdge) {
@@ -50,6 +50,6 @@ TEST(real4b11, runningDoubledEdge) {
 	}
 
 	// Should get a warning for the doubled edge, but NOT one for a trigger error!
-	ASSERT_EQ(1, eth.recentWarnings()->getCount());
+	ASSERT_EQ(1u, eth.recentWarnings()->getCount());
 	ASSERT_EQ(ObdCode::CUSTOM_PRIMARY_DOUBLED_EDGE, eth.recentWarnings()->get(0).Code);
 }

--- a/unit_tests/tests/trigger/test_real_4g93.cpp
+++ b/unit_tests/tests/trigger/test_real_4g93.cpp
@@ -61,7 +61,7 @@ TEST(real4g93, cranking) {
 	ASSERT_TRUE(reader.gotRpm);
 	ASSERT_TRUE(reader.gotSync);
 
-	ASSERT_EQ(0, eth.recentWarnings()->getCount());
+	ASSERT_EQ(0u, eth.recentWarnings()->getCount());
 }
 
 TEST(real4g93, crankingOn11) {
@@ -114,5 +114,5 @@ TEST(real4g93, crankingCamOnly) {
 	ASSERT_TRUE(reader.gotRpm);
 	ASSERT_TRUE(reader.gotSync);
 
-	ASSERT_EQ(1, eth.recentWarnings()->getCount());
+	ASSERT_EQ(1u, eth.recentWarnings()->getCount());
 }

--- a/unit_tests/tests/trigger/test_real_6g72_3000gt.cpp
+++ b/unit_tests/tests/trigger/test_real_6g72_3000gt.cpp
@@ -47,7 +47,7 @@ static void constructTriggerFromRecording(CsvReader *reader) {
 	}
 }
 
-static void runTriggerTest(const char *fileName, int totalErrors, int syncCounter, float firstRpm) {
+static void runTriggerTest(const char *fileName, uint32_t totalErrors, int syncCounter, float firstRpm) {
 	EngineTestHelper eth(engine_type_e::TEST_ENGINE);
 
 	prepare(&eth, trigger_type_e::TT_VVT_MITSU_6G72);

--- a/unit_tests/tests/trigger/test_real_arctic_cat.cpp
+++ b/unit_tests/tests/trigger/test_real_arctic_cat.cpp
@@ -18,6 +18,6 @@ TEST(arctic, realStartFromFile) {
 		reader.processLine(&eth);
 	}
 
-	ASSERT_EQ( 1, eth.recentWarnings()->getCount())<< "warningCounter#arcticRealCranking";
+	ASSERT_EQ( 1u, eth.recentWarnings()->getCount())<< "warningCounter#arcticRealCranking";
 	ASSERT_EQ(2165, round(Sensor::getOrZero(SensorType::Rpm)))<< reader.lineIndex();
 }

--- a/unit_tests/tests/trigger/test_real_cas_24_plus_1.cpp
+++ b/unit_tests/tests/trigger/test_real_cas_24_plus_1.cpp
@@ -53,5 +53,5 @@ TEST(realCas24Plus1, spinningOnBench) {
 		}
 	}
 
-	ASSERT_EQ(0, eth.recentWarnings()->getCount());
+	ASSERT_EQ(0u, eth.recentWarnings()->getCount());
 }

--- a/unit_tests/tests/trigger/test_real_cranking_miata_NA.cpp
+++ b/unit_tests/tests/trigger/test_real_cranking_miata_NA.cpp
@@ -25,7 +25,7 @@ TEST(cranking, realCrankingFromFile) {
 	}
 
 	EXPECT_EQ(0, round(Sensor::getOrZero(SensorType::Rpm)))<< reader.lineIndex();
-	EXPECT_EQ( 0, eth.recentWarnings()->getCount());
+	EXPECT_EQ(0u, eth.recentWarnings()->getCount());
 
 	// This tooth should be first sync point
 	reader.readLine(&eth);
@@ -47,6 +47,6 @@ TEST(cranking, realCrankingFromFile) {
 		reader.processLine(&eth);
 	}
 
-	EXPECT_EQ(0, eth.recentWarnings()->getCount())<< "warningCounter#realCranking";
+	EXPECT_EQ(0u, eth.recentWarnings()->getCount())<< "warningCounter#realCranking";
 	EXPECT_EQ(191, round(Sensor::getOrZero(SensorType::Rpm)))<< reader.lineIndex();
 }

--- a/unit_tests/tests/trigger/test_real_cranking_miata_na6.cpp
+++ b/unit_tests/tests/trigger/test_real_cranking_miata_na6.cpp
@@ -157,7 +157,7 @@ TEST(cranking, hardcodedRealCranking) {
 	/* 133 */ EVENT(/* timestamp*/3.00650825, TriggerWheel::T_SECONDARY, /*value*/true);
 	/* 134 */ EVENT(/* timestamp*/3.031735, TriggerWheel::T_PRIMARY, /*value*/true);
 
-	EXPECT_EQ( 0,  getRecentWarnings()->getCount()) << "warningCounter#realCranking";
+	EXPECT_EQ( 0u,  getRecentWarnings()->getCount()) << "warningCounter#realCranking";
 
 	EXPECT_EQ(623,  round(Sensor::getOrZero(SensorType::Rpm))) << "RPM at the end";
 }
@@ -173,6 +173,6 @@ TEST(cranking, naCrankFromFile) {
 		reader.processLine(&eth);
 	}
 
-	EXPECT_EQ(0, eth.recentWarnings()->getCount());
+	EXPECT_EQ(0u, eth.recentWarnings()->getCount());
 	EXPECT_EQ(669, round(Sensor::getOrZero(SensorType::Rpm)));
 }

--- a/unit_tests/tests/trigger/test_real_cranking_nissan_vq40.cpp
+++ b/unit_tests/tests/trigger/test_real_cranking_nissan_vq40.cpp
@@ -50,7 +50,7 @@ static void test(int engineSyncCam, float camOffsetAdd) {
 	ASSERT_EQ(102, round(Sensor::getOrZero(SensorType::Rpm)))<< reader.lineIndex();
 
 	// TODO: why warnings?
-	ASSERT_EQ(2, eth.recentWarnings()->getCount());
+	ASSERT_EQ(2u, eth.recentWarnings()->getCount());
 	ASSERT_EQ(ObdCode::CUSTOM_OUT_OF_ORDER_COIL, eth.recentWarnings()->get(0).Code);	// this is from a coil being protected by overdwell protection
 	ASSERT_EQ(ObdCode::CUSTOM_PRIMARY_TOO_MANY_TEETH, eth.recentWarnings()->get(1).Code);
 }

--- a/unit_tests/tests/trigger/test_real_ford_coyote.cpp
+++ b/unit_tests/tests/trigger/test_real_ford_coyote.cpp
@@ -2,7 +2,7 @@
 
 #include "logicdata_csv_reader.h"
 
-static void runCoyoteIntakeCam(bool invertPrimaryTriggerSignal, int warningCount, int rpm) {
+static void runCoyoteIntakeCam(bool invertPrimaryTriggerSignal, uint32_t warningCount, int rpm) {
 	CsvReader reader(1, /* vvtCount */ 0);
 
 	reader.open("tests/trigger/resources/ford-coyote-intake-cam.csv");
@@ -27,7 +27,7 @@ TEST(fordCoyote, intakeCam) {
   runCoyoteIntakeCam(false, 1, 1093);
 }
 
-static void runCoyoteExhaustCam(bool invertPrimaryTriggerSignal, int warningCount, int rpm) {
+static void runCoyoteExhaustCam(bool invertPrimaryTriggerSignal, uint32_t warningCount, int rpm) {
 	CsvReader reader(1, /* vvtCount */ 0);
 
 	reader.open("tests/trigger/resources/ford-coyote-exhaust-cam.csv");

--- a/unit_tests/tests/trigger/test_real_gm_24x.cpp
+++ b/unit_tests/tests/trigger/test_real_gm_24x.cpp
@@ -22,6 +22,6 @@ TEST(crankingGm24x_5, gmRealCrankingFromFile) {
 		reader.assertFirstRpm(77, 23);
 	}
 
-	ASSERT_EQ( 0, eth.recentWarnings()->getCount())<< "warningCounter#vwRealCranking";
+	ASSERT_EQ( 0u, eth.recentWarnings()->getCount())<< "warningCounter#vwRealCranking";
 	ASSERT_EQ( 139, round(Sensor::getOrZero(SensorType::Rpm)))<< reader.lineIndex();
 }

--- a/unit_tests/tests/trigger/test_real_k24a2.cpp
+++ b/unit_tests/tests/trigger/test_real_k24a2.cpp
@@ -16,7 +16,7 @@ static void doTest(const char* testFile, int expectedRpm) {
 		reader.processLine(&eth);
 	}
 
-	ASSERT_EQ(0, eth.recentWarnings()->getCount())<< "warningCounter#vwRealCranking";
+	ASSERT_EQ(0u, eth.recentWarnings()->getCount())<< "warningCounter#vwRealCranking";
 	ASSERT_EQ(expectedRpm, round(Sensor::getOrZero(SensorType::Rpm)))<< reader.lineIndex();
 }
 

--- a/unit_tests/tests/trigger/test_real_nb2_cranking.cpp
+++ b/unit_tests/tests/trigger/test_real_nb2_cranking.cpp
@@ -28,7 +28,7 @@ TEST(realCrankingNB2, normalCranking) {
 
 	ASSERT_EQ(876, round(Sensor::getOrZero(SensorType::Rpm)));
 
-	EXPECT_EQ(2, eth.recentWarnings()->getCount());
+	EXPECT_EQ(2u, eth.recentWarnings()->getCount());
 	EXPECT_EQ(ObdCode::CUSTOM_PRIMARY_NOT_ENOUGH_TEETH, eth.recentWarnings()->get(0).Code);
 	EXPECT_EQ(ObdCode::CUSTOM_CAM_TOO_MANY_TEETH, eth.recentWarnings()->get(1).Code);
 }
@@ -49,7 +49,7 @@ TEST(realCrankingNB2, crankingMissingInjector) {
 
 	ASSERT_EQ(316, round(Sensor::getOrZero(SensorType::Rpm)));
 
-	EXPECT_EQ(3, eth.recentWarnings()->getCount());
+	EXPECT_EQ(3u, eth.recentWarnings()->getCount());
 	EXPECT_EQ(ObdCode::CUSTOM_PRIMARY_NOT_ENOUGH_TEETH, eth.recentWarnings()->get(0).Code);
 	EXPECT_EQ(ObdCode::CUSTOM_CAM_TOO_MANY_TEETH, eth.recentWarnings()->get(1).Code);
 	EXPECT_EQ(ObdCode::CUSTOM_PRIMARY_TOO_MANY_TEETH, eth.recentWarnings()->get(2).Code);

--- a/unit_tests/tests/trigger/test_real_nissan_hr.cpp
+++ b/unit_tests/tests/trigger/test_real_nissan_hr.cpp
@@ -17,8 +17,8 @@ TEST(nissan, realFromFile) {
 		reader.processLine(&eth);
 	}
 
-	ASSERT_EQ( 1, eth.recentWarnings()->getCount())<< "warningCounter#nissanRealCranking";
-	ASSERT_EQ(1,  engine->triggerCentral.triggerState.totalTriggerErrorCounter);
+	ASSERT_EQ(1u,  eth.recentWarnings()->getCount())<< "warningCounter#nissanRealCranking";
+	ASSERT_EQ(1u,  engine->triggerCentral.triggerState.totalTriggerErrorCounter);
 	ASSERT_EQ(528, round(Sensor::getOrZero(SensorType::Rpm)))<< reader.lineIndex();
 }
 
@@ -38,8 +38,8 @@ TEST(nissan, realNoSparkPlugsFromFile) {
 	}
 
 
-	ASSERT_EQ( 1, eth.recentWarnings()->getCount())<< "warningCounter#nissanRealCranking";
-	ASSERT_EQ(1,  engine->triggerCentral.triggerState.totalTriggerErrorCounter);
+	ASSERT_EQ(1u,  eth.recentWarnings()->getCount())<< "warningCounter#nissanRealCranking";
+	ASSERT_EQ(1u,  engine->triggerCentral.triggerState.totalTriggerErrorCounter);
 	ASSERT_EQ(215, round(Sensor::getOrZero(SensorType::Rpm)))<< reader.lineIndex();
 }
 
@@ -59,7 +59,7 @@ TEST(nissan, realFromFile4seconds) {
 //		printf("RPM=%f\n", Sensor::getOrZero(SensorType::Rpm));
 	}
 
-	ASSERT_EQ( 0, eth.recentWarnings()->getCount())<< "warningCounter#nissanRealCranking";
-	ASSERT_EQ(0,  engine->triggerCentral.triggerState.totalTriggerErrorCounter);
+	ASSERT_EQ(0u,  eth.recentWarnings()->getCount())<< "warningCounter#nissanRealCranking";
+	ASSERT_EQ(0u,  engine->triggerCentral.triggerState.totalTriggerErrorCounter);
 	ASSERT_EQ(0, round(Sensor::getOrZero(SensorType::Rpm)))<< reader.lineIndex();
 }

--- a/unit_tests/tests/trigger/test_real_nissan_hr_vvt.cpp
+++ b/unit_tests/tests/trigger/test_real_nissan_hr_vvt.cpp
@@ -14,7 +14,7 @@ TEST(nissan, realFromFileVVTIN) {
 		reader.processLine(&eth);
 	}
 
-	ASSERT_EQ( 0, eth.recentWarnings()->getCount())<< "warningCounter#realFromFileVVTIN";
-	ASSERT_EQ(0,  engine->triggerCentral.triggerState.totalTriggerErrorCounter);
+	ASSERT_EQ(0u,  eth.recentWarnings()->getCount())<< "warningCounter#realFromFileVVTIN";
+	ASSERT_EQ(0u,  engine->triggerCentral.triggerState.totalTriggerErrorCounter);
 	ASSERT_EQ(202, round(Sensor::getOrZero(SensorType::Rpm)))<< reader.lineIndex();
 }

--- a/unit_tests/tests/trigger/test_real_subaru_ej20g.cpp
+++ b/unit_tests/tests/trigger/test_real_subaru_ej20g.cpp
@@ -21,7 +21,7 @@ TEST(real, SubaruEj20gcranking_only_cam7) {
 	ASSERT_TRUE(reader.gotRpm);
 	ASSERT_FALSE(reader.gotSync);
 
-	ASSERT_EQ(0, eth.recentWarnings()->getCount());
+	ASSERT_EQ(0u, eth.recentWarnings()->getCount());
 }
 
 TEST(real, SubaruEj20gDefaultCranking) {

--- a/unit_tests/tests/trigger/test_real_volkswagen.cpp
+++ b/unit_tests/tests/trigger/test_real_volkswagen.cpp
@@ -23,7 +23,7 @@ TEST(crankingVW, vwRealCrankingFromFile) {
 		reader.processLine(&eth);
 	}
 
-	ASSERT_EQ( 0, eth.recentWarnings()->getCount())<< "warningCounter#vwRealCranking";
+	ASSERT_EQ( 0u, eth.recentWarnings()->getCount())<< "warningCounter#vwRealCranking";
 	ASSERT_EQ( 1695, round(Sensor::getOrZero(SensorType::Rpm)))<< reader.lineIndex();
 }
 
@@ -43,7 +43,7 @@ TEST(crankingVW, crankingTwiceWithGap) {
 			reader.processLine(&eth);
 		}
 
-		ASSERT_EQ(0, eth.recentWarnings()->getCount())<< "warningCounter#vwRealCranking";
+		ASSERT_EQ(0u, eth.recentWarnings()->getCount())<< "warningCounter#vwRealCranking";
 		ASSERT_EQ(1695, round(Sensor::getOrZero(SensorType::Rpm)))<< reader.lineIndex();
 	}
 
@@ -59,7 +59,7 @@ TEST(crankingVW, crankingTwiceWithGap) {
 			reader.processLine(&eth);
 		}
 
-		ASSERT_EQ(0, eth.recentWarnings()->getCount());
+		ASSERT_EQ(0u, eth.recentWarnings()->getCount());
 		ASSERT_EQ(1695, round(Sensor::getOrZero(SensorType::Rpm)))<< reader.lineIndex();
 	}
 
@@ -73,7 +73,7 @@ TEST(crankingVW, crankingTwiceWithGap) {
 			reader.processLine(&eth);
 		}
 
-		ASSERT_EQ(0, eth.recentWarnings()->getCount());
+		ASSERT_EQ(0u, eth.recentWarnings()->getCount());
 		ASSERT_EQ(1695, round(Sensor::getOrZero(SensorType::Rpm)))<< reader.lineIndex();
 	}
 }

--- a/unit_tests/tests/trigger/test_rpm_acceleration.cpp
+++ b/unit_tests/tests/trigger/test_rpm_acceleration.cpp
@@ -6,14 +6,14 @@ TEST(engine, testRpmAcceleration) {
 
 	// first revolution
 	eth.smartFireTriggerEvents2(/*count*/1, /*delay*/ 40);
-    ASSERT_EQ(0,  engine->triggerCentral.triggerState.totalTriggerErrorCounter);
+    ASSERT_EQ(0u,  engine->triggerCentral.triggerState.totalTriggerErrorCounter);
 	ASSERT_EQ(1500, Sensor::getOrZero(SensorType::Rpm));
 	// no acceleration info YET, huh?
 	ASSERT_EQ(0, engine->rpmCalculator.getRpmAcceleration());
 
 	// second revolution same speed
 	eth.smartFireTriggerEvents2(/*count*/1, /*delay*/ 40);
-	ASSERT_EQ(0,  engine->triggerCentral.triggerState.totalTriggerErrorCounter);
+	ASSERT_EQ(0u,  engine->triggerCentral.triggerState.totalTriggerErrorCounter);
 	ASSERT_EQ(1500, Sensor::getOrZero(SensorType::Rpm));
 	// we got RPM we got acceleration
 	ASSERT_EQ(9375, engine->rpmCalculator.getRpmAcceleration());
@@ -22,5 +22,5 @@ TEST(engine, testRpmAcceleration) {
 	eth.smartFireTriggerEvents2(/*count*/1, /*delay*/ 80);
 	ASSERT_EQ(1000, Sensor::getOrZero(SensorType::Rpm));
 	ASSERT_NEAR(-2083.3335, engine->rpmCalculator.getRpmAcceleration(), EPS3D);
-    ASSERT_EQ(0,  engine->triggerCentral.triggerState.totalTriggerErrorCounter);
+    ASSERT_EQ(0u,  engine->triggerCentral.triggerState.totalTriggerErrorCounter);
 }

--- a/unit_tests/tests/trigger/test_symmetrical_crank.cpp
+++ b/unit_tests/tests/trigger/test_symmetrical_crank.cpp
@@ -26,20 +26,20 @@ TEST(engine, testAngleLogicInSymmetricalCrankIssue2980) {
 	// Check one angle just after every trigger tooth, for two full revolutions (720 degrees, one engine cycle, 4 loops of the trigger)
 
 	// First quarter
-	EXPECT_FINDANGLE(0 * 180 + 5, 0);		// 5
-	EXPECT_FINDANGLE(0 * 180 + 115, 2);		// 115
+	EXPECT_FINDANGLE(0 * 180 + 5, 0u);		// 5
+	EXPECT_FINDANGLE(0 * 180 + 115, 2u);		// 115
 
 	// Second quarter
-	EXPECT_FINDANGLE(1 * 180 + 5, 4);		// 180+5 = 185
-	EXPECT_FINDANGLE(1 * 180 + 115, 6);		// 180+115 = 295
+	EXPECT_FINDANGLE(1 * 180 + 5, 4u);		// 180+5 = 185
+	EXPECT_FINDANGLE(1 * 180 + 115, 6u);		// 180+115 = 295
 
 	// Third quarter
-	EXPECT_FINDANGLE(2 * 180 + 5, 8);		// 360+5 = 365
-	EXPECT_FINDANGLE(2 * 180 + 115, 10);	// 360+115 = 475
+	EXPECT_FINDANGLE(2 * 180 + 5, 8u);		// 360+5 = 365
+	EXPECT_FINDANGLE(2 * 180 + 115, 10u);	// 360+115 = 475
 
 	// Fourth quarter
-	EXPECT_FINDANGLE(3 * 180 + 5, 12);		// 540+5 = 545
-	EXPECT_FINDANGLE(3 * 180 + 115, 14);	// 540+115 = 655
+	EXPECT_FINDANGLE(3 * 180 + 5, 12u);		// 540+5 = 545
+	EXPECT_FINDANGLE(3 * 180 + 115, 14u);	// 540+115 = 655
 }
 
 TEST(engine, testSymmetricalCrank) {

--- a/unit_tests/tests/trigger/test_toyota_3_tooth_cam.cpp
+++ b/unit_tests/tests/trigger/test_toyota_3_tooth_cam.cpp
@@ -41,7 +41,7 @@ TEST(Toyota3ToothCam, RealEngineRunning) {
 	ASSERT_EQ(3078, round(Sensor::getOrZero(SensorType::Rpm)));
 
 	// TODO: why warnings?
-	ASSERT_EQ(1, eth.recentWarnings()->getCount());
+	ASSERT_EQ(1u, eth.recentWarnings()->getCount());
 	ASSERT_EQ(ObdCode::CUSTOM_PRIMARY_TOO_MANY_TEETH, eth.recentWarnings()->get(0).Code);
 }
 

--- a/unit_tests/tests/trigger/test_trigger_decoder.cpp
+++ b/unit_tests/tests/trigger/test_trigger_decoder.cpp
@@ -359,7 +359,7 @@ TEST(trigger, testTriggerDecoder) {
 		TriggerWaveform * s = &engine->triggerCentral.triggerShape;
 
 		initializeSkippedToothTrigger(s, 2, 0, FOUR_STROKE_CAM_SENSOR, SyncEdge::Rise);
-		ASSERT_EQ(4, s->getSize()) << "shape size";
+		ASSERT_EQ(4u, s->getSize()) << "shape size";
 		ASSERT_EQ(s->wave.getSwitchTime(0), 0.25);
 		ASSERT_EQ(s->wave.getSwitchTime(1), 0.5);
 		ASSERT_EQ(s->wave.getSwitchTime(2), 0.75);
@@ -454,7 +454,7 @@ static void setTestBug299(EngineTestHelper *eth) {
 	// inj #0 |.......#|........|.......#|........|
 	// inj #1 |........|.......#|........|.......#|
 	ASSERT_EQ( 4,  engine->scheduler.size()) << "qs#00";
-	ASSERT_EQ( 3,  getRevolutionCounter()) << "rev cnt#3";
+	ASSERT_EQ( 3u, getRevolutionCounter()) << "rev cnt#3";
 	eth->assertInjectorUpEvent("setTestBug299: 1@0", 0, MS2US(8.5), 2);
 	eth->assertInjectorDownEvent("@1", 1, MS2US(10), 2);
 	eth->assertInjectorUpEvent("1@2", 2, MS2US(18.5), 3);
@@ -477,7 +477,7 @@ static void setTestBug299(EngineTestHelper *eth) {
 	// inj #0 |.......#|........|.......#|........|
 	// inj #1 |........|.......#|........|.......#|
 	ASSERT_EQ( 8,  engine->scheduler.size()) << "qs#0";
-	ASSERT_EQ( 3,  getRevolutionCounter()) << "rev cnt#3";
+	ASSERT_EQ( 3u, getRevolutionCounter()) << "rev cnt#3";
 	eth->assertInjectorUpEvent("02@0", 0, MS2US(-11.5), 2);
 	eth->assertInjectorDownEvent("@1", 1, MS2US(-10), 2);
 	eth->assertInjectorUpEvent("@2", 2, MS2US(-1.5), 3);
@@ -520,7 +520,7 @@ static void setTestBug299(EngineTestHelper *eth) {
 	// inj #0 |.......#|........|........|........|
 	// inj #1 |........|.......#|........|........|
 	ASSERT_EQ( 4,  engine->scheduler.size()) << "qs#0-2";
-	ASSERT_EQ( 4,  getRevolutionCounter()) << "rev cnt#4";
+	ASSERT_EQ( 4u, getRevolutionCounter()) << "rev cnt#4";
 	eth->assertInjectorUpEvent("0@0", 0, MS2US(8.5), 0);
 	eth->assertInjectorDownEvent("0@1", 1, MS2US(10), 0);
 	eth->assertInjectorUpEvent("0@2", 2, MS2US(18.5), 1);
@@ -582,9 +582,9 @@ void doTestFuelSchedulerBug299smallAndMedium(int startUpDelayMs) {
 	ASSERT_EQ( 0,  engine->scheduler.size()) << "qs#1#2";
 
 
-	ASSERT_EQ( 4,  getRevolutionCounter()) << "rev cnt#4#0";
+	ASSERT_EQ( 4u,  getRevolutionCounter()) << "rev cnt#4#0";
 	eth.firePrimaryTriggerRise();
-	ASSERT_EQ( 5,  getRevolutionCounter()) << "rev cnt#4#1";
+	ASSERT_EQ( 5u,  getRevolutionCounter()) << "rev cnt#4#1";
 	// time...|0.......|10......|20......|30......|40......|50......|60......|
 	// inj #0 |########|##...###|########|.....###|########|........|........|
 	// inj #1 |.....###|########|....####|########|........|........|........|
@@ -612,7 +612,7 @@ void doTestFuelSchedulerBug299smallAndMedium(int startUpDelayMs) {
 
 	eth.fireFall(20);
 	ASSERT_EQ( 8,  engine->scheduler.size()) << "qs#2#1";
-	ASSERT_EQ( 5,  getRevolutionCounter()) << "rev cnt#5";
+	ASSERT_EQ( 5u, getRevolutionCounter()) << "rev cnt#5";
 	// using old fuel schedule - but already wider pulses
 	// time...|-20.....|-10.....|0.......|10......|20......|30......|40......|
 	// inj #0 |........|.....###|########|.....###|########|........|........|
@@ -655,7 +655,7 @@ void doTestFuelSchedulerBug299smallAndMedium(int startUpDelayMs) {
 
 	eth.firePrimaryTriggerRise();
 	ASSERT_EQ( 4,  engine->scheduler.size()) << "qs#2#2";
-	ASSERT_EQ( 6,  getRevolutionCounter()) << "rev cnt6";
+	ASSERT_EQ( 6u, getRevolutionCounter()) << "rev cnt6";
 	// time...|-20.....|-10.....|0.......|10......|20......|30......|40......|
 	// inj #0 |########|.....###|########|....####|........|........|........|
 	// inj #1 |.....###|########|.....###|########|........|........|........|
@@ -695,7 +695,7 @@ void doTestFuelSchedulerBug299smallAndMedium(int startUpDelayMs) {
 	eth.firePrimaryTriggerFall();
 
 	ASSERT_EQ( 5,  engine->scheduler.size()) << "qs#3";
-	ASSERT_EQ( 6,  getRevolutionCounter()) << "rev cnt6";
+	ASSERT_EQ( 6u, getRevolutionCounter()) << "rev cnt6";
 	ASSERT_EQ( 0,  eth.executeActions()) << "executed #6";
 
 
@@ -786,7 +786,7 @@ void doTestFuelSchedulerBug299smallAndMedium(int startUpDelayMs) {
 ////	assertInjectorDownEvent("8@8", 8, MS2US(45), 1);
 ////	assertInjectorDownEvent("8@9", 9, MS2US(55), 0);
 
-	ASSERT_EQ( 0,  getRecentWarnings()->getCount()) << "warningCounter#testFuelSchedulerBug299smallAndMedium";
+	ASSERT_EQ( 0u,  getRecentWarnings()->getCount()) << "warningCounter#testFuelSchedulerBug299smallAndMedium";
 }
 
 void setInjectionMode(int value) {
@@ -1036,7 +1036,7 @@ TEST(big, testFuelSchedulerBug299smallAndLarge) {
 
 	eth.moveTimeForwardUs(MS2US(20));
 	eth.executeActions();
-	ASSERT_EQ( 0,  getRecentWarnings()->getCount()) << "warningCounter#testFuelSchedulerBug299smallAndLarge";
+	ASSERT_EQ( 0u,  getRecentWarnings()->getCount()) << "warningCounter#testFuelSchedulerBug299smallAndLarge";
 }
 #endif //FUEL_RPM_COUNT == 16
 
@@ -1111,7 +1111,7 @@ TEST(big, testSparkReverseOrderBug319) {
 
 	eth.fireFall(20);
 	eth.executeActions();
-	ASSERT_EQ( 1,  engine->engineState.sparkOutOfOrderCounter) << "out-of-order #4";
+	ASSERT_EQ( 1u,  engine->engineState.sparkOutOfOrderCounter) << "out-of-order #4";
 
 	printf("*************************************************** (rpm is back) now let's have a good engine cycle and confirm things work\r\n");
 
@@ -1140,7 +1140,7 @@ TEST(big, testSparkReverseOrderBug319) {
 	eth.fireFall(20);
 	eth.executeActions();
 	ASSERT_EQ( 1,  engine->engineState.sparkOutOfOrderCounter) << "out-of-order #8";
-	ASSERT_EQ( 2,  getRecentWarnings()->getCount()) << "warningCounter#SparkReverseOrderBug319";
+	ASSERT_EQ( 2u, getRecentWarnings()->getCount()) << "warningCounter#SparkReverseOrderBug319";
 	ASSERT_EQ(ObdCode::CUSTOM_DWELL_TOO_LONG, getRecentWarnings()->get(0).Code) << "warning @0";
 	ASSERT_EQ(ObdCode::CUSTOM_OUT_OF_ORDER_COIL, getRecentWarnings()->get(1).Code);
 }
@@ -1156,27 +1156,27 @@ TEST(big, testAssertWeAreNotMissingASpark299) {
 	engineConfiguration->isIgnitionEnabled = true;
 	engineConfiguration->isInjectionEnabled = false;
 
-	ASSERT_EQ( 0,  getRecentWarnings()->getCount()) << "warningCounter#0";
+	ASSERT_EQ( 0u,  getRecentWarnings()->getCount()) << "warningCounter#0";
 
   // todo: migrate to 'smartFireRise' see header which explains the difference
 	eth.fireRise(20);
 	eth.executeActions();
-	ASSERT_EQ( 0,  engine->triggerCentral.triggerState.currentCycle.current_index) << "ci#0";
+	ASSERT_EQ( 0u,  engine->triggerCentral.triggerState.currentCycle.current_index) << "ci#0";
 
 
 	eth.fireFall(20);
 	eth.executeActions();
-	ASSERT_EQ( 1,  engine->triggerCentral.triggerState.currentCycle.current_index) << "ci#1";
+	ASSERT_EQ( 1u,  engine->triggerCentral.triggerState.currentCycle.current_index) << "ci#1";
 
 
 	eth.fireRise(20);
 	eth.executeActions();
-	ASSERT_EQ( 0,  engine->triggerCentral.triggerState.currentCycle.current_index) << "ci#2";
+	ASSERT_EQ( 0u,  engine->triggerCentral.triggerState.currentCycle.current_index) << "ci#2";
 
 
 	eth.fireFall(20);
 	eth.executeActions();
-	ASSERT_EQ( 1,  engine->triggerCentral.triggerState.currentCycle.current_index) << "ci#3";
+	ASSERT_EQ( 1u,  engine->triggerCentral.triggerState.currentCycle.current_index) << "ci#3";
 
 
 	eth.fireRise(20);
@@ -1185,7 +1185,7 @@ TEST(big, testAssertWeAreNotMissingASpark299) {
 
 	eth.fireFall(20);
 	eth.executeActions();
-	ASSERT_EQ( 1,  eth.engine.triggerCentral.triggerState.currentCycle.current_index) << "ci#5";
+	ASSERT_EQ( 1u,  eth.engine.triggerCentral.triggerState.currentCycle.current_index) << "ci#5";
 
 
 	printf("*************************************************** testMissedSpark299 start\r\n");
@@ -1228,5 +1228,5 @@ TEST(big, testAssertWeAreNotMissingASpark299) {
 	eth.fireFall(20);
 	eth.executeActions();
 
-	ASSERT_EQ( 0,  getRecentWarnings()->getCount()) << "warningCounter#1";
+	ASSERT_EQ( 0u,  getRecentWarnings()->getCount()) << "warningCounter#1";
 }

--- a/unit_tests/tests/trigger/test_trigger_decoder_2.cpp
+++ b/unit_tests/tests/trigger/test_trigger_decoder_2.cpp
@@ -39,29 +39,29 @@ TEST(TriggerDecoder, FindsFirstSyncPoint) {
 	t += MS2NT(1);
 	doTooth(dut, shape, cfg, t);
 	EXPECT_FALSE(dut.getShaftSynchronized());
-	EXPECT_EQ(2, dut.currentCycle.current_index);
+	EXPECT_EQ(2u, dut.currentCycle.current_index);
 
 	t += MS2NT(1);
 	doTooth(dut, shape, cfg, t);
 	EXPECT_FALSE(dut.getShaftSynchronized());
-	EXPECT_EQ(4, dut.currentCycle.current_index);
+	EXPECT_EQ(4u, dut.currentCycle.current_index);
 
 	t += MS2NT(1);
 	doTooth(dut, shape, cfg, t);
 	EXPECT_FALSE(dut.getShaftSynchronized());
-	EXPECT_EQ(6, dut.currentCycle.current_index);
+	EXPECT_EQ(6u, dut.currentCycle.current_index);
 
 	// Missing tooth, 2x normal length!
 	t += MS2NT(2);
 	doTooth(dut, shape, cfg, t);
 	EXPECT_TRUE(dut.getShaftSynchronized());
-	EXPECT_EQ(0, dut.currentCycle.current_index);
+	EXPECT_EQ(0u, dut.currentCycle.current_index);
 
 	// Normal tooth after the missing tooth, should be index 2 now (one rise + one fall)
 	t += MS2NT(1);
 	doTooth(dut, shape, cfg, t);
 	EXPECT_TRUE(dut.getShaftSynchronized());
-	EXPECT_EQ(2, dut.currentCycle.current_index);
+	EXPECT_EQ(2u, dut.currentCycle.current_index);
 
 	EXPECT_FALSE(dut.someSortOfTriggerError());
 }
@@ -90,7 +90,7 @@ TEST(TriggerDecoder, FindsSyncPointMultipleRevolutions) {
 	t += MS2NT(2);
 	doTooth(dut, shape, cfg, t);
 	EXPECT_TRUE(dut.getShaftSynchronized());
-	EXPECT_EQ(0, dut.currentCycle.current_index);
+	EXPECT_EQ(0u, dut.currentCycle.current_index);
 	EXPECT_EQ(0, dut.getSynchronizationCounter());
 
 	// Do 100 turns and make sure we stay synchronized
@@ -98,18 +98,18 @@ TEST(TriggerDecoder, FindsSyncPointMultipleRevolutions) {
 		// normal tooth
 		t += MS2NT(1);
 		doTooth(dut, shape, cfg, t);
-		EXPECT_EQ(2, dut.currentCycle.current_index);
+		EXPECT_EQ(2u, dut.currentCycle.current_index);
 
 		// normal tooth
 		t += MS2NT(1);
 		doTooth(dut, shape, cfg, t);
-		EXPECT_EQ(4, dut.currentCycle.current_index);
+		EXPECT_EQ(4u, dut.currentCycle.current_index);
 
 		// Missing tooth, 2x normal length!
 		t += MS2NT(2);
 		doTooth(dut, shape, cfg, t);
 		EXPECT_TRUE(dut.getShaftSynchronized());
-		EXPECT_EQ(0, dut.currentCycle.current_index);
+		EXPECT_EQ(0u, dut.currentCycle.current_index);
 		EXPECT_FALSE(dut.someSortOfTriggerError());
 
 		// We do one revolution per loop iteration
@@ -147,7 +147,7 @@ TEST(TriggerDecoder, TooManyTeeth_CausesError) {
 	t += MS2NT(2);
 	doTooth(dut, shape, cfg, t);
 	EXPECT_TRUE(dut.getShaftSynchronized());
-	EXPECT_EQ(0, dut.currentCycle.current_index);
+	EXPECT_EQ(0u, dut.currentCycle.current_index);
 
 	// Fake that we have RPM so that all trigger error detection is enabled
 	Sensor::setMockValue(SensorType::Rpm, 1000);
@@ -155,20 +155,20 @@ TEST(TriggerDecoder, TooManyTeeth_CausesError) {
 	t += MS2NT(1);
 	doTooth(dut, shape, cfg, t);
 	EXPECT_TRUE(dut.getShaftSynchronized());
-	EXPECT_EQ(2, dut.currentCycle.current_index);
+	EXPECT_EQ(2u, dut.currentCycle.current_index);
 
 	t += MS2NT(1);
 	doTooth(dut, shape, cfg, t);
 	EXPECT_TRUE(dut.getShaftSynchronized());
-	EXPECT_EQ(4, dut.currentCycle.current_index);
-	EXPECT_EQ(0, dut.totalTriggerErrorCounter);
+	EXPECT_EQ(4u, dut.currentCycle.current_index);
+	EXPECT_EQ(0u, dut.totalTriggerErrorCounter);
 
 	// This tooth is extra - expect a call to onTriggerError() and loss of sync!
 	t += MS2NT(1);
 	doTooth(dut, shape, cfg, t);
 	EXPECT_FALSE(dut.getShaftSynchronized());
-	EXPECT_EQ(6, dut.currentCycle.current_index);
-	EXPECT_EQ(1, dut.totalTriggerErrorCounter);
+	EXPECT_EQ(6u, dut.currentCycle.current_index);
+	EXPECT_EQ(1u, dut.totalTriggerErrorCounter);
 
 	// Fire some normal revolutions to ensure we recover without additional error types.
 	for (size_t i = 0; i < 10; i++) {
@@ -176,17 +176,17 @@ TEST(TriggerDecoder, TooManyTeeth_CausesError) {
 		t += MS2NT(2);
 		doTooth(dut, shape, cfg, t);
 		EXPECT_TRUE(dut.getShaftSynchronized());
-		EXPECT_EQ(0, dut.currentCycle.current_index);
+		EXPECT_EQ(0u, dut.currentCycle.current_index);
 
 		// normal tooth
 		t += MS2NT(1);
 		doTooth(dut, shape, cfg, t);
-		EXPECT_EQ(2, dut.currentCycle.current_index);
+		EXPECT_EQ(2u, dut.currentCycle.current_index);
 
 		// normal tooth
 		t += MS2NT(1);
 		doTooth(dut, shape, cfg, t);
-		EXPECT_EQ(4, dut.currentCycle.current_index);
+		EXPECT_EQ(4u, dut.currentCycle.current_index);
 	}
 
 	// Should now have sync again
@@ -225,7 +225,7 @@ TEST(TriggerDecoder, NotEnoughTeeth_CausesError) {
 	t += MS2NT(2);
 	doTooth(dut, shape, cfg, t);
 	EXPECT_TRUE(dut.getShaftSynchronized());
-	EXPECT_EQ(0, dut.currentCycle.current_index);
+	EXPECT_EQ(0u, dut.currentCycle.current_index);
 
 	// Fake that we have RPM so that all trigger error detection is enabled
 	Sensor::setMockValue(SensorType::Rpm, 1000);
@@ -233,9 +233,9 @@ TEST(TriggerDecoder, NotEnoughTeeth_CausesError) {
 	t += MS2NT(1);
 	doTooth(dut, shape, cfg, t);
 	EXPECT_TRUE(dut.getShaftSynchronized());
-	EXPECT_EQ(2, dut.currentCycle.current_index);
+	EXPECT_EQ(2u, dut.currentCycle.current_index);
 	EXPECT_FALSE(dut.someSortOfTriggerError());
-	EXPECT_EQ(0, dut.totalTriggerErrorCounter);
+	EXPECT_EQ(0u, dut.totalTriggerErrorCounter);
 
 	// Missing tooth, but it comes early - not enough teeth have happened yet!
 	t += MS2NT(2);
@@ -243,8 +243,8 @@ TEST(TriggerDecoder, NotEnoughTeeth_CausesError) {
 
 	// Sync is lost until we get to another sync point
 	EXPECT_FALSE(dut.getShaftSynchronized());
-	EXPECT_EQ(0, dut.currentCycle.current_index);
-	EXPECT_EQ(1, dut.totalTriggerErrorCounter);
+	EXPECT_EQ(0u, dut.currentCycle.current_index);
+	EXPECT_EQ(1u, dut.totalTriggerErrorCounter);
 	EXPECT_TRUE(dut.someSortOfTriggerError());
 
 	// Fire some normal revolutions to ensure we recover without additional error types.
@@ -252,18 +252,18 @@ TEST(TriggerDecoder, NotEnoughTeeth_CausesError) {
 		// normal tooth
 		t += MS2NT(1);
 		doTooth(dut, shape, cfg, t);
-		EXPECT_EQ(2, dut.currentCycle.current_index);
+		EXPECT_EQ(2u, dut.currentCycle.current_index);
 
 		// normal tooth
 		t += MS2NT(1);
 		doTooth(dut, shape, cfg, t);
-		EXPECT_EQ(4, dut.currentCycle.current_index);
+		EXPECT_EQ(4u, dut.currentCycle.current_index);
 
 		// Missing tooth, 2x normal length!
 		t += MS2NT(2);
 		doTooth(dut, shape, cfg, t);
 		EXPECT_TRUE(dut.getShaftSynchronized());
-		EXPECT_EQ(0, dut.currentCycle.current_index);
+		EXPECT_EQ(0u, dut.currentCycle.current_index);
 	}
 
 	// Should now have sync again

--- a/unit_tests/tests/trigger/test_trigger_input_adc.cpp
+++ b/unit_tests/tests/trigger/test_trigger_input_adc.cpp
@@ -83,7 +83,7 @@ static void simulateTrigger(EngineTestHelper &eth, TriggerAdcDetector &trigAdcSt
 	}
 }
 
-static void testOnCsvData(const char *fileName, int finalRpm, int risingCnt, int fallingCnt, int errCnt) {
+static void testOnCsvData(const char *fileName, int finalRpm, int risingCnt, int fallingCnt, uint32_t errCnt) {
 	EngineTestHelper eth(engine_type_e::TEST_ENGINE);
 
 	engineConfiguration->ignitionMode = IM_WASTED_SPARK;
@@ -97,7 +97,7 @@ static void testOnCsvData(const char *fileName, int finalRpm, int risingCnt, int
 	// we generate the data that way
 	engineConfiguration->invertPrimaryTriggerSignal = true;
 
-	ASSERT_EQ(0, engine->triggerCentral.triggerState.totalTriggerErrorCounter);
+	ASSERT_EQ(0u, engine->triggerCentral.triggerState.totalTriggerErrorCounter);
 	ASSERT_EQ(0,  Sensor::getOrZero(SensorType::Rpm)) << "testTriggerInputAdc RPM #1 on " << fileName;
 
 	trigAdcState.init();

--- a/unit_tests/tests/trigger/test_trigger_noiseless.cpp
+++ b/unit_tests/tests/trigger/test_trigger_noiseless.cpp
@@ -94,7 +94,7 @@ static void testNoiselessDecoderProcedure(EngineTestHelper &eth, int errorTolera
 	fireNoisyCycle60_2(&eth, 2, 1000, -1, 0, 0, 0);
 
 	// should be no errors anyway
-	ASSERT_EQ( 0,  engine->triggerCentral.triggerState.totalTriggerErrorCounter) << "testNoiselessDecoderProcedure totalTriggerErrorCounter";
+	ASSERT_EQ( 0u, engine->triggerCentral.triggerState.totalTriggerErrorCounter) << "testNoiselessDecoderProcedure totalTriggerErrorCounter";
 	// check if we're imitating the 60-2 signal correctly
 	ASSERT_EQ( 0,  eth.engine.triggerCentral.triggerState.getCurrentIndex()) << "index #1";
 	// check rpm (60secs / (1000us * 60teeth)) = 1000rpm
@@ -155,7 +155,7 @@ static void testNoiselessDecoderProcedure(EngineTestHelper &eth, int errorTolera
 	// alas, this is a hard case even for noiseless decoder, and it fails...
 	// but still we're close to 33% signal-noise ratio threshold - not bad!
 	// so here's an error anyway!
-	ASSERT_EQ( 1,  engine->triggerCentral.triggerState.totalTriggerErrorCounter) << "testNoiselessDecoder noise#7_fail_test";
+	ASSERT_EQ( 1u,  engine->triggerCentral.triggerState.totalTriggerErrorCounter) << "testNoiselessDecoder noise#7_fail_test";
 }
 
 TEST(trigger, noiselessDecoder) {
@@ -168,7 +168,7 @@ TEST(trigger, noiselessDecoder) {
 	// we'll test on 60-2 wheel
 	eth.setTriggerType(trigger_type_e::TT_TOOTHED_WHEEL_60_2);
 
-	ASSERT_EQ(0, engine->triggerCentral.triggerState.totalTriggerErrorCounter);
+	ASSERT_EQ( 0u, engine->triggerCentral.triggerState.totalTriggerErrorCounter);
 	ASSERT_EQ( 0,  Sensor::getOrZero(SensorType::Rpm)) << "testNoiselessDecoder RPM";
 
 	//printTriggerDebug = true;

--- a/unit_tests/tests/trigger/test_trigger_sequence_finder.cpp
+++ b/unit_tests/tests/trigger/test_trigger_sequence_finder.cpp
@@ -28,7 +28,7 @@ static bool tryGapSequence(size_t length, int toothIndex, TriggerWaveform &form,
 		trigger_config_s &triggerConfig) {
 	int toothCount = form.getSize() / 2;
 
-	for (int gapIndex = 0; gapIndex < length; gapIndex++) {
+	for (size_t gapIndex = 0; gapIndex < length; gapIndex++) {
 
 		int ratioIndex = toothIndex - gapIndex;
 		if (ratioIndex < 0)
@@ -36,7 +36,7 @@ static bool tryGapSequence(size_t length, int toothIndex, TriggerWaveform &form,
 		float ratio = ratios[ratioIndex];
 		ratiosThisTime[ratioIndex] = ratio;
 //			printf("trying %d ratio %f\n", gapIndex, ratio);
-    form.setTriggerSynchronizationGap4(gapIndex, ratio);
+		form.setTriggerSynchronizationGap4(gapIndex, ratio);
 	}
 
 	TriggerDecoderBase decoder("test");
@@ -50,7 +50,7 @@ static bool tryGapSequence(size_t length, int toothIndex, TriggerWaveform &form,
 				triggerConfiguration);
 
 		if (!form.shapeDefinitionError) {
-			for (int i = 0; i < length; i++) {
+			for (int i = 0; i < (int)length; i++) {
 				float ratio = ratiosThisTime[i];
 				printf("happy ratio %f @ %d\n", ratio, i);
 			}
@@ -109,11 +109,11 @@ static size_t findAllSyncSequences(trigger_type_e t, size_t maxLength,
 }
 
 TEST(trigger, finder) {
-	ASSERT_EQ(9, findAllSyncSequences(trigger_type_e::TT_VVT_BOSCH_QUICK_START, 3, [] (TriggerWaveform* form) {
+	ASSERT_EQ(9u, findAllSyncSequences(trigger_type_e::TT_VVT_BOSCH_QUICK_START, 3, [] (TriggerWaveform* form) {
 						configureQuickStartSenderWheel(form);
 					}));
 
-	ASSERT_EQ(27, findAllSyncSequences(trigger_type_e::TT_GM_24x_3, 3, [] (TriggerWaveform* form) {
+	ASSERT_EQ(27u, findAllSyncSequences(trigger_type_e::TT_GM_24x_3, 3, [] (TriggerWaveform* form) {
 						initGmLS24_3deg(form);
 					}));
 

--- a/unit_tests/tests/util/test_buffered_writer.cpp
+++ b/unit_tests/tests/util/test_buffered_writer.cpp
@@ -18,16 +18,16 @@ TEST(BufferedWriter, WriteSmall) {
 	// No calls to dut expected
 	StrictMock<MockBufferedWriter<10>> dut;
 
-	EXPECT_EQ(0, dut.write(testBuffer, 5));
+	EXPECT_EQ(0u, dut.write(testBuffer, 5));
 }
 
 TEST(BufferedWriter, WriteSmallFlush) {
 	StrictMock<MockBufferedWriter<10>> dut;
 	EXPECT_CALL(dut, writeInternal(_, 5)).WillOnce(Return(5));
 
-	ASSERT_EQ(0, dut.write(testBuffer, 5));
+	ASSERT_EQ(0u, dut.write(testBuffer, 5));
 
-	EXPECT_EQ(dut.flush(), 5);
+	EXPECT_EQ(dut.flush(), 5u);
 }
 
 TEST(BufferedWriter, WriteMultipleSmall) {
@@ -37,13 +37,13 @@ TEST(BufferedWriter, WriteMultipleSmall) {
 		EXPECT_CALL(dut, writeInternal(_, 2)).WillOnce(Return(2));
 	}
 
-	EXPECT_EQ(0, dut.write(testBuffer, 3));
-	EXPECT_EQ(0, dut.write(testBuffer, 3));
-	EXPECT_EQ(0, dut.write(testBuffer, 3));
-	EXPECT_EQ(10, dut.write(testBuffer, 3));	// <- this one should trigger a flush
+	EXPECT_EQ(0u, dut.write(testBuffer, 3));
+	EXPECT_EQ(0u, dut.write(testBuffer, 3));
+	EXPECT_EQ(0u, dut.write(testBuffer, 3));
+	EXPECT_EQ(10u, dut.write(testBuffer, 3));	// <- this one should trigger a flush
 
 	// Flush the remainder
-	EXPECT_EQ(dut.flush(), 2);
+	EXPECT_EQ(dut.flush(), 2u);
 }
 
 TEST(BufferedWriter, WriteSingleFullBufferSize) {
@@ -51,10 +51,10 @@ TEST(BufferedWriter, WriteSingleFullBufferSize) {
 
 	EXPECT_CALL(dut, writeInternal(_, 50)).WillOnce(Return(50));
 
-	EXPECT_EQ(50, dut.write(testBuffer, 50));
+	EXPECT_EQ(50u, dut.write(testBuffer, 50));
 
 	// Nothing left to flush!
-	EXPECT_EQ(0, dut.flush());
+	EXPECT_EQ(0u, dut.flush());
 }
 
 TEST(BufferedWriter, WriteLarge) {
@@ -64,9 +64,9 @@ TEST(BufferedWriter, WriteLarge) {
 		EXPECT_CALL(dut, writeInternal(_, 45)).WillOnce(Return(45));
 	}
 
-	EXPECT_EQ(45, dut.write(testBuffer, 45));
+	EXPECT_EQ(45u, dut.write(testBuffer, 45));
 
-	EXPECT_EQ(0, dut.flush());
+	EXPECT_EQ(0u, dut.flush());
 }
 
 TEST(BufferedWriter, WriteLargeAfterSmall) {
@@ -77,9 +77,9 @@ TEST(BufferedWriter, WriteLargeAfterSmall) {
 		EXPECT_CALL(dut, writeInternal(_, 36)).WillOnce(Return(36));
 	}
 
-	EXPECT_EQ(0, dut.write(testBuffer, 1));
+	EXPECT_EQ(0u, dut.write(testBuffer, 1));
 
-	EXPECT_EQ(46, dut.write(testBuffer, 45));
+	EXPECT_EQ(46u, dut.write(testBuffer, 45));
 
-	EXPECT_EQ(0, dut.flush());
+	EXPECT_EQ(0u, dut.flush());
 }

--- a/unit_tests/tests/util/test_lua_script_executor.h
+++ b/unit_tests/tests/util/test_lua_script_executor.h
@@ -24,7 +24,7 @@ private:
 template<typename... Args>
 void TestLuaScriptExecutor::executeFormattedLuaScript(const char* const luaScriptFormatString, Args... args) {
 	char luaScript[256];
-	const int luaScriptLength = std::snprintf(luaScript, sizeof(luaScript), luaScriptFormatString, args...);
+	const size_t luaScriptLength = std::snprintf(luaScript, sizeof(luaScript), luaScriptFormatString, args...);
 	ASSERT_TRUE(0 <= luaScriptLength) << "Encoding error" << std::endl << luaScriptFormatString;
 	ASSERT_TRUE(luaScriptLength < sizeof(luaScript)) << "Insufficient buffer" << std::endl <<  luaScriptFormatString;
 	executeLuaScript(luaScript);


### PR DESCRIPTION
Shutup annoying compiler output.
In some GCC version was added a feature to warn about (unsigned int) == (int) comparision, that makes actual compiler log a very bloated.
Also removed a few warnings 'unused function argument' in a lua_hooks module.