### PR TITLE
Improve getBitRange() / setBitRange() #8473

### DIFF
--- a/firmware/util/efilib.h
+++ b/firmware/util/efilib.h
@@ -127,13 +127,30 @@ constexpr remove_reference_t<_Ty>&& move(_Ty&& _Arg) noexcept {
 }
 }
 
-int getBitRangeLsb(const uint8_t data[], int bitIndex, int bitWidth);
-/**
- for instance DBC 8|16@0
- */
-int getBitRangeMsb(const uint8_t data[], int bitIndex, int bitWidth);
-void setBitRangeMsb(uint8_t data[], int totalBitIndex, int bitWidth, int value);
+// DBC bit numbers
+// byte 0    7  6  5  4  3  2  1  0
+// byte 1   15 14 13 12 11 10  9  8
+// byte 2   23 22 21 20 19 18 17 16
+// byte 3   31 30 29 28 27 26 25 24
+// byte 4   39 38 37 36 35 34 33 32
+// byte 5   47 46 45 44 43 42 41 40
+// byte 6   55 54 53 52 51 50 49 48
+// byte 7   63 62 61 60 57 58 57 56
 
+// Intel byte order, bitIndex is the least significant bit of the value
+// DBC sample: 0|16@1+
+uint32_t getBitRangeLsb(const uint8_t data[], int bitIndex, int bitWidth);
+void setBitRangeLsb(uint8_t data[], int totalBitIndex, int bitWidth, uint32_t value);
+
+// Motorola byte order, bitIndex is the least significant bit of the value
+// not used in DBC
+uint32_t getBitRangeMsb(const uint8_t data[], int bitIndex, int bitWidth);
+void setBitRangeMsb(uint8_t data[], int totalBitIndex, int bitWidth, uint32_t value);
+
+// Motorola byte order, bitIndex is the most significant bit of the value
+// DBC sample: 7|16@0+
+uint32_t getBitRangeMoto(const uint8_t data[], int bitIndex, int bitWidth);
+void setBitRangeMoto(uint8_t data[], int totalBitIndex, int bitWidth, uint32_t value);
+
+// convert bitIndex from LSB to MSB style
 int motorolaMagicFromDbc(int b, int length);
-int getBitRangeMoto(const uint8_t data[], int bitIndex, int bitWidth);
-void setBitRangeMoto(uint8_t data[], int totalBitIndex, int bitWidth, int value);

