### PR TITLE
custom flag for Celsius/Fahrenheit selector

### DIFF
--- a/firmware/tunerstudio/tunerstudio.template.ini
+++ b/firmware/tunerstudio/tunerstudio.template.ini
@@ -36,6 +36,8 @@ enable2ndByteCanID = false
 ;    settingOption = CONN_SLOW, "Slower / Wireless"
 ;    settingOption = CONN_FAST, "High Speed / USB"
 
+#set USE_METRIC_UNITS       ; unset for Fahrenheit
+
 [MegaTune]
  ; https://rusefi.com/forum/viewtopic.php?p=36201#p36201
 	signature	= @@TS_SIGNATURE@@
@@ -238,9 +240,8 @@ page = 3
 	wbo0_hasFault = { enableAemXSeries && ((wb1faultCode >= 1) || !wb1isValid) }
 
 ; calculated temperatures by F/C
-; This is not officially documented in the .ini reference,
-; but at the first occurrence of "#if CELSIUS", TS creates a settingGroup with the unit selector, which defaults to Fahrenheit.
-#if CELSIUS
+; "USE_METRIC_UNITS" set to true means that all units displayed to the user will be in Celsius.
+#if USE_METRIC_UNITS
 	; this output channels are used on tables/curves, so we need to make a new output chanel and then override it here with the celsius conditional
 	coolantTemperature = { coolant }
 	intakeTemperature = { intake }
@@ -1705,7 +1706,7 @@ gaugeCategory = Debug
 gaugeCategory = Sensors - Basic
 	RPMGauge			= RPMValue,			"RPM - engine speed",		"RPM",		0, {rpmHardLimit + 2000},	200, {cranking_rpm}, {rpmHardLimit - 500},  {rpmHardLimit},	0,	0
 
-#if CELSIUS
+#if USE_METRIC_UNITS
 	CLTGauge			= coolantTemperature,		@@GAUGE_LONG_NAME_CLT@@,		@@UNITS_CELSIUS@@,		-40,	140,	-15,		1,		95,	110,	@@GAUGE_PRECISION_TEMPERATURE_C@@
 	IATGauge			= intakeTemperature,		@@GAUGE_LONG_NAME_IAT@@,		@@UNITS_CELSIUS@@,		-40,	140,	-15,		1,		95,	110,	@@GAUGE_PRECISION_TEMPERATURE_C@@
 #else
@@ -1772,7 +1773,7 @@ gaugeCategory = Sensors - O2
 	afr1Gauge			= AFRValue,           @@GAUGE_NAME_AFR@@,        "",        10,     19.4,        12,         13,         15,          16,     2,     2
 	afr2Gauge			= AFRValue2,          @@GAUGE_NAME_AFR2@@,       "",        10,     19.4,        12,         13,         15,          16,     2,     2
 	wb1heaterDuty		= wb1heaterDuty,      "WBO1: Heater Duty",       "%",      0.0,    100.0,       1.0,        3.0,         90,          95,     1,     1,		{ canWbo1_type == @@can_wbo_type_e_RUSEFI@@ }
-#if CELSIUS
+#if USE_METRIC_UNITS
 	wb1tempC			= wb1tempC,           "WBO1: Sensor t",          @@UNITS_CELSIUS@@,      500,     1050,       500,        650,        800,         950,     0,     0,		{ canWbo1_type == @@can_wbo_type_e_RUSEFI@@ }
 #else
 	wb1tempC			= wb1tempF,           "WBO1: Sensor t",          @@UNITS_FAHRENHEIT@@,      932,     1922,       932,       1202,      1472,         1742,     0,     0,		{ canWbo1_type == @@can_wbo_type_e_RUSEFI@@ }
@@ -1780,7 +1781,7 @@ gaugeCategory = Sensors - O2
 	wb1nernstVoltage    = wb1nernstVoltage,   "WBO1: nernst V",          "V",     -0.2,      1.1,      0.35,       0.40,       0.50,        0.55,     3,     3,		{ canWbo1_type == @@can_wbo_type_e_RUSEFI@@ }
 	wb1esr				= wb1esr,             "WBO1: ESR",            "ohms",        0,      600,       200,        200,        350,         400,     0,     0,		{ canWbo1_type == @@can_wbo_type_e_RUSEFI@@ }
 	wb2heaterDuty		= wb2heaterDuty,      "WBO2: Heater Duty",       "%",      0.0,    100.0,       1.0,        3.0,         90,          95,     1,     1,		{ canWbo2_type == @@can_wbo_type_e_RUSEFI@@ }
-#if CELSIUS
+#if USE_METRIC_UNITS
 	wb2tempC			= wb2tempC,           "WBO2: Sensor t",          @@UNITS_CELSIUS@@,      500,     1050,       500,        650,        800,         950,     0,     0,		{ canWbo2_type == @@can_wbo_type_e_RUSEFI@@ }
 #else
 	wb2tempC			= wb2tempF,           "WBO2: Sensor t",          @@UNITS_FAHRENHEIT@@,      932,     1922,       932,       1202,      1472,         1742,     0,     0,		{ canWbo2_type == @@can_wbo_type_e_RUSEFI@@ }

--- a/java_tools/configuration_definition/src/test/java/com/rusefi/test/TsOutputTest.java
+++ b/java_tools/configuration_definition/src/test/java/com/rusefi/test/TsOutputTest.java
@@ -52,7 +52,7 @@ class TsOutputTest {
         String content = tsOutput.getContent();
         
         // Verify the content contains both Celsius and Fahrenheit conditionals
-        assertTrue(content.contains("#if CELSIUS"));
+        assertTrue(content.contains("#if USE_METRIC_UNITS"));
         assertTrue(content.contains("#else"));
         assertTrue(content.contains("#endif"));
 

--- a/java_tools/configuration_definition_base/src/main/java/com/rusefi/output/TsOutput.java
+++ b/java_tools/configuration_definition_base/src/main/java/com/rusefi/output/TsOutput.java
@@ -28,7 +28,7 @@ public class TsOutput {
     private final boolean isConstantsSection;
     private final StringBuilder tsHeader = new StringBuilder();
     private final TreeSet<String> usedNames = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
-    private final String celsiusConditionalStart = "#if CELSIUS" + EOL;
+    private final String celsiusConditionalStart = "#if USE_METRIC_UNITS" + EOL;
     private final String celsiusConditionalElse = "#else" + EOL;
     private final String celsiusConditionalEnd = "#endif" + EOL;
     private final String temperatureCelsiusUnit = quote("C");


### PR DESCRIPTION
replace of `#if CELSIUS` (which defaults to fahrenheit in TS), with new "TEMP_UNITS_CELSIUS" (which defaults to Celsius)

<img width="642" height="552" alt="image" src="https://github.com/user-attachments/assets/188f062e-2a05-4682-809b-f157b759ffef" />


settingGroup doesn't support a default value, so I can't give it fancy labels for the user.