### PR TITLE
TS: extract TS calibration helpers

### DIFF
--- a/firmware/console/binary/tunerstudio.mk
+++ b/firmware/console/binary/tunerstudio.mk
@@ -7,6 +7,7 @@ TUNERSTUDIO_SRC_CPP = $(PROJECT_DIR)/console/binary/tunerstudio_io.cpp \
 	$(PROJECT_DIR)/console/binary/serial_can.cpp \
 	$(PROJECT_DIR)/console/binary/tuner_detector_utils.cpp \
 	$(PROJECT_DIR)/console/binary/tunerstudio.cpp \
+	$(PROJECT_DIR)/console/binary/tunerstudio_calibration_channel.cpp \
 	$(PROJECT_DIR)/console/binary/tunerstudio_commands.cpp \
 	$(PROJECT_DIR)/console/binary/bluetooth.cpp \
 	$(PROJECT_DIR)/console/binary/signature.cpp \

--- a/firmware/console/binary/tunerstudio_calibration_channel.cpp
+++ b/firmware/console/binary/tunerstudio_calibration_channel.cpp
@@ -1,0 +1,45 @@
+/**
+ * @file	tunerstudio_calibration_channel.cpp
+ * @brief	maintainConstantValue implementation
+ */
+
+// See TS ini file specification
+// See output_channels.txt for calibrationValue and calibrationMode
+// See rusefi_enum.h for TsCalMode
+
+#include "pch.h"
+
+#include "tunerstudio_calibration_channel.h"
+
+/*
+ * TODO:
+ * extract to livedata module
+ * avoid TsCalMode casts
+ */
+
+static Timer tsCalibrationTimer;
+static float tsCalibrationTimeout;
+
+void tsCalibrationSetData(TsCalMode mode, float value, float value2, float timeoutMs) {
+	// TODO: do under lock!
+	engine->outputChannels.calibrationMode = (uint8_t)mode;
+	engine->outputChannels.calibrationValue = value;
+	engine->outputChannels.calibrationValue2 = value2;
+
+	tsCalibrationTimeout = timeoutMs;
+	tsCalibrationTimer.reset();
+}
+
+bool tsCalibrationIsIdle() {
+	if ((engine->outputChannels.calibrationMode != (uint8_t)TsCalMode::None) &&
+		(tsCalibrationTimer.hasElapsedMs(tsCalibrationTimeout))) {
+		engine->outputChannels.calibrationMode = (uint8_t)TsCalMode::None;
+	}
+
+	return (engine->outputChannels.calibrationMode == (uint8_t)TsCalMode::None);
+}
+
+void tsCalibrationSetIdle()
+{
+	engine->outputChannels.calibrationMode = (uint8_t)TsCalMode::None;
+}

--- a/firmware/console/binary/tunerstudio_calibration_channel.h
+++ b/firmware/console/binary/tunerstudio_calibration_channel.h
@@ -1,0 +1,10 @@
+/**
+ * @file	tunerstudio_calibration_channel.h
+ * @brief	maintainConstantValue implementation header
+ */
+
+#pragma once
+
+void tsCalibrationSetData(TsCalMode mode, float value, float value2 = 0, float timeoutMs = 300);
+bool tsCalibrationIsIdle();
+void tsCalibrationSetIdle();

--- a/firmware/console/status_loop.cpp
+++ b/firmware/console/status_loop.cpp
@@ -40,6 +40,7 @@
 #include "speed_density.h"
 
 #include "tunerstudio.h"
+#include "tunerstudio_calibration_channel.h"
 #include "fuel_math.h"
 #include "main_trigger_callback.h"
 #include "spark_logic.h"
