### PR TITLE
Update interactive pinouts and enable error on parse warnings

### DIFF
--- a/.github/workflows/gen-pinouts.yaml
+++ b/.github/workflows/gen-pinouts.yaml
@@ -17,12 +17,13 @@ jobs:
     - uses: actions/checkout@v5
 
     - name: Generate Pinouts
-      uses: chuckwagoncomputing/interactive-pinout@2.15
+      uses: chuckwagoncomputing/interactive-pinout@2.16
       with:
         mapping-path: firmware/config/boards/*/connectors/*.yaml
         warnings: "false"
         warning-no-pins: "skip"
         warning-dupe: "error"
+        warning-parse: "error"
         columns: |
           {
           "pin":"Pin Number",


### PR DESCRIPTION
This release also features pin interpolation which I forgot that I had never released. ¯\\\_(ツ)\_/¯