### PR TITLE
ETB: calibration, wrong scale 3% calibration error

### DIFF
--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -589,8 +589,9 @@ bit useSpiImu,"yes","no";If enabled - use onboard SPI Accelerometer, otherwise l
 bit enableStagedInjection,"enabled","disabled"
 bit useIdleAdvanceWhileCoasting,"yes","no"
 
-! note: 0.00489 mult is correct for "faking" 10 bit ADC with 5V Vref
-custom tps_limit_t 2 scalar, S16, @OFFSET@, "V", 0.0048828125, 0, 0, 5, 2
+! note: 0.00489 mult is correct for "faking" 10 bit ADC with 5V Vref - NOPE!
+! note: see TPS_TS_CONVERSION, this is TS related legacy stuff that should be removed someday. 1000 units for 0..5V range
+custom tps_limit_t 2 scalar, S16, @OFFSET@, "V", 0.005, 0, 0, 5, 2
 tps_limit_t tpsMin;Closed voltage for primary throttle position sensor
 tps_limit_t tpsMax;Fully opened voltage for primary throttle position sensor
 


### PR DESCRIPTION
During calibration we report TPS1 and TPS2 min/max values back to TS and then TS applys these limits to ECU.
While sending values to TS were using 0.0048828125 scale factor (5/1024) But during TPS sensor initialization TPS_TS_CONVERSION = 200 was used (5/1000) This cause 1024/1000 = 2.4% error.