### PR TITLE
getBitRangeXXX() with sign extension magic

### DIFF
--- a/firmware/util/efilib.cpp
+++ b/firmware/util/efilib.cpp
@@ -212,10 +212,23 @@ static uint32_t getBitRangeCommon(const uint8_t data[], int bitIndex, int bitWid
 uint32_t getBitRangeLsb(const uint8_t data[], int bitIndex, int bitWidth) {
   return getBitRangeCommon(data, bitIndex, bitWidth, 1);
 }
+int32_t getBitRangeLsbSigned(const uint8_t data[], int bitIndex, int bitWidth) {
+  int32_t val = getBitRangeCommon(data, bitIndex, bitWidth, 1);
+  val <<= (32 - bitWidth);
+  val >>= (32 - bitWidth);
+  return val;
+}
+
 
 // see also getBitRangeMsb in lua_lib.h
 uint32_t getBitRangeMsb(const uint8_t data[], int bitIndex, int bitWidth) {
   return getBitRangeCommon(data, bitIndex, bitWidth, -1);
+}
+int32_t getBitRangeMsbSigned(const uint8_t data[], int bitIndex, int bitWidth) {
+  int32_t val = getBitRangeCommon(data, bitIndex, bitWidth, -1);
+  val <<= (32 - bitWidth);
+  val >>= (32 - bitWidth);
+  return val;
 }
 
 void setBitRangeLsb(uint8_t data[], const int totalBitIndex, const int bitWidth, const uint32_t value) {
@@ -264,6 +277,13 @@ int motorolaMagicFromDbc(int b, int length) {
 uint32_t getBitRangeMoto(const uint8_t data[], int bitIndex, int bitWidth) {
 	const int b = motorolaMagicFromDbc(bitIndex, bitWidth);
 	return getBitRangeMsb(data, b, bitWidth);
+}
+int32_t getBitRangeMotoSigned(const uint8_t data[], int bitIndex, int bitWidth) {
+	const int b = motorolaMagicFromDbc(bitIndex, bitWidth);
+	int val = getBitRangeMsb(data, b, bitWidth);
+  val <<= (32 - bitWidth);
+  val >>= (32 - bitWidth);
+  return val;
 }
 
 void setBitRangeMoto(uint8_t data[], const int totalBitIndex, const int bitWidth, const uint32_t value) {

--- a/firmware/util/efilib.h
+++ b/firmware/util/efilib.h
@@ -140,16 +140,19 @@ constexpr remove_reference_t<_Ty>&& move(_Ty&& _Arg) noexcept {
 // Intel byte order, bitIndex is the least significant bit of the value
 // DBC sample: 0|16@1+
 uint32_t getBitRangeLsb(const uint8_t data[], int bitIndex, int bitWidth);
+int32_t getBitRangeLsbSigned(const uint8_t data[], int bitIndex, int bitWidth);
 void setBitRangeLsb(uint8_t data[], int totalBitIndex, int bitWidth, uint32_t value);
 
 // Motorola byte order, bitIndex is the least significant bit of the value
 // not used in DBC
 uint32_t getBitRangeMsb(const uint8_t data[], int bitIndex, int bitWidth);
+int32_t getBitRangeMsbSigned(const uint8_t data[], int bitIndex, int bitWidth);
 void setBitRangeMsb(uint8_t data[], int totalBitIndex, int bitWidth, uint32_t value);
 
 // Motorola byte order, bitIndex is the most significant bit of the value
 // DBC sample: 7|16@0+
 uint32_t getBitRangeMoto(const uint8_t data[], int bitIndex, int bitWidth);
+int32_t getBitRangeMotoSigned(const uint8_t data[], int bitIndex, int bitWidth);
 void setBitRangeMoto(uint8_t data[], int totalBitIndex, int bitWidth, uint32_t value);
 
 // convert bitIndex from LSB to MSB style

--- a/unit_tests/tests/lua/test_bit_range.cpp
+++ b/unit_tests/tests/lua/test_bit_range.cpp
@@ -46,3 +46,27 @@ TEST(BitRangeTest, setBitRangeLsb) {
     setBitRangeLsb(data3, 4, 28, 0xDD'CC'BB'Aul);
     EXPECT_THAT(data3, testing::ElementsAre(0xA0, 0xBB, 0xCC, 0xDD));
 }
+
+TEST(BitRangeTest, getBitRangeLsbSigned) {
+
+    uint8_t data1[] = { 0x11, 0x22 };
+    EXPECT_EQ(getBitRangeLsbSigned(data1, 0, 16), (int16_t)0x2211);
+    EXPECT_EQ(getBitRangeLsbSigned(data1, 0, 12), (int16_t)0x0211);
+    EXPECT_EQ(getBitRangeLsbSigned(data1, 4, 12), (int16_t)0x0221);
+
+    uint8_t data2[] = { 0xAA, 0xBB };
+    EXPECT_EQ(getBitRangeLsbSigned(data2, 0, 16), (int16_t)0xBBAA);
+    EXPECT_EQ(getBitRangeLsbSigned(data2, 0, 12), (int16_t)0xFBAA);
+    EXPECT_EQ(getBitRangeLsbSigned(data2, 4, 12), (int16_t)0xFBBA);
+}
+
+TEST(BitRangeTest, getBitRangeMotoSigned) {
+
+    uint8_t data1[] = { 0xFE }; // 0b1111'1110
+    EXPECT_EQ(getBitRangeMotoSigned(data1, 5, 3), -1);  // 0b111
+    EXPECT_EQ(getBitRangeMotoSigned(data1, 7, 8), -2);  // 0b1111'1110
+
+    uint8_t data2[] = { 0x11 }; // 0b0001'0001
+    EXPECT_EQ(getBitRangeMotoSigned(data2, 5, 3), 2);  // 0b010
+    EXPECT_EQ(getBitRangeMotoSigned(data2, 7, 8), 0x11);
+}


### PR DESCRIPTION
in some cases we need to get signed values from CAN

`setBitRange()` should work in either case, same function both for signed and unsigned values