### PR TITLE
Hellen based ECU have different analogInputDividerCoefficient on CPU module's IN_CRANK input

### DIFF
--- a/firmware/config/boards/hellen/hellen_common.cpp
+++ b/firmware/config/boards/hellen/hellen_common.cpp
@@ -238,6 +238,15 @@ int boardGetAnalogDiagnostic()
 #endif
 }
 
+float getAnalogInputDividerCoefficient(adc_channel_e hwChannel) {
+	if (hwChannel == MM100_IN_CRANK_ANALOG) [[unlikely]] {
+		// (4.7K || 5.1K) + 4.7K divider
+		// 4.7K || 5.1K == 2.445K
+		return (4.7f + 2.445f) / 4.7f;
+	}
+	return engineConfiguration->analogInputDividerCoefficient;
+}
+
 #ifndef EFI_BOOTLOADER
 bool boardSdCardEnable() {
 	// on mega-module we manage SD card power supply

--- a/firmware/config/boards/hellen/uaefi/connectors/D.yaml
+++ b/firmware/config/boards/hellen/uaefi/connectors/D.yaml
@@ -9,8 +9,8 @@ pins:
     function: Auxiliary analog input 1
 
   - pin: D2
-    meta: MM100_IN_CRANK
-    class: switch_inputs
+    id: [MM100_IN_CRANK_ANALOG, MM100_IN_CRANK]
+    class: [analog_inputs, switch_inputs]
     color: yellow
     ts_name: ___ BUTTON1
     function: Button input 1
@@ -59,8 +59,8 @@ pins:
     color: yellow
 
   - pin: D10
-    meta: MM100_IN_CAM
-    class: switch_inputs
+    id: [MM100_IN_CAM_ANALOG, MM100_IN_CAM]
+    class: [analog_inputs, switch_inputs]
     color: green
     ts_name: ___ A/C Request / BUTTON2
     function: A/C Request / Button input 2


### PR DESCRIPTION
This input is used, for example, as IN_BUTTON1 input on uaEFI.
This also enables analog mode for IN_BUTTON1 and IN_BUTTON2 inputs on uaEFI.

Fixes https://github.com/rusefi/rusefi/issues/8502