### PR TITLE
ConfigField: fix prefix handling for iterated structs

### DIFF
--- a/java_tools/configuration_definition/src/test/java/com/rusefi/test/OutputsTest.java
+++ b/java_tools/configuration_definition/src/test/java/com/rusefi/test/OutputsTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
 
 import static com.rusefi.AssertCompatibility.assertEquals;
 import static com.rusefi.AssertCompatibility.assertThrows;
+import static com.rusefi.AssertCompatibility.assertTrue;
 
 public class OutputsTest {
     @Test
@@ -192,6 +193,23 @@ public class OutputsTest {
 "\ttriggerSimulatorPins1 = \"Each rusEFI piece can provide synthetic trigger signal for external ECU. Sometimes these wires are routed back into trigger inputs of the same rusEFI board.\\nSee also directSelfStimulation which is different. 1\"\n" +
         "\ttriggerSimulatorPins2 = \"Each rusEFI piece can provide synthetic trigger signal for external ECU. Sometimes these wires are routed back into trigger inputs of the same rusEFI board.\\nSee also directSelfStimulation which is different. 2\"\n" +
         "\ttriggerSimulatorPins3 = \"Each rusEFI piece can provide synthetic trigger signal for external ECU. Sometimes these wires are routed back into trigger inputs of the same rusEFI board.\\nSee also directSelfStimulation which is different. 3\"\n", tsProjectConsumer.getSettingContextHelpForUnitTest());
+    }
+
+    @Test
+    public void iteratedStructNoPrefixUniqueNames() {
+        ReaderStateImpl state = new ReaderStateImpl();
+        String test = "struct_no_prefix acc_s\n" +
+                "uint8_t acc_max;Max accumulator value;\"\", 1, 0, 0, 255, 0\n" +
+                "end_struct\n" +
+                "struct total\n" +
+                "acc_s[3 iterate] accumulators;Accumulators\n" +
+                "end_struct\n";
+        TestTSProjectConsumer tsProjectConsumer = new TestTSProjectConsumer(state);
+        state.readBufferedReader(test, tsProjectConsumer);
+        String content = tsProjectConsumer.getContent();
+        assertTrue("Expected accumulators1_acc_max but got: " + content, content.contains("accumulators1_acc_max"));
+        assertTrue("Expected accumulators2_acc_max but got: " + content, content.contains("accumulators2_acc_max"));
+        assertTrue("Expected accumulators3_acc_max but got: " + content, content.contains("accumulators3_acc_max"));
     }
 
     @Test

--- a/java_tools/configuration_definition_base/src/main/java/com/rusefi/output/FragmentDialogConsumer.java
+++ b/java_tools/configuration_definition_base/src/main/java/com/rusefi/output/FragmentDialogConsumer.java
@@ -38,7 +38,7 @@ public class FragmentDialogConsumer implements ConfigurationConsumer {
 
                 ConfigStructure cs = configField.getStructureType();
                 if (cs != null) {
-                    String extraPrefix = cs.isWithPrefix() ? configField.getName() + "_" : "";
+                    String extraPrefix = (cs.isWithPrefix() || configField.isFromIterate()) ? configField.getName() + "_" : "";
                     return writeFields(cs.getTsFields(), prefix + extraPrefix, tsPosition);
                 }
 

--- a/java_tools/configuration_definition_base/src/main/java/com/rusefi/output/TsOutput.java
+++ b/java_tools/configuration_definition_base/src/main/java/com/rusefi/output/TsOutput.java
@@ -140,7 +140,9 @@ public class TsOutput {
                 }
 
                 if (cs != null) {
-                    String extraPrefix = cs.isWithPrefix() ? configField.getName() + "_" : "";
+                    // For iterated structs, always include the field name (which carries the index) as prefix
+                    // even if the struct is struct_no_prefix, to avoid duplicate field names across iterations.
+                    String extraPrefix = (cs.isWithPrefix() || configField.isFromIterate()) ? configField.getName() + "_" : "";
                     return writeFields(cs.getTsFields(), prefix + extraPrefix, tsPosition);
                 }
 


### PR DESCRIPTION
before:

```
rotationalIdleController_accumulators_adder = scalar, U08, 4028, "", 1, 0, 0, 100, 0
rotationalIdleController_accumulators_max = scalar, U08, 4029, "", 1, 0, 0, 255, 0
rotationalIdleController_accumulators_offset = scalar, U08, 4030, "", 1, 0, 0, 100, 0
rotationalIdleController_accumulators_adder = scalar, U08, 4032, "", 1, 0, 0, 100, 0
rotationalIdleController_accumulators_max = scalar, U08, 4033, "", 1, 0, 0, 255, 0
rotationalIdleController_accumulators_offset = scalar, U08, 4034, "", 1, 0, 0, 100, 0
rotationalIdleController_accumulators_adder = scalar, U08, 4036, "", 1, 0, 0, 100, 0
rotationalIdleController_accumulators_max = scalar, U08, 4037, "", 1, 0, 0, 255, 0
rotationalIdleController_accumulators_offset = scalar, U08, 4038, "", 1, 0, 0, 100, 0
``` 

now:

```
rotationalIdleController_accumulators1_acc_adder = scalar, U08, 4016, "", 1, 0, 0, 100, 0
rotationalIdleController_accumulators1_acc_max = scalar, U08, 4017, "", 1, 0, 0, 255, 0
rotationalIdleController_accumulators1_acc_offset = scalar, U08, 4018, "", 1, 0, 0, 100, 0
rotationalIdleController_accumulators2_acc_adder = scalar, U08, 4020, "", 1, 0, 0, 100, 0
rotationalIdleController_accumulators2_acc_max = scalar, U08, 4021, "", 1, 0, 0, 255, 0
rotationalIdleController_accumulators2_acc_offset = scalar, U08, 4022, "", 1, 0, 0, 100, 0
rotationalIdleController_accumulators3_acc_adder = scalar, U08, 4024, "", 1, 0, 0, 100, 0
rotationalIdleController_accumulators3_acc_max = scalar, U08, 4025, "", 1, 0, 0, 255, 0
rotationalIdleController_accumulators3_acc_offset = scalar, U08, 4026, "", 1, 0, 0, 100, 0

``` 