### PR TITLE
start() was hidden another fix?

### DIFF
--- a/firmware/controllers/can/can.h
+++ b/firmware/controllers/can/can.h
@@ -55,12 +55,6 @@ void processCanRxMessage(const size_t busIndex, const CANRxFrame& msg, efitick_t
 void registerCanListener(CanListener& listener);
 void registerCanSensor(CanSensorBase& sensor);
 
-class CanWrite final : public PeriodicController</*TStackSize*/512> {
-public:
-	CanWrite();
-	void PeriodicTask(efitick_t nowNt) override;
-};
-
 // allow using shorthand CI
 using CI = CanInterval;
 

--- a/firmware/controllers/can/can_tx.cpp
+++ b/firmware/controllers/can/can_tx.cpp
@@ -11,6 +11,7 @@
 
 #if EFI_CAN_SUPPORT
 #include "can.h"
+#include "can_tx.h"
 #include "can_hw.h"
 #include "can_dash.h"
 #include "obd2.h"

--- a/firmware/controllers/can/can_tx.h
+++ b/firmware/controllers/can/can_tx.h
@@ -1,0 +1,13 @@
+// file can_tx.h
+
+#include "pch.h"
+#include "can.h"
+
+#pragma once
+
+
+class CanWrite final : public PeriodicController</*TStackSize*/512> {
+public:
+	CanWrite();
+	void PeriodicTask(efitick_t nowNt) override;
+};

--- a/firmware/hw_layer/drivers/can/can_hw.cpp
+++ b/firmware/hw_layer/drivers/can/can_hw.cpp
@@ -18,6 +18,7 @@
 
 #include "can.h"
 #include "can_hw.h"
+#include "can_tx.h"
 #include "can_msg_tx.h"
 #include "string.h"
 #include "mpu_util.h"


### PR DESCRIPTION
Why I cannot reproduce this locally?
```
 In file included from ../global.h:28,
                 from ../pch/pch.h:22:
../controllers/system/thread_controller.h: In instantiation of 'class ThreadController<512>':
../controllers/system/periodic_thread_controller.h:36:7:   required from 'class PeriodicController<512>'
   36 | class PeriodicController : public ThreadController<TStackSize>
      |       ^~~~~~~~~~~~~~~~~~
../controllers/can/can.h:58:31:   required from here
   58 | class CanWrite final : public PeriodicController</*TStackSize*/512> {
      |                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../ChibiOS/os/various/cpp_wrappers/ch.hpp:1337:21: error: 'chibios_rt::ThreadReference chibios_rt::BaseStaticThread<N>::start(tprio_t) [with int N = 512; tprio_t = long unsigned int]' was hidden [-Werror=overloaded-virtual=]
 1337 |     ThreadReference start(tprio_t prio) override {
      |                     ^~~~~
In file included from ../controllers/system/periodic_thread_controller.h:10,
                 from ../controllers/can/can.h:20,
                 from ../hw_layer/drivers/can/can_msg_tx.h:16,
                 from ../hw_layer/board_overrides.h:33,
                 from ../././config/boards/hellen/alphax-4K-GDI/board_configuration.cpp:6:
../controllers/system/thread_controller.h:48:14: note:   by 'void ThreadController<TStackSize>::start() [with int TStackSize = 512]'
   48 |         void start()
      |            