### PR TITLE
UI: online vs burn - add undo/redo actions

### DIFF
--- a/java_console/ui/src/main/java/com/rusefi/ui/TuningPane.java
+++ b/java_console/ui/src/main/java/com/rusefi/ui/TuningPane.java
@@ -8,11 +8,15 @@ import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
 import java.awt.*;
+import java.util.ArrayDeque;
 
 /**
  * Andrey Belomutskiy, (c) 2013-2026
  */
 public class TuningPane {
+    private static final int MAX_UNDO = 15;
+    private static final int IDLE_TIMEOUT_MS = 300;
+
     private final JPanel content = new JPanel(new BorderLayout());
 
     public TuningPane(UIContext uiContext) {
@@ -26,7 +30,47 @@ public class TuningPane {
         // Accumulated tune edits across all dialogs for this session.
         final ConfigurationImage[] sessionImage = {null};
 
-        JPanel toolbar = getToolbar(uiContext, right, currentKey, sessionImage);
+        // Undo/redo history — each entry is a snapshot of sessionImage before an edit.
+        final ArrayDeque<ConfigurationImage> undoStack = new ArrayDeque<>();
+        final ArrayDeque<ConfigurationImage> redoStack = new ArrayDeque<>();
+        final ConfigurationImage[] undoBaseline = {null};
+
+        JButton undoButton = new JButton("Undo");
+        JButton redoButton = new JButton("Redo");
+        undoButton.setEnabled(false);
+        redoButton.setEnabled(false);
+
+        Runnable updateUndoRedoButtons = () -> {
+            undoButton.setEnabled(!undoStack.isEmpty());
+            redoButton.setEnabled(!redoStack.isEmpty());
+        };
+
+        // Commits any captured baseline to the undo stack (called by timer and on navigation).
+        Runnable flushUndoBaseline = () -> {
+            if (undoBaseline[0] != null) {
+                undoStack.push(undoBaseline[0]);
+                if (undoStack.size() > MAX_UNDO) undoStack.removeLast();
+                redoStack.clear();
+                undoBaseline[0] = null;
+                updateUndoRedoButtons.run();
+            }
+        };
+
+        // Debounce timer: coalesces rapid edits (e.g., per-keystroke text field events) into a single undo point
+        Timer undoCommitTimer = new Timer(IDLE_TIMEOUT_MS, e -> flushUndoBaseline.run());
+        undoCommitTimer.setRepeats(false);
+
+        Runnable onDiscardExtra = () -> {
+            undoCommitTimer.stop();
+            undoStack.clear();
+            redoStack.clear();
+            undoBaseline[0] = null;
+            updateUndoRedoButtons.run();
+        };
+
+        JPanel toolbar = getToolbar(uiContext, right, currentKey, sessionImage, onDiscardExtra);
+        toolbar.add(undoButton);
+        toolbar.add(redoButton);
 
         JSplitPane splitPane = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT, left.getContentPane(), rightScrollPane);
         splitPane.setResizeWeight(0.3);
@@ -37,6 +81,12 @@ public class TuningPane {
                 return;
             }
 
+            // Flush any in-progress debounce window before loading a new section.
+            if (undoCommitTimer.isRunning()) {
+                undoCommitTimer.stop();
+                flushUndoBaseline.run();
+            }
+
             // On first navigation, seed the session image from the live ECU state.
             // On subsequent navigations, carry forward whatever the user has edited so far
             // so that changes made in dialogs, tables, or curves are not lost when opening another.
@@ -44,21 +94,61 @@ public class TuningPane {
             if (pending != null) {
                 sessionImage[0] = pending;
             } else if (sessionImage[0] == null) {
-                sessionImage[0] = bp.getControllerConfiguration();
+                sessionImage[0] = bp.getControllerConfiguration().clone();
             }
 
             currentKey[0] = subMenu.getKey();
             right.update(subMenu.getKey(), uiContext.iniFileState.getIniFileModel(), sessionImage[0]);
         });
 
-        right.setOnConfigChange(left::refreshExpressions);
+        // All edit events (dialog fields, table cells, curve drags) flow through onConfigChange.
+        // Text fields fire per-keystroke, so we use a debounce timer to coalesce them into
+        // a single undo point per editing pause.
+        right.setOnConfigChange(image -> {
+            // Capture the pre-edit state at the start of each debounce window.
+            if (undoBaseline[0] == null && sessionImage[0] != null) {
+                undoBaseline[0] = sessionImage[0];
+            }
+            // Clone because workingImage is mutated in-place by further edits.
+            sessionImage[0] = image.clone();
+            left.refreshExpressions(image);
+            undoCommitTimer.restart();
+        });
+
+        undoButton.addActionListener(e -> {
+            if (undoStack.isEmpty()) return;
+            // Discard any uncommitted edit sequence so we don't accidentally push it.
+            undoCommitTimer.stop();
+            undoBaseline[0] = null;
+            if (sessionImage[0] != null) redoStack.push(sessionImage[0]);
+            sessionImage[0] = undoStack.pop();
+            if (currentKey[0] != null) {
+                right.update(currentKey[0], uiContext.iniFileState.getIniFileModel(), sessionImage[0]);
+            }
+            updateUndoRedoButtons.run();
+        });
+
+        redoButton.addActionListener(e -> {
+            if (redoStack.isEmpty()) return;
+            undoCommitTimer.stop();
+            undoBaseline[0] = null;
+            if (sessionImage[0] != null) undoStack.push(sessionImage[0]);
+            sessionImage[0] = redoStack.pop();
+            if (currentKey[0] != null) {
+                right.update(currentKey[0], uiContext.iniFileState.getIniFileModel(), sessionImage[0]);
+            }
+            updateUndoRedoButtons.run();
+        });
 
         content.add(toolbar, BorderLayout.NORTH);
         content.add(splitPane, BorderLayout.CENTER);
     }
 
