### PR TITLE
Test suite is fixed to allow debugging from IDE. Before this fix `Loa…

### DIFF
--- a/java_tools/tune-tools/src/test/java/com/rusefi/tune/TuneCanToolTest.java
+++ b/java_tools/tune-tools/src/test/java/com/rusefi/tune/TuneCanToolTest.java
@@ -11,6 +11,8 @@ import com.rusefi.tune.xml.Page;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import java.io.File;
+
 import static com.devexperts.logging.Logging.getLogging;
 import static com.rusefi.ConfigFieldImpl.unquote;
 import static org.junit.jupiter.api.Assertions.*;
@@ -21,6 +23,9 @@ public class TuneCanToolTest {
     @BeforeAll
     public static void before() {
         RootHolder.ROOT = "../../firmware/";
+        // somewhere deep we have append prefix is not absolute path, so let's make path absolute
+        //TODO: check if there exists more elegant way to initialize `TuneCanTool.boardPath` properly
+        TuneCanTool.boardPath = new File(RootHolder.ROOT + "config/boards/hellen/uaefi/").getAbsolutePath() + File.separator;
     }
 
     @Test


### PR DESCRIPTION
…dOlderTuneTest.loadOlderTuneAgainstCurrentIni` test initialized this static field properly that allowed `./gradlew clean build` to success.

only:uaefi