@@ -701,6 +702,8 @@ void updateTunerStudioState() {
 	updateFuelInfo();
 	updateIgnition(rpm);
 	updateFlags();
+	// update calibration channel, reset to None state after timeout
+	tsCalibrationIsIdle();
 
 	// Output both the estimated air flow, and measured air flow (if available)
 	tsOutputChannels->mafMeasured = Sensor::getOrZero(SensorType::Maf);

--- a/firmware/controllers/actuators/electronic_throttle.cpp
+++ b/firmware/controllers/actuators/electronic_throttle.cpp
@@ -45,6 +45,7 @@
 #include "dc_motors.h"
 #include "defaults.h"
 #include "tunerstudio.h"
+#include "tunerstudio_calibration_channel.h"
 #include "transition_events.h"
 
 #if defined(HAS_OS_ACCESS)
@@ -478,16 +479,13 @@ expected<percent_t> EtbController::getClosedLoopAutotune(percent_t target, perce
 
 		switch (m_autotuneCurrentParam) {
 		case 0:
-			engine->outputChannels.calibrationMode = (uint8_t)TsCalMode::EtbKp;
-			engine->outputChannels.calibrationValue = kp;
+			tsCalibrationSetData(TsCalMode::EtbKp, kp);
 			break;
 		case 1:
-			engine->outputChannels.calibrationMode = (uint8_t)TsCalMode::EtbKi;
-			engine->outputChannels.calibrationValue = ki;
+			tsCalibrationSetData(TsCalMode::EtbKi, ki);
 			break;
 		case 2:
-			engine->outputChannels.calibrationMode = (uint8_t)TsCalMode::EtbKd;
-			engine->outputChannels.calibrationValue = kd;
+			tsCalibrationSetData(TsCalMode::EtbKd, kd);
 			break;
 		}
 

--- a/firmware/controllers/bench_test.cpp
+++ b/firmware/controllers/bench_test.cpp
@@ -22,6 +22,7 @@
 
 #include "pch.h"
 #include "tunerstudio.h"
+#include "tunerstudio_calibration_channel.h"
 #include "long_term_fuel_trim.h"
 #include "can_common.h"
 #include "can_rx.h"
@@ -548,7 +549,7 @@ static void handleCommandX14(uint16_t index) {
 	case TS_ETB_STOP_AUTOTUNE:
 			engine->etbAutoTune = false;
 			#if EFI_TUNER_STUDIO
-				engine->outputChannels.calibrationMode = (uint8_t)TsCalMode::None;
+				tsCalibrationSetIdle();
 			#endif // EFI_TUNER_STUDIO
 		return;
 	case TS_ETB_DISABLE_JAM_DETECT:

--- a/firmware/controllers/sensors/tps.cpp
+++ b/firmware/controllers/sensors/tps.cpp
@@ -4,6 +4,7 @@
 #include "pch.h"
 #include "sent.h"
 #include "tunerstudio.h"
+#include "tunerstudio_calibration_channel.h"
 
 /*
 void grabTPSIsClosed() {
@@ -31,30 +32,24 @@ void grabPedalIsUp() {
 	/**
 	 * search for 'maintainConstantValue' to find how this TS magic works
 	 */
-	engine->outputChannels.calibrationMode = (uint8_t)TsCalMode::PedalMin;
-	engine->outputChannels.calibrationValue = Sensor::getRaw(SensorType::AcceleratorPedalPrimary);
-	engine->outputChannels.calibrationValue2 = Sensor::getRaw(SensorType::AcceleratorPedalSecondary);
+	tsCalibrationSetData(TsCalMode::PedalMin, Sensor::getRaw(SensorType::AcceleratorPedalPrimary), Sensor::getRaw(SensorType::AcceleratorPedalSecondary));
 	onGrabPedal();
 }
 
 void grabPedalIsWideOpen() {
-	engine->outputChannels.calibrationMode = (uint8_t)TsCalMode::PedalMax;
-	engine->outputChannels.calibrationValue = Sensor::getRaw(SensorType::AcceleratorPedalPrimary);
-	engine->outputChannels.calibrationValue2 = Sensor::getRaw(SensorType::AcceleratorPedalSecondary);
+	tsCalibrationSetData(TsCalMode::PedalMax, Sensor::getRaw(SensorType::AcceleratorPedalPrimary), Sensor::getRaw(SensorType::AcceleratorPedalSecondary));
 	onGrabPedal();
 }
 
 // In case of cable throttle we need support calibration of primary sensor of first throttle only
 void grapTps1PrimaryIsClosed()
 {
-	engine->outputChannels.calibrationMode = (uint8_t)TsCalMode::Tps1Min;
-	engine->outputChannels.calibrationValue = Sensor::getRaw(SensorType::Tps1Primary);
+	tsCalibrationSetData(TsCalMode::Tps1Min, Sensor::getRaw(SensorType::Tps1Primary));
 }
 
 void grapTps1PrimaryIsOpen()
 {
-	engine->outputChannels.calibrationMode = (uint8_t)TsCalMode::Tps1Max;
-	engine->outputChannels.calibrationValue = Sensor::getRaw(SensorType::Tps1Primary);
+	tsCalibrationSetData(TsCalMode::Tps1Max, Sensor::getRaw(SensorType::Tps1Primary));
 }
 
 #if EFI_SENT_SUPPORT


### PR DESCRIPTION
TS calibration channel is used to update min/max value for pedal, tps and for PID values during auto-calibration of ETB.
Each user implements same code for accessing few fields in `outputChannels`.
Extract this code to helpers.
Also fix issue when some of users "forget" to clear `calibrationMode` and leaving all calibration buttons "disabled".
Now user can do TPS, Pedal and PID calibrations in any order with no need to reset ECU.