### PR TITLE
fix "ign/ve table is not in freedom units when selected"

### DIFF
--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -2090,11 +2090,11 @@ uint16_t[VVT_TABLE_SIZE] vvtTable2LoadBins;;"L", 1, 0, 0,  @@MAP_UPPER_LIMIT@@, 
 uint16_t[VVT_TABLE_RPM_SIZE] vvtTable2RpmBins;;"RPM", 1, 0, 0, 18000, 0
 
 int16_t[IGN_LOAD_COUNT x IGN_RPM_COUNT] autoscale ignitionTable;;"deg", 0.1, 0, -20, 90, 1
-uint16_t[IGN_LOAD_COUNT] ignitionLoadBins;;"Load", 1, 0, 0,  @@MAP_UPPER_LIMIT@@, 0
+uint16_t[IGN_LOAD_COUNT] ignitionLoadBins;;{bitStringValue(ignLoadUnitLabels, ignLoadUnitIdxPcv)}, {(ignOverrideMode != 0 && ignOverrideMode != 1) || useMetricOnInterface ? 1 : @@UNITS_KPA_TO_PSI@@}, 0, 0, {ignOverrideMode == 0 || ignOverrideMode == 1 ? (useMetricOnInterface ? @@MAP_UPPER_LIMIT@@ : @@MAP_UPPER_LIMIT@@ * @@UNITS_KPA_TO_PSI@@) : 100}, 0
 uint16_t[IGN_RPM_COUNT] ignitionRpmBins;;"RPM",	   1, 0, 0, 18000, 0
 
 uint16_t[VE_LOAD_COUNT x VE_RPM_COUNT] autoscale veTable;;"%", 0.1, 0, 0, 999, 1
-uint16_t[VE_LOAD_COUNT] veLoadBins;;{bitStringValue(fuelUnits, fuelAlgorithm) },	1, 0, 0,  @@MAP_UPPER_LIMIT@@, 0
+uint16_t[VE_LOAD_COUNT] veLoadBins;;{bitStringValue(veLoadUnitLabels, veLoadUnitIdxPcv)}, {!(veOverrideMode == 1 || (veOverrideMode == 0 && fuelAlgorithm == 0)) || useMetricOnInterface ? 1 : @@UNITS_KPA_TO_PSI@@}, 0, 0, {veOverrideMode == 1 || (veOverrideMode == 0 && fuelAlgorithm == 0) ? (useMetricOnInterface ? @@MAP_UPPER_LIMIT@@ : @@MAP_UPPER_LIMIT@@ * @@UNITS_KPA_TO_PSI@@) : (veOverrideMode == 2 ? 100 : @@MAP_UPPER_LIMIT@@)}, 0
 uint16_t[VE_RPM_COUNT] veRpmBins;;"RPM",	   1, 0, 0, 18000, 0
 
 ! TODO at some point we need to flip this table to use AFR on the affected tests, since otherwise we get some no-to-nice fields as consequence

--- a/firmware/tunerstudio/tunerstudio.template.ini
+++ b/firmware/tunerstudio/tunerstudio.template.ini
@@ -303,11 +303,25 @@ page = 3
 	; Closed Loop Fuel Correction / Short Term Fuel Trims
 	isSTFT = { fuelClosedLoopCorrectionEnabled == 1 }
 
+	; true when VE load axis is pressure-based (kPa/psi)
+	veLoadIsPressure = { veOverrideMode == 1 || (veOverrideMode == 0 && fuelAlgorithm == 0) }
+	; true when ignition load axis is pressure-based (kPa/psi)
+	ignLoadIsPressure = { ignOverrideMode == 0 || ignOverrideMode == 1 }
+	; unit label index: 0=psi, 1=kPa, 2=%
+	ignLoadUnitIdx = { ignLoadIsPressure * useMetricOnInterface + (1 - ignLoadIsPressure) * 2 }
+	; unit label index: 0=psi, 1=kPa, 2=%, 3=MAF, 4=%TPS, 5=Lua
+	veLoadUnitIdx = { veLoadIsPressure * useMetricOnInterface + (1 - veLoadIsPressure) * (veOverrideMode == 2) * 2 + (1 - veLoadIsPressure) * (1 - (veOverrideMode == 2)) * (5 - 2 * (fuelAlgorithm == 1) - (fuelAlgorithm == 2)) }
+
 [PcVariables]
