### PR TITLE
Set isSecondWheelCam for 1+1

### DIFF
--- a/firmware/controllers/trigger/decoders/trigger_universal.cpp
+++ b/firmware/controllers/trigger/decoders/trigger_universal.cpp
@@ -77,6 +77,7 @@ void configureOnePlusOne(TriggerWaveform *s) {
 	s->addEvent360(270, TriggerValue::RISE, TriggerWheel::T_SECONDARY);
 	s->addEvent360(360, TriggerValue::FALL, TriggerWheel::T_SECONDARY);
 
+	s->isSecondWheelCam = true;
 	s->isSynchronizationNeeded = false;
 	s->useOnlyPrimaryForSync = true;
 }


### PR DESCRIPTION
As far as I can tell, this parameter is only used for TriggerImage.
The second wheel's angles would make no sense as a crank trigger, so I'm pretty sure it's meant to be a cam trigger.
Before:
<img width="1910" height="1050" alt="trigger_TT_ONE_PLUS_ONE" src="https://github.com/user-attachments/assets/8670bfaf-8f31-4ceb-8a8d-fee65d3e4ec0" />
After:
<img width="1910" height="1050" alt="trigger_TT_ONE_PLUS_ONE" src="https://github.com/user-attachments/assets/1b96ee04-d2d5-4ba0-8626-5a2f29c03c09" />
