### PR TITLE
Don't change dir in generate_matrix

### DIFF
--- a/.github/workflows/build-firmware.yaml
+++ b/.github/workflows/build-firmware.yaml
@@ -135,6 +135,7 @@ jobs:
 
     - name: Set matrix
       id: set-matrix
+      working-directory: firmware
       run: |
         export EVENT_NAME="${{github.event_name}}"
         export RUN_ATTEMPT="${{github.run_attempt}}"
@@ -142,7 +143,7 @@ jobs:
         ${{ github.event.head_commit.message }}
         EOM
         export COMMIT_MESSAGE
-        echo "matrix=$(bash firmware/bin/generate_matrix.sh config/boards)" >> $GITHUB_OUTPUT
+        echo "matrix=$(bash bin/generate_matrix.sh config/boards)" >> $GITHUB_OUTPUT
 
   build-firmware:
     runs-on: ubuntu-latest

--- a/firmware/bin/generate_matrix.sh
+++ b/firmware/bin/generate_matrix.sh
@@ -5,11 +5,9 @@ SCAN_DIR=$1
 # The full path of the firmware directory
 FDIR=$(cd "$(dirname "$0")/.."; pwd -P)
 
-cd $FDIR
-
 getTarget ()
 {
-	source config/boards/common_script_read_meta_env.inc $1 >/dev/null
+	source "${2}/config/boards/common_script_read_meta_env.inc" "$1" >/dev/null
 	SKIP_RATE=${SKIP_RATE:-0}
 	ONLY=$(echo "$COMMIT_MESSAGE" | grep -Po '(?<=only:)[^\s]*')
 	if [[ ( "$EVENT_NAME" == 'workflow_dispatch' \
@@ -24,8 +22,8 @@ getTarget ()
 }
 
 echo -n '{"include": ['
-find ${SCAN_DIR} -name "meta-info*.env" -print0 | while IFS= read -r -d '' f; do
-	echo -n "$(getTarget $f)"
+find "${SCAN_DIR}" -name "meta-info*.env" -print0 | while IFS= read -r -d '' F; do
+	echo -n $(getTarget "$F" "$FDIR")
 done
 echo "]}"
 


### PR DESCRIPTION
This should let us keep everything relative to custom firmware repo root for less confusion.

I'll PR relevant fw_custom_example change after this is merged.