### PR TITLE
fix cranking-to-run idle with AC 

### DIFF
--- a/firmware/controllers/actuators/idle_thread.cpp
+++ b/firmware/controllers/actuators/idle_thread.cpp
@@ -128,7 +128,7 @@ percent_t IdleController::getRunningOpenLoop(IIdleController::Phase phase, float
 	);
 
 	// Now we bump it by the AC/fan amount if necessary
-    if(engine->module<AcController>().unmock().acButtonState && phase == Phase::Idling) {
+    if (engine->module<AcController>().unmock().acButtonState && (phase == Phase::Idling || phase == Phase::CrankToIdleTaper)) {
     	running += engineConfiguration->acIdleExtraOffset;
     }
 


### PR DESCRIPTION
we need to compensate ac idle output while crank-to-run is active. compressor doesn't care