### PR TITLE
uaefi: engine_config: can3 verbose and listen only bits

### DIFF
--- a/firmware/config/boards/hellen/uaefi/board_engine_configuration.txt
+++ b/firmware/config/boards/hellen/uaefi/board_engine_configuration.txt
@@ -1,3 +1,5 @@
 	can_baudrate_e can3BaudRate
 	Gpio can3TxPin
 	Gpio can3RxPin
+bit can3ListenMode,"Listen only","Allow TX"
+bit verboseCan3,"Print all","Do not print"


### PR DESCRIPTION
Why newly added bit fields with explicitly defined names are counted as "true/false"?

```
E 251008 132337.682 [main] ConfigDefinition - unexpected
java.lang.IllegalStateException: We are trying to reduce inhumane true/false bitNames: 345
	at com.rusefi.ConfigDefinition.main(ConfigDefinition.java:60)
java.lang.IllegalStateException: We are trying to reduce inhumane true/false bitNames: 345
	at com.rusefi.ConfigDefinition.main(ConfigDefinition.java:60)

```