### PR TITLE
ISensorHolder: include label variables in indicator evaluations and context

### DIFF
--- a/java_console/io/src/main/java/com/rusefi/core/ISensorHolder.java
+++ b/java_console/io/src/main/java/com/rusefi/core/ISensorHolder.java
@@ -98,15 +98,22 @@ public interface ISensorHolder {
 
         // Third pass: read output channels referenced by any indicator (front-page or dialog
         // indicatorPanels) that were not already covered by a gauge definition.
+        // Include label variables so bitStringValue() index args (e.g. fuelCutReason) are fetched.
         Set<String> indicatorVars = new HashSet<>();
         FrontPageModel frontPage = ini.getFrontPage();
         if (frontPage != null) {
-            for (IndicatorModel indicator : frontPage.getIndicators())
+            for (IndicatorModel indicator : frontPage.getIndicators()) {
                 indicatorVars.addAll(ExpressionEvaluator.extractVariables(indicator.getExpression()));
+                indicatorVars.addAll(ExpressionEvaluator.extractVariables(indicator.getOnLabel()));
+                indicatorVars.addAll(ExpressionEvaluator.extractVariables(indicator.getOffLabel()));
+            }
         }
         for (DialogModel dialog : ini.getDialogs().values()) {
-            for (IndicatorModel indicator : dialog.getIndicators())
+            for (IndicatorModel indicator : dialog.getIndicators()) {
                 indicatorVars.addAll(ExpressionEvaluator.extractVariables(indicator.getExpression()));
+                indicatorVars.addAll(ExpressionEvaluator.extractVariables(indicator.getOnLabel()));
+                indicatorVars.addAll(ExpressionEvaluator.extractVariables(indicator.getOffLabel()));
+            }
         }
         for (String varName : indicatorVars) {
             if (!outputChannelValues.containsKey(varName)) {

--- a/java_console/ui/src/main/java/com/rusefi/ui/widgets/tune/CalibrationDialogWidget.java
+++ b/java_console/ui/src/main/java/com/rusefi/ui/widgets/tune/CalibrationDialogWidget.java
@@ -7,6 +7,7 @@ import com.opensr5.ini.ExpressionEvaluator;
 import com.opensr5.ini.GaugeModel;
 import com.opensr5.ini.IndicatorModel;
 import com.opensr5.ini.IniFileModel;
+import com.opensr5.ini.TsStringFunction;
 import com.opensr5.ini.ReadoutModel;
 import com.opensr5.ini.PanelModel;
 import com.opensr5.ini.TableModel;
@@ -421,7 +422,11 @@ public class CalibrationDialogWidget {
 
     private static void applyIndicatorState(JLabel label, IndicatorModel indicator, IniFileModel ini, ConfigurationImage ci) {
         // Build evaluation context: config image fields first, then live sensor/output-channel values.
-        Set<String> vars = ExpressionEvaluator.extractVariables(indicator.getExpression());
+        // Include variables from the labels so bitStringValue() index args are resolved.
+        Set<String> vars = new HashSet<>();
+        vars.addAll(ExpressionEvaluator.extractVariables(indicator.getExpression()));
+        vars.addAll(ExpressionEvaluator.extractVariables(indicator.getOnLabel()));
+        vars.addAll(ExpressionEvaluator.extractVariables(indicator.getOffLabel()));
         Map<String, Double> context = new HashMap<>();
         for (String var : vars) {
             Optional<IniField> field = ini.findIniField(var);
@@ -434,15 +439,24 @@ public class CalibrationDialogWidget {
         }
         Boolean active = ExpressionEvaluator.evaluateBooleanExpression(indicator.getExpression(), context);
         if (Boolean.TRUE.equals(active)) {
-            label.setText(stripBraces(indicator.getOnLabel()));
+            label.setText(resolveLabel(indicator.getOnLabel(), ini, context));
             label.setBackground(parseDialogIndicatorColor(indicator.getOnBg()));
             label.setForeground(parseDialogIndicatorColor(indicator.getOnFg()));
         } else {
-            String offText = stripBraces(indicator.getOffLabel());
+            String offText = resolveLabel(indicator.getOffLabel(), ini, context);
             label.setText(offText.isEmpty() ? " " : offText);
             label.setBackground(parseDialogIndicatorColor(indicator.getOffBg()));
             label.setForeground(parseDialogIndicatorColor(indicator.getOffFg()));
         }
+    }
+
+    private static String resolveLabel(String label, IniFileModel ini, Map<String, Double> context) {
+        if (label == null) return "";
+        if (TsStringFunction.containsStringFunction(label)) {
+            String resolved = TsStringFunction.resolve(label, ini, null, context);
+            return resolved != null ? resolved : "";
+        }
+        return stripBraces(label);
     }
 
     private static String stripBraces(String s) {


### PR DESCRIPTION
related #9194

<img width="1258" height="890" alt="image" src="https://github.com/user-attachments/assets/5339f11d-b4ee-4072-98cf-1298f6f6f79f" />
<img width="417" height="172" alt="image" src="https://github.com/user-attachments/assets/3931e28e-321b-46ee-ba9c-f3f973ff6694" />

I need to add the gauges inside panels, and we're relatively close to being able to interpret and display every part of the .ini file :D