### PR TITLE
TriggerScheduler: add cancel() method - should reduce false warning, no changes in engine operation

### DIFF
--- a/firmware/controllers/engine_cycle/spark_logic.cpp
+++ b/firmware/controllers/engine_cycle/spark_logic.cpp
@@ -195,6 +195,9 @@ static void overFireSparkAndPrepareNextSchedule(IgnitionEvent *event) {
 		"cylinder %d %s overcharge %f ms",
 		event->cylinderIndex + 1, event->outputs[0]->getName(), actualDwellMs);
 
+	// kill pending fire
+	engine->module<TriggerScheduler>()->cancel(&event->sparkEvent);
+
 	engine->engineState.overDwellCounter++;
 	event->wasSparkCanceled = true;
 	fireSparkAndPrepareNextSchedule(event);

--- a/firmware/controllers/system/timer/trigger_scheduler.cpp
+++ b/firmware/controllers/system/timer/trigger_scheduler.cpp
@@ -87,6 +87,12 @@ void TriggerScheduler::schedule(const char *msg, AngleBasedEvent* event, action_
 	}
 }
 
+void TriggerScheduler::cancel(AngleBasedEvent* event) {
+	chibios_rt::CriticalSectionLocker csl;
+
+	LL_DELETE2(m_angleBasedEventsHead, event, nextToothEvent);
+}
+
 void TriggerScheduler::scheduleEventsUntilNextTriggerTooth(float rpm,
 							   efitick_t edgeTimestamp, float currentPhase, float nextPhase) {
 

--- a/firmware/controllers/system/timer/trigger_scheduler.h
+++ b/firmware/controllers/system/timer/trigger_scheduler.h
@@ -15,6 +15,8 @@ public:
 			     action_s action,
 				 float currentPhase, float nextPhase);
 
+	void cancel(AngleBasedEvent* event);
+
     // scheduleForActualTimeBasedExecution using underlying time-base scheduler
 	void scheduleEventsUntilNextTriggerTooth(float rpm,
 						 efitick_t edgeTimestamp,


### PR DESCRIPTION
If overcharge event happens we need to remove penging sparkEvent from TriggerScheduler's list.
Otherwice we can get 9011 CUSTOM_RE_ADDING_INTO_EXECUTION_QUEUE warning is some cases on single coil or wasted spark configurations

Related to https://github.com/rusefi/rusefi/pull/8725 .
Calling fastCallback() cause Dwell re-calculation. In some single-coil tests Dwell rises too much and dwell overlap during cranking.
See "crankingVW.crankingTwiceWithGap" test for example
```

[13.407208]efiPrintfInternal:msg`[Coil 1] 92 sparkUp scheduling revolution 23 angle 299.4 (+2.4) later`
[13.407208]efiPrintfInternal:msg`[Coil 1] 92 sparkUp scheduled at 1340861562 ticks (13.408615)`
[13.407208]efiPrintfInternal:msg`[Coil 1] 92 sparkDown scheduling revolution 23 angle 340.0`
[13.407208]efiPrintfInternal:msg`[Coil 1] 92 sparkDown scheduled to queue`
[13.407208]efiPrintfInternal:msg`[Coil 1] 92 overdwell scheduling at 1341761562 ticks (13.417615)`
[13.407208]efiPrintfInternal:msg`spark dwell@ 299.4 spark@ 340.00 id=0 sparkCounter=92`
[13.408615]efiPrintfInternal:msg`[Coil 1] 92 spark goes high revolution 23 tick 13408615 current value 0`
[13.408615]efiPrintfInternal:msg`pin Coil 1 goes high`
[13.408615]efiPrintfInternal:msg`pin goes 1`
[13.410000]efiPrintfInternal:msg`sparkDwell 6.0, dwellDurationAngle 10.3`
[13.411028]efiPrintfInternal:msg`onTriggerEventSparkLogic rpm 286.4 303.0 -> 309.0`
[13.411028]efiPrintfInternal:msg` 1.7 degress for 1mS`
[13.415000]efiPrintfInternal:msg`sparkDwell 6.0, dwellDurationAngle 10.3`
[13.415016]efiPrintfInternal:msg`onTriggerEventSparkLogic rpm 284.2 309.0 -> 315.0`
[13.415016]efiPrintfInternal:msg` 1.7 degress for 1mS`
[13.417615]efiPrintfInternal:msg`[Coil 1] 92 overFireSparkAndPrepareNextSchedule`
WARNING: C9353: cylinder 3 Coil 1 overcharge 9.000000 ms
[13.417615]efiPrintfInternal:msg`[Coil 1] 92 spark goes low revolution 23 tick 13417615 current value 1`
[13.417615]efiPrintfInternal:msg`pin Coil 1 goes low`
[13.417615]efiPrintfInternal:msg`pin goes 0`
[13.419288]efiPrintfInternal:msg`onTriggerEventSparkLogic rpm 279.8 315.0 -> 321.0`
[13.419288]efiPrintfInternal:msg` 1.7 degress for 1mS`
[13.419898]efiPrintfInternal:msg`pin Injector 1 goes high`
[13.419898]efiPrintfInternal:msg`pin goes 1`
[13.419898]efiPrintfInternal:msg`pin Injector 2 goes high`
[13.419898]efiPrintfInternal:msg`pin goes 1`
[13.419898]efiPrintfInternal:msg`pin Injector 3 goes high`
[13.419898]efiPrintfInternal:msg`pin goes 1`
[13.419898]efiPrintfInternal:msg`pin Injector 4 goes high`
[13.419898]efiPrintfInternal:msg`pin goes 1`
[13.420000]efiPrintfInternal:msg`sparkDwell 6.0, dwellDurationAngle 10.1`
[13.422965]efiPrintfInternal:msg`pin Injector 1 goes low`
[13.422965]efiPrintfInternal:msg`pin goes 0`
[13.422965]efiPrintfInternal:msg`pin Injector 2 goes low`
[13.422965]efiPrintfInternal:msg`pin goes 0`
[13.422965]efiPrintfInternal:msg`pin Injector 3 goes low`
[13.422965]efiPrintfInternal:msg`pin goes 0`
[13.422965]efiPrintfInternal:msg`pin Injector 4 goes low`
[13.422965]efiPrintfInternal:msg`pin goes 0`
[13.423792]efiPrintfInternal:msg`onTriggerEventSparkLogic rpm 274.2 321.0 -> 327.0`
[13.423792]efiPrintfInternal:msg` 1.6 degress for 1mS`
[13.425000]efiPrintfInternal:msg`sparkDwell 6.0, dwellDurationAngle 9.9`
[13.428622]efiPrintfInternal:msg`onTriggerEventSparkLogic rpm 266.7 327.0 -> 333.0`
[13.428622]efiPrintfInternal:msg` 1.6 degress for 1mS`
[13.430000]efiPrintfInternal:msg`sparkDwell 6.0, dwellDurationAngle 9.6`
[13.433328]efiPrintfInternal:msg`onTriggerEventSparkLogic rpm 261.1 333.0 -> 339.0`
[13.433328]efiPrintfInternal:msg` 1.6 degress for 1mS`
[13.433328]efiPrintfInternal:msg`[Coil 1] 93 sparkUp scheduling revolution 23 angle 337.5 (+4.5) later`
[13.433328]efiPrintfInternal:msg`[Coil 1] 93 sparkUp scheduled at 1343619875 ticks (13.436198)`
[13.433328]efiPrintfInternal:msg`[Coil 1] 93 sparkDown scheduling revolution 23 angle 347.8`
WARNING: C9011: re-adding element into event_queue
```