### PR TITLE
Define make dependency chain better

### DIFF
--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -455,3 +455,5 @@ CLEAN_BUNDLE_HOOK:
 POST_MAKE_ALL_RULE_HOOK: $(BUILDDIR)/$(PROJECT).elf
 	@java -jar ../java_tools/gcc_map_reader.jar $(BUILDDIR)/$(PROJECT).map | grep Total || echo Unable to run gcc_map_reader
 	@$(TRGT)objdump -h $(BUILDDIR)/$(PROJECT).elf | grep -w ram4
+
+VPATH     = $(patsubst ./%,%,$(SRCPATHS))

--- a/firmware/bundle.mk
+++ b/firmware/bundle.mk
@@ -161,16 +161,16 @@ BUNDLE_FILES = \
   $(UPDATE_BUNDLE_FILES) \
   $(FULL_BUNDLE_CONTENT)
 
-$(SIMULATOR_EXE): $(CONFIG_FILES) .FORCE
+$(SIMULATOR_EXE): $(CONFIG_FILES) $(DOCS_ENUMS) .FORCE
 	$(MAKE) -C ../simulator -r OS="Windows_NT" SUBMAKE=yes
 
 # make sure not to invoke in parallel with SIMULATOR_EXE rule above
-../simulator/build/rusefi_simulator.linux: $(CONFIG_FILES) .FORCE
+../simulator/build/rusefi_simulator.linux: $(CONFIG_FILES) $(DOCS_ENUMS) .FORCE
 	$(MAKE) -C ../simulator -r OS="Linux" SUBMAKE=yes
 
 # make Windows simulator a prerequisite so that we don't try compiling them concurrently
 # that also means no incremental compilation making that rule less useful. See 'rusefi_simulator.linux' above
-../simulator/build/rusefi_simulator.both: $(CONFIG_FILES) .FORCE | $(SIMULATOR_EXE)
+../simulator/build/rusefi_simulator.both: $(CONFIG_FILES) $(DOCS_ENUMS) .FORCE | $(SIMULATOR_EXE)
 	$(MAKE) -C ../simulator -r OS="Linux" SUBMAKE=yes
 
 $(BOOTLOADER_HEX) $(BOOTLOADER_BIN): .bootloader-sentinel ;

--- a/firmware/common.mk
+++ b/firmware/common.mk
@@ -2,8 +2,8 @@ include $(PROJECT_DIR)/init/init.mk
 include $(PROJECT_DIR)/util/util.mk
 include $(PROJECT_DIR)/config/engines/engines.mk
 include $(PROJECT_DIR)/console/console.mk
-include $(PROJECT_DIR)/controllers/lua/lua.mk
 include $(PROJECT_DIR)/controllers/controllers.mk
+include $(PROJECT_DIR)/controllers/lua/lua.mk
 include $(PROJECT_DIR)/development/development.mk
 include $(PROJECT_DIR)/hw_layer/hw_layer.mk
 include $(PROJECT_DIR)/hw_layer/sensors/sensors.mk

--- a/firmware/docs_enums.mk
+++ b/firmware/docs_enums.mk
@@ -17,7 +17,6 @@ DOCS_ENUMS_INPUTS = \
   $(PROJECT_DIR)/controllers/actuators/electronic_throttle.txt \
   $(PROJECT_DIR)/hw_layer/drivers/gpio/mc33810_state.txt \
   $(PROJECT_DIR)/integration/LiveData.yaml \
-  $(PROJECT_DIR)/console/binary/generated/live_data_ids.h \
   $(PROJECT_DIR)/controllers/sensors/sensor_type.h \
   $(PROJECT_DIR)/controllers/trigger/decoders/sync_edge.h \
   $(PROJECT_DIR)/controllers/algo/engine_types.h \
@@ -27,7 +26,50 @@ DOCS_ENUMS_INPUTS = \
   $(PROJECT_DIR)/libfirmware/can/can_common.h \
   $(PROJECT_DIR)/hw_layer/drivers/can/can_category.h \
   $(PROJECT_DIR)/config/boards/cypress/rusefi_hw_enums.h \
