### PR TITLE
add portConnectionDelay on openSerial, related #8526

### DIFF
--- a/java_console/io/src/main/java/com/rusefi/io/serial/SerialIoStream.java
+++ b/java_console/io/src/main/java/com/rusefi/io/serial/SerialIoStream.java
@@ -25,6 +25,8 @@ public abstract class SerialIoStream extends AbstractIoStream {
     protected final SerialPort sp;
     protected final String port;
     private boolean withListener;
+    // used by "serialPort.openPort", time waited before connecting to serial port, in mS
+    private final static int portConnectionDelay = 500;
 
     static {
         log.info("Using com.fazecast.jSerialComm " + SerialPort.getVersion());
@@ -41,7 +43,7 @@ public abstract class SerialIoStream extends AbstractIoStream {
     protected static SerialPort openSerial(String port) {
         SerialPort serialPort = SerialPort.getCommPort(port);
         serialPort.setBaudRate(BaudRateHolder.INSTANCE.baudRate);
-        boolean openedOk = serialPort.openPort();
+        boolean openedOk = serialPort.openPort(portConnectionDelay);
         if (!openedOk) {
             log.error("Error opening " + port + " maybe no permissions?");
             // todo: leverage jSerialComm method once we start using version 2.9+


### PR DESCRIPTION
not-so-nice to wait on all methods that depend on `openSerial` instead of creating a separate one for updating calibrations, but it's just a test for tomorrow.

https://fazecast.github.io/jSerialComm/javadoc/com/fazecast/jSerialComm/SerialPort.html#openPort(int)

> safetySleepTime - The number of milliseconds to sleep before opening the port in case of frequent closing/openings.

#8526