### PR TITLE
AE: disable on tuning

### DIFF
--- a/firmware/controllers/algo/accel_enrichment.cpp
+++ b/firmware/controllers/algo/accel_enrichment.cpp
@@ -23,6 +23,7 @@
 
 #include "pch.h"
 #include "accel_enrichment.h"
+#include "tunerstudio.h"
 
 
 // on this level we do not distinguish between multiplier and 'ms adder' modes
@@ -38,6 +39,12 @@ float TpsAccelEnrichment::getTpsEnrichment() {
 		// If disabled, return 0.
 		return 0;
 	}
+
+#if EFI_TUNER_STUDIO
+	if (isTuningVeNow()) {
+		return 0;
+	}
+#endif
 
 	float rpm = Sensor::getOrZero(SensorType::Rpm);
 	if (rpm < engineConfiguration->cranking.rpm) {

--- a/firmware/controllers/algo/accel_enrichment.cpp
+++ b/firmware/controllers/algo/accel_enrichment.cpp
@@ -38,17 +38,16 @@ float TpsAccelEnrichment::getTpsEnrichment() {
 		// If disabled, return 0.
 		return 0;
 	}
+
 	float rpm = Sensor::getOrZero(SensorType::Rpm);
 	if (rpm < engineConfiguration->cranking.rpm) {
 		return 0;
 	}
 
 	if (isAboveAccelThreshold) {
-    valueFromTable = interpolate3d(config->tpsTpsAccelTable,
-      config->tpsTpsAccelToRpmBins, tpsTo,
-      config->tpsTpsAccelFromRpmBins, tpsFrom
-    );
-
+		valueFromTable = interpolate3d(config->tpsTpsAccelTable,
+			config->tpsTpsAccelToRpmBins, tpsTo,
+			config->tpsTpsAccelFromRpmBins, tpsFrom);
 		extraFuel = valueFromTable;
 		m_timeSinceAccel.reset();
 	} else if (isBelowDecelThreshold) {
@@ -126,8 +125,9 @@ void TpsAccelEnrichment::onEngineCycleTps() {
 int TpsAccelEnrichment::getMaxDeltaIndex() {
 	int len = minI(cb.getSize(), cb.getCount());
 	tooShort = len < 2;
-	if (tooShort)
+	if (tooShort) {
 		return 0;
+	}
 	int ci = cb.currentIndex - 1;
 	float maxValue = cb.get(ci) - cb.get(ci - 1);
 	int resultIndex = ci;
@@ -221,6 +221,5 @@ float TpsAccelEnrichment::getTimeSinceAcell() const {
 }
 
 void initAccelEnrichment() {
-
 	engine->module<TpsAccelEnrichment>()->onConfigurationChange(nullptr);
 }

--- a/firmware/tunerstudio/tunerstudio.template.ini
+++ b/firmware/tunerstudio/tunerstudio.template.ini
@@ -5087,8 +5087,9 @@ include_file controllers/modules/fan_control/fan_control.dialogs.ini
 
 	dialog = TpsAccelPanel, "TPS"
 		field = "Accel Enrichment Mode",        accelEnrichmentMode
+		field = "Detect Tuning and Suspend",	tuningDetector
 		field = "" ; spacer
-			field = "Length",						tpsAccelLookback
+		field = "Length",						tpsAccelLookback
 		field = "Inhibit closed loop fuel after accel", noFuelTrimAfterAccelTime
 		field = "Accel Activation Threshold",				tpsAccelEnrichmentThreshold
 		field = "Decel Threshold",				tpsDecelEnleanmentThreshold
@@ -5102,11 +5103,14 @@ include_file controllers/modules/fan_control/fan_control.dialogs.ini
 		field = "evaporation time constant / tau",		wwaeTau, { complexWallModel == 0 }
 		field = "added to wall coef / beta",			wwaeBeta, { complexWallModel == 0 }
 
+	indicatorPanel = AccelEnfichIndicatorsPanel
+		indicator = { isTuningNow }, "No tuning happening", "Tuning Detected",  white,  black,  green,  black
 
 ;			Tuning->AccelEnrichment
 	dialog = AccelEnrich,	"Accel/Decel Enrichment"
 		panel = TpsAccelPanel
 		panel = WallWettingAccelPanel
+		panel = AccelEnfichIndicatorsPanel
 
 	dialog = wwTauCurves, "Wall wetting AE evaporation time"
 		field = "#Set a base evaporation time based on coolant temperature, and a multiplier based on MAP."

--- a/firmware/tunerstudio/tunerstudio.template.ini
+++ b/firmware/tunerstudio/tunerstudio.template.ini
@@ -314,6 +314,9 @@ page = 3
 	isPpsPrimary = { throttlePedalPositionAdcChannel != @@ADC_CHANNEL_NONE@@ }
 	isPpsSecondary = { throttlePedalPositionSecondAdcChannel != @@ADC_CHANNEL_NONE@@ }
 
+	; Closed Loop Fuel Correction / Short Term Fuel Trims
+	isSTFT = { fuelClosedLoopCorrectionEnabled == 1 }
+
 [PcVariables]
 	fuelUnits = bits, U08, [0:2], "kPa", "MAF", "%TPS", "Lua"
 	pwmAxisLabels = bits, U08, [0:5], "Zero", "TPS %", "MAP kPa", "CLT C", "IAT C", "Fuel Load", "Ignition Load", "Aux Temp 1 C", "Aux Temp 2 C", "Accel Pedal %", "Battery Voltage Volts", "VVT 1 I Deg", "VVT 1 E Deg", "VVT 2 I Deg", "VVT 2 E Deg", "Ethanol (Flex) %", "Aux Linear 1 *", "Aux Linear 2 *", "GPPWM Output 1 %", "GPPWM Output 2 %", "GPPWM Output 3 %", "GPPWM Output 4 %", "Lua Gauge 1", "Lua Gauge 2", "RPM", "Gear (detected)", "Baro pressure kPa", "EGT 1 C", "EGT 2 C", "Aux Linear 3", "Aux Linear 4", "Vehicle Speed KPH", "Oil pressure kPa", "Oil temp C", "Fuel Pressure", "Throttle Pressure Ratio"
@@ -4580,23 +4583,23 @@ include_file controllers/modules/fan_control/fan_control.dialogs.ini
 	dialog = fuelClosedLoopSettings, "Short term fuel trim"
 		field = "Short term fuel trim",								fuelClosedLoopCorrectionEnabled
 		field = "Settings used for both correction and learning:"
-		field = "Minimum CLT",							stft_minClt, {fuelClosedLoopCorrectionEnabled == 1}
-		field = "Startup delay"							stft_startupDelay, {fuelClosedLoopCorrectionEnabled == 1}
-		field = "After DFCO delay",						noFuelTrimAfterDfcoTime, {fuelClosedLoopCorrectionEnabled == 1}
-		field = "Detect Tuning and Suspend",			tuningDetector, {fuelClosedLoopCorrectionEnabled == 1}
+		field = "Minimum CLT",							stft_minClt, { isSTFT }
+		field = "Startup delay"							stft_startupDelay, { isSTFT }
+		field = "After DFCO delay",						noFuelTrimAfterDfcoTime, { isSTFT }
+		field = "Detect Tuning and Suspend",			tuningDetector, { isSTFT }
 		field = "Settings used for learning only:"
-		field = "Minimum AFR for learning",				stft_minAfr, {fuelClosedLoopCorrectionEnabled == 1}
-		field = "Maximum AFR for learning",				stft_maxAfr, {fuelClosedLoopCorrectionEnabled == 1}
-		field = "Adjustment deadband",					stft_deadband, {fuelClosedLoopCorrectionEnabled == 1}
-		field = "Ignore error magnitude",				stftIgnoreErrorMagnitude, {fuelClosedLoopCorrectionEnabled == 1}
+		field = "Minimum AFR for learning",				stft_minAfr, { isSTFT }
+		field = "Maximum AFR for learning",				stft_maxAfr, { isSTFT }
+		field = "Adjustment deadband",					stft_deadband, { isSTFT }
+		field = "Ignore error magnitude",				stftIgnoreErrorMagnitude, { isSTFT }
 
 	dialog = fuelClosedLoopConfig
 		panel = fuelClosedLoopSettings
-		panel = stftPartitioning, {fuelClosedLoopCorrectionEnabled == 1}
-		panel = stftPartitionSettingsIdle, {fuelClosedLoopCorrectionEnabled == 1}
-		panel = stftPartitionSettingsOverrun, {fuelClosedLoopCorrectionEnabled == 1}
-		panel = stftPartitionSettingsPower, {fuelClosedLoopCorrectionEnabled == 1}
-		panel = stftPartitionSettingsMain, {fuelClosedLoopCorrectionEnabled == 1}
+		panel = stftPartitioning, { isSTFT }
+		panel = stftPartitionSettingsIdle, { isSTFT }
+		panel = stftPartitionSettingsOverrun, { isSTFT }
+		panel = stftPartitionSettingsPower, { isSTFT }
+		panel = stftPartitionSettingsMain, { isSTFT }
 		panel = fuelClosedLoopIndicators
 
 	indicatorPanel = fuelClosedLoopInputIndicatorsPanelBank1, 2
@@ -4692,8 +4695,8 @@ include_file controllers/modules/fan_control/fan_control.dialogs.ini
 
 	dialog = fuelLTFCConfig
 		field = "Short term fuel trims should be enabled and configured"
-		panel = fuelLTFCSettings, Center, { fuelClosedLoopCorrectionEnabled }
-		panel = ltftButtons, { fuelClosedLoopCorrectionEnabled }
+		panel = fuelLTFCSettings, Center, { isSTFT }
+		panel = ltftButtons, { isSTFT }
 		panel = ltftIndicators
 
 	dialog = fuelLtftLoopBank1, "Trim bank 1"


### PR DESCRIPTION
Reuse same timeout as used for Closed Loop Fuel.
Copy indicator and timeout settings to Accel Enrichment dialog.
<img width="403" height="508" alt="Screenshot from 2025-09-26 19-38-48" src="https://github.com/user-attachments/assets/eef3da6c-b3ae-49e4-b0f4-45db0ece08d8" />
