### PR TITLE
Make COMPRESS_IMAGE check macos bash compatible

### DIFF
--- a/firmware/hw_layer/mass_storage/create_image.sh
+++ b/firmware/hw_layer/mass_storage/create_image.sh
@@ -35,7 +35,8 @@ do
   echo "File '$file' is added to the image."
 done
 
-if [ "${COMPRESS_IMAGE,,}" = "true" ]; then
+# macOS bash 3.x compatible version.
+if [ "$(printf '%s' "$COMPRESS_IMAGE" | tr '[:upper:]' '[:lower:]')" = "true" ]; then
   # Compress the image as DEFLATE with gzip
   gzip $IMAGE
   IMAGE_TO_OUTPUT=$IMAGE.gz


### PR DESCRIPTION
macOS has an old version of bash (3.x) due to licensing constraints and doesn't have the {$VAR,,} syntax available. Replaced with a POSIX compliant version from 3.X that works in both worlds.