### PR TITLE
Now we terminate migration/import tune process if we failed to backup…

### DIFF
--- a/java_console/io/src/main/java/com/rusefi/binaryprotocol/BinaryProtocol.java
+++ b/java_console/io/src/main/java/com/rusefi/binaryprotocol/BinaryProtocol.java
@@ -6,6 +6,7 @@ import com.opensr5.ConfigurationImageMetaVersion0_0;
 import com.opensr5.ConfigurationImage;
 import com.opensr5.ConfigurationImageWithMeta;
 import com.opensr5.ini.IniFileModel;
+import com.opensr5.ini.field.OrdinalOutOfRangeException;
 import com.opensr5.io.DataListener;
 import com.rusefi.ConfigurationImageDiff;
 import com.rusefi.NamedThreadFactory;
@@ -369,7 +370,7 @@ public class BinaryProtocol {
                 );
             } catch (JAXBException e) {
                 log.error("JAXBException", e);
-            } catch (IOException e) {
+            } catch (final IOException | OrdinalOutOfRangeException e) {
                 log.info("Ignoring " + e, e);
             } catch (Exception e) {
                 log.error("Unexpected exception:" + e, e);

--- a/java_console/io/src/main/java/com/rusefi/util/TuneBackupUtil.java
+++ b/java_console/io/src/main/java/com/rusefi/util/TuneBackupUtil.java
@@ -46,8 +46,9 @@ public class TuneBackupUtil {
         try {
             final Msq tune = MsqFactory.valueOf(image, ini);
             tune.writeXmlFile(xmlFileName);
-        } catch (OrdinalOutOfRangeException e) {
-            log.warn("Unexpected " + e, e);
+        } catch (final OrdinalOutOfRangeException e) {
+            log.warn("OrdinalOutOfRangeException exception on saving .msq file:" + e, e);
+            throw e;
         }
     }
 }


### PR DESCRIPTION
… .msq file for a migrated tune into `state` folder (closes #8570)

only:uaefi