### PR TITLE
luaHeapAlloc: try to not use osize

### DIFF
--- a/firmware/controllers/lua/lua_heap.cpp
+++ b/firmware/controllers/lua/lua_heap.cpp
@@ -181,6 +181,7 @@ void* luaHeapAlloc(void* /*ud*/, void* optr, size_t osize, size_t nsize) {
     }
 
     if (optr) {
+    	chDbgAssert(osize <= chHeapGetSize(optr), "Lua lost track of allocated mem");
         // An old pointer was passed in. Only free it if we successfully allocated a new one.
         size_t oldSize = chHeapGetSize(optr);
         if (nptr != nullptr) {


### PR DESCRIPTION
https://www.lua.org/manual/5.3/manual.html#lua_Alloc

> When ptr is not NULL, osize is the size of the block pointed by ptr, that is, the size given when it was allocated or reallocated.
> 
> When ptr is NULL, osize encodes the kind of object that Lua is allocating. osize is any of [LUA_TSTRING](https://www.lua.org/manual/5.3/manual.html#pdf-LUA_TSTRING), [LUA_TTABLE](https://www.lua.org/manual/5.3/manual.html#pdf-LUA_TTABLE), [LUA_TFUNCTION](https://www.lua.org/manual/5.3/manual.html#pdf-LUA_TFUNCTION), [LUA_TUSERDATA](https://www.lua.org/manual/5.3/manual.html#pdf-LUA_TUSERDATA), or [LUA_TTHREAD](https://www.lua.org/manual/5.3/manual.html#pdf-LUA_TTHREAD) when (and only when) Lua is creating a new object of that type. When osize is some other value, Lua is allocating memory for something else.

[...]

> When nsize is not zero, the allocator must behave like realloc. The allocator returns NULL if and only if it cannot fulfill the request. Lua assumes that the allocator never fails when osize >= nsize.

will use a bit more of ram, but `chHeapGetSize` should get us the correct sizes, also this prevents the reboot when we try to use all or more than available ram #8774



before:

```
2025-12-07_00_09_23_371: EngineState: Starting watchdog with timeout 500 ms...
2025-12-07_00_09_23_371: EngineState: Reset Cause: NVIC_SystemReset or by debugger
2025-12-07_00_09_23_371: EngineState: WD resets: 0
2025-12-07_00_09_23_371: EngineState: Power cycle count: 4
2025-12-07_00_09_23_371: EngineState: Last error type ChibiOS panic
2025-12-07_00_09_23_371: EngineState: msg Lua lost track of allocated mem
2025-12-07_00_09_23_371: EngineState: file ChibiOS/os/rt/src/chsys.c
2025-12-07_00_09_23_371: EngineState: line 220
2025-12-07_00_09_23_371: EngineState: SP 0x200099D4
``` 

now:

```
2025-12-07_01_19_25_344: EngineState: TS -> Page 0 write chunk offset 12876 count 832 (output_count=393)
2025-12-07_01_19_25_344: EngineState: confirmation_luareset:8
2025-12-07_01_19_25_344: EngineState: unregistering NONE
2025-12-07_01_19_25_344: EngineState: unregistering NONE
2025-12-07_01_19_25_350: EngineState: unregistering NONE
2025-12-07_01_19_25_350: EngineState: unregistering NONE
2025-12-07_01_19_25_353: EngineState: unregistering NONE
2025-12-07_01_19_25_353: EngineState: unregistering NONE
2025-12-07_01_19_25_355: EngineState: unregistering NONE
2025-12-07_01_19_25_355: EngineState: unregistering NONE
2025-12-07_01_19_25_360: EngineState: LUA: Tearing down instance...
2025-12-07_01_19_25_362: EngineState: LUA loading script length: 6260...
2025-12-07_01_19_25_362: EngineState: LUA ERROR loading script: not enough memory
2025-12-07_01_19_25_362: EngineState: LUA: Tearing down instance...
``` 
