### PR TITLE
H7: WFI_IDLE allow overriding by board

### DIFF
--- a/firmware/hw_layer/ports/stm32/stm32h7/cfg/chconf.h
+++ b/firmware/hw_layer/ports/stm32/stm32h7/cfg/chconf.h
@@ -2,7 +2,9 @@
  * @brief   Sleep at idle.
  * @details This option enables call to __WFI() from idle thread to save power.
  */
+#ifndef CORTEX_ENABLE_WFI_IDLE
 #define CORTEX_ENABLE_WFI_IDLE FALSE
+#endif
 
 /* Use common ST32 ChibiOS config */
 #include "chconf_stm32.h"


### PR DESCRIPTION
WFI_IDLE is disabled for H7 long time ago with some wierd comment. Lets allow overriding this thing for some board on their own risk.