### PR TITLE
Specify jar destinationDirectory separately

### DIFF
--- a/java_console/autoupdate/build.gradle
+++ b/java_console/autoupdate/build.gradle
@@ -21,7 +21,8 @@ evaluationDependsOn(':core_io')
 shadowJar {
   duplicatesStrategy = DuplicatesStrategy.FAIL
   base {
-    archivesName = "${rootDir}/../console/rusefi_autoupdate"
+    archiveFileName = 'rusefi_autoupdate.jar'
+    destinationDirectory = file("${rootDir}/../console")
     archiveClassifier = ''
   }
 

--- a/java_console/ui/build.gradle
+++ b/java_console/ui/build.gradle
@@ -27,7 +27,8 @@ dependencies {
 
 shadowJar {
     base {
-        archivesName = "${rootDir}/../console/rusefi_console"
+        archiveFileName = 'rusefi_console.jar'
+        destinationDirectory = file("${rootDir}/../console")
         archiveClassifier = ''
     }
 


### PR DESCRIPTION
Fix #7925

When building console (`./gradlew :ui:shadowJar`), rusefi_autoupdate.jar is also produced, but not the shadowJar version, so its MANIFEST.MF contains only the Manifest-Version field. Usually the console is built before the autoupdate jar and the correct shadowJar could overwrite the incorrect jar, but the build order is not explicitly specified, so the vagaries of parallelism sometimes resulted in the console being built after the autoupdate shadowJar, overwriting it with a normal jar missing the meta info.

I don't understand why building console also built the autoupdate jar. This fix is based on an LLM's suggestion, but it was not able to satisfactorily explain why the autoupdate jar was built, just spewed some hand-wavey baloney. All I know is that now building the console does not produce rusefi_autoupdate.jar.