### PR TITLE
add Fahrenheit support for auxiliary sensors and EGT gauges in tunerstudio.template

### DIFF
--- a/firmware/tunerstudio/tunerstudio.template.ini
+++ b/firmware/tunerstudio/tunerstudio.template.ini
@@ -1793,7 +1793,7 @@ gaugeCategory = Sensors - Extra 1
 	AuxT2Gauge		= auxTemp2,	@@GAUGE_NAME_AUX_TEMP2@@,		@@UNITS_CELSIUS@@,		-40,	140,	-15,		1,		95,	110,	@@GAUGE_PRECISION_TEMPERATURE_C@@
 	ambientTempGauge		= ambientTemp,	@@GAUGE_LONG_NAME_AAT@@,		@@UNITS_CELSIUS@@,		-40,	140,	-15,		1,		95,	110,	@@GAUGE_PRECISION_TEMPERATURE_C@@
 	lowFuelPressureGauge = lowFuelPressure, @@GAUGE_NAME_FUEL_PRESSURE_LOW@@, @@GAUGE_NAME_FUEL_PRESSURE_LOW_UNITS@@, 0, 700, 0, 0, 700, 700, 1, 0
-	acPressureGauge		= acPressure,	@@GAUGE_NAME_AC_PRESSURE@@, "kPa", 0, 900, 0, 0, 900, 900, 0, 0
+	acPressureGauge		= acPressure,	@@GAUGE_NAME_AC_PRESSURE@@, @@UNITS_KPA@@, 0, 900, 0, 0, 900, 900, 0, 0
 	fuelTempGauge = fuelTemp, @@GAUGE_NAME_FUEL_TEMPERATURE@@, @@UNITS_CELSIUS@@,	0,	100,	0,	0,	75,  100,	@@GAUGE_PRECISION_TEMPERATURE_C@@
 #else
 	AuxT1Gauge				= auxTemp1,			@@GAUGE_NAME_AUX_TEMP1@@,			@@UNITS_FAHRENHEIT@@,		-40,	284,	5,		1,		203,	230,	@@GAUGE_PRECISION_TEMPERATURE_F@@


### PR DESCRIPTION
- 	auxTemp1
- 	auxTemp2
- 	ambientTemp
- 	lowFuelPressure
- 	acPressure
- 	fuelTemp
- 	egt1 to egt8

related #4788 