+
+    // TODO: move buttons to a factory!, also the undo/redo
     private static @NotNull JPanel getToolbar(UIContext uiContext, CalibrationDialogWidget right,
-                                              String[] currentKey, ConfigurationImage[] sessionImage) {
+                                              String[] currentKey, ConfigurationImage[] sessionImage,
+                                              Runnable onDiscardExtra) {
         JButton burnButton = new JButton("Burn to ECU");
         burnButton.addActionListener(e -> {
             BinaryProtocol bp = uiContext.getBinaryProtocol();
@@ -79,10 +169,11 @@ public class TuningPane {
             // Reset session to the snapshot captured when we connected to this ECU.
             ConfigurationImage baseline = bp.getCachedImage();
             if (baseline == null) baseline = bp.getControllerConfiguration();
-            sessionImage[0] = baseline;
+            sessionImage[0] = baseline.clone();
             if (currentKey[0] != null) {
                 right.update(currentKey[0], uiContext.iniFileState.getIniFileModel(), sessionImage[0]);
             }
+            onDiscardExtra.run();
         });
 
         JPanel toolbar = new JPanel(new FlowLayout(FlowLayout.LEFT));

--- a/java_console/ui/src/main/java/com/rusefi/ui/widgets/tune/CalibrationDialogWidget.java
+++ b/java_console/ui/src/main/java/com/rusefi/ui/widgets/tune/CalibrationDialogWidget.java
@@ -116,17 +116,21 @@ public class CalibrationDialogWidget {
             }
             workingImage = ci != null ? ci.clone() : null;
 
+            Runnable notifyEdit = () -> { if (onConfigChange != null) onConfigChange.accept(workingImage); };
+
             TableModel table = iniFileModel.getTable(key);
             if (table != null) {
                 contentPane.setLayout(new BoxLayout(contentPane, BoxLayout.Y_AXIS));
                 TuningTableView tuningTableView = new TuningTableView(table.getTitle());
                 tuningTableView.displayTable(iniFileModel, table.getTableId(), workingImage);
+                tuningTableView.setOnEdit(notifyEdit);
                 contentPane.add(tuningTableView.getContent());
             } else {
                 CurveModel curve = iniFileModel.getCurves().get(key);
                 if (curve != null) {
                     contentPane.setLayout(new BoxLayout(contentPane, BoxLayout.Y_AXIS));
                     CurveWidget curveWidget = new CurveWidget(curve, iniFileModel, workingImage);
+                    curveWidget.setOnEdit(notifyEdit);
                     contentPane.add(curveWidget.getContentPane());
                 }
             }
@@ -137,6 +141,7 @@ public class CalibrationDialogWidget {
 
     private void fillPanel(JPanel container, DialogModel dialogModel, IniFileModel iniFileModel, ConfigurationImage ci) {
         Runnable onChange = this::refreshExpressions;
+        Runnable notifyEdit = () -> { if (onConfigChange != null) onConfigChange.accept(workingImage); };
 
         for (DialogModel.Field field : dialogModel.getFields()) {
             JPanel row;
@@ -187,6 +192,7 @@ public class CalibrationDialogWidget {
             CurveModel curve = iniFileModel.getCurves().get(panel.getPanelName());
             if (curve != null) {
                 CurveWidget curveWidget = new CurveWidget(curve, iniFileModel, workingImage);
+                curveWidget.setOnEdit(notifyEdit);
                 JComponent content = curveWidget.getContentPane();
                 CalibrationFieldFactory.applyStyle(content);
                 content.setAlignmentX(Component.LEFT_ALIGNMENT);
@@ -198,6 +204,7 @@ public class CalibrationDialogWidget {
             if (table != null) {
                 TuningTableView tuningTableView = new TuningTableView(table.getTitle());
                 tuningTableView.displayTable(iniFileModel, table.getTableId(), workingImage);
+                tuningTableView.setOnEdit(notifyEdit);
                 JComponent content = tuningTableView.getContent();
                 CalibrationFieldFactory.applyStyle(content);
                 content.setAlignmentX(Component.LEFT_ALIGNMENT);

--- a/java_console/ui/src/main/java/com/rusefi/ui/widgets/tune/CurveWidget.java
+++ b/java_console/ui/src/main/java/com/rusefi/ui/widgets/tune/CurveWidget.java
@@ -46,6 +46,7 @@ public class CurveWidget {
     private ConfigurationImage imageTarget;
     private ArrayIniField xBinsField;
     private ArrayIniField yBinsField;
+    private Runnable onEdit;
 
     public CurveWidget(CurveModel curveModel, IniFileModel iniFileModel, ConfigurationImage ci) {
         table.getTableHeader().setReorderingAllowed(false);
@@ -91,6 +92,10 @@ public class CurveWidget {
         table.setModel(new CurveTableModel());
         content.revalidate();
         content.repaint();
+    }
+
+    public void setOnEdit(Runnable onEdit) {
+        this.onEdit = onEdit;
     }
 
     private void writeBackToImage() {
@@ -149,6 +154,7 @@ public class CurveWidget {
         private Double[] y;
 
         private Integer draggingIndex = null;
+        private boolean dragged = false;
 
         public CurveCanvas() {
             setBackground(Color.BLACK);
@@ -156,20 +162,26 @@ public class CurveWidget {
                 @Override
                 public void mousePressed(MouseEvent e) {
                     draggingIndex = findIndex(e.getPoint());
+                    dragged = false;
                 }
 
                 @Override
                 public void mouseReleased(MouseEvent e) {
+                    if (dragged) {
+                        writeBackToImage();
+                        if (onEdit != null) onEdit.run();
+                    }
                     draggingIndex = null;
+                    dragged = false;
                 }
 
                 @Override
                 public void mouseDragged(MouseEvent e) {
                     if (draggingIndex != null) {
                         updatePoint(draggingIndex, e.getPoint());
+                        dragged = true;
                         repaint();
                         table.repaint();
-                        writeBackToImage();
                     }
                 }
             };
@@ -374,6 +386,7 @@ public class CurveWidget {
                 fireTableCellUpdated(rowIndex, columnIndex);
                 canvas.repaint();
                 writeBackToImage();
+                if (onEdit != null) onEdit.run();
             } catch (NumberFormatException ignored) {}
         }
     }

--- a/java_console/ui/src/main/java/com/rusefi/ui/widgets/tune/TuningTableView.java
+++ b/java_console/ui/src/main/java/com/rusefi/ui/widgets/tune/TuningTableView.java
@@ -28,6 +28,7 @@ public class TuningTableView {
     private double maxValue = -Double.MAX_VALUE;
     private ConfigurationImage imageTarget;
     private ArrayIniField zBinsField;
+    private Runnable onEdit;
 
     public TuningTableView(String title) {
         this(title, false);
@@ -154,9 +155,14 @@ public class TuningTableView {
         surface3DView.setData(model.data, model.xBins, model.yBins, minValue, maxValue);
     }
 
+    public void setOnEdit(Runnable onEdit) {
+        this.onEdit = onEdit;
+    }
+
     private void writeBackZBins(TuningTableModel model) {
         if (imageTarget == null || zBinsField == null) return;
         ConfigurationImageGetterSetter.setArrayValues(zBinsField, imageTarget, model.data);
+        if (onEdit != null) onEdit.run();
     }
 
     private void applyDelta(JTextField deltaField, int sign) {


### PR DESCRIPTION
related #9100 

baseline:
<img width="984" height="383" alt="image" src="https://github.com/user-attachments/assets/0a86b05e-4a8b-4e21-b9e1-b1d2ca075e2b" />
make 2 edits on the table:
<img width="824" height="277" alt="image" src="https://github.com/user-attachments/assets/faaa1a70-6c96-431d-8274-5bf7332eae34" />
undo once:
<img width="864" height="317" alt="image" src="https://github.com/user-attachments/assets/aa12f6e5-61da-492c-b4e1-edf19050520d" />
use discard changes button:
<img width="874" height="323" alt="image" src="https://github.com/user-attachments/assets/babc8175-1b37-4f66-a234-b2236d11bef3" />
