### PR TITLE
Fix RiseOnly triggers again

### DIFF
--- a/firmware/controllers/trigger/decoders/trigger_structure.cpp
+++ b/firmware/controllers/trigger/decoders/trigger_structure.cpp
@@ -416,6 +416,17 @@ uint16_t TriggerWaveform::findAngleIndex(TriggerFormDetails *details, angle_t ta
 	return left;
 }
 
+int TriggerWaveform::findNextChannelEvent(size_t index) {
+#if EFI_UNIT_TEST
+	for (int i = index + 1; i < efi::size(triggerSignalIndeces); i++) {
+		if (triggerSignalIndeces[index] == triggerSignalIndeces[i]) {
+			return i;
+		}
+	}
+#endif
+	return index;
+}
+
 void TriggerWaveform::setShapeDefinitionError(bool value) {
 	shapeDefinitionError = value;
 }

--- a/firmware/controllers/trigger/decoders/trigger_structure.h
+++ b/firmware/controllers/trigger/decoders/trigger_structure.h
@@ -237,6 +237,8 @@ public:
 
 	uint16_t findAngleIndex(TriggerFormDetails *details, angle_t angle) const;
 
+	int findNextChannelEvent(size_t index);
+
 	/**
 	 * These angles are in trigger DESCRIPTION coordinates - i.e. the way you add events while declaring trigger shape
 	 */

--- a/firmware/controllers/trigger/trigger_decoder.cpp
+++ b/firmware/controllers/trigger/trigger_decoder.cpp
@@ -160,7 +160,9 @@ void TriggerFormDetails::prepareEventAngles(TriggerWaveform *shape) {
 				// In case this is a rising event, replace the following fall event with the rising as well
 				if (shape->isRiseEvent[triggerDefinitionIndex]) {
 					eventAngles[eventIndex] = angle;
-					eventAngles[eventIndex + 1] = angle;
+					// How many events away is the next event on this channel?
+					int nextCount = shape->findNextChannelEvent(triggerDefinitionIndex) - triggerDefinitionIndex;
+					eventAngles[eventIndex + nextCount] = angle;
 				}
 			} else {
 				eventAngles[eventIndex] = angle;


### PR DESCRIPTION
The bug I imagined hiding in #9135 did in fact exist. I thought that no patterns had multiple teeth on both wheels, but because TriTach is FOUR_STROKE_CRANK_SENSOR, it effectively did.
This will fix TriTach and any future cases.