### PR TITLE
SPECIAL_CASE_* require scale of 1 fix on error throw

### DIFF
--- a/java_tools/configuration_definition_base/src/main/java/com/rusefi/ConfigFieldImpl.java
+++ b/java_tools/configuration_definition_base/src/main/java/com/rusefi/ConfigFieldImpl.java
@@ -141,7 +141,7 @@ public class ConfigFieldImpl implements ConfigField {
         String units = getUnits();
         String scale = tokens[1].trim();
 
-        if(units.startsWith("SPECIAL_CASE_") && Integer.valueOf(scale) != 1){
+        if(units.startsWith("SPECIAL_CASE_") && Double.valueOf(scale) != 1){
             throw new FieldOutOfRangeException(name + ": incorrect scale for SPECIAL_CASE_* field, use 1 as scale");
         }
     }


### PR DESCRIPTION
From:

```
Caused by: com.rusefi.ParsingException: While parsing uint32_t[VBAT_INJECTOR_CURVE_PRESSURE_SIZE] autoscale battLagCorrPressBins;Injector correction pressure;"SPECIAL_CASE_PRESSURE", 0.1, 0, 0, 30000, 2
        at com.rusefi.ReaderStateImpl.processField(ReaderStateImpl.java:358)
        at com.rusefi.ReaderStateImpl.readBufferedReader(ReaderStateImpl.java:312)
        at com.rusefi.ReaderStateImpl.doJob(ReaderStateImpl.java:126)
        ... 2 more
Caused by: java.lang.NumberFormatException: For input string: "0.1"
        at java.base/java.lang.NumberFormatException.forInputString(NumberFormatException.java:67)
```

to:

```
Caused by: com.rusefi.ConfigFieldImpl$FieldOutOfRangeException: battLagCorrPressBins: incorrect scale for SPECIAL_CASE_* field, use 1 as scale
        at com.rusefi.ConfigFieldImpl.validateScale(ConfigFieldImpl.java:145)
        at com.rusefi.ConfigFieldImpl.<init>(ConfigFieldImpl.java:116)
        at com.rusefi.ConfigFieldImpl.parse(ConfigFieldImpl.java:242)
        at com.rusefi.ReaderStateImpl.processField(ReaderStateImpl.java:356)
```


resolves #8431