### PR TITLE
Add support for additional headers in lua live data access code

### DIFF
--- a/java_tools/configuration_definition_base/src/main/java/com/rusefi/output/GetOutputValueConsumer.java
+++ b/java_tools/configuration_definition_base/src/main/java/com/rusefi/output/GetOutputValueConsumer.java
@@ -32,6 +32,7 @@ public class GetOutputValueConsumer implements ConfigurationConsumer {
     public boolean moduleMode;
     public String currentEngineModule;
     public String conditional;
+    public String additionalHeaders = "";
     public Boolean isPtr = false;
 
     public GetOutputValueConsumer(String fileName, LazyFile.LazyFileFactory fileFactory) {
@@ -90,6 +91,7 @@ public class GetOutputValueConsumer implements ConfigurationConsumer {
 
         return
                 GetConfigValueConsumer.getHeader(getClass()) +
+                additionalHeaders +
                 "float getOutputValueByHash(const int hash) {\n" +
                 fullSwitch +
                 getterBody + "\treturn EFI_ERROR_CODE;\n" +


### PR DESCRIPTION
So some modules that require special access to their internals can define their own headers directly in yaml