### PR TITLE
NO_CACHE also need to be aligned

### DIFF
--- a/firmware/hw_layer/ports/stm32/stm32f4/global_port.h
+++ b/firmware/hw_layer/ports/stm32/stm32f4/global_port.h
@@ -10,13 +10,13 @@
 #if defined(AT32F4XX)
 #define CCM_OPTIONAL
 #define SDRAM_OPTIONAL
-#define NO_CACHE
+#define NO_CACHE __attribute__((aligned(4)))
 #define BKUP_RAM_NOINIT
 #else
 // CCM memory is 64k
 #define CCM_OPTIONAL __attribute__((section(".ram4")))
 #define SDRAM_OPTIONAL __attribute__((section(".ram7")))
-#define NO_CACHE	// F4 has no cache, do nothing
+#define NO_CACHE __attribute__((aligned(4)))	// F4 has no cache, do nothing
 #define BKUP_RAM_NOINIT __attribute__((section(".bkup_ram_noinit")))
 #define MCU_HAS_CCM_RAM	TRUE
 #endif

--- a/firmware/hw_layer/ports/stm32/stm32f7/global_port.h
+++ b/firmware/hw_layer/ports/stm32/stm32f7/global_port.h
@@ -5,7 +5,7 @@
 
 // SRAM2 is 16k and set to disable dcache (see STM32_NOCACHE_ENABLE in mcuconf.h)
 // we have another way to put something in no cache area - __nocache_ prefix in name
-#define NO_CACHE __attribute__((section(".ram2")))
+#define NO_CACHE __attribute__((aligned(4))) __attribute__((section(".ram2")))
 
 // TODO: test and switch to this
 // Current ChibiOS puts nocache data into SRAM3/DTCM that is not chached by design

--- a/firmware/hw_layer/ports/stm32/stm32h7/global_port.h
+++ b/firmware/hw_layer/ports/stm32/stm32h7/global_port.h
@@ -3,6 +3,6 @@
 //TODO: update LD file!
 #define SDRAM_OPTIONAL __attribute__((section(".ram8")))
 // SRAM3 is 32k and set to disable dcache
-#define NO_CACHE __attribute__((section(".ram3")))
+#define NO_CACHE __attribute__((aligned(4))) __attribute__((section(".ram3")))
 
 #define BKUP_RAM_NOINIT __attribute__((section(".bkup_ram_noinit")))


### PR DESCRIPTION
Usualy NO_CACHE is used for data that is accessed by DMA. DMA needs so alignment.
Set some safe 4 byte align for all NO_CACHE