### PR TITLE
Fix map prediction rpm

### DIFF
--- a/firmware/controllers/algo/airmass/speed_density_airmass.cpp
+++ b/firmware/controllers/algo/airmass/speed_density_airmass.cpp
@@ -53,7 +53,7 @@ float SpeedDensityAirmass::getAirflow(float rpm, float map, bool postState) {
 }
 
 float SpeedDensityAirmass::getPredictiveMap(float rpm, bool postState, float mapSensor) {
-	float blendDuration = = interpolate2d(rpm, config->tpsTspCorrValuesBins,
+	float blendDuration = interpolate2d(rpm, config->tpsTspCorrValuesBins,
 						config->tpsTspCorrValues);
 	if ( blendDuration > 2) {
 		blendDuration = 1;

--- a/firmware/controllers/algo/airmass/speed_density_airmass.cpp
+++ b/firmware/controllers/algo/airmass/speed_density_airmass.cpp
@@ -53,7 +53,12 @@ float SpeedDensityAirmass::getAirflow(float rpm, float map, bool postState) {
 }
 
 float SpeedDensityAirmass::getPredictiveMap(float rpm, bool postState, float mapSensor) {
-	float blendDuration = engineConfiguration->mapPredictionBlendDuration;
+	float blendDuration = = interpolate2d(rpm, config->tpsTspCorrValuesBins,
+						config->tpsTspCorrValues);
+	if ( blendDuration > 2) {
+		blendDuration = 1;
+	}
+
 	float elapsedTime = m_predictionTimer.getElapsedSeconds();
 
 	if (m_isMapPredictionActive && elapsedTime >= blendDuration) {


### PR DESCRIPTION
uses the TPS/TPS extra fuel RPM correction as a variable Blend Duration, ignoring this scalar/single value:
<img width="347" height="146" alt="image" src="https://github.com/user-attachments/assets/6f14f41a-feb2-416f-a02d-fbe9f1043558" />

We should always have varibale duration because we don't need prediction in upper RPMs where airspeed is fast