### PR TITLE
ETB: boardEtbAdjustment fix sign.

### DIFF
--- a/firmware/controllers/actuators/electronic_throttle.cpp
+++ b/firmware/controllers/actuators/electronic_throttle.cpp
@@ -322,7 +322,7 @@ expected<percent_t> EtbController::getSetpointEtb() {
 	float rpm = Sensor::getOrZero(SensorType::Rpm);
   percent_t preBoard = m_pedalProvider->getValue(rpm, sanitizedPedal);
 	etbCurrentTarget = boardAdjustEtbTarget(preBoard);
-	boardEtbAdjustment = preBoard - etbCurrentTarget;
+	boardEtbAdjustment = etbCurrentTarget - preBoard;
 
 	percent_t etbIdlePosition = clampPercentValue(m_idlePosition);
 	percent_t etbIdleAddition = PERCENT_DIV * engineConfiguration->etbIdleThrottleRange * etbIdlePosition;


### PR DESCRIPTION
boardAdjustEtbTarget should be positive if boardAdjustEtbTarget() incresed ETB target.
And vise versa.

Affects only logging.