### PR TITLE
Fuel: calculate last injection pulse to previous pulse ratio

### DIFF
--- a/firmware/console/binary/output_channels.txt
+++ b/firmware/console/binary/output_channels.txt
@@ -79,6 +79,7 @@ int16_t rpmAcceleration;dRPM;"RPM acceleration/Rate of Change/ROC",1, 0, 0, 5, 2
 	int16_t autoscale vvtPositionB1I;@@GAUGE_NAME_VVT_B1I@@;"deg",{1/@@PACK_MULT_ANGLE@@}, 0, 0, 0, 1
 
 	uint16_t autoscale actualLastInjection;@@GAUGE_NAME_FUEL_LAST_INJECTION@@\nActual last injection time - including all compensation and injection mode;"ms",{1/@@PACK_MULT_MS@@}, 0, 0, 0, 3
+	float actualLastInjectionRatio;@@GAUGE_NAME_FUEL_LAST_INJECTION_RATIO@@\nLast injection time divided to previous injection time;"", 1, 0, 0, 0, 3
 
   uint8_t stopEngineCode
 
@@ -400,6 +401,7 @@ float mapFast
 	uint8_t[MAX_CYLINDER_COUNT iterate] injectorDiagnostic
 
 	uint16_t autoscale actualLastInjectionStage2;@@GAUGE_NAME_FUEL_LAST_INJECTION_STAGE_2@@;"ms",{1/@@PACK_MULT_MS@@}, 0, 0, 0, 3
+	float actualLastInjectionRatioStage2;@@GAUGE_NAME_FUEL_LAST_INJECTION_RATIO_STAGE_2@@;"", 1, 0, 0, 0, 3
 
 	uint8_t autoscale injectorDutyCycleStage2;@@GAUGE_NAME_FUEL_INJ_DUTY_STAGE_2@@;"%",{1/2}, 0, 0, 0, 0
 	uint8_t rawFlexFreq

--- a/firmware/controllers/engine_cycle/main_trigger_callback.cpp
+++ b/firmware/controllers/engine_cycle/main_trigger_callback.cpp
@@ -126,6 +126,16 @@ void InjectionEvent::onTriggerTooth(efitick_t nowNt, float currentPhase, float n
 #endif /*EFI_PRINTF_FUEL_DETAILS */
 
 	if (this->cylinderNumber == 0) {
+		if (engine->outputChannels.actualLastInjection) {
+			engine->outputChannels.actualLastInjectionRatio = injectionDurationStage1 / engine->outputChannels.actualLastInjection;
+		} else {
+			engine->outputChannels.actualLastInjectionRatio = 0;
+		}
+		if (engine->outputChannels.actualLastInjectionStage2) {
+			engine->outputChannels.actualLastInjectionRatioStage2 = injectionDurationStage2 / engine->outputChannels.actualLastInjectionStage2;
+		} else {
+			engine->outputChannels.actualLastInjectionRatioStage2 = 0;
+		}
 		engine->outputChannels.actualLastInjection = injectionDurationStage1;
 		engine->outputChannels.actualLastInjectionStage2 = injectionDurationStage2;
 	}

--- a/firmware/integration/rusefi_config_shared.txt
+++ b/firmware/integration/rusefi_config_shared.txt
@@ -175,6 +175,8 @@
 #define GAUGE_NAME_FUEL_RUNNING "Fuel: running"
 #define GAUGE_NAME_FUEL_LAST_INJECTION "Fuel: Last inj pulse width"
 #define GAUGE_NAME_FUEL_LAST_INJECTION_STAGE_2 "Fuel: Last inj pulse width stg 2"
+#define GAUGE_NAME_FUEL_LAST_INJECTION_RATIO "Fuel: Last inj pulse growth"
+#define GAUGE_NAME_FUEL_LAST_INJECTION_RATIO_STAGE_2 "Fuel: Last inj pulse growth stg 2"
 #define GAUGE_NAME_FUEL_BASE "Fuel: base cycle mass"
 #define GAUGE_NAME_FUEL_STFT_1 "Short Term Fuel Trim: Bank 1"
 #define GAUGE_NAME_FUEL_STFT_2 "Short Term Fuel Trim: Bank 2"

--- a/firmware/tunerstudio/tunerstudio.template.ini
+++ b/firmware/tunerstudio/tunerstudio.template.ini
@@ -1919,6 +1919,8 @@ gaugeCategory = Fueling
 	injectorDutyCycleStg2Gauge=injectorDutyCycleStage2, @@GAUGE_NAME_FUEL_INJ_DUTY_STAGE_2@@,"%",		0,	120,		10,	10,	100,	100,	1,	1
 	actualLastInjectionGauge	= actualLastInjection,	@@GAUGE_NAME_FUEL_LAST_INJECTION@@, "mSec",		0,	25.5,	1.0,	1.2,		20,	25,	3, 1
 	actualLastInjectionStg2Gauge	= actualLastInjectionStage2,	@@GAUGE_NAME_FUEL_LAST_INJECTION_STAGE_2@@, "mSec",		0,	25.5,	1.0,	1.2,		20,	25,	3, 1
+	actualLastInjectionRatioGauge	= actualLastInjectionRatio,	@@GAUGE_NAME_FUEL_LAST_INJECTION_RATIO@@, "",		0,	10,	0.2,	0.5,		2,	5,	3, 1
+	actualLastInjectionRatioStg2Gauge	= actualLastInjectionRatioStage2,	@@GAUGE_NAME_FUEL_LAST_INJECTION_RATIO_STAGE_2@@, "",		0,	10,	0.2,	0.5,		2,	5,	3, 1
 	veValueGauge		= veValue,					@@GAUGE_NAME_FUEL_VE@@,				"",		0,	120,		10,	10,	100,	100,	1,	1
   gegoGauge            = Gego,                                      "EGO",                             "",             50,      160,            10,     10,     100,    100,    1,      1
 


### PR DESCRIPTION
I'm not good in terms, but seems this ration is not ROC.
Just a ration between last and prev injection pulse widths.
<img width="431" height="357" alt="Screenshot from 2025-09-17 19-16-56" src="https://github.com/user-attachments/assets/5b34fa69-83b4-4b5b-8966-107780d2e3ef" />
<img width="897" height="571" alt="Screenshot from 2025-09-17 19-22-58" src="https://github.com/user-attachments/assets/28592ff8-7d85-484b-a2a0-9cc88de3a1ea" />
