### PR TITLE
WD reboot counter, stay in bootloader after 10 WD reboots

### DIFF
--- a/firmware/bootloader/bootloader_main.cpp
+++ b/firmware/bootloader/bootloader_main.cpp
@@ -20,6 +20,20 @@ static blt_bool wdReset;
 
 static const uint8_t maxWdRebootCounter = 10;
 
+#if (BOOT_COP_HOOKS_ENABLE > 0)
+// Functions for controlling the watchdog
+void CpuInit(void) {
+	// Nothing to do...
+}
+
+void CopService(void) {
+	// We need to reset WDT here
+#if HAL_USE_WDG
+	wdgResetI(&WDGD1);
+#endif
+}
+#endif
+
 class BlinkyThread : public chibios_rt::BaseStaticThread<256> {
 protected:
 	void main(void) override {

--- a/firmware/bootloader/openblt_chibios/openblt_chibios.cpp
+++ b/firmware/bootloader/openblt_chibios/openblt_chibios.cpp
@@ -5,13 +5,11 @@ extern "C" {
 	#include "flash.h"
 }
 
-void CpuInit() { }
 void CopInit() { }
 
 void TimerInit() { }
 void TimerReset() { }
 
-void CopService() { }
 void TimerUpdate() { }
 
 // See also STM32_NOCACHE_ENABLE option will enable MPU init

--- a/firmware/hw_layer/openblt/shared_params.h
+++ b/firmware/hw_layer/openblt/shared_params.h
@@ -44,6 +44,8 @@
  */
 #define SHARED_PARAMS_CFG_BUFFER_DATA_LEN        (16 - 4 - 2)
 
+/* TODO: add enum with shared parameters idx/offset to avoid magic numbers in Read/Write calls */
+
 
 /****************************************************************************************
 * Function prototypes

--- a/firmware/hw_layer/ports/stm32/stm32_reset_cause.cpp
+++ b/firmware/hw_layer/ports/stm32/stm32_reset_cause.cpp
@@ -52,8 +52,6 @@ static Reset_Cause_t readMCUResetCause() {
 
 	if (cause & BORRSTF) {
 		return Reset_Cause_BOR;
-    } else if (cause & PINRSTF) {
-		return Reset_Cause_NRST_Pin;
 	} else if (cause & PORRSTF) {
 		return Reset_Cause_POR;
 	} else if (cause & SFTRSTF) {
@@ -64,6 +62,11 @@ static Reset_Cause_t readMCUResetCause() {
         return Reset_Cause_WWatchdog;
 	} else if (cause & LPWRRSTF) {
 		return Reset_Cause_Illegal_Mode;
+	} else if (cause & PINRSTF) {
+		// See STM32 datasheet "Simplified diagram of the reset circuit"
+		// All internal resets happens through driving NRST pin low
+		// This cause rise of PINRSTF bit in CSR register
+		return Reset_Cause_NRST_Pin;
 	}
     return Reset_Cause_Unknown;
 }


### PR DESCRIPTION
Bootloader checks for WD reset. After 10 continues reset due to WD it stops in bootloader allowing user to upload fixed FW.
In this mode red LED stays on.
FW resets WD reset counter after 3 seconds of normal operation.