-  $(PROJECT_DIR)/config/boards/kinetis/rusefi_hw_enums.h
+  $(PROJECT_DIR)/config/boards/kinetis/rusefi_hw_enums.h \
+
+DOCS_ENUMS = \
+  $(PROJECT_DIR)/controllers/algo/auto_generated_engine_type_e.cpp \
+  $(PROJECT_DIR)/controllers/algo/auto_generated_engine_type_e.h \
+  $(PROJECT_DIR)/controllers/algo/auto_generated_commonenum.cpp \
+  $(PROJECT_DIR)/controllers/algo/auto_generated_commonenum.h \
+  $(PROJECT_DIR)/$(META_OUTPUT_ROOT_FOLDER)controllers/algo/auto_generated_enums.cpp \
+  $(PROJECT_DIR)/$(META_OUTPUT_ROOT_FOLDER)controllers/algo/auto_generated_enums.h \
+  $(PROJECT_DIR)/controllers/algo/auto_generated_enginetypes.cpp \
+  $(PROJECT_DIR)/controllers/algo/auto_generated_enginetypes.h \
+  $(PROJECT_DIR)/controllers/trigger/decoders/auto_generated_sync_edge.cpp \
+  $(PROJECT_DIR)/controllers/trigger/decoders/auto_generated_sync_edge.h \
+  $(PROJECT_DIR)/controllers/sensors/auto_generated_sensor.cpp \
+  $(PROJECT_DIR)/controllers/sensors/auto_generated_sensor.h \
+  $(PROJECT_DIR)/hw_layer/drivers/can/auto_generated_can_category.cpp \
+  $(PROJECT_DIR)/hw_layer/drivers/can/auto_generated_can_category.h \
+  $(PROJECT_DIR)/$(META_OUTPUT_ROOT_FOLDER)controllers/lua/generated/output_lookup_generated.cpp \
+  $(PROJECT_DIR)/$(META_OUTPUT_ROOT_FOLDER)console/binary/generated/data_logs.ini \
+  $(PROJECT_DIR)/$(META_OUTPUT_ROOT_FOLDER)console/binary/generated/fancy_content.ini \
+  $(PROJECT_DIR)/$(META_OUTPUT_ROOT_FOLDER)console/binary/generated/fancy_menu.ini \
+  $(PROJECT_DIR)/$(META_OUTPUT_ROOT_FOLDER)console/binary/generated/gauges.ini \
+  $(PROJECT_DIR)/$(META_OUTPUT_ROOT_FOLDER)console/binary/generated/live_data_fragments.h \
+  $(PROJECT_DIR)/$(META_OUTPUT_ROOT_FOLDER)console/binary/generated/live_data_fragments.ini \
+  $(PROJECT_DIR)/$(META_OUTPUT_ROOT_FOLDER)console/binary/generated/live_data_ids.h \
+  $(PROJECT_DIR)/$(META_OUTPUT_ROOT_FOLDER)console/binary/generated/log_fields_generated.h \
+  $(PROJECT_DIR)/$(META_OUTPUT_ROOT_FOLDER)console/binary/generated/sensors.java \
+  $(PROJECT_DIR)/$(META_OUTPUT_ROOT_FOLDER)console/binary/generated/total_live_data_generated.h \
+  $(PROJECT_DIR)/../java_tools/trigger-image/src/main/java/com/rusefi/config/generated/TriggerVariableRegistryValues.java \
+  $(PROJECT_DIR)/../java_console/io/src/main/java/com/rusefi/enums/SensorType.java \
+  $(PROJECT_DIR)/../java_console/io/src/main/java/com/rusefi/enums/StateDictionaryFactory.java \
+  $(PROJECT_DIR)/../java_console/io/src/main/java/com/rusefi/enums/SyncEdge.java \
+  $(PROJECT_DIR)/../java_console/io/src/main/java/com/rusefi/enums/live_data_e.java \
+  $(PROJECT_DIR)/../java_console/models/src/main/java/com/rusefi/config/generated/Integration.java \
+  $(PROJECT_DIR)/../java_console/models/src/main/java/com/rusefi/enums/bench_mode_e.java \
+  $(PROJECT_DIR)/../java_console/models/src/main/java/com/rusefi/enums/bench_test_io_control_e.java \
+  $(PROJECT_DIR)/../java_console/models/src/main/java/com/rusefi/enums/bench_test_magic_numbers_e.java \
+  $(PROJECT_DIR)/../java_console/models/src/main/java/com/rusefi/enums/bench_test_packet_ids_e.java \
+  $(PROJECT_DIR)/../java_console/models/src/main/java/com/rusefi/enums/debug_mode_e.java \
+  $(PROJECT_DIR)/../java_console/models/src/main/java/com/rusefi/enums/engine_type_e.java \
+  $(PROJECT_DIR)/../java_console/models/src/main/java/com/rusefi/enums/trigger_type_e.java \
+  $(PROJECT_DIR)/../java_console/models/src/main/java/com/rusefi/enums/ts_14_command.java \
+  $(PROJECT_DIR)/../java_console/models/src/main/java/com/rusefi/enums/ts_command_e.java \
+  $(PROJECT_DIR)/../java_console/models/src/main/java/com/rusefi/tracing/EnumNames.java
 
 ifneq ("$(wildcard $(BOARD_DIR)/extra.txt)","")
   DOCS_ENUMS_INPUTS += $(BOARD_DIR)/extra.txt
@@ -50,7 +92,7 @@ endif
 
 docs-enums: .docsenums-sentinel
 
