### PR TITLE
Generated cppsrc redo

### DIFF
--- a/firmware/rusefi.mk
+++ b/firmware/rusefi.mk
@@ -27,11 +27,9 @@ endif
 
 -include $(BOARD_DIR)/config.mk
 
-PIN_NAMES_FILE=$(BOARD_DIR)/connectors/generated_ts_name_by_pin.cpp
-
-ifneq ("$(wildcard $(PIN_NAMES_FILE))","")
-$(info found $(PIN_NAMES_FILE) )
-ALLCPPSRC += $(PIN_NAMES_FILE)
+# Build the generated pin code only if the connector directory exists
+ifneq ("$(wildcard $(BOARD_DIR)/connectors)","")
+  ALLCPPSRC += $(BOARD_DIR)/connectors/generated_ts_name_by_pin.cpp
 endif
 
 # CPU-dependent defs


### PR DESCRIPTION
rusefi.mk is not included by the unit_tests Makefile.
rusefi_config.mk is.
This isn't normally an issue, but when building unit tests with a board's meta-env, BOARD_DIR/connectors now exists and results in an error.

generated_ts_name_by_pin.cpp is not built for unit tests, either before or after this PR.