### PR TITLE
port: stm32: adc: fix typo causing ADC channels mess

### DIFF
--- a/firmware/hw_layer/ports/stm32/stm32_adc_v2.cpp
+++ b/firmware/hw_layer/ports/stm32/stm32_adc_v2.cpp
@@ -292,11 +292,11 @@ static void slowAdcEnableDisableChannel(adc_channel_e hwChannel, bool en)
 							 (channelHwIndex << shift);
 	} else if (channelAdcIndex <= 11) {
 		size_t shift = (channelAdcIndex - 6) * 5;
-		convGroupSlow.sqr2 = (convGroupSlow.sqr3 & (~(0x1f << shift))) |
+		convGroupSlow.sqr2 = (convGroupSlow.sqr2 & (~(0x1f << shift))) |
 							 (channelHwIndex << shift);
 	} else {
 		size_t shift = (channelAdcIndex - 12) * 5;
-		convGroupSlow.sqr1 = (convGroupSlow.sqr3 & (~(0x1f << shift))) |
+		convGroupSlow.sqr1 = (convGroupSlow.sqr1 & (~(0x1f << shift))) |
 							 (channelHwIndex << shift);
 	}
 }


### PR DESCRIPTION
https://github.com/rusefi/rusefi/issues/8477