### PR TITLE
uaefi h7: fix for 20MHz HSE oscillator

### DIFF
--- a/firmware/config/boards/hellen/uaefi/board.mk
+++ b/firmware/config/boards/hellen/uaefi/board.mk
@@ -16,9 +16,8 @@ DDEFS += -DFIRMWARE_ID=\"uaefi\" $(VAR_DEF_ENGINE_TYPE)
 ifeq ($(PROJECT_CPU),ARCH_STM32H7)
 	# Default H743 linker script is not compatible
 	LDSCRIPT = $(PROJECT_DIR)/hw_layer/ports/stm32/stm32h7/STM32H723xG_ITCM64k.ld
-	# We are developing on WeAct devkit with 25 MHz ocsilator
-	# TODO: fix!
-	DDEFS += -DSTM32_HSECLK=25000000
+	# Do not use HSE autodetection
+	DDEFS += -DSTM32_HSECLK=20000000
 	DDEFS += -DENABLE_AUTO_DETECT_HSE=FALSE
 else
 	#Knock is available on F4 and F7 only

--- a/firmware/hw_layer/ports/stm32/stm32h7/cfg/mcuconf_stm32h723.h
+++ b/firmware/hw_layer/ports/stm32/stm32h7/cfg/mcuconf_stm32h723.h
@@ -40,7 +40,7 @@
 #define STM32_PLL1_P_ENABLED                TRUE
 #define STM32_PLL1_Q_ENABLED                TRUE
 #define STM32_PLL1_R_ENABLED                TRUE
-#define STM32_PLL1_DIVM_VALUE               5
+#define STM32_PLL1_DIVM_VALUE               4
 #define STM32_PLL1_DIVN_VALUE               104
 #define STM32_PLL1_FRACN_VALUE              0
 #define STM32_PLL1_DIVP_VALUE               1
@@ -50,7 +50,7 @@
 #define STM32_PLL2_P_ENABLED                TRUE
 #define STM32_PLL2_Q_ENABLED                TRUE
 #define STM32_PLL2_R_ENABLED                TRUE
-#define STM32_PLL2_DIVM_VALUE               5
+#define STM32_PLL2_DIVM_VALUE               4
 #define STM32_PLL2_DIVN_VALUE               160
 #define STM32_PLL2_FRACN_VALUE              0
 #define STM32_PLL2_DIVP_VALUE               40
@@ -60,7 +60,7 @@
 #define STM32_PLL3_P_ENABLED                TRUE
 #define STM32_PLL3_Q_ENABLED                TRUE
 #define STM32_PLL3_R_ENABLED                TRUE
-#define STM32_PLL3_DIVM_VALUE               5
+#define STM32_PLL3_DIVM_VALUE               4
 #define STM32_PLL3_DIVN_VALUE               96
 #define STM32_PLL3_FRACN_VALUE              0
 #define STM32_PLL3_DIVP_VALUE               10


### PR DESCRIPTION
stm32h723 is alive on uaefi.
And have some RAM for BIG LUA:
```
2025-10-03_00_15_26_321: EngineState: luaCycle 3us including luaRxTime 1us
2025-10-03_00_15_26_322: EngineState: Lua total heap(s) usage: 15029 / 180552 bytes = 8.3%
2025-10-03_00_15_26_322: EngineState: Common ChibiOS heap: 216 bytes free
2025-10-03_00_15_26_323: EngineState: ChibiOS memcore usage: 18368 / 180552
2025-10-03_00_15_26_324: EngineState: confirmation_luamemory:9
```