### PR TITLE
ISensorHolder: Add support for EnumIniField

### DIFF
--- a/java_console/inifile/src/main/java/com/rusefi/ini/reader/IniFileReader.java
+++ b/java_console/inifile/src/main/java/com/rusefi/ini/reader/IniFileReader.java
@@ -335,6 +335,16 @@ public class IniFileReader {
                 double multiplier = list.size() > 5 ? IniField.parseDouble(list.get(5)) : 1.0;
                 double digits = list.size() > 6 ? IniField.parseDouble(list.get(6)) : 0.0;
                 allOutputChannels.put(name, new ScalarIniField(name, offset, unit, scalarType, multiplier, "0", digits));
+                break;
+            }
+            case FIELD_TYPE_BITS: {
+                // Output channel bits format: name = bits, type, offset, [bitLow:bitHigh], "label"
+                FieldType type = FieldType.parseTs(list.get(2));
+                int offset = Integer.parseInt(list.get(3));
+                String bitRange = list.get(4);
+                EnumIniReaderHelper.ParseBitRange parseBitRange = new EnumIniReaderHelper.ParseBitRange().invoke(bitRange);
+                allOutputChannels.put(name, new EnumIniField(name, offset, type, new EnumIniField.EnumKeyValueMap(Collections.emptyMap()), parseBitRange.getBitPosition(), parseBitRange.getBitSize0()));
+                break;
             }
         }
     }


### PR DESCRIPTION
fix for this warnings:

```
W 260216 010137.182 [ECU Communication Executor1] ISensorHolder - Member not found for fuelClosedLoopBinIdxGauge=com.opensr5.ini.GaugeModel@c05ebf2                                                                           
W 260216 010137.182 [ECU Communication Executor1] ISensorHolder - Member not found for fuelClosedLoopLearningBinIdxGauge=com.opensr5.ini.GaugeModel@6f3a9d5a
``` 

prev work before cleanup on ISensorHolder on name of [de-slop sandbox, add tune viewer tab into console #9068](https://github.com/rusefi/rusefi/issues/9068)