### PR TITLE
OpenBLT may skip erase command in some conditions #8515

### DIFF
--- a/firmware/hw_layer/ports/stm32/flash_int.cpp
+++ b/firmware/hw_layer/ports/stm32/flash_int.cpp
@@ -216,16 +216,13 @@ static int intFlashSectorErase(flashsector_t sector) {
 }
 
 int intFlashErase(flashaddr_t address, size_t size) {
-	while (size > 0) {
+	flashaddr_t endAddress = address + size - 1;
+	while (address <= endAddress) {
 		flashsector_t sector = intFlashSectorAt(address);
 		int err = intFlashSectorErase(sector);
 		if (err != FLASH_RETURN_SUCCESS)
 			return err;
 		address = intFlashSectorEnd(sector);
-		size_t sector_size = flashSectorSize(sector);
-		if (sector_size >= size)
-			break;
-		size -= sector_size;
 	}
 
 	return FLASH_RETURN_SUCCESS;

--- a/java_console/ui/src/main/java/com/rusefi/maintenance/OpenBltFlasher.java
+++ b/java_console/ui/src/main/java/com/rusefi/maintenance/OpenBltFlasher.java
@@ -96,7 +96,7 @@ public class OpenBltFlasher {
         mCallbacks.setPhase("Erase", true);
         final ProgressUpdater pu = new ProgressUpdater();
 
-        forEachFirmwareChunk(65536, (Chunk c) -> {
+        forEachFirmwareChunk(32768, (Chunk c) -> {
             mLoader.clearMemory(c.address, c.data.length);
 
             pu.processBytes(c.data.length);


### PR DESCRIPTION
in some cases `intFlashErase` may skip erasing of the last sector

see #8515 for details