### PR TITLE
Y label for fuel cylinder trims

### DIFF
--- a/firmware/tunerstudio/tunerstudio.template.ini
+++ b/firmware/tunerstudio/tunerstudio.template.ini
@@ -1283,73 +1283,73 @@ curve = rangeMatrix, "Range Switch Input Matrix"
 
 	table = fuelTrimTbl1,  fuelTrimMap1,  "Fuel trim cyl 1",	1
 		xBins = fuelTrimRpmBins,  RPMValue
-		yBins = fuelTrimLoadBins, veTableYAxis
+		yBins = fuelTrimLoadBins, fuelingLoad
 		zBins = fuelTrims1_table
 		upDownLabel = "(RICHER)", "(LEANER)"
 
 	table = fuelTrimTbl2,  fuelTrimMap2,  "Fuel trim cyl 2",	1
 		xBins = fuelTrimRpmBins,  RPMValue
-		yBins = fuelTrimLoadBins, veTableYAxis
+		yBins = fuelTrimLoadBins, fuelingLoad
 		zBins = fuelTrims2_table
 		upDownLabel = "(RICHER)", "(LEANER)"
 
 	table = fuelTrimTbl3,  fuelTrimMap3,  "Fuel trim cyl 3",	1
 		xBins = fuelTrimRpmBins,  RPMValue
-		yBins = fuelTrimLoadBins, veTableYAxis
+		yBins = fuelTrimLoadBins, fuelingLoad
 		zBins = fuelTrims3_table
 		upDownLabel = "(RICHER)", "(LEANER)"
 
 	table = fuelTrimTbl4,  fuelTrimMap4,  "Fuel trim cyl 4",	1
 		xBins = fuelTrimRpmBins,  RPMValue
-		yBins = fuelTrimLoadBins, veTableYAxis
+		yBins = fuelTrimLoadBins, fuelingLoad
 		zBins = fuelTrims4_table
 		upDownLabel = "(RICHER)", "(LEANER)"
 
 	table = fuelTrimTbl5,  fuelTrimMap5,  "Fuel trim cyl 5",	1
 		xBins = fuelTrimRpmBins,  RPMValue
-		yBins = fuelTrimLoadBins, veTableYAxis
+		yBins = fuelTrimLoadBins, fuelingLoad
 		zBins = fuelTrims5_table
 		upDownLabel = "(RICHER)", "(LEANER)"
 
 	table = fuelTrimTbl6,  fuelTrimMap6,  "Fuel trim cyl 6",	1
 		xBins = fuelTrimRpmBins,  RPMValue
-		yBins = fuelTrimLoadBins, veTableYAxis
+		yBins = fuelTrimLoadBins, fuelingLoad
 		zBins = fuelTrims6_table
 		upDownLabel = "(RICHER)", "(LEANER)"
 
 	table = fuelTrimTbl7,  fuelTrimMap7,  "Fuel trim cyl 7",	1
 		xBins = fuelTrimRpmBins,  RPMValue
-		yBins = fuelTrimLoadBins, veTableYAxis
+		yBins = fuelTrimLoadBins, fuelingLoad
 		zBins = fuelTrims7_table
 		upDownLabel = "(RICHER)", "(LEANER)"
 
 	table = fuelTrimTbl8,  fuelTrimMap8,  "Fuel trim cyl 8",	1
 		xBins = fuelTrimRpmBins,  RPMValue
-		yBins = fuelTrimLoadBins, veTableYAxis
+		yBins = fuelTrimLoadBins, fuelingLoad
 		zBins = fuelTrims8_table
 		upDownLabel = "(RICHER)", "(LEANER)"
 
 	table = fuelTrimTbl9,  fuelTrimMap9,  "Fuel trim cyl 9",	1@@if_ts_show_fuel_trim_cylinder_9
 		xBins = fuelTrimRpmBins,  RPMValue@@if_ts_show_fuel_trim_cylinder_9
-		yBins = fuelTrimLoadBins, veTableYAxis@@if_ts_show_fuel_trim_cylinder_9
+		yBins = fuelTrimLoadBins, fuelingLoad@@if_ts_show_fuel_trim_cylinder_9
 		zBins = fuelTrims9_table@@if_ts_show_fuel_trim_cylinder_9
 		upDownLabel = "(RICHER)", "(LEANER)"@@if_ts_show_fuel_trim_cylinder_9
 
 	table = fuelTrimTbl10,  fuelTrimMap10,  "Fuel trim cyl 10",	1@@if_ts_show_fuel_trim_cylinder_10
 		xBins = fuelTrimRpmBins,  RPMValue@@if_ts_show_fuel_trim_cylinder_10
-		yBins = fuelTrimLoadBins, veTableYAxis@@if_ts_show_fuel_trim_cylinder_10
+		yBins = fuelTrimLoadBins, fuelingLoad@@if_ts_show_fuel_trim_cylinder_10
 		zBins = fuelTrims10_table@@if_ts_show_fuel_trim_cylinder_10
 		upDownLabel = "(RICHER)", "(LEANER)"@@if_ts_show_fuel_trim_cylinder_10
 
 	table = fuelTrimTbl11,  fuelTrimMap11,  "Fuel trim cyl 11",	1@@if_ts_show_fuel_trim_cylinder_11
 		xBins = fuelTrimRpmBins,  RPMValue@@if_ts_show_fuel_trim_cylinder_11
-		yBins = fuelTrimLoadBins, veTableYAxis@@if_ts_show_fuel_trim_cylinder_11
+		yBins = fuelTrimLoadBins, fuelingLoad@@if_ts_show_fuel_trim_cylinder_11
 		zBins = fuelTrims11_table@@if_ts_show_fuel_trim_cylinder_11
 		upDownLabel = "(RICHER)", "(LEANER)"@@if_ts_show_fuel_trim_cylinder_11
 
 	table = fuelTrimTbl12,  fuelTrimMap12,  "Fuel trim cyl 12",	1@@if_ts_show_fuel_trim_cylinder_12
 		xBins = fuelTrimRpmBins,  RPMValue@@if_ts_show_fuel_trim_cylinder_12
-		yBins = fuelTrimLoadBins, veTableYAxis@@if_ts_show_fuel_trim_cylinder_12
+		yBins = fuelTrimLoadBins, fuelingLoad@@if_ts_show_fuel_trim_cylinder_12
 		zBins = fuelTrims12_table@@if_ts_show_fuel_trim_cylinder_12
 		upDownLabel = "(RICHER)", "(LEANER)"@@if_ts_show_fuel_trim_cylinder_12
 


### PR DESCRIPTION
see on: `getCylinderFuelTrim` on `fuel_math.h`

```c++
	auto trimPercent = interpolate3d(
		config->fuelTrims[cylinderNumber].table,
		config->fuelTrimLoadBins, fuelLoad,
		config->fuelTrimRpmBins, rpm
	);
``` 
new UI:

<img width="436" height="384" alt="image" src="https://github.com/user-attachments/assets/1b09be10-9723-4a9b-920f-8d552ca04652" />

