### PR TITLE
repaint panel overlay on ecu connection/disconection

### DIFF
--- a/java_console/ui/src/main/java/com/rusefi/ui/console/TabbedPanel.java
+++ b/java_console/ui/src/main/java/com/rusefi/ui/console/TabbedPanel.java
@@ -38,16 +38,28 @@ public class TabbedPanel {
                 switch (ConnectionStatusLogic.INSTANCE.getValue()) {
                     case NOT_CONNECTED:
                         text = "Not connected";
+                        g.setColor(Color.white);
                         break;
                     case LOADING:
                         text = "Loading";
+                        g.setColor(Color.white);
                         break;
                     default:
                         text = "";
                 }
             }
-            int labelWidth = g.getFontMetrics().stringWidth(text);
-            g.drawString(text, (d.width - labelWidth) / 2, d.height / 2);
+            if (text.isEmpty())
+                return;
+            FontMetrics fm = g.getFontMetrics();
+            int labelWidth = fm.stringWidth(text);
+            int x = (d.width - labelWidth) / 2;
+            int y = d.height / 2;
+            int padding = 12;
+            Color textColor = g.getColor();
+            g.setColor(new Color(0, 0, 0, 180));
+            g.fillRoundRect(x - padding, y - fm.getAscent() - padding, labelWidth + padding * 2, fm.getHeight() + padding * 2, 16, 16);
+            g.setColor(textColor);
+            g.drawString(text, x, y);
         }
     };
 


### PR DESCRIPTION
fix for this:
<img width="820" height="344" alt="image" src="https://github.com/user-attachments/assets/342e1798-a010-4403-9226-0a84cd122171" />

now: 
<img width="861" height="892" alt="image" src="https://github.com/user-attachments/assets/559e65bc-3c1c-4bd3-b200-858b5ee9623f" />

related #9092