-$(CONFIG_FILES): .docsenums-sentinel
+$(DOCS_ENUMS): .docsenums-sentinel
 
 # This is necessary because the ChibiOS makefile builds a .o file and generates
 #  the deps for that .o file in the same GCC call, so if the .deps aren't already

--- a/firmware/rusefi_config.mk
+++ b/firmware/rusefi_config.mk
@@ -34,6 +34,7 @@ endif
 # Build the generated pin code only if the connector directory exists
 ifneq ("$(wildcard $(BOARD_DIR)/connectors)","")
   PIN_FILES = \
+    $(PROJECT_DIR)/$(BOARD_DIR)/connectors/generated_board_pin_names.h \
     $(PROJECT_DIR)/$(BOARD_DIR)/connectors/generated_outputs.h \
     $(PROJECT_DIR)/$(BOARD_DIR)/connectors/generated_ts_name_by_pin.cpp
 endif
@@ -47,6 +48,12 @@ CONFIG_FILES = \
   $(PROJECT_DIR)/$(META_OUTPUT_ROOT_FOLDER)controllers/generated/rusefi_generated_$(SHORT_BOARD_NAME).h \
   $(PROJECT_DIR)/$(META_OUTPUT_ROOT_FOLDER)controllers/generated/signature_$(SHORT_BOARD_NAME).h \
   $(PROJECT_DIR)/$(META_OUTPUT_ROOT_FOLDER)controllers/generated/engine_configuration_generated_structures_$(SHORT_BOARD_NAME).h \
+  $(PROJECT_DIR)/$(META_OUTPUT_ROOT_FOLDER)controllers/generated/generated_fields_api_header.h \
+  $(PROJECT_DIR)/$(META_OUTPUT_ROOT_FOLDER)controllers/generated/page_1_generated.h \
+  $(PROJECT_DIR)/$(META_OUTPUT_ROOT_FOLDER)controllers/generated/page_2_generated.h \
+  $(PROJECT_DIR)/$(META_OUTPUT_ROOT_FOLDER)controllers/lua/generated/value_lookup_generated.cpp \
+  $(PROJECT_DIR)/$(META_OUTPUT_ROOT_FOLDER)controllers/lua/generated/value_lookup_generated.md \
+  $(PROJECT_DIR)/../java_console/models/src/main/java/com/rusefi/config/generated/VariableRegistryValues.java \
   $(FIELDS) \
   $(PIN_FILES)
 
@@ -74,7 +81,7 @@ $(RAMDISK): .ramdisk-sentinel ;
 	bash $(PROJECT_DIR)/bin/gen_image_board.sh $(BOARD_DIR) $(SHORT_BOARD_NAME)
 	@touch $@
 
-$(CONFIG_FILES): .config-sentinel ;
+$(CONFIG_FILES): .config-sentinel;
 
 # CONFIG_DEFINITION is always rebuilt, but the file will only be updated if it needs to be,
 # so it won't trigger a config file generation unless it needs to.

--- a/java_tools/java_tools.mk
+++ b/java_tools/java_tools.mk
@@ -20,7 +20,7 @@ AUTOUPDATE_JAR = $(PROJECT_DIR)/../console/rusefi_autoupdate.jar
 # We use .FORCE to always rebuild these tools. Gradle won't actually touch the jars if it doesn't need to,
 # so we don't have to worry about triggering rebuilds of things that have these tools as a prerequisite.
 
-$(CONFIG_DEFINITION_JAR): .FORCE
+$(CONFIG_DEFINITION_JAR): .docsenums-sentinel .FORCE
 	cd $(JAVA_TOOLS) && $(FLOCK) ./gradlew :config_definition:shadowJar
 
 $(CONFIG_DEFINITION_BASE_JAR): .FORCE
@@ -35,7 +35,7 @@ $(ENUM_TO_STRING_JAR): .FORCE
 $(TS_PLUGIN_LAUNCHER_JAR): .FORCE
 	cd $(JAVA_TOOLS) && $(FLOCK) ./gradlew :ts_plugin_launcher:shadowJar
 
-$(CONSOLE_JAR): .FORCE
+$(CONSOLE_JAR): .docsenums-sentinel .config-sentinel .FORCE
 	cd $(JAVA_TOOLS) && $(FLOCK) ./gradlew :ui:shadowJar
 
 $(AUTOUPDATE_JAR): .FORCE

--- a/simulator/Makefile
+++ b/simulator/Makefile
@@ -312,6 +312,7 @@ ifeq ($(SHORT_BOARD_NAME),)
   SHORT_BOARD_NAME = f407-discovery
 endif
 include $(PROJECT_DIR)/rusefi_config.mk
+include $(PROJECT_DIR)/docs_enums.mk
 endif
 
 # Enable precompiled header


### PR DESCRIPTION
This should guarantee (assuming I got it right) that any generated files that config_definition depends on are regenerated if necessary  before config_definition is built.