### PR TITLE
Wizard-TsHeadlessPlugin, init plugin instance only once

### DIFF
--- a/java_tools/ts_plugin_launcher/src/main/java/com/rusefi/ts_plugin/headless/TsHeadlessPlugin.java
+++ b/java_tools/ts_plugin_launcher/src/main/java/com/rusefi/ts_plugin/headless/TsHeadlessPlugin.java
@@ -11,25 +11,50 @@ public interface TsHeadlessPlugin {
 
     Logging log = Logging.getLogging(TsHeadlessPlugin.class);
 
+    class Holder {
+        private static volatile TsHeadlessPlugin INSTANCE;
+    }
+
+    static TsHeadlessPlugin getOrCreateInstance() {
+        TsHeadlessPlugin local = Holder.INSTANCE;
+        if (local != null) {
+            return local;
+        }
+        synchronized (Holder.class) {
+            if (Holder.INSTANCE == null) {
+                try {
+                    Class clazz = getPluginClass(PLUGIN_HEADLESS_IMPL_CLASS);
+                    if (clazz == null) {
+                        return null;
+                    }
+                    Holder.INSTANCE = (TsHeadlessPlugin) clazz.newInstance();
+                    log.info("Created TsHeadlessPluginImpl instance");
+                } catch (Exception e) {
+                    log.warn("Error creating TsHeadlessPluginImpl instance: " + e, e);
+                    return null;
+                }
+            }
+            return Holder.INSTANCE;
+        }
+    }
+
     static void start() {
         try {
-            Class clazz = getPluginClass(PLUGIN_HEADLESS_IMPL_CLASS);
-            TsHeadlessPlugin instance = (TsHeadlessPlugin) clazz.newInstance();
+            TsHeadlessPlugin instance = getOrCreateInstance();
             instance.run();
-        } catch (ClassNotFoundException | MalformedURLException | InstantiationException | IllegalAccessException e) {
+        } catch (Exception e) {
             log.warn("Error " + e, e);
         }
     }
 
     static boolean displayPlugin(String signature) {
         try {
-            Class clazz = getPluginClass(PLUGIN_HEADLESS_IMPL_CLASS);
-            TsHeadlessPlugin instance = (TsHeadlessPlugin) clazz.newInstance();
-            instance.getDisplayPlugin(signature);
-        } catch (ClassNotFoundException | MalformedURLException | InstantiationException | IllegalAccessException e) {
+            TsHeadlessPlugin instance = getOrCreateInstance();
+            return instance.getDisplayPlugin(signature);
+        } catch (Exception e) {
             log.warn("Error " + e, e);
+            return false;
         }
-        return true;
     }
 
     void run();


### PR DESCRIPTION
fix for this crash when launching tunerstudio with the target board already connected and ts opening the last (and correct) project

```
Connecting to https://rusefi.com/build_server/autoupdate/rusefi_plugin_body.jar
I 251107 002741.048 [AWT-EventQueue-0] TsPluginLauncher - displayPlugin 
I 251107 002741.052 [AWT-EventQueue-0] Updater - Using C:\Users\FDSoftware\.rusEFI\rusefi_plugin_body.jar
W 251107 002741.052 [AWT-EventQueue-0] TsHeadlessPlugin - Error java.lang.ClassNotFoundException: com.rusefi.ts_plugin.headless.TsHeadlessPluginImpl
java.lang.ClassNotFoundException: com.rusefi.ts_plugin.headless.TsHeadlessPluginImpl
	at java.net.URLClassLoader.findClass(URLClassLoader.java:387)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:418)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:351)
	at java.lang.Class.forName0(Native Method)
	at java.lang.Class.forName(Class.java:348)
	at com.rusefi.ts_plugin.Updater.getPluginClass(Updater.java:72)
	at com.rusefi.ts_plugin.headless.TsHeadlessPlugin.displayPlugin(TsHeadlessPlugin.java:26)
	at com.rusefi.ts_plugin.TsPluginLauncher.displayPlugin(TsPluginLauncher.java:70)
	at aP.dB.i(Unknown Source)

``` 


related #8666