### PR TITLE
disable metrics/imperial units selector on ts template

### DIFF
--- a/firmware/tunerstudio/tunerstudio.template.ini
+++ b/firmware/tunerstudio/tunerstudio.template.ini
@@ -36,7 +36,9 @@ enable2ndByteCanID = false
 ;    settingOption = CONN_SLOW, "Slower / Wireless"
 ;    settingOption = CONN_FAST, "High Speed / USB"
 
-#set USE_METRIC_UNITS       ; unset for Fahrenheit
+; disabled!, see pull #8647 for details
+;#set USE_METRIC_UNITS       ; unset for Fahrenheit
+#define USE_METRIC_UNITS=true
 
 [MegaTune]
  ; https://rusefi.com/forum/viewtopic.php?p=36201#p36201


### PR DESCRIPTION
solves part:

>  @FDSoftware what's the smallest change to disable feature in .ini? can we go #if 1 instead of #if USE_METRIC_UNITS?

of #8647
button for change metrics/imperial are hide and the selected units are metric

<img width="1543" height="766" alt="image" src="https://github.com/user-attachments/assets/37ebce34-75d2-413d-816e-53934ae17d4d" />
