### PR TITLE
TS_RESPONSE_OUT_OF_RANGE, don't duplicate error messages on TS output

### DIFF
--- a/java_console/io/src/main/java/com/rusefi/binaryprotocol/BinaryProtocol.java
+++ b/java_console/io/src/main/java/com/rusefi/binaryprotocol/BinaryProtocol.java
@@ -329,6 +329,9 @@ public class BinaryProtocol {
             ConfigurationImageWithMeta image = BinaryProtocolLocalCache.getAndValidateLocallyCached(this);
 
             if (image.isEmpty()) {
+                // Drop any stale bytes (e.g. a duplicate error code left in the buffer by a prior failed CRC-check command)
+                // prior 2026 we have a bug sending duplicate error codes from validateOffsetCount, see #9145
+                dropPending(stream);
                 image = readFullImageFromController(arguments, meta);
                 if (image.isEmpty())
                     return;


### PR DESCRIPTION
WIP. I only had a "wait a minute" moment while working on another ticket; need to test with hw/ts/console


related #9145