### PR TITLE
Injector lag time calculation hack for pre Aug 3 2025 tunes

### DIFF
--- a/firmware/controllers/algo/fuel/injector_model.cpp
+++ b/firmware/controllers/algo/fuel/injector_model.cpp
@@ -78,7 +78,13 @@ InjectorNonlinearMode InjectorModelSecondary::getNonlinearMode() const {
 }
 
 void InjectorModelWithConfig::updateState() {
-  pressureCorrectionReference = getFuelDifferentialPressure().Value;
+	// TODO: remove at the end of 2025
+	// hack not to break tunes before 2779925f54f5c2d23499cbb2797f71508c652f54 "injector lag lookup should be done based on differential pressure"
+	if (engineConfiguration->useAbsolutePressureForLagTime) {
+		pressureCorrectionReference = getFuelPressure().Value;
+	} else {
+		pressureCorrectionReference = getFuelDifferentialPressure().Value;
+	}
 }
 
 expected<float> InjectorModelWithConfig::getFuelPressure() const {

--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -913,7 +913,9 @@ spi_device_e digitalPotentiometerSpiDevice;Digital Potentiometer is used by stoc
 	bit enableAemXSeries;AEM X-Series or rusEFI Wideband
 	bit modeledFlowIdle
 	bit isTuningDetectorEnabled,"yes","no"
-	! bits 30, 31 are free to use
+	! hack not to break tunes before 2779925f54f5c2d23499cbb2797f71508c652f54 "injector lag lookup should be done based on differential pressure"
+	bit useAbsolutePressureForLagTime,"yes","no"
+	! bit 31 is free to use
 	! 'unused32nd' is the 32nd bit here, you would need another bit region if more bits are desired
 
 	brain_input_pin_e[LOGIC_ANALYZER_CHANNEL_COUNT iterate] logicAnalyzerPins;

--- a/firmware/tunerstudio/tunerstudio.template.ini
+++ b/firmware/tunerstudio/tunerstudio.template.ini
@@ -3011,6 +3011,10 @@ cmd_set_engine_type_default					= "@@TS_IO_TEST_COMMAND_char@@@@ts_command_e_TS_
 		field = "Stoichiometric ratio",			stoichRatioPrimary, {isInjectionEnabled == 1}
 		field = "E100 stoichiometric ratio",	stoichRatioSecondary, {isInjectionEnabled == 1 && flexSensorPin != 0 }
 
+	dialog = fuelExperimental, "Experimental settings, do not touch", yAxis
+		field = "!Experimental, do not enable"
+		field = "Use absolute fuel pressure for dead time calculation", useAbsolutePressureForLagTime
+
 	dialog = injectorOutputSettings, "Injector Outputs",	yAxis
 		field = "Use only first half of outputs for batch mode"
 		field = "# wire each output to the corresponding cylinder number"
@@ -3128,6 +3132,7 @@ cmd_set_engine_type_default					= "@@TS_IO_TEST_COMMAND_char@@@@ts_command_e_TS_
 		panel = injChars, { ! useInjectorFlowLinearizationTable}
 		panel = fuelParams
 		panel = injectorsDeadTime, {isInjectionEnabled}
+		panel = fuelExperimental
 
 	dialog = ignitionCylExtra, "Cylinder offsets"
 		field = "Offset angle for each cylinder if you have an odd fire"


### PR DESCRIPTION
On Aug 3 2025 "injector lag lookup should be done based on differential pressure" was commited to master.
This fixes issue with absolute pressure were previously used for injector lag time calculation. But this also breaks previous tunes. Add experimental flag to enable old logic.

See 2779925f54f5c2d23499cbb2797f71508c652f54.