### PR TITLE
port: h7: allow disabling LSE

### DIFF
--- a/firmware/hw_layer/ports/stm32/stm32h7/cfg/mcuconf_stm32h723.h
+++ b/firmware/hw_layer/ports/stm32/stm32h7/cfg/mcuconf_stm32h723.h
@@ -27,7 +27,9 @@
 #define STM32_CSI_ENABLED                   TRUE
 #define STM32_HSI48_ENABLED                 TRUE
 #define STM32_HSE_ENABLED                   TRUE
+#ifndef STM32_LSE_ENABLED
 #define STM32_LSE_ENABLED                   TRUE
+#endif
 #define STM32_HSIDIV                        STM32_HSIDIV_DIV1
 
 /*
@@ -78,7 +80,11 @@
  * Reading STM32 Reference Manual is required.
  */
 #define STM32_SW                            STM32_SW_PLL1_P_CK
+#if (STM32_LSE_ENABLED == TRUE)
 #define STM32_RTCSEL                        STM32_RTCSEL_LSE_CK
+#else
+#define STM32_RTCSEL                        STM32_RTCSEL_LSI_CK
+#endif
 #define STM32_D1CPRE                        STM32_D1CPRE_DIV1
 #define STM32_D1HPRE                        STM32_D1HPRE_DIV2
 #define STM32_D1PPRE3                       STM32_D1PPRE3_DIV2

--- a/firmware/hw_layer/ports/stm32/stm32h7/cfg/mcuconf_stm32h743.h
+++ b/firmware/hw_layer/ports/stm32/stm32h7/cfg/mcuconf_stm32h743.h
@@ -29,8 +29,10 @@
 #define STM32_CSI_ENABLED                   TRUE
 #define STM32_HSI48_ENABLED                 TRUE
 #define STM32_HSE_ENABLED                   TRUE
+#ifndef STM32_LSE_ENABLED
 // see RUSEFI_STM32_LSE_WAIT_MAX
 #define STM32_LSE_ENABLED                   TRUE
+#endif
 #define STM32_HSIDIV                        STM32_HSIDIV_DIV1
 
 /*
@@ -86,7 +88,11 @@
  */
 #define STM32_SW                            STM32_SW_PLL1_P_CK
 // see RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL
+#if (STM32_LSE_ENABLED == TRUE)
 #define STM32_RTCSEL                        STM32_RTCSEL_LSE_CK
+#else
+#define STM32_RTCSEL                        STM32_RTCSEL_LSI_CK
+#endif
 #define STM32_D1CPRE                        STM32_D1CPRE_DIV1
 #define STM32_D1HPRE                        STM32_D1HPRE_DIV2
 #define STM32_D1PPRE3                       STM32_D1PPRE3_DIV2


### PR DESCRIPTION
Some boards may want to use PC14, PC15 as gpio.