### PR TITLE
BackgroundWizard: TS does not always call "displayPlugin" with signature in case of project change with plugin loaded

### DIFF
--- a/java_console/shared_ui/src/main/java/com/rusefi/wizard/BackgroundWizard.java
+++ b/java_console/shared_ui/src/main/java/com/rusefi/wizard/BackgroundWizard.java
@@ -17,14 +17,13 @@ public class BackgroundWizard {
     private static Supplier<ControllerAccess> controllerAccessSupplier;
     static OutputChannelClient onlineListener = new EcuOnlineListener();
 
-    private static int CURRENT_STATE_UNKNOWN = -1;
-    private static int CURRENT_STATE_OFFLINE = 0;
-    private static int CURRENT_STATE_ONLINE = 1;
-    private static int currentState = -1;
-    private static int lastState = -1;
+    private static final int CURRENT_STATE_UNKNOWN = -1;
+    private static final int CURRENT_STATE_OFFLINE = 0;
+    private static final int CURRENT_STATE_ONLINE = 1;
+    private static int currentState = CURRENT_STATE_UNKNOWN;
+    private static int lastState = CURRENT_STATE_UNKNOWN;
     private static boolean pluginEnabled = false;
     private static boolean ecuVinToogle = true;
-    private static String ecuVin = null;
 
 
     public static void start(Supplier<ControllerAccess> controllerAccessSupplier) {
@@ -60,9 +59,6 @@ public class BackgroundWizard {
     }
 
     private static void periodicWizardLogic() throws ControllerException {
-        // todo: check if ECU is connected
-        // todo: run logic
-        // todo: use something based on TunerStudioIntegration to actually open dialog!
         if (currentState != lastState) {
             if (currentState == CURRENT_STATE_UNKNOWN) {
                 log.info("ECU is not connected / no updates from TS");
@@ -80,10 +76,18 @@ public class BackgroundWizard {
             // weird way of getting the equivalent of "page = 1" on the ini file
             String mainConfigName = controllerAccessSupplier.get().getEcuConfigurationNames()[0];
             ControllerParameter currentVin = controllerAccessSupplier.get().getControllerParameterServer().getControllerParameter(mainConfigName, ECU_VIN_KEY);
-            ecuVin = currentVin.getStringValue();
+            String ecuVin = currentVin.getStringValue();
+            if (ecuVin == null || ecuVin.isEmpty()){
+                launchVinUI();
+            }
             log.info("ECU vin is " + ecuVin);
             ecuVinToogle = false;
         }
+    }
+
+    private static void launchVinUI() {
+        // todo: use something based on TunerStudioIntegration to actually open dialog!
+        log.info("Launching VIN UI");
     }
 
     public static boolean displayPlugin(String serialSignature) {

--- a/java_tools/ts_plugin/src/main/java/com/rusefi/ts_plugin/headless/TsHeadlessPluginImpl.java
+++ b/java_tools/ts_plugin/src/main/java/com/rusefi/ts_plugin/headless/TsHeadlessPluginImpl.java
@@ -31,6 +31,8 @@ public class TsHeadlessPluginImpl implements TsHeadlessPlugin {
         RusEfiSignature s = SignatureHelper.parse(iniFileModel.getSignature());
         System.out.println(port + " with OpenBlt, signature=" + s);
 
+        BackgroundWizard.displayPlugin(s.getBundleTarget());
+
         String updateUrl = TsHeadlessPluginImpl.getUpdateUrl(iniFileModel);
         String isObfuscated = iniFileModel.getProtocolMeta().get("RE_obfuscated");
         if (updateUrl == null) {


### PR DESCRIPTION
no ticket but can be found on the logs:

```
I 251103 113159.477 [ECU Communication Executor1] SerialIoStream - COM3: Closed port.
COM3 with OpenBlt, signature=RusEfiSignature{branch='lts-25houston', year='2025', month='06', day='02', bundleTarget='hd81', hash='2975283369'}
W 251103 113159.483 [ECU Communication Executor1] TsHeadlessPlugin - Not sure where to download from [null]/[null]
I 251103 113159.577 [ECU text pull1] BinaryProtocol - Port shutdown: Stopping text pull
03/11/25 11:32:02 :Info: Initializing Help.
03/11/25 11:32:02 :Info: Initializing Edition Features.
03/11/25 11:32:02 :Info: Initializing App Events.
03/11/25 11:32:02 :Debug: App Name:TunerStudio, appEdition:MS
03/11/25 11:32:02 :Info: Initializing User Interface
I 251103 113202.576 [AWT-EventQueue-0] TsPluginLauncher - displayPlugin 
``` 
note ` TsPluginLauncher - displayPlugin ` empty where code is:

```java
 @Override
    public boolean displayPlugin(String signature) {
        log.info("displayPlugin " + signature);
        // todo: smarter implementation one day
        TsHeadlessPlugin.displayPlugin(signature);
        return true;
    }
``` 


also fixed a couple of warnings

related: #8666 