--- a/unit_tests/tests/lua/test_bit_range.cpp
+++ b/unit_tests/tests/lua/test_bit_range.cpp
@@ -1,0 +1,48 @@
+#include "pch.h"
+
+
+
+TEST(BitRangeTest, getBitRangeMsb) {
+
+    uint8_t data[] = {0xAA, 0xBB, 0xCC, 0xDD};
+    EXPECT_EQ(getBitRangeMsb(data, 24, 32), 0xAA'BB'CC'DDul);
+    EXPECT_EQ(getBitRangeMsb(data, 24, 28), 0x0A'BB'CC'DDul);
+    EXPECT_EQ(getBitRangeMsb(data, 28, 28), 0xAA'BB'CC'Dul);
+}
+
+TEST(BitRangeTest, setBitRangeMsb) {
+
+    uint8_t data1[4] {}, data2[4] {}, data3[4] {};
+
+    setBitRangeMsb(data1, 24, 32, 0xAA'BB'CC'DDul);
+    EXPECT_THAT(data1, testing::ElementsAre(0xAA, 0xBB, 0xCC, 0xDD));
+
+    setBitRangeMsb(data2, 24, 28, 0x0A'BB'CC'DDul);
+    EXPECT_THAT(data2, testing::ElementsAre(0x0A, 0xBB, 0xCC, 0xDD));
+
+    setBitRangeMsb(data3, 28, 28, 0xAA'BB'CC'Dul);
+    EXPECT_THAT(data3, testing::ElementsAre(0xAA, 0xBB, 0xCC, 0xD0));
+}
+
+
+TEST(BitRangeTest, getBitRangeLsb) {
+
+    uint8_t data[] = {0xAA, 0xBB, 0xCC, 0xDD};
+    EXPECT_EQ(getBitRangeLsb(data, 0, 32), 0xDD'CC'BB'AAul);
+    EXPECT_EQ(getBitRangeLsb(data, 0, 28), 0x0D'CC'BB'AAul);
+    EXPECT_EQ(getBitRangeLsb(data, 4, 28), 0xDD'CC'BB'Aul);
+}
+
+TEST(BitRangeTest, setBitRangeLsb) {
+
+    uint8_t data1[4] {}, data2[4] {}, data3[4] {};
+
+    setBitRangeLsb(data1, 0, 32, 0xDD'CC'BB'AAul);
+    EXPECT_THAT(data1, testing::ElementsAre(0xAA, 0xBB, 0xCC, 0xDD));
+
+    setBitRangeLsb(data2, 0, 28, 0x0D'CC'BB'AAul);
+    EXPECT_THAT(data2, testing::ElementsAre(0xAA, 0xBB, 0xCC, 0x0D));
+
+    setBitRangeLsb(data3, 4, 28, 0xDD'CC'BB'Aul);
+    EXPECT_THAT(data3, testing::ElementsAre(0xA0, 0xBB, 0xCC, 0xDD));
+}

--- a/unit_tests/tests/lua/test_bit_range_msb.cpp
+++ b/unit_tests/tests/lua/test_bit_range_msb.cpp
@@ -12,7 +12,7 @@ TEST(BitRangeMsbTest, offtopicTestGetBitRangeMsb) {
     //                 ^------------^
     uint8_t data[] = { 0x9F,     0x41,     0x32,     0x20,     0x23,     0x30,     0xFF,     0x43 };
 
-    EXPECT_EQ(getBitRangeMsb(data, 12, 12), 0x9F4); // 1001 1111 0100
+    EXPECT_EQ(getBitRangeMsb(data, 12, 12), 0x9F4u); // 1001 1111 0100
 }
 
 // inspired by TEST(LuaE65, offtopicTestGetBitRangeMsb2) from test_lua_e65.cpp
@@ -20,55 +20,55 @@ TEST(BitRangeMsbTest, offtopicTestGetBitRangeMsb2) {
     //                 0111 0000 0000 0100 0001 1111
     //                 ^-----------------^
     uint8_t data[] = { 0x70,     0x04,     0x1F};
-    EXPECT_EQ(getBitRangeMsb(data, 16, 16), 0x41F); // 0111 0000 0000 0100
+    EXPECT_EQ(getBitRangeMsb(data, 16, 16), 0x41Fu); // 0111 0000 0000 0100
 }
 
 // inspired by TEST(LuaE65, offtopicTestSetBitRangeMsb2) from test_lua_e65.cpp
 TEST(BitRangeMsbTest, offtopicTestSetBitRangeMsb2) {
-    //                      1000 0000 0111
-    //                      v------------v
+    //                    0 1000 0000 0111
+    //                    v--------------v
     //                 0110 1000 0000 0111
     uint8_t data[] = { 0x68,     0x07 };
     setBitRangeMsb(data, 8, 13, 0x807); // 1000 0000 0111
     EXPECT_THAT(data, testing::ElementsAre(0x68, 0x07));
 
-    EXPECT_EQ(getBitRangeMsb(data, 8, 13), 0x807);
+    EXPECT_EQ(getBitRangeMsb(data, 8, 13), 0x807u);
 }
 
 // inspired by TEST(LuaE65, offtopicTestSetBitRangeMsb3) from test_lua_e65.cpp
 TEST(BitRangeMsbTest, offtopicTestSetBitRangeMsb3) {
-    //                      0011 0000 0100
-    //                      v------------v
+    //                    0 0011 0000 0100
+    //                    v--------------v
     //                 0110 1000 0000 0111
     uint8_t data[] = { 0x68,     0x07 };
     setBitRangeMsb(data, 8, 13, 0x304); // 0011 0000 0100
     EXPECT_THAT(data, testing::ElementsAre(0x63, 0x04));
 
-    EXPECT_EQ(getBitRangeMsb(data, 8, 13), 0x304);
+    EXPECT_EQ(getBitRangeMsb(data, 8, 13), 0x304u);
 }
 
 // inspired by TEST(LuaE65, offtopicTestGetBitRangeMsb2) from test_lua_e65.cpp
 TEST(BitRangeMsbTest, getBitRangeMsbTest) {
     //                 1001 1111 0000 0001 0011 0010 0010 0000 0010 0011 0110 0111 0100 0000 0000 0000
-    //                                                                        ^------------^
+    //                                                                      ^--------------^
     uint8_t data[] = { 0x9F,     0x01,     0x32,     0x20,     0x23,     0x67,     0x40,     0x00 };
 
-    EXPECT_EQ(getBitRangeMsb(data, 6 * 8, 13), 0x740); // 0111 0100 0000
+    EXPECT_EQ(getBitRangeMsb(data, 6 * 8, 13), 0x740u); // 0111 0100 0000
 }
 
 // inspired by TEST(LuaE65, setBitRangeMsbTest) from test_lua_e65.cpp
 TEST(BitRangeMsbTest, setBitRangeMsbTest) {
-    //                                                                        v--------------v
+    //                                                                      v--------------v
     //                 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000
     uint8_t data[] = { 0x00,     0x00,     0x00,     0x00,     0x00,     0x00,     0x00,     0x00 };
-    setBitRangeMsb(data, 6 * 8, 13, 0x740); // 0111 0100 0000
+    setBitRangeMsb(data, 6 * 8, 13, 0x740u); // 0111 0100 0000
     EXPECT_THAT(
         data,
         //                   0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0111 0100 0000 0000 0000
         testing::ElementsAre(0x00,     0x00,     0x00,     0x00,     0x00,     0x07,     0x40,     0x00)
     );
 
-    EXPECT_EQ(getBitRangeMsb(data, 6 * 8, 13), 0x740);
+    EXPECT_EQ(getBitRangeMsb(data, 6 * 8, 13), 0x740u);
 }
 
 TEST(BitRangeMsbTest, getBitRangeMsbTest1) {
@@ -77,27 +77,27 @@ TEST(BitRangeMsbTest, getBitRangeMsbTest1) {
 
     //                0000 0000 1111 1111 0000 0000
     //                          ^-------^
-    EXPECT_EQ(getBitRangeMsb(data, 8, 8), 0xFF); // 1111 1111
+    EXPECT_EQ(getBitRangeMsb(data, 8, 8), 0xFFu); // 1111 1111
 
     //                0000 0000 1111 1111 0000 0000
     //                        ^--------^
-    EXPECT_EQ(getBitRangeMsb(data, 9, 8), 0x7F); // 0111 1111
+    EXPECT_EQ(getBitRangeMsb(data, 9, 8), 0x7Fu); // 0111 1111
 
     //                0000 0000 1111 1111 0000 0000
     //                           ^--------^
-    EXPECT_EQ(getBitRangeMsb(data, 23, 8), 0xFE); // 1111 1110
+    EXPECT_EQ(getBitRangeMsb(data, 23, 8), 0xFEu); // 1111 1110
 
     //                0000 0000 1111 1111 0000 0000
     //                          ^---------^
-    EXPECT_EQ(getBitRangeMsb(data, 23, 9), 0x1FE); // 0001 1111 1110
+    EXPECT_EQ(getBitRangeMsb(data, 23, 9), 0x1FEu); // 0001 1111 1110
 
     //                0000 0000 1111 1111 0000 0000
     //                        ^---------^
-    EXPECT_EQ(getBitRangeMsb(data, 8, 9), 0x0FF); // 0 1111 1111
+    EXPECT_EQ(getBitRangeMsb(data, 8, 9), 0x0FFu); // 0 1111 1111
 
     //                0000 0000 1111 1111 0000 0000
     //                        ^-----------^
-    EXPECT_EQ(getBitRangeMsb(data, 23, 10), 0x1FE); // 0001 1111 1110
+    EXPECT_EQ(getBitRangeMsb(data, 23, 10), 0x1FEu); // 0001 1111 1110
 }
 
 TEST(BitRangeMsbTest, getBitRangeMsbTest2) {
@@ -106,25 +106,25 @@ TEST(BitRangeMsbTest, getBitRangeMsbTest2) {
 
     //                1111 1111 0111 1110 1111 1111
     //                          ^-------^
-    EXPECT_EQ(getBitRangeMsb(data, 8, 8), 0x7E); // 0111 1110
+    EXPECT_EQ(getBitRangeMsb(data, 8, 8), 0x7Eu); // 0111 1110
 
     //                1111 1111 0111 1110 1111 1111
     //                        ^--------^
-    EXPECT_EQ(getBitRangeMsb(data, 9, 8), 0xBF); // 1011 1111
+    EXPECT_EQ(getBitRangeMsb(data, 9, 8), 0xBFu); // 1011 1111
 
     //                1111 1111 0111 1110 1111 1111
     //                           ^--------^
-    EXPECT_EQ(getBitRangeMsb(data, 23, 8), 0xFD); // 1111 1101
+    EXPECT_EQ(getBitRangeMsb(data, 23, 8), 0xFDu); // 1111 1101
 
     //                1111 1111 0111 1110 1111 1111
     //                          ^---------^
-    EXPECT_EQ(getBitRangeMsb(data, 23, 9), 0x0FD); // 0000 1111 1101
+    EXPECT_EQ(getBitRangeMsb(data, 23, 9), 0x0FDu); // 0000 1111 1101
 
     //                1111 1111 0111 1110 1111 1111
     //                        ^---------^
-    EXPECT_EQ(getBitRangeMsb(data, 8, 9), 0x17E); // 0001 0111 1110
+    EXPECT_EQ(getBitRangeMsb(data, 8, 9), 0x17Eu); // 0001 0111 1110
 
     //                1111 1111 0111 1110 1111 1111
     //                        ^-----------^
-    EXPECT_NE(getBitRangeMsb(data, 23, 10), 0x2FD); // 0010 1111 1101
+    EXPECT_EQ(getBitRangeMsb(data, 23, 10), 0x2FDu); // 0010 1111 1101 
 }

--- a/unit_tests/tests/tests.mk
+++ b/unit_tests/tests/tests.mk
@@ -94,6 +94,7 @@ TESTS_SRC_CPP = \
 	tests/test_fft.cpp \
 	tests/lua/test_lua_basic.cpp \
 	tests/lua/test_bit_range_msb.cpp \
+	tests/lua/test_bit_range.cpp \
 	tests/lua/test_lua_dbc.cpp \
 	tests/lua/test_motorola_dbc.cpp \
 	tests/lua/test_lua_bit_range_msb.cpp \


### PR DESCRIPTION
Two modifications here

- reworked getBitRange() to handle more than 2 bytes
- added missing setBitRangeLsb() (we had only LUA version before)

Minor fixes:
- a bit more clear description for these functions
- fixed comments in the BitRangeMsbTest (code itself was correct)
