### PR TITLE
start() was hidden fix?

### DIFF
--- a/firmware/controllers/system/thread_controller.h
+++ b/firmware/controllers/system/thread_controller.h
@@ -42,6 +42,8 @@ public:
 	{
 	}
 
+	using chibios_rt::BaseStaticThread<TStackSize>::start;
+
 	/**
 	 * @brief Start the thread.
 	 */


### PR DESCRIPTION
Why I cannot reproduce this locally?
```
 In file included from ../global.h:28,
                 from ../pch/pch.h:22:
../controllers/system/thread_controller.h: In instantiation of 'class ThreadController<512>':
../controllers/system/periodic_thread_controller.h:36:7:   required from 'class PeriodicController<512>'
   36 | class PeriodicController : public ThreadController<TStackSize>
      |       ^~~~~~~~~~~~~~~~~~
../controllers/can/can.h:58:31:   required from here
   58 | class CanWrite final : public PeriodicController</*TStackSize*/512> {
      |                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../ChibiOS/os/various/cpp_wrappers/ch.hpp:1337:21: error: 'chibios_rt::ThreadReference chibios_rt::BaseStaticThread<N>::start(tprio_t) [with int N = 512; tprio_t = long unsigned int]' was hidden [-Werror=overloaded-virtual=]
 1337 |     ThreadReference start(tprio_t prio) override {
      |                     ^~~~~
In file included from ../controllers/system/periodic_thread_controller.h:10,
                 from ../controllers/can/can.h:20,
                 from ../hw_layer/drivers/can/can_msg_tx.h:16,
                 from ../hw_layer/board_overrides.h:33,
                 from ../././config/boards/hellen/alphax-4K-GDI/board_configuration.cpp:6:
../controllers/system/thread_controller.h:48:14: note:   by 'void ThreadController<TStackSize>::start() [with int TStackSize = 512]'
   48 |         void start()
      |              ^~~~~
```