### PR TITLE
Nicer error message on bundle mismatch errors

### DIFF
--- a/java_console/io/src/main/java/com/rusefi/binaryprotocol/BinaryProtocol.java
+++ b/java_console/io/src/main/java/com/rusefi/binaryprotocol/BinaryProtocol.java
@@ -185,9 +185,10 @@ public class BinaryProtocol {
         }
 
         // Check for bundle/ECU mismatch before attempting to read configuration
+        // Skip check if bundle target is unknown (e.g., simulator, local development)
         RusEfiSignature ecuSignature = SignatureHelper.parse(signature);
         String bundleTarget = BundleUtil.getBundleTarget();
-        if (ecuSignature != null && bundleTarget != null) {
+        if (ecuSignature != null && bundleTarget != null && !"unknown".equalsIgnoreCase(bundleTarget)) {
             // [tag:QC_firmware]
             if (!bundleTarget.equalsIgnoreCase(ecuSignature.getBundleTarget()) && !bundleTarget.contains("_QC_")) {
                 String errorMsg = String.format(
@@ -370,7 +371,8 @@ public class BinaryProtocol {
                     RusEfiSignature ecuSig = SignatureHelper.parse(signature);
                     String bundleTgt = BundleUtil.getBundleTarget();
                     String mismatchInfo = "";
-                    if (ecuSig != null && bundleTgt != null && !bundleTgt.equalsIgnoreCase(ecuSig.getBundleTarget())) {
+                    if (ecuSig != null && bundleTgt != null && !"unknown".equalsIgnoreCase(bundleTgt)
+                        && !bundleTgt.equalsIgnoreCase(ecuSig.getBundleTarget())) {
                         mismatchInfo = String.format(" Bundle/ECU mismatch: bundle=%s, ECU=%s.", bundleTgt, ecuSig.getBundleTarget());
                     }
                     throw new IllegalStateException(

--- a/java_console/ui/src/main/java/com/rusefi/io/BootloaderHelper.java
+++ b/java_console/ui/src/main/java/com/rusefi/io/BootloaderHelper.java
@@ -23,6 +23,7 @@ public class BootloaderHelper {
         String fileSystemBundleTarget = BundleUtil.getBundleTarget();
         if (fileSystemBundleTarget != null && controllerSignature != null) {
             // hack: QC firmware self-identifies as "normal" not QC firmware :(
+            // [tag:QC_firmware]
             if (!UiProperties.skipEcuTypeDetection() &&
                 !fileSystemBundleTarget.equalsIgnoreCase(controllerSignature.getBundleTarget()) && !fileSystemBundleTarget.contains("_QC_")) {
                 String message = String.format("You have \"%s\" controller does not look right to program it with \"%s\"", controllerSignature.getBundleTarget(), fileSystemBundleTarget);


### PR DESCRIPTION
related #9019

<img width="587" height="350" alt="image" src="https://github.com/user-attachments/assets/a28a0eb9-22d5-414a-9864-dcf0ea7b85f1" />

new terminal msg;

```
E 260128 161635.976 [ECU Communication Executor1] Launcher - onConnectionFailed Bundle/ECU mismatch detected!

Connected ECU: uaefi
Bundle target: unknown

Please download the correct bundle for your ECU from:
https://wiki.rusefi.com/Download/

The .ini file in this bundle is not compatible with your ECU's memory layout.
``` 