### PR TITLE
UI: fix isIdling indicator

### DIFF
--- a/firmware/controllers/actuators/idle_state.txt
+++ b/firmware/controllers/actuators/idle_state.txt
@@ -26,6 +26,7 @@ custom idle_state_e 4 bits, S32, @OFFSET@, [0:2], "not important"
 	bit looksLikeCrankToIdle
     bit isIdleCoasting;Idle: coasting
 	bit isIdleClosedLoop;Idle: Closed loop active
+	bit isIdling; Idle: idling
 
 	uint16_t idleTarget;Idle: Target RPM
 	uint16_t idleEntryRpm;Idle: Entry threshold

--- a/firmware/controllers/actuators/idle_thread.cpp
+++ b/firmware/controllers/actuators/idle_thread.cpp
@@ -366,6 +366,9 @@ float IdleController::getIdlePosition(float rpm) {
 		float vehicleSpeed = Sensor::getOrZero(SensorType::VehicleSpeed);
 		auto phase = determinePhase(rpm, targetRpm, tps, vehicleSpeed, crankingTaper);
 
+		// update TS flag
+		isIdling = (phase == Phase::Idling) || (phase == Phase::CrankToIdleTaper);
+
     if (phase != m_lastPhase && phase == Phase::Idling) {
         // Just entered idle, reset timer
  		    m_timeInIdlePhase.reset();

--- a/firmware/tunerstudio/tunerstudio.template.ini
+++ b/firmware/tunerstudio/tunerstudio.template.ini
@@ -2131,7 +2131,7 @@ gaugeCategory = GPPWM Outputs
 	indicator =				{ brakePedalState },			"No braking",		"Brake down",  white,  black,	red,  black@@if_ts_show_brake_pedal_indicator
 	indicator =				{ acButtonState },		"AC Switch off",		"AC Switch on",  white,  black,	blue,  white@@if_ts_show_air_conditioning
 	indicator =					{ m_acEnabled },		"AC Relay off",		"AC Relay on",  white,  black,	blue,  white@@if_ts_show_air_conditioning
-	indicator =			{ isIdleClosedLoop },			"Not idling",				"Idling",  white,  black,  green,  black
+	indicator =			{ isIdling },			"Not idling",				"Idling",  white,  black,  green,  black
 	indicator =				{ isIdleCoasting },		"Not coasting",			"Coasting",  white,  black,  green,  black
 	indicator =					{ dfcoActive },  "Not decel fuel cut",	"Decel fuel cut",  white,  black, yellow,  black
 	indicator =				{ isAboveAccelThreshold },		"No TPS accel",  "TPS accel active",  white,  black, yellow,  black
@@ -4062,7 +4062,7 @@ cmd_set_engine_type_default					= "@@TS_IO_TEST_COMMAND_char@@@@ts_command_e_TS_
 		indicator = { wb2fwOutdated }, "FW: compatible", "FW: need update", green, black, yellow, black
 
 	indicatorPanel = ignitionTableIndicators, 1
-		indicator =			{ isIdleClosedLoop && useSeparateAdvanceForIdle == 1 }, "Using normal ignition table", "Using idle ignition table",  white,  black,  green,  black
+		indicator =			{ isIdling && useSeparateAdvanceForIdle == 1 }, "Using normal ignition table", "Using idle ignition table",  white,  black,  green,  black
 
 	dialog = uegoCan0Gauges
 		gauge = afr1Gauge


### PR DESCRIPTION
Idling is green if in Idling or CrankToIdleTaper states independently of closed or open loop idle.

https://github.com/rusefi/rusefi/issues/8542
https://github.com/rusefi/rusefi/issues/8498