### PR TITLE
ci_gcov --merge-mode-functions=separate

### DIFF
--- a/unit_tests/ci_gcov.sh
+++ b/unit_tests/ci_gcov.sh
@@ -13,6 +13,6 @@ mkdir gcov
 echo -e "\nGenerating rusEFI unit test coverage"
 
 # for debug use --html-details --html-single-page --verbose  to generate a single html
-gcovr --exclude-throw-branches --exclude-unreachable-branches --decisions \
+gcovr --exclude-throw-branches --exclude-unreachable-branches --decisions --merge-mode-functions=separate \
       --exclude '/.*/googletest/' \
       -j4  -r ../.. --html-nested gcov/index.html


### PR DESCRIPTION
this should fix this problem:
https://github.com/rusefi/rusefi/issues/8950#issuecomment-3731535372
because now it will separate the coverage for mocked vs unmocked


related #8953 