### PR TITLE
Update meta information for pin K40

### DIFF
--- a/firmware/config/boards/hellen/hellen154hyundai_f7/connectors/main.yaml
+++ b/firmware/config/boards/hellen/hellen154hyundai_f7/connectors/main.yaml
@@ -149,7 +149,7 @@ pins:
     function: Analog Ground
 
   - pin: K40
-    meta: H144_IN_VSS
+    meta: H144_IN_D_4
     class: event_inputs
     ts_name: K40 VSS
     function: Vehicle Speed Sensor


### PR DESCRIPTION
IN_VSS is D5 (PF11), while actual VSS input is on H144_IN_D_4 (PE15)