### PR TITLE
TS UI fixes

### DIFF
--- a/firmware/tunerstudio/tunerstudio.template.ini
+++ b/firmware/tunerstudio/tunerstudio.template.ini
@@ -3892,7 +3892,7 @@ cmd_set_engine_type_default					= "@@TS_IO_TEST_COMMAND_char@@@@ts_command_e_TS_
 		field = "MAP voltage high value",					mapHighValueVoltage, { map_sensor_hwChannel != @@ADC_CHANNEL_NONE@@ && map_sensor_type == 0 }
 
 	indicatorPanel = mapValidIndicators, 1
-		indicator = {isMapValid}, "BAD Map Input", "Good MAP Input"
+		indicator = {isMapValid}, "BAD Map Input", "Good MAP Input", red, black, green, black
 
 	dialog = mapCommon, "MAP common settings"
 		field = "Low value threshold",					mapErrorDetectionTooLow

--- a/firmware/tunerstudio/tunerstudio.template.ini
+++ b/firmware/tunerstudio/tunerstudio.template.ini
@@ -692,7 +692,7 @@ include_file controllers/actuators/boost_control.curves.ini
 	curve = idleAdvanceCurve, "Idle Advance Angle"
 		columnLabel = "RPM", "degrees"
 		xAxis		= 0, 2400, 13
-		yAxis		= -100, 100, 11
+		yAxis		= -20, 90, 12
 		xBins		= idleAdvanceBins, rpmForIgnitionIdleTableDot
 		yBins		= idleAdvance
 		gauge		= RPMGauge


### PR DESCRIPTION
Fix this (default Y scale is outside allowed values range):
<img width="649" height="473" alt="Screenshot from 2025-08-25 16-15-02" src="https://github.com/user-attachments/assets/dee0b741-232f-4f1a-b03d-4441461ade58" />
And this (good is green):
<img width="433" height="98" alt="Screenshot from 2025-08-25 16-19-52" src="https://github.com/user-attachments/assets/b4e8fb06-8698-4a82-9ee2-9e4316d8fcbc" />
