### PR TITLE
fix dwell clamping for single-tooth triggers

### DIFF
--- a/firmware/controllers/engine_cycle/spark_logic.cpp
+++ b/firmware/controllers/engine_cycle/spark_logic.cpp
@@ -385,6 +385,17 @@ static void scheduleSparkEvent(bool limitedSpark, IgnitionEvent *event,
 		angleOffset += engine->engineState.engineCycle;
 	}
 
+	// For single-tooth triggers (currentPhase == nextPhase), all dwell angles map to the
+	// same trigger tooth. When the dwell angle is just below the current phase, the offset
+	// wraps to nearly a full engine cycle, scheduling the dwell far in the future
+	// Clamp to 0 so the spark starts immediately.
+	if (currentPhase == nextPhase && angleOffset > engine->engineState.engineCycle / 2) {
+		angleOffset = 0;
+#if SPARK_EXTREME_LOGGING
+	    efiPrintf("Clamping spark dwell to current phase due to single-tooth trigger");
+#endif /* SPARK_EXTREME_LOGGING */
+	}
+
 	/**
 	 * By the way 32-bit value should hold at least 400 hours of events at 6K RPM x 12 events per revolution
 	 * [tag:duration_limit]

--- a/unit_tests/tests/trigger/test_2_stroke.cpp
+++ b/unit_tests/tests/trigger/test_2_stroke.cpp
@@ -22,6 +22,7 @@ TEST(trigger, twoStrokeSingleToothTrigger) {
 	ASSERT_EQ(750, Sensor::getOrZero(SensorType::Rpm));
 }
 
+// See #9108 and #9045
 TEST(trigger, twoStrokeSingleToothWith30DegOffset_sparkOutOfOrder) {
 	EngineTestHelper eth(engine_type_e::TEST_CRANK_ENGINE);
 	engineConfiguration->twoStroke = true;
@@ -35,13 +36,12 @@ TEST(trigger, twoStrokeSingleToothWith30DegOffset_sparkOutOfOrder) {
 	eth.smartFireTriggerEvents2(/*count*/20, /*delay*/ 40);
 	ASSERT_EQ(750, Sensor::getOrZero(SensorType::Rpm));
 
-	// the bug doesn't appear immediately - need more revolutions for it to manifest
+	// run some more revolutions
 	eth.smartFireTriggerEvents2(/*count*/200, /*delay*/ 40);
 
-	// continue running to accumulate more out-of-order events
 	eth.smartFireTriggerEvents2(/*count*/200, /*delay*/ 40);
 
-	EXPECT_NE(0, engine->engineState.sparkOutOfOrderCounter) << "demonstrates sparkOutOfOrder bug with single tooth + 30deg offset";
+	ASSERT_EQ(0, engine->engineState.sparkOutOfOrderCounter) << "sparkOutOfOrder should be 0 during normal operation";
 }
 
 TEST(trigger, twoStrokeSingleToothWith72DegOffset) {


### PR DESCRIPTION
before:
<img width="1620" height="581" alt="image" src="https://github.com/user-attachments/assets/4c11746b-88e0-49f8-8537-8c20f0f72b3f" />

now:
<img width="1621" height="562" alt="image" src="https://github.com/user-attachments/assets/eb21f51e-fb36-44bf-b1c9-d72f3f19dfe3" />

resolves #9108
[DataLogs.zip](https://github.com/user-attachments/files/25328977/DataLogs.zip)
