### PR TITLE
Validate TS field expressions to prevent forward references

### DIFF
--- a/java_tools/configuration_definition_base/src/main/java/com/rusefi/ReaderStateImpl.java
+++ b/java_tools/configuration_definition_base/src/main/java/com/rusefi/ReaderStateImpl.java
@@ -253,6 +253,10 @@ public class ReaderStateImpl implements ReaderState {
         if (log.debugEnabled())
             log.debug("Ending structure " + structure.getName());
         structure.addAlignmentFill(this, 4);
+        // Validate only on top-level structs
+        if (isStackEmpty()) {
+            structure.validateNoForwardReferences();
+        }
 
         ConfigStructureImpl existing = structures.put(structure.getName(), structure);
         if (existing != null)


### PR DESCRIPTION
```
Caused by: java.lang.IllegalStateException: Field 'maxAcClt' references 'useMetricOnInterface' which is defined later in the structure (forward reference). Reorder fields in rusefi_config.txt so that 'useMetricOnInterface' is defined before it is used.
        at com.rusefi.output.ConfigStructureImpl.checkForwardReferences(ConfigStructureImpl.java:236)
        at com.rusefi.output.ConfigStructureImpl.checkForwardReferences(ConfigStructureImpl.java:218)
        at com.rusefi.output.ConfigStructureImpl.validateNoForwardReferences(ConfigStructureImpl.java:200)
        at com.rusefi.ReaderStateImpl.handleEndStruct(ReaderStateImpl.java:258)
        at com.rusefi.ReaderStateImpl.readBufferedReader(ReaderStateImpl.java:314)
        at com.rusefi.ReaderStateImpl.doJob(ReaderStateImpl.java:141)
        ... 2 more
``` 

resolves #9138