-	fuelUnits = bits, U08, [0:2], "kPa", "MAF", "%TPS", "Lua"
+	fuelUnits = bits, U08, [0:2], @@UNITS_KPA@@, "MAF", "%TPS", "Lua"
 	pwmAxisLabels = bits, U08, [0:5], "Zero", "TPS %", "MAP kPa", "CLT C", "IAT C", "Fuel Load", "Ignition Load", "Aux Temp 1 C", "Aux Temp 2 C", "Accel Pedal %", "Battery Voltage Volts", "VVT 1 I Deg", "VVT 1 E Deg", "VVT 2 I Deg", "VVT 2 E Deg", "Ethanol (Flex) %", "Aux Linear 1 *", "Aux Linear 2 *", "GPPWM Output 1 %", "GPPWM Output 2 %", "GPPWM Output 3 %", "GPPWM Output 4 %", "Lua Gauge 1", "Lua Gauge 2", "RPM", "Gear (detected)", "Baro pressure kPa", "EGT 1 C", "EGT 2 C", "Aux Linear 3", "Aux Linear 4", "Vehicle Speed KPH", "Oil pressure kPa", "Oil temp C", "Fuel Pressure", "Throttle Pressure Ratio"
 	veAxisLabels = bits, U08, [0:1], "load", "MAP", "TPS"
 	targetAfrAxisLabels = bits, U08, [0:2], "load", "MAP", "TPS", "Acc Pedal", "Cyl Filling %"
+	ignAxisLabels = bits, U08, [0:2], "Load", "MAP", "TPS", "Acc Pedal", "Cyl Filling %"
+	ignLoadUnitLabels = bits, U08, [0:1], @@UNITS_PSI@@, @@UNITS_KPA@@, "%"
+	veLoadUnitLabels = bits, U08, [0:2], @@UNITS_PSI@@, @@UNITS_KPA@@, "%", "MAF", "%TPS", "Lua"
+	ignLoadUnitIdxPcv = continuousChannelValue, ignLoadUnitIdx
+	veLoadUnitIdxPcv = continuousChannelValue, veLoadUnitIdx
 
 	tuneCrcPcVariable = continuousChannelValue, tuneCrc16
 
@@ -1171,7 +1185,7 @@ curve = rangeMatrix, "Range Switch Input Matrix"
 		upDownLabel = "(RICHER)", "(LEANER)"
 
 	table = ignitionTableTbl,  ignitionTableMap,  @@IGNITION_ADVANCE_TABLE_NAME@@,	1
-		xyLabels = "RPM", "Ignition Load"
+		xyLabels = "RPM", {bitStringValue(ignAxisLabels, ignOverrideMode)}
 		xBins		= ignitionRpmBins,  rpmForIgnitionTableDot
 		yBins		= ignitionLoadBins,  loadForIgnitionTableDot
 		zBins		= ignitionTable
@@ -5035,8 +5049,12 @@ dialog = tcuControls, "Transmission Settings"
 		panel = IgnitionDiagPanel
 		panel = InjectionDiagPanel
 
+	dialog = ignitionOverrideModeSelector, "Load override"
+		field = "Override ignition table load axis", ignOverrideMode
+
 	dialog = IgnitionTableDialog, ""
 		panel = ignitionTableIndicators
+		panel = ignitionOverrideModeSelector
 		panel = ignitionTableTbl
 
 [Tools]


### PR DESCRIPTION
resolves #9057

<img width="1840" height="707" alt="image" src="https://github.com/user-attachments/assets/b2945f2a-2417-4599-ba18-e3aca54c3355" />
<img width="1830" height="729" alt="image" src="https://github.com/user-attachments/assets/2ca6afbd-32c1-4b46-9a10-da428469b13e" />

also added the load override dialog on the VE table to match the ignition table, also fixed the ve table of this exact problem