### PR TITLE
Crop black borders and menu from TS dialog screenshots

### DIFF
--- a/java_tools/ts_screenshots/src/main/java/com/rusefi/UiUtils.java
+++ b/java_tools/ts_screenshots/src/main/java/com/rusefi/UiUtils.java
@@ -55,16 +55,33 @@ public class UiUtils {
 
         // Remove black bars from dialogs
         if (component instanceof JDialog) {
-            Insets insets = ((JDialog) component).getInsets();
-
-            int x = insets.left;
-            int y = insets.top;
-            int w = image.getWidth() - insets.left - insets.right;
-            int h = image.getHeight() - insets.top - insets.bottom;
-
-            BufferedImage cropped = image.getSubimage(x, y, w, h);
-            return cropped;            
+            return cropDialog(component, image);
         }
         return image;
+    }
+
+    static BufferedImage cropDialog(Component component, BufferedImage image) {
+        Insets insets = ((JDialog) component).getInsets();
+
+        int menuH = 0;
+        Container pane = ((JDialog) component).getContentPane();
+        if (pane != null) {
+            Component container = pane.getComponent(0);
+            if (container != null) {
+                Component menu = ((JPanel) container).getComponent(0);
+                // Some dialogs don't have a menu, so their first component is a JPanel
+                if (menu != null && ! (menu instanceof JPanel)) {
+                    menuH = menu.getHeight();
+                }
+            }
+        }
+
+        int x = insets.left;
+        int y = insets.top + menuH;
+        int w = image.getWidth() - insets.left - insets.right;
+        int h = image.getHeight() - insets.top - insets.bottom - menuH;
+
+        BufferedImage cropped = image.getSubimage(x, y, w, h);
+        return cropped;
     }
 }


### PR DESCRIPTION
This is a little bit hacky because (if I'm understanding correctly) we don't have the real class names of the menu bar. I'm getting "aP.bl" for the menu bar and "aP.hg" for the container. I assume those won't be consistent between TS builds and versions.