### PR TITLE
validate scale for SPECIAL_CASE_TEMPERATURE fields

### DIFF
--- a/java_tools/configuration_definition_base/src/main/java/com/rusefi/ConfigFieldImpl.java
+++ b/java_tools/configuration_definition_base/src/main/java/com/rusefi/ConfigFieldImpl.java
@@ -113,6 +113,7 @@ public class ConfigFieldImpl implements ConfigField {
             }
         }
         validateRange();
+        validateScale();
     }
 
     private void validateRange() {
@@ -130,6 +131,19 @@ public class ConfigFieldImpl implements ConfigField {
         double maxValue = scale * TypesHelper.getMaxValue(type);
         if (max > maxValue)
             throw new FieldOutOfRangeException(name + ": max value " + max + " outside of range. Type " + type + " maxValue " + maxValue);
+    }
+
+    private void validateScale(){
+        String[] tokens = getTokens();
+        if (tokens.length < 2) {
+            return;
+        }
+        String units = getUnits();
+        String scale = tokens[1].trim();
+
+        if(units.startsWith("SPECIAL_CASE_TEMPERATURE") && Integer.valueOf(scale) != 1){
+            throw new FieldOutOfRangeException(name + ": incorrect scale for SPECIAL_CASE_TEMPERATURE field, use 1 as scale");
+        }
     }
 
     @Override


### PR DESCRIPTION
```
E 250811 144247.611 [main] ConfigDefinition - unexpected
java.lang.IllegalStateException: While processing integration/rusefi_config.txt
        at com.rusefi.ReaderStateImpl.doJob(ReaderStateImpl.java:128)
        at com.rusefi.ConfigDefinition.doJob(ConfigDefinition.java:204)
        at com.rusefi.ConfigDefinition.main(ConfigDefinition.java:55)
Caused by: com.rusefi.ParsingException: While parsing int16_t[CLT_CURVE_SIZE] autoscale cltIdleRpmBins;CLT-based target RPM for automatic idle controller;"SPECIAL_CASE_TEMPERATURE", 2, 0, -40, @@CLT_UPPER_LIMIT@@, 0
        at com.rusefi.ReaderStateImpl.processField(ReaderStateImpl.java:358)
        at com.rusefi.ReaderStateImpl.readBufferedReader(ReaderStateImpl.java:312)
        at com.rusefi.ReaderStateImpl.doJob(ReaderStateImpl.java:126)
        ... 2 more
Caused by: com.rusefi.ConfigFieldImpl$FieldOutOfRangeException: cltIdleRpmBins: incorrect scale for SPECIAL_CASE_TEMPERATURE field, use 1 as scale
        at com.rusefi.ConfigFieldImpl.validateScale(ConfigFieldImpl.java:145)
        at com.rusefi.ConfigFieldImpl.<init>(ConfigFieldImpl.java:116)
        at com.rusefi.ConfigFieldImpl.parse(ConfigFieldImpl.java:242)
        at com.rusefi.ReaderStateImpl.processField(ReaderStateImpl.java:356)
        ... 4 more
```