### PR TITLE
Add compile_commands.json to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,9 @@ log.txt
 # Eclipse
 .metadata/
 
+# LSP server
+compile_commands.json
+
 # rusEFI simulator makes logs, ignore those
 rusefi_simulator_log.mlg
 


### PR DESCRIPTION
Both mainstream LSP servers for C/C++, clangd and ccls require a compile_commands.json file.
I don't think it's worthwhile including this file in the repo, because it's about 300k lines, 11MB, and if source files are added or removed it needs to be updated.