### PR TITLE
Measure and show Vref+ voltage

### DIFF
--- a/firmware/console/binary/output_channels.txt
+++ b/firmware/console/binary/output_channels.txt
@@ -53,6 +53,7 @@ int16_t rpmAcceleration;dRPM;"RPM acceleration/Rate of Change/ROC",1, 0, 0, 5, 2
 	uint16_t autoscale speedToRpmRatio;@@GAUGE_NAME_GEAR_RATIO@@;"value",{1/@@PACK_MULT_PERCENT@@}, 0, 0, 0, 2
 	uint8_t unusedVehicleSpeedKph;@@GAUGE_NAME_VVS@@;"kph",1, 0, 0, 0, 1
 	int8_t internalMcuTemperature;@@GAUGE_NAME_CPU_TEMP@@;"deg C",1, 0, 0, 0, 0
+	int16_t autoscale internalVref;;"V",{1/@@PACK_MULT_VOLTAGE@@}, 0, 0, 5, 3
 
 	int16_t autoscale coolant;@@GAUGE_NAME_CLT@@;"deg C",{1/@@PACK_MULT_TEMPERATURE@@}, 0, 0, 0, 1
 	int16_t autoscale intake;@@GAUGE_NAME_IAT@@;"deg C",{1/@@PACK_MULT_TEMPERATURE@@}, 0, 0, 0, 1

--- a/firmware/console/status_loop.cpp
+++ b/firmware/console/status_loop.cpp
@@ -551,6 +551,7 @@ static void updateMiscSensors() {
 
 #if	HAL_USE_ADC
 	engine->outputChannels.internalMcuTemperature = getMCUInternalTemperature();
+	engine->outputChannels.internalVref = getMCUVref();
 #endif /* HAL_USE_ADC */
 }
 

--- a/firmware/hw_layer/adc/adc_inputs.h
+++ b/firmware/hw_layer/adc/adc_inputs.h
@@ -116,6 +116,7 @@ void onKnockSamplingComplete();
 
 // Slow ADC stuff
 float getMCUInternalTemperature(void);
+float getMCUVref(void);
 // wait until at least 1 slowADC sampling is complete
 void waitForSlowAdc(uint32_t lastAdcCounter = 1);
 

--- a/firmware/hw_layer/adc/adc_onchip_slow.cpp
+++ b/firmware/hw_layer/adc/adc_onchip_slow.cpp
@@ -27,6 +27,7 @@ static volatile NO_CACHE adcsample_t slowAdcSamples[SLOW_ADC_CHANNEL_COUNT];
 static uint32_t slowAdcConversionCount = 0;
 
 static float mcuTemperature;
+static float mcuVrefVoltage;
 
 void adcOnchipSlowUpdate(efitick_t nowNt) {
 	{
@@ -50,6 +51,8 @@ void adcOnchipSlowUpdate(efitick_t nowNt) {
 			 */
 			//criticalError("Invalid CPU temperature measured %f", degrees);
 		}
+
+		mcuVrefVoltage = getMcuVrefVoltage();
 	}
 }
 
@@ -74,6 +77,10 @@ void adcOnchipSlowShowReport()
 
 float getMCUInternalTemperature() {
 	return mcuTemperature;
+}
+
+float getMCUVref() {
+	return mcuVrefVoltage;
 }
 
 /* TODO: kill this */

--- a/firmware/hw_layer/ports/cypress/mpu_util.cpp
+++ b/firmware/hw_layer/ports/cypress/mpu_util.cpp
@@ -266,6 +266,11 @@ float getMcuTemperature() {
 	return 0;
 }
 
+float getMcuVrefVoltage() {
+	// TODO: implement me!
+	return engineConfiguration->adcVcc;
+}
+
 bool readSlowAnalogInputs(adcsample_t* convertedSamples) {
 	// TODO: implement me!
 	return true;

--- a/firmware/hw_layer/ports/kinetis/mpu_util.cpp
+++ b/firmware/hw_layer/ports/kinetis/mpu_util.cpp
@@ -272,6 +272,11 @@ float getMcuTemperature() {
 	return 0;
 }
 
+float getMcuVrefVoltage() {
+	// TODO: implement me!
+	return engineConfiguration->adcVcc;
+}
+
 bool readSlowAnalogInputs(adcsample_t* convertedSamples) {
 	// TODO: implement me!
 	return true;

--- a/firmware/hw_layer/ports/mpu_util.h
+++ b/firmware/hw_layer/ports/mpu_util.h
@@ -39,6 +39,7 @@ int getAdcChannelPin(adc_channel_e hwChannel);
 
 void portInitAdc();
 float getMcuTemperature();
+float getMcuVrefVoltage();
 // Convert all slow ADC inputs.  Returns true if the conversion succeeded, false if a failure occured.
 bool readSlowAnalogInputs(adcsample_t* convertedSamples);
 #endif

--- a/firmware/hw_layer/ports/stm32/stm32_adc_v2.cpp
+++ b/firmware/hw_layer/ports/stm32/stm32_adc_v2.cpp
@@ -80,7 +80,7 @@ float getMcuTemperature() {
 		sum += tempSensorSamples[i];
 	}
 
-	float volts = (float)sum / (4096 * tempSensorOversample);
+	float volts = (float)sum / (ADC_MAX_VALUE * tempSensorOversample);
 	volts *= engineConfiguration->adcVcc;
 
 	volts -= 0.760f; // Subtract the reference voltage at 25 deg C

--- a/firmware/hw_layer/ports/stm32/stm32_adc_v2.cpp
+++ b/firmware/hw_layer/ports/stm32/stm32_adc_v2.cpp
@@ -16,6 +16,7 @@
 
 /* HW channels count per ADC */
 constexpr size_t adcChannelCount = 16;
+constexpr size_t adcAuxChannelCount = 2;
 
 /* Depth of the conversion buffer, channels are sampled X times each.*/
 #define SLOW_ADC_OVERSAMPLE      8
@@ -37,9 +38,9 @@ static void slowAdcErrorCB(ADCDriver *, adcerror_t);
 /*
  * ADC conversion group.
  */
-static const ADCConversionGroup tempSensorConvGroup = {
+static const ADCConversionGroup auxConvGroup = {
 	.circular			= FALSE,
-	.num_channels		= 1,
+	.num_channels		= adcAuxChannelCount,
 #if (EFI_INTERNAL_SLOW_ADC_BACKGROUND == TRUE)
 	.end_cb				= slowAdcEndCB,
 #else
@@ -51,36 +52,39 @@ static const ADCConversionGroup tempSensorConvGroup = {
 	.cr2				= ADC_CR2_SWSTART,
 	// sample times for channels 10...18
 	.smpr1 =
-		ADC_SMPR1_SMP_VBAT(ADC_SAMPLE_144)    |	/* input18 - temperature and vbat input on some STM32F7xx */
-		ADC_SMPR1_SMP_SENSOR(ADC_SAMPLE_144),	/* input16 - temperature sensor input on STM32F4xx */
+		ADC_SMPR1_SMP_VBAT(ADC_SAMPLE_144) |	/* input18 - temperature and vbat input on some STM32F7xx */
+		ADC_SMPR1_SMP_SENSOR(ADC_SAMPLE_144) |	/* input16 - temperature sensor input on STM32F4xx */
+		ADC_SMPR1_SMP_VREF(ADC_SAMPLE_144),		/* input17 - Vrefint input */
 	.smpr2 = 0,
 	.htr = 0, .ltr = 0,
 	.sqr1 = 0,
 	.sqr2 = 0,
+	.sqr3 =
 #if defined(STM32F4XX)
-	.sqr3 = ADC_SQR3_SQ1_N(16),
+		ADC_SQR3_SQ1_N(16) |
 #endif
 #if defined(STM32F7XX)
-	.sqr3 = ADC_SQR3_SQ1_N(18),
+		ADC_SQR3_SQ1_N(18) |
 #endif
+		ADC_SQR3_SQ2_N(17),
 };
 
 // 4x oversample is plenty
-static constexpr int tempSensorOversample = 4;
-static volatile NO_CACHE adcsample_t tempSensorSamples[tempSensorOversample];
+static constexpr int auxSensorOversample = 4;
+static volatile NO_CACHE adcsample_t auxSensorSamples[adcAuxChannelCount * auxSensorOversample];
 
 float getMcuTemperature() {
 #if (EFI_INTERNAL_SLOW_ADC_BACKGROUND == FALSE)
 	// Temperature sensor is only physically wired to ADC1
-	adcConvert(&ADCD1, &tempSensorConvGroup, (adcsample_t *)tempSensorSamples, tempSensorOversample);
+	adcConvert(&ADCD1, &auxConvGroup, (adcsample_t *)auxSensorSamples, auxSensorOversample);
 #endif
 
 	uint32_t sum = 0;
-	for (size_t i = 0; i < tempSensorOversample; i++) {
-		sum += tempSensorSamples[i];
+	for (size_t i = 0; i < auxSensorOversample; i++) {
+		sum += auxSensorSamples[0 + adcAuxChannelCount * i];
 	}
 
-	float volts = (float)sum / (ADC_MAX_VALUE * tempSensorOversample);
+	float volts = (float)sum / (ADC_MAX_VALUE * auxSensorOversample);
 	volts *= engineConfiguration->adcVcc;
 
 	volts -= 0.760f; // Subtract the reference voltage at 25 deg C
@@ -89,6 +93,21 @@ float getMcuTemperature() {
 	degrees += 25.0; // Add the 25 deg C
 
 	return degrees;
+}
+
+float getMcuVrefVoltage() {
+	uint32_t sum = 0;
+	for (size_t i = 0; i < auxSensorOversample; i++) {
+		sum += auxSensorSamples[1 + adcAuxChannelCount * i];
+	}
+
+	// TODO: apply calibration value from OTP (if exists)
+	// vrefint should be 1.21V
+	// Let's calculate external Vref+
+	// sum / (ADC_MAX_VALUE * auxSensorOversample) * Vref+ = 1.21;
+	float Vref = 1.21f * auxSensorOversample * ADC_MAX_VALUE / sum;
+
+	return Vref;
 }
 
 // See https://github.com/rusefi/rusefi/issues/976 for discussion on these values
@@ -167,7 +186,7 @@ typedef enum {
 #ifdef ADC_MUX_PIN
 	convertMuxed,
 #endif
-	convertTemperature
+	convertAux,
 } slowAdcState_t;
 
 static slowAdcState_t slowAdcGetNextState(slowAdcState_t state)
@@ -177,7 +196,7 @@ static slowAdcState_t slowAdcGetNextState(slowAdcState_t state)
 		#ifdef ADC_MUX_PIN
 		return convertMuxed;
 		#else
-		return convertTemperature;
+		return convertAux;
 		#endif
 	break;
 #ifdef ADC_MUX_PIN
@@ -185,7 +204,7 @@ static slowAdcState_t slowAdcGetNextState(slowAdcState_t state)
 		return convertTemperature;
 	break;
 #endif
-	case convertTemperature:
+	case convertAux:
 		return convertPrimary;
 	break;
 	}
@@ -215,8 +234,8 @@ static void slowAdcEndCB(ADCDriver *adcp) {
 			adcStartConversionI(adcp, &convGroupSlow, (adcsample_t *)slowSampleBufferMuxed, SLOW_ADC_OVERSAMPLE);
 			break;
 		#endif
-		case convertTemperature:
-			adcStartConversionI(adcp, &tempSensorConvGroup, (adcsample_t *)tempSensorSamples, tempSensorOversample);
+		case convertAux:
+			adcStartConversionI(adcp, &auxConvGroup, (adcsample_t *)auxSensorSamples, auxSensorOversample);
 			break;
 		}
 		chSysUnlockFromISR();

--- a/firmware/hw_layer/ports/stm32/stm32_adc_v2.cpp
+++ b/firmware/hw_layer/ports/stm32/stm32_adc_v2.cpp
@@ -240,7 +240,7 @@ static bool readBatch(adcsample_t* convertedSamples, adcsample_t* b) {
 		size_t index = i;
 		for (size_t j = 0; j < SLOW_ADC_OVERSAMPLE; j++) {
 			sum += b[index];
-			index += 16;
+			index += adcChannelCount;
 		}
 
 		adcsample_t value = static_cast<adcsample_t>(sum / SLOW_ADC_OVERSAMPLE);

--- a/firmware/hw_layer/ports/stm32/stm32_adc_v4.cpp
+++ b/firmware/hw_layer/ports/stm32/stm32_adc_v4.cpp
@@ -59,6 +59,11 @@ float getMcuTemperature() {
 	return 0;
 }
 
+float getMcuVrefVoltage() {
+	// TODO: implement me!
+	return engineConfiguration->adcVcc;
+}
+
 adcsample_t* fastSampleBuffer;
 
 static void adc_callback(ADCDriver *adcp) {

--- a/firmware/tunerstudio/tunerstudio.template.ini
+++ b/firmware/tunerstudio/tunerstudio.template.ini
@@ -1762,6 +1762,7 @@ gaugeCategory = Sensors - Extra 1
 	turboSpeedGauge	= turboSpeed,			@@GAUGE_NAME_TURBO_SPEED@@, "hz",			0,	200,		0,		1,		3,	4,	1,	1
 	baroPressureGauge	= baroPressure,			@@GAUGE_NAME_BARO_PRESSURE@@,		"kPa",		0,	130,		40,		50,		110,	120,	2,	0
 	internalMcuTemperatureGauge = internalMcuTemperature, @@GAUGE_NAME_ECU_TEMPERATURE@@, @@UNITS_CELSIUS@@,	0,	100,	0,	0,	75,  100,	@@GAUGE_PRECISION_TEMPERATURE_C@@
+	internalVrefGauge = internalVref, "ECU Vref voltage", "V", 0, 7, 2.5, 3, 5, 5.5, 2, 1
 	OilPressGauge		= oilPressure,	@@GAUGE_NAME_OIL_PRESSURE@@,		"kPa",		0,	750,		35,	75,	550,	700,	0,	0
 	OilTempGauge		= oilTemp,	@@GAUGE_NAME_OIL_TEMPERATURE@@,		@@UNITS_CELSIUS@@,		-40,	140,	-15,		1,		95,	110,	@@GAUGE_PRECISION_TEMPERATURE_C@@
 	AuxT1Gauge		= auxTemp1,	@@GAUGE_NAME_AUX_TEMP1@@,		@@UNITS_CELSIUS@@,		-40,	140,	-15,		1,		95,	110,	@@GAUGE_PRECISION_TEMPERATURE_C@@


### PR DESCRIPTION
Use ADC to measure internal Vrefint with known value (1.21V). And then do some math to calculate externally supplied Vref+.
This is first step toward Vref diagnostic. We can compare this value to `engineConfiguration->adcVcc`

<img width="422" height="379" alt="Screenshot from 2025-08-29 12-18-56" src="https://github.com/user-attachments/assets/3211445e-c767-4b37-abdc-df60e2b98a3b" />
