### PR TITLE
unit_tests: TestExecutor::executeAll always expect time in uS

### DIFF
--- a/unit_tests/test-framework/engine_test_helper.cpp
+++ b/unit_tests/test-framework/engine_test_helper.cpp
@@ -350,20 +350,19 @@ void EngineTestHelper::moveTimeForwardAndInvokeEventsUs(int deltaTimeUs) {
 void EngineTestHelper::setTimeAndInvokeEventsUs(int targetTimeUs) {
 	int counter = 0;
 	while (true) {
-	  criticalAssertVoid(counter++ < 100'000, "EngineTestHelper: failing to setTimeAndInvokeEventsUs");
+		criticalAssertVoid(counter++ < 100'000, "EngineTestHelper: failing to setTimeAndInvokeEventsUs");
 		scheduling_s* nextScheduledEvent = engine.scheduler.getHead();
 		if (nextScheduledEvent == nullptr) {
 			// nothing pending - we are done here
 			break;
 		}
-		int nextEventTime = nextScheduledEvent->getMomentUs();
-		if (nextEventTime > targetTimeUs) {
+		efitick_t nextEventNt = nextScheduledEvent->getMomentNt();
+		if (nextEventNt > US2NT(targetTimeUs)) {
 			// next event is too far in the future
 			break;
 		}
-		setTimeNowUs(nextEventTime);
-		extern bool unitTestTaskPrecisionHack;
-		engine.scheduler.executeAll(getTimeNowUs());
+		setTimeNowNt(nextEventNt);
+		engine.scheduler.executeAllNt(getTimeNowNt());
 	}
 
 	setTimeNowUs(targetTimeUs);

--- a/unit_tests/test-framework/engine_test_helper.cpp
+++ b/unit_tests/test-framework/engine_test_helper.cpp
@@ -363,11 +363,7 @@ void EngineTestHelper::setTimeAndInvokeEventsUs(int targetTimeUs) {
 		}
 		setTimeNowUs(nextEventTime);
 		extern bool unitTestTaskPrecisionHack;
-		if (unitTestTaskPrecisionHack) {
-			engine.scheduler.executeAll(getTimeNowUs());
-		} else {
-			engine.scheduler.executeAll(getTimeNowNt());
-		}
+		engine.scheduler.executeAll(getTimeNowUs());
 	}
 
 	setTimeNowUs(targetTimeUs);

--- a/unit_tests/test-framework/test_executor.cpp
+++ b/unit_tests/test-framework/test_executor.cpp
@@ -16,7 +16,11 @@ TestExecutor::~TestExecutor() {
 }
 
 int TestExecutor::executeAll(efitimeus_t nowUs) {
-	return schedulingQueue.executeAll(US2NT(nowUs));
+	return executeAllNt(US2NT(nowUs));
+}
+
+int TestExecutor::executeAllNt(efitick_t nowNt) {
+	return schedulingQueue.executeAll(nowNt);
 }
 
 void TestExecutor::clear() {

--- a/unit_tests/test-framework/test_executor.h
+++ b/unit_tests/test-framework/test_executor.h
@@ -20,6 +20,7 @@ public:
 
 	void clear();
 	int executeAll(efitimeus_t nowUs);
+	int executeAllNt(efitick_t nowNt);
 	int size();
 	scheduling_s * getHead();
 	scheduling_s * getForUnitTest(int index);


### PR DESCRIPTION
It does not depend on unitTestTaskPrecisionHack

Fixes CUSTOM_OUT_OF_ORDER_COIL in some tests.

Needs some tests fixing.

This reverts part of https://github.com/rusefi/rusefi/pull/7576/commits/ee4f4e1c81faa925e995b77b624bdc5f473ba680

@FDSoftware can you review this?

https://github.com/rusefi/rusefi/issues/7245