### PR TITLE
OpenBLT: USB: always flush

### DIFF
--- a/firmware/bootloader/openblt_chibios/openblt_usb.cpp
+++ b/firmware/bootloader/openblt_chibios/openblt_usb.cpp
@@ -41,6 +41,9 @@ void Rs232TransmitPacket(blt_int8u *data, blt_int8u len)
   Rs232TransmitByte(len);
 
   chnWriteTimeout(&SDU1, data, len, TIME_INFINITE);
+
+  /* wait for transmission ends */
+  usb_serial_flush();
 } /*** end of Rs232TransmitPacket ***/
 
 PUBLIC_API_WEAK void openBltUnexpectedByte(blt_int8u firstByte) {

--- a/firmware/hw_layer/ports/stm32/serial_over_usb/usbconsole.cpp
+++ b/firmware/hw_layer/ports/stm32/serial_over_usb/usbconsole.cpp
@@ -55,6 +55,10 @@ bool is_usb_serial_ready() {
 	return isUsbSerialInitialized && SDU1.config->usbp->state == USB_ACTIVE;
 }
 
+void usb_serial_flush() {
+	usbTransmitWait(serusbcfg.usbp, serusbcfg.bulk_in);
+}
+
 #else
 bool is_usb_serial_ready() {
 	return false;

--- a/firmware/hw_layer/ports/stm32/serial_over_usb/usbconsole.h
+++ b/firmware/hw_layer/ports/stm32/serial_over_usb/usbconsole.h
@@ -14,6 +14,7 @@ extern "C"
 
 void usb_serial_start();
 bool is_usb_serial_ready();
+void usb_serial_flush();
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Flush USB serial before return from Rs232TransmitPacket() So PC side will see last OpenBLT reply before strarting RE FW.