### PR TITLE
TopLevelMenuSandbox: use UIContext, solve margin issue on larger dialogs

### DIFF
--- a/java_console/ui/src/main/java/com/rusefi/ui/widgets/tune/MainMenuTreeWidget.java
+++ b/java_console/ui/src/main/java/com/rusefi/ui/widgets/tune/MainMenuTreeWidget.java
@@ -34,7 +34,8 @@ public class MainMenuTreeWidget {
     private String lastSearchSelectedKey = null;
     private Consumer<SubMenuModel> onSelect;
 
-    public MainMenuTreeWidget(UIContext uiContext, IniFileModel model) {
+    public MainMenuTreeWidget(UIContext uiContext) {
+        IniFileModel model = uiContext.iniFileState.getIniFileModel();
         for (MenuModel menu : model.getMenus()) {
             DefaultMutableTreeNode menuNode = new DefaultMutableTreeNode(menu.getName());
             root.add(menuNode);

--- a/java_console/ui/src/test/java/com/rusefi/ui/TopLevelMenuSandbox.java
+++ b/java_console/ui/src/test/java/com/rusefi/ui/TopLevelMenuSandbox.java
@@ -18,6 +18,7 @@ import java.awt.*;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 
+
 import static com.rusefi.ui.basic.UiHelper.commonUiStartup;
 
 public class TopLevelMenuSandbox {
@@ -65,25 +66,21 @@ public class TopLevelMenuSandbox {
     }
 
     private static void runAwt(UIContext uiContext) {
-        IniFileModel model = uiContext.iniFileState.getIniFileModel();
-        ConfigurationImage ci = uiContext.getLinkManager().getBinaryProtocol().getControllerConfiguration();
         FrameHelper frameHelper = new FrameHelper(JDialog.EXIT_ON_CLOSE);
 
-        JPanel panel = new JPanel(new GridBagLayout());
-
-        // todo: can we not require model here? make MainMenuTreeWidget more dynamic in terms of model?
-        MainMenuTreeWidget left = new MainMenuTreeWidget(uiContext, model);
-        panel.add(left.getContentPane(), new GridBagConstraints(0, 0, 1, 1, 1, 1, GridBagConstraints.CENTER, GridBagConstraints.BOTH, new Insets(0, 0, 0, 0), 0, 0));
+        MainMenuTreeWidget left = new MainMenuTreeWidget(uiContext);
 
         CalibrationDialogWidget right = new CalibrationDialogWidget(uiContext);
-        panel.add(right.getContentPane(), new GridBagConstraints(1, 0, 1, 1, 2, 1, GridBagConstraints.CENTER, GridBagConstraints.BOTH, new Insets(0, 0, 0, 0), 0, 0));
+        JScrollPane rightScrollPane = new JScrollPane(right.getContentPane());
 
-        // todo: things should be integrated via uiContext
+        JSplitPane splitPane = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT, left.getContentPane(), rightScrollPane);
+        splitPane.setResizeWeight(0.3);
+
         left.setOnSelect(subMenu -> {
-            right.update(subMenu.getKey(), model, ci);
+            right.update(subMenu.getKey());
         });
 
-        frameHelper.showFrame(panel);
+        frameHelper.showFrame(splitPane);
         left.selectSubMenu("dwellSettings");
     }
 }

--- a/java_console/ui/src/test/java/com/rusefi/ui/widgets/MainMenuTreeWidgetTest.java
+++ b/java_console/ui/src/test/java/com/rusefi/ui/widgets/MainMenuTreeWidgetTest.java
@@ -161,8 +161,9 @@ todo: spllit into smaller tests?
         String iniPath = "../../java_console/io/src/test/java/com/rusefi/io/pin_output_mode_with_and_without_dollar/test_data/rusefi_uaefi.ini";
         IniFileModel model = IniFileReaderUtil.readIniFile(iniPath);
         assertNotNull(model);
+        uiContext.iniFileState.setIniFileModelForTest(model);
 
-        com.rusefi.ui.widgets.tune.MainMenuTreeWidget widget = new com.rusefi.ui.widgets.tune.MainMenuTreeWidget(uiContext, model);
+        com.rusefi.ui.widgets.tune.MainMenuTreeWidget widget = new com.rusefi.ui.widgets.tune.MainMenuTreeWidget(uiContext);
         JPanel content = widget.getContentPane();
         assertNotNull(content);
 
@@ -217,7 +218,8 @@ todo: spllit into smaller tests?
 
         String iniPath = "../../java_console/io/src/test/java/com/rusefi/io/pin_output_mode_with_and_without_dollar/test_data/rusefi_uaefi.ini";
         IniFileModel model = IniFileReaderUtil.readIniFile(iniPath);
-        com.rusefi.ui.widgets.tune.MainMenuTreeWidget widget = new com.rusefi.ui.widgets.tune.MainMenuTreeWidget(uiContext, model);
+        uiContext.iniFileState.setIniFileModelForTest(model);
+        com.rusefi.ui.widgets.tune.MainMenuTreeWidget widget = new com.rusefi.ui.widgets.tune.MainMenuTreeWidget(uiContext);
         JPanel content = widget.getContentPane();
 
         JPanel topPanel = (JPanel) content.getComponent(0);
@@ -292,8 +294,9 @@ todo: spllit into smaller tests?
         UIContext uiContext = new UIContext();
         String iniPath = "../../java_console/io/src/test/java/com/rusefi/io/pin_output_mode_with_and_without_dollar/test_data/rusefi_uaefi.ini";
         IniFileModel model = IniFileReaderUtil.readIniFile(iniPath);
+        uiContext.iniFileState.setIniFileModelForTest(model);
 
-        com.rusefi.ui.widgets.tune.MainMenuTreeWidget left = new MainMenuTreeWidget(uiContext, model);
+        com.rusefi.ui.widgets.tune.MainMenuTreeWidget left = new MainMenuTreeWidget(uiContext);
         com.rusefi.ui.widgets.tune.CalibrationDialogWidget right = new CalibrationDialogWidget(uiContext);
 
         AtomicReference<SubMenuModel> selectedSubMenu = new AtomicReference<>();


### PR DESCRIPTION
related #9068 

before:
<img width="1280" height="701" alt="image" src="https://github.com/user-attachments/assets/6576c631-72f0-484c-8923-36efc2e50249" />
now:
<img width="1280" height="701" alt="image" src="https://github.com/user-attachments/assets/69ee8c09-db62-43f6-8f47-53ed5f0f27c5" />