### PR TITLE
Fix gcc warnings

### DIFF
--- a/firmware/bootloader/bootloader_stubs.cpp
+++ b/firmware/bootloader/bootloader_stubs.cpp
@@ -13,7 +13,7 @@ void chDbgPanic3(const char* /*msg*/, const char* /*file*/, int /*line*/) {
 }
 
 extern "C" {
-void logHardFault(uint32_t type, uintptr_t faultAddress, void* sp, struct port_extctx* ctx, uint32_t csfr) { }
+void logHardFault(uint32_t /*type*/, uintptr_t /*faultAddress*/, void* /*sp*/, struct port_extctx* /*ctx*/, uint32_t /*csfr*/) { }
 }
 
 void setPinConfigurationOverrides() { }

--- a/firmware/bootloader/openblt_chibios/openblt_usb.cpp
+++ b/firmware/bootloader/openblt_chibios/openblt_usb.cpp
@@ -46,7 +46,7 @@ void Rs232TransmitPacket(blt_int8u *data, blt_int8u len)
   usb_serial_flush();
 } /*** end of Rs232TransmitPacket ***/
 
-PUBLIC_API_WEAK void openBltUnexpectedByte(blt_int8u firstByte) {
+PUBLIC_API_WEAK void openBltUnexpectedByte([[maybe_unused]] blt_int8u firstByte) {
 #if defined(OPEN_BLT_TEST_COMMAND)
 // 'z' is right at the end of 128 ascii range
 static_assert(BOOT_COM_RS232_RX_MAX_DATA < 'z');

--- a/firmware/console/binary/tunerstudio.cpp
+++ b/firmware/console/binary/tunerstudio.cpp
@@ -159,7 +159,7 @@ static void setTsSpeed(int value) {
 	printTsStats();
 }
 
-void tunerStudioDebug(TsChannelBase* tsChannel, const char *msg) {
+void tunerStudioDebug([[maybe_unused]] TsChannelBase* tsChannel, [[maybe_unused]] const char *msg) {
 #if EFI_TUNER_STUDIO_VERBOSE
 	efiPrintf("%s: %s", tsChannel->name, msg);
 #endif /* EFI_TUNER_STUDIO_VERBOSE */

--- a/firmware/console/binary/tunerstudio_io_serial.cpp
+++ b/firmware/console/binary/tunerstudio_io_serial.cpp
@@ -6,7 +6,7 @@
 
 #if defined(TS_PRIMARY_UxART_PORT) || defined(TS_SECONDARY_UxART_PORT)
 #if HAL_USE_SERIAL
-void SerialTsChannel::start(uint32_t baud) {
+void SerialTsChannel::start([[maybe_unused]] uint32_t baud) {
 	SerialConfig cfg = {
 		#if EFI_PROD_CODE
 			.speed = baud,

--- a/firmware/controllers/actuators/electronic_throttle.cpp
+++ b/firmware/controllers/actuators/electronic_throttle.cpp
@@ -1100,6 +1100,7 @@ const electronic_throttle_s* getLiveData(size_t idx) {
 
 	return etbControllers[idx];
 #else
+	UNUSED(idx);
 	return nullptr;
 #endif
 }

--- a/firmware/controllers/algo/engine_type_impl.cpp
+++ b/firmware/controllers/algo/engine_type_impl.cpp
@@ -50,11 +50,11 @@ static_assert(libPROTEUS_STIM_QC == (int)engine_type_e::PROTEUS_STIM_QC);
 static_assert(libHELLEN_2CHAN_STIM_QC == (int)engine_type_e::HELLEN_2CHAN_STIM_QC);
 static_assert(libHELLEN_4CHAN_STIM_QC == (int)engine_type_e::HELLEN_4CHAN_STIM_QC);
 
-void applyUnknownEngineType(engine_type_e engineType) {
+void applyUnknownEngineType(engine_type_e /*engineType*/) {
 		// placeholder
 }
 
-void boardAfterTuneDefaults(engine_type_e engineType) {
+void boardAfterTuneDefaults(engine_type_e /*engineType*/) {
   // placeholder
 }
 

--- a/firmware/controllers/algo/fuel_math.cpp
+++ b/firmware/controllers/algo/fuel_math.cpp
@@ -448,7 +448,7 @@ float getBaroCorrection() {
 	}
 }
 
-percent_t getFuelALSCorrection(float rpm) {
+percent_t getFuelALSCorrection([[maybe_unused]] float rpm) {
 #if EFI_ANTILAG_SYSTEM
 		if (engine->antilagController.isAntilagCondition) {
 			float throttleIntent = Sensor::getOrZero(SensorType::DriverThrottleIntent);

--- a/firmware/controllers/algo/shift_torque_reduction_controller.cpp
+++ b/firmware/controllers/algo/shift_torque_reduction_controller.cpp
@@ -95,10 +95,10 @@ static bool isShiftTorqueBelowTemperatureThreshold() {
 
 // todo: rename method since we now check temperature not just pin state
 void ShiftTorqueReductionController::updateTriggerPinState(
-    const switch_input_pin_e pin,
-    const pin_input_mode_e mode,
-    const bool invertPhysicalPin,
-    const bool invalidPinState
+    [[maybe_unused]] const switch_input_pin_e pin,
+    [[maybe_unused]] const pin_input_mode_e mode,
+    [[maybe_unused]] const bool invertPhysicalPin,
+    [[maybe_unused]] const bool invalidPinState
 ) {
   if (!torqueReductionTriggerPinState) {
     isBelowTemperatureThreshold = isShiftTorqueBelowTemperatureThreshold();

--- a/firmware/controllers/algo/transition_events.h
+++ b/firmware/controllers/algo/transition_events.h
@@ -16,7 +16,7 @@ enum class TransitionEvent : char
 	CruiseControl = 6,
 };
 
-inline void onTransitionEvent(TransitionEvent event) {
+inline void onTransitionEvent([[maybe_unused]] TransitionEvent event) {
 #if EFI_PROD_CODE
   engine->outputChannels.transitionEventCode = (int)event;
   engine->outputChannels.transitionEventsCounter++;

--- a/firmware/controllers/bench_test.cpp
+++ b/firmware/controllers/bench_test.cpp
@@ -300,7 +300,7 @@ void fuelPumpBench() {
 	fuelPumpBenchExt(BENCH_FUEL_PUMP_DURATION);
 }
 
-static void vvtValveBench(int vvtIndex) {
+static void vvtValveBench([[maybe_unused]] int vvtIndex) {
 #if EFI_VVT_PID
 	pinbench(BENCH_VVT_DURATION, 100.0, 1, getVvtOutputPin(vvtIndex));
 #endif // EFI_VVT_PID
@@ -666,7 +666,7 @@ static void processCanSetCalibration(const CANRxFrame& frame) {
  * see fields_api.txt for well-known fields
  * see generated_fields_api_header.h for corresponding hashes
  */
-static void processCanRequestCalibration(const CANRxFrame& frame) {
+static void processCanRequestCalibration([[maybe_unused]] const CANRxFrame& frame) {
 #if EFI_LUA_LOOKUP
   int hash = getFourBytesLsb(frame, 2);
   efiPrintf("processCanRequestCalibration=%x", hash);

--- a/firmware/controllers/can/can_bench_test.cpp
+++ b/firmware/controllers/can/can_bench_test.cpp
@@ -97,7 +97,7 @@ static void qcSetEtbState(uint8_t dcIndex, uint8_t direction) {
 }
 
 static void setPin(const CANRxFrame& frame, [[maybe_unused]] int value) {
-		size_t outputIndex = frame.data8[2];
+		int outputIndex = frame.data8[2];
 		if (outputIndex >= getBoardMetaOutputsCount()) {
 		  criticalError("QC pin index %d out of range", outputIndex);
 			return;

--- a/firmware/controllers/can/can_bench_test.cpp
+++ b/firmware/controllers/can/can_bench_test.cpp
@@ -58,7 +58,7 @@ void setHwQcMode() {
 
 #if EFI_CAN_SUPPORT
 
-static void directWritePad(Gpio pin, int value, const char *msg = "") {
+static void directWritePad(Gpio pin, [[maybe_unused]] int value, const char *msg = "") {
   if (!isBrainPinValid(pin)) {
     criticalError("QC of invalid pin %d %s", (int)pin, msg);
     return;
@@ -96,7 +96,7 @@ static void qcSetEtbState(uint8_t dcIndex, uint8_t direction) {
   }
 }
 
-static void setPin(const CANRxFrame& frame, int value) {
+static void setPin(const CANRxFrame& frame, [[maybe_unused]] int value) {
 		size_t outputIndex = frame.data8[2];
 		if (outputIndex >= getBoardMetaOutputsCount()) {
 		  criticalError("QC pin index %d out of range", outputIndex);
@@ -218,7 +218,7 @@ void sendQcBenchRawAnalogValues(size_t bus) {
 	}
 }
 
-static void sendOutBoardMeta(size_t bus) {
+static void sendOutBoardMeta([[maybe_unused]] size_t bus) {
 #if EFI_PROD_CODE
 	CanTxMessage msg(CanCategory::BENCH_TEST, (int)bench_test_packet_ids_e::IO_META_INFO, 8, bus, /*isExtended*/true);
 	msg[0] = (int)bench_test_magic_numbers_e::BENCH_HEADER;
@@ -229,7 +229,7 @@ static void sendOutBoardMeta(size_t bus) {
 #endif // EFI_PROD_CODE
 }
 
-void sendQcBenchBoardStatus(size_t bus) {
+void sendQcBenchBoardStatus([[maybe_unused]] size_t bus) {
 #if EFI_PROD_CODE
 	CanTxMessage msg(CanCategory::BENCH_TEST, (int)bench_test_packet_ids_e::BOARD_STATUS, 8, bus, /*isExtended*/true);
 
@@ -242,7 +242,7 @@ void sendQcBenchBoardStatus(size_t bus) {
 	msg[3] = TRUNCATE_TO_BYTE(numSecondsSinceReset >> 8);
 	msg[4] = TRUNCATE_TO_BYTE(numSecondsSinceReset);
 
-    int engineType = (int) engineConfiguration->engineType;
+	int engineType = (int) engineConfiguration->engineType;
 	msg[5] = engineType >> 8;
 	msg[6] = engineType;
 	sendOutBoardMeta(bus);

--- a/firmware/controllers/can/can_verbose.cpp
+++ b/firmware/controllers/can/can_verbose.cpp
@@ -208,7 +208,7 @@ struct PerCylinderKnock {
 };
 
 void populateFrame(PerCylinderKnock& msg) {
-  for (size_t index = 0;index<std::min(8, MAX_CYLINDER_COUNT);index++) {
+  for (int index = 0; index<std::min(8, MAX_CYLINDER_COUNT); index++) {
 	  msg.knock[index] = engine->module<KnockController>()->m_knockCyl[index];
   }
 }

--- a/firmware/controllers/can/isotp/isotp.cpp
+++ b/firmware/controllers/can/isotp/isotp.cpp
@@ -196,7 +196,7 @@ int CanStreamerState::sendDataTimeout(const uint8_t *txbuf, int numBytes, can_sy
 		return 0;
 
 	// 1 frame
-	if (numBytes <= 7 - isoHeaderByteIndex) {
+	if (numBytes <= 7 - (int)isoHeaderByteIndex) {
 		IsoTpFrameHeader header;
 		header.frameType = ISO_TP_FRAME_SINGLE;
 		header.numBytes = numBytes;
@@ -443,7 +443,7 @@ int IsoTpRx::readTimeout(uint8_t *rxbuf, size_t *size, sysinterval_t timeout)
 		}
 
 		if (isFirstFrame) {
-			if ((buf) && (waitingForNumBytes > availableAtBuffer)) {
+			if ((buf) && (waitingForNumBytes > (int)availableAtBuffer)) {
 				efiPrintf("receive buffer is not enough %d > %d", waitingForNumBytes, availableAtBuffer);
 			}
 			isFirstFrame = false;
@@ -457,7 +457,7 @@ int IsoTpRx::readTimeout(uint8_t *rxbuf, size_t *size, sysinterval_t timeout)
 			availableAtBuffer -= numBytesToCopy;
 
 			// if there are some more bytes left, receive and drop
-			if (numBytesAvailable > numBytesToCopy) {
+			if ((int)numBytesAvailable > numBytesToCopy) {
 				overflow = true;
 			}
 		}

--- a/firmware/controllers/can/isotp/isotp.h
+++ b/firmware/controllers/can/isotp/isotp.h
@@ -204,7 +204,7 @@ public:
 	}
 
 	/* CAN messages entry point */
-	virtual void decodeFrame(const CANRxFrame& frame, efitick_t nowNt)
+	virtual void decodeFrame(const CANRxFrame& frame, [[maybe_unused]] efitick_t nowNt)
 	{
 		if (frame.DLC < 1 + isoHeaderByteIndex) {
 			// invalid++;

--- a/firmware/controllers/core/error_handling.cpp
+++ b/firmware/controllers/core/error_handling.cpp
@@ -666,6 +666,7 @@ static void firmwareErrorV(ObdCode code, const char *fmt, va_list ap) {
 	enginePins.communicationLedPin.setValue(1, /*force*/true);
 #else // EFI_PROD_CODE
 
+	UNUSED(code);
 	// large buffer on stack is risky we better use normal memory
 	static char errorBuffer[200];
 

--- a/firmware/controllers/core/main_loop.cpp
+++ b/firmware/controllers/core/main_loop.cpp
@@ -38,7 +38,7 @@ LoopPeriod MainLoop::makePeriodFlags() {
 	return lp;
 }
 
-void MainLoop::PeriodicTask(efitick_t nowNt) {
+void MainLoop::PeriodicTask([[maybe_unused]] efitick_t nowNt) {
 	ScopePerf perf(PE::MainLoop);
 
 	LoopPeriod currentLoopPeriod = makePeriodFlags();

--- a/firmware/controllers/engine_controller.cpp
+++ b/firmware/controllers/engine_controller.cpp
@@ -209,7 +209,7 @@ void initPeriodicEvents() {
 	fastController.start();
 }
 
-char * getPinNameByAdcChannel(const char *msg, adc_channel_e hwChannel, char *buffer, size_t bufferSize) {
+char * getPinNameByAdcChannel([[maybe_unused]] const char *msg, [[maybe_unused]] adc_channel_e hwChannel, char *buffer, size_t bufferSize) {
 #if HAL_USE_ADC
 	if (!isAdcChannelValid(hwChannel)) {
 		snprintf(buffer, bufferSize, "NONE");

--- a/firmware/controllers/engine_cycle/prime_injection.cpp
+++ b/firmware/controllers/engine_cycle/prime_injection.cpp
@@ -76,7 +76,7 @@ void PrimeController::onIgnitionStateChanged(bool ignitionOn) {
 	setKeyCycleCounter(ignSwitchCounter + 1);
 }
 
-void PrimeController::setKeyCycleCounter(uint32_t count) {
+void PrimeController::setKeyCycleCounter([[maybe_unused]] uint32_t count) {
 #if EFI_BACKUP_SRAM
 	backupRamSave(backup_ram_e::IgnCounter, count);
 #endif // EFI_BACKUP_SRAM

--- a/firmware/controllers/lua/lua_hooks.cpp
+++ b/firmware/controllers/lua/lua_hooks.cpp
@@ -695,7 +695,7 @@ void configureRusefiLuaHooks(lua_State* lState) {
 
 	lua_register(lState, "readPin", lua_readpin);
 #if EFI_PROD_CODE && EFI_SHAFT_POSITION_INPUT
-	lua_register(lState, "startCrankingEngine", [](lua_State* l) {
+	lua_register(lState, "startCrankingEngine", [](lua_State*) {
 		doStartCranking();
 		return 0;
 	});

--- a/firmware/controllers/modules/trip_odometer/trip_odometer.cpp
+++ b/firmware/controllers/modules/trip_odometer/trip_odometer.cpp
@@ -12,7 +12,7 @@ void TripOdometer::reset() {
 	m_ignitionOnSeconds = 0;
 }
 
-void TripOdometer::consumeFuel(float grams, efitick_t nowNt) {
+void TripOdometer::consumeFuel([[maybe_unused]] float grams, [[maybe_unused]] efitick_t nowNt) {
 // we have some drama with simulator busy loop in reality :(
 #if EFI_PROD_CODE || EFI_UNIT_TEST
 	m_consumedRemainder += grams;

--- a/firmware/controllers/settings.cpp
+++ b/firmware/controllers/settings.cpp
@@ -648,7 +648,7 @@ void initSettings() {
 	addConsoleActionF("set_whole_timing_map", setWholeTimingMapCmd);
 #endif // EFI_ENGINE_CONTROL
 
-	addConsoleAction("stopengine", (Void) scheduleStopEngine);
+	addConsoleAction("stopengine", scheduleStopEngine);
 
 	// todo: refactor this - looks like all boolean flags should be controlled with less code duplication
 	addConsoleActionI("enable_spi", enableSpi);
@@ -674,7 +674,7 @@ void initSettings() {
 	addConsoleActionS("bench_setpin", benchSetPin);
 	addConsoleActionS("readpin", readPin);
 	addConsoleAction("hw_qc_mode", [](){
-  	setHwQcMode();
+	setHwQcMode();
   });
 	addConsoleActionS("bench_set_output_mode", [](const char *pinName){
 	  brain_pin_e pin = parseBrainPinWithErrorMessage(pinName);
@@ -705,13 +705,14 @@ void setDateTime(const char * const isoDateTime) {
 	printRtcDateTime();
 	if (strlen(isoDateTime) >= 19 && isoDateTime[10] == 'T') {
 		efidatetime_t dateTime;
-		dateTime.year = atoi(isoDateTime);
+    int32_t year = atoi(isoDateTime);
+		dateTime.year = year;   // may overflow in case of ATOI_ERROR_CODE
 		dateTime.month = atoi(isoDateTime + 5);
 		dateTime.day = atoi(isoDateTime + 8);
 		dateTime.hour = atoi(isoDateTime + 11);
 		dateTime.minute = atoi(isoDateTime + 14);
 		dateTime.second = atoi(isoDateTime + 17);
-		if (dateTime.year != ATOI_ERROR_CODE &&
+		if (year != ATOI_ERROR_CODE &&
 				dateTime.month >= 1 && dateTime.month <= 12 &&
 				dateTime.day >= 1 && dateTime.day <= 31 &&
 				dateTime.hour <= 23 &&

--- a/firmware/controllers/settings.cpp
+++ b/firmware/controllers/settings.cpp
@@ -726,6 +726,7 @@ void setDateTime(const char * const isoDateTime) {
 	}
 	efiPrintf("date_set Date parameter %s is wrong", isoDateTime);
 #else // EFI_RTC
+	UNUSED(isoDateTime);
 	efiPrintf("Cannot set time: RTC not supported");
 #endif // EFI_RTC
 }

--- a/firmware/controllers/system/efi_gpio.h
+++ b/firmware/controllers/system/efi_gpio.h
@@ -32,7 +32,7 @@ public:
 	// 6000 RPM is 100Hz we can fit a few years worth of sparks into 32 bits, right?
 	// 2_000_000_000 / 100 = 20_000_000 seconds = 231 days?
 	// [tag:duration_limit]
-	int signalFallSparkId;
+	uint32_t signalFallSparkId;
 	int8_t coilIndex;
 };
 

--- a/firmware/controllers/system/injection_gpio.cpp
+++ b/firmware/controllers/system/injection_gpio.cpp
@@ -26,7 +26,7 @@ InjectorOutputPin::InjectorOutputPin() : NamedOutputPin() {
 	injectorIndex = -1;
 }
 
-void InjectorOutputPin::open(efitick_t nowNt) {
+void InjectorOutputPin::open([[maybe_unused]] efitick_t nowNt) {
 	// per-output counter for error detection
 	overlappingCounter++;
 	// global counter for logging
@@ -56,7 +56,7 @@ void InjectorOutputPin::open(efitick_t nowNt) {
 	}
 }
 
-void InjectorOutputPin::close(efitick_t nowNt) {
+void InjectorOutputPin::close([[maybe_unused]] efitick_t nowNt) {
 #if FUEL_MATH_EXTREME_LOGGING
 	if (printFuelDebug) {
 		printf("InjectorOutputPin::close %s %d %d\r\n", getName(), overlappingCounter, time2print(getTimeNowUs()));

--- a/firmware/controllers/system/timer/pwm_generator_logic.cpp
+++ b/firmware/controllers/system/timer/pwm_generator_logic.cpp
@@ -156,7 +156,7 @@ void PwmConfig::handleCycleStart() {
 
 	efiAssertVoid(ObdCode::CUSTOM_ERR_6580, periodNt != 0, "period not initialized");
 	efiAssertVoid(ObdCode::CUSTOM_ERR_6580, iterationLimit > 0, "iterationLimit invalid");
-	if (forceCycleStart || safe.periodNt != periodNt || safe.iteration == iterationLimit) {
+	if (forceCycleStart || safe.periodNt != periodNt || (uint32_t)safe.iteration == iterationLimit) {
 		/**
 		 * period length has changed - we need to reset internal state
 		 */

--- a/firmware/controllers/trigger/decoders/trigger_structure.cpp
+++ b/firmware/controllers/trigger/decoders/trigger_structure.cpp
@@ -416,7 +416,7 @@ uint16_t TriggerWaveform::findAngleIndex(TriggerFormDetails *details, angle_t ta
 	return left;
 }
 
-TriggerWheel TriggerWaveform::getWheel(size_t index) {
+TriggerWheel TriggerWaveform::getWheel([[maybe_unused]] size_t index) {
 #if EFI_UNIT_TEST
 	return triggerSignalIndeces[index];
 #endif

--- a/firmware/controllers/trigger/trigger_central.cpp
+++ b/firmware/controllers/trigger/trigger_central.cpp
@@ -232,6 +232,7 @@ static angle_t wrapVvt(angle_t vvtPosition, int period) {
 }
 
 static void logVvtFront(bool useOnlyRise, bool isImportantFront, TriggerValue front, efitick_t nowNt, int index) {
+	UNUSED(nowNt);
 	if (!useOnlyRise || engineConfiguration->displayLogicLevelsInEngineSniffer) {
 		// If we care about both edges OR displayLogicLevel is set, log every front exactly as it is
 		addEngineSnifferVvtEvent(index, front == TriggerValue::RISE ? FrontDirection::UP : FrontDirection::DOWN);

--- a/firmware/controllers/trigger/trigger_decoder.cpp
+++ b/firmware/controllers/trigger/trigger_decoder.cpp
@@ -116,7 +116,7 @@ void TriggerWaveform::initializeSyncPoint(TriggerDecoderBase& state,
 
 void TriggerFormDetails::prepareEventAngles(TriggerWaveform *shape) {
 	int triggerShapeSynchPointIndex = shape->triggerShapeSynchPointIndex;
-	if (triggerShapeSynchPointIndex == EFI_ERROR_CODE) {
+	if (triggerShapeSynchPointIndex == (int)EFI_ERROR_CODE) {
 		return;
 	}
 	angle_t firstAngle = shape->getAngle(triggerShapeSynchPointIndex);

--- a/firmware/development/engine_sniffer.cpp
+++ b/firmware/development/engine_sniffer.cpp
@@ -33,8 +33,8 @@ static char shaft_signal_msg_index[15];
 
 #if EFI_ENGINE_SNIFFER
 #define addEngineSnifferEvent(name, msg) { if (getTriggerCentral()->isEngineSnifferEnabled) { waveChart.addEvent3((name), (msg)); } }
- #else
-#define addEngineSnifferEvent(name, msg) { UNUSED(name); }
+#else
+#define addEngineSnifferEvent(name, msg) { UNUSED(name); UNUSED(msg); }
 #endif /* EFI_ENGINE_SNIFFER */
 
 #if EFI_ENGINE_SNIFFER
@@ -247,7 +247,7 @@ void addEngineSnifferTdcEvent(int rpm) {
 #if EFI_ENGINE_SNIFFER
 	waveChart.startDataCollection();
 #endif
-	addEngineSnifferEvent(TOP_DEAD_CENTER_MESSAGE, (char* ) rpmBuffer);
+	addEngineSnifferEvent(TOP_DEAD_CENTER_MESSAGE, rpmBuffer);
 }
 
 void addEngineSnifferLogicAnalyzerEvent(int laIndex, FrontDirection frontDirection) {
@@ -264,7 +264,7 @@ void addEngineSnifferCrankEvent(int wheelIndex, int triggerEventIndex, FrontDire
 	// shaft_signal_msg_index[1] is assigned once and forever in the init method below
 	itoa10(&shaft_signal_msg_index[2], triggerEventIndex);
 
-	addEngineSnifferEvent(crankName[wheelIndex], (char* ) shaft_signal_msg_index);
+	addEngineSnifferEvent(crankName[wheelIndex], shaft_signal_msg_index);
 }
 
 void addEngineSnifferVvtEvent(int vvtIndex, FrontDirection frontDirection) {

--- a/firmware/development/perf_trace.cpp
+++ b/firmware/development/perf_trace.cpp
@@ -45,7 +45,7 @@ static void stopTrace() {
 	s_nextIdx = 0;
 }
 
-static void perfEventImpl(PE event, EPhase phase) {
+static void perfEventImpl([[maybe_unused]] PE event, [[maybe_unused]] EPhase phase) {
 #if EFI_PROD_CODE
 	// Bail if we aren't allowed to trace
 	if constexpr (!ENABLE_PERF_TRACE) {

--- a/firmware/hw_layer/adc/adc_inputs.cpp
+++ b/firmware/hw_layer/adc/adc_inputs.cpp
@@ -25,7 +25,7 @@ ObdCode PUBLIC_API_WEAK boardGetAnalogDiagnostic() {
 }
 
 /* simple implementation if board does not provide advanced diagnostic */
-int PUBLIC_API_WEAK boardGetAnalogInputDiagnostic(adc_channel_e channel, float) {
+int PUBLIC_API_WEAK boardGetAnalogInputDiagnostic([[maybe_unused]] adc_channel_e channel, float /*voltage*/) {
 #if EFI_PROD_CODE
 	/* for on-chip ADC inputs we check common analog health */
 	if (isAdcChannelOnChip(channel)) {

--- a/firmware/hw_layer/digital_input/trigger/trigger_input_adc.cpp
+++ b/firmware/hw_layer/digital_input/trigger/trigger_input_adc.cpp
@@ -241,13 +241,12 @@ void TriggerAdcDetector::reset() {
 	prevStamp = 0;
 }
 
-void TriggerAdcDetector::digitalCallback(efitick_t stamp, bool isPrimary, bool rise) {
+void TriggerAdcDetector::digitalCallback(
+		[[maybe_unused]] efitick_t stamp, [[maybe_unused]] bool isPrimary, [[maybe_unused]] bool rise) {
 #if !EFI_SIMULATOR && EFI_SHAFT_POSITION_INPUT
 	if (curAdcMode != TRIGGER_ADC_EXTI) {
 		return;
 	}
-
-	UNUSED(isPrimary);
 
 	onTriggerChanged(stamp, isPrimary, rise);
 
@@ -425,7 +424,7 @@ void TriggerAdcDetector::analogCallback(efitick_t stamp, triggerAdcSample_t valu
 #endif // ! EFI_SIMULATOR && ((HAL_TRIGGER_USE_ADC && HAL_USE_ADC) || EFI_UNIT_TEST)
 }
 
-void TriggerAdcDetector::setWeakSignal(bool isWeak) {
+void TriggerAdcDetector::setWeakSignal([[maybe_unused]] bool isWeak) {
 #if HAL_USE_ADC || EFI_UNIT_TEST
 	isSignalWeak = isWeak;
 	if (!isSignalWeak) {

--- a/firmware/hw_layer/drivers/can/can_hw.cpp
+++ b/firmware/hw_layer/drivers/can/can_hw.cpp
@@ -33,7 +33,7 @@ extern const CANConfig *findCanConfig(can_baudrate_e rate);
 // It's impossible to set CAN bitrate from userspace, so we can't set it.
 static const CANConfig canConfig_dummy;
 
-static const CANConfig * findCanConfig(can_baudrate_e rate)
+static const CANConfig * findCanConfig(can_baudrate_e /*rate*/)
 {
 	return &canConfig_dummy;
 }
@@ -193,7 +193,7 @@ void startCanPins() {
 }
 
 // Move to port CAN helpers file
-static void applyListenOnly(CANConfig* canConfig, bool isListenOnly) {
+static void applyListenOnly([[maybe_unused]] CANConfig* canConfig, [[maybe_unused]] bool isListenOnly) {
 #if defined(STM32F4XX) || defined(STM32F7XX)
 	if (isListenOnly) {
 		canConfig->btr |= CAN_BTR_SILM;

--- a/firmware/hw_layer/drivers/i2c/i2c_bb.cpp
+++ b/firmware/hw_layer/drivers/i2c/i2c_bb.cpp
@@ -34,7 +34,7 @@ void BitbangI2c::scl_low() {
 #endif
 }
 
-bool BitbangI2c::init(brain_pin_e scl, brain_pin_e sda) {
+bool BitbangI2c::init([[maybe_unused]] brain_pin_e scl, [[maybe_unused]] brain_pin_e sda) {
 #if EFI_PROD_CODE
 	if (m_sdaPort) {
 	    return false;

--- a/firmware/hw_layer/io_pins.cpp
+++ b/firmware/hw_layer/io_pins.cpp
@@ -77,7 +77,9 @@ void efiSetPadModeWithoutOwnershipAcquisition(const char *msg, brain_pin_e brain
 		}
 	#endif
 
-#endif /* EFI_PROD_CODE */
+#else /* EFI_PROD_CODE */
+	UNUSED(msg); UNUSED(brainPin); UNUSED(mode);
+#endif
 }
 
 #if EFI_PROD_CODE

--- a/firmware/hw_layer/pin_repository.cpp
+++ b/firmware/hw_layer/pin_repository.cpp
@@ -311,9 +311,7 @@ void gpio_pin_markUnused(ioportid_t port, ioportmask_t pin) {
 }
 
 const char *getPinFunction(brain_input_pin_e brainPin) {
-	int index;
-
-	index = brainPin_to_index(brainPin);
+	int index = brainPin_to_index(brainPin);
 	if (index < 0)
 		return NULL;
 
@@ -321,10 +319,11 @@ const char *getPinFunction(brain_input_pin_e brainPin) {
 }
 #else
 const char *hwPhysicalPinName(Gpio brainPin) {
+	UNUSED(brainPin);
 	return "N/A";
 }
 const char *hwPortname(Gpio brainPin) {
-	(void)brainPin;
+	UNUSED(brainPin);
 	return "N/A";
 }
 #endif /* EFI_PROD_CODE */

--- a/firmware/hw_layer/ports/stm32/backup_ram.cpp
+++ b/firmware/hw_layer/ports/stm32/backup_ram.cpp
@@ -6,7 +6,7 @@
 
 #include "backup_ram.h"
 
-uint32_t backupRamLoad(backup_ram_e idx) {
+uint32_t backupRamLoad([[maybe_unused]] backup_ram_e idx) {
 #if HAL_USE_RTC
 	switch (idx) {
 	case backup_ram_e::StepperPosition:
@@ -22,7 +22,7 @@ uint32_t backupRamLoad(backup_ram_e idx) {
 #endif /* HAL_USE_RTC */
 }
 
-void backupRamSave(backup_ram_e idx, uint32_t value) {
+void backupRamSave([[maybe_unused]] backup_ram_e idx, [[maybe_unused]] uint32_t value) {
 #if HAL_USE_RTC
 	switch (idx) {
 	case backup_ram_e::StepperPosition:

--- a/firmware/hw_layer/ports/stm32/stm32_can.cpp
+++ b/firmware/hw_layer/ports/stm32/stm32_can.cpp
@@ -417,7 +417,7 @@ void canHwInfo(CANDriver* cand) {
 #endif
 }
 
-void canHwRecover(const size_t busIndex, CANDriver *cand)
+void canHwRecover([[maybe_unused]] const size_t busIndex, [[maybe_unused]] CANDriver *cand)
 {
 #if STM32_CAN_USE_FDCAN1 || STM32_CAN_USE_FDCAN2 || STM32_CAN_USE_FDCAN3
 	// equal to TIMEOUT_INIT_MS

--- a/firmware/hw_layer/ports/stm32/stm32_common.cpp
+++ b/firmware/hw_layer/ports/stm32/stm32_common.cpp
@@ -36,7 +36,8 @@ extern "C" {
 #define ALLOW_JUMP_WITH_IGNITION_VOLTAGE TRUE
 #endif
 
-static void reset_and_jump(void) {
+[[maybe_unused]]
+static void reset_and_jump() {
 #if !ALLOW_JUMP_WITH_IGNITION_VOLTAGE
   if (isIgnVoltage()) {
     criticalError("Not allowed with ignition power");
@@ -119,7 +120,7 @@ BOR_Result_t BOR_Set(BOR_Level_t BORValue) {
 	return BOR_Result_Ok;
 }
 
-void startWatchdog(int timeoutMs) {
+void startWatchdog([[maybe_unused]] int timeoutMs) {
 #if HAL_USE_WDG
 	// RL is a 12-bit value so we use a "2 ms" prescaler to support long timeouts (> 4.095 sec)
 	static WDGConfig wdgcfg;

--- a/firmware/hw_layer/stepper.cpp
+++ b/firmware/hw_layer/stepper.cpp
@@ -32,7 +32,7 @@ void StepperMotorBase::initialize(StepperHw *hardware, int totalSteps) {
 // todo: EFI_STEPPER macro
 #if EFI_PROD_CODE || EFI_SIMULATOR
 
-void StepperMotorBase::saveStepperPos(int pos) {
+void StepperMotorBase::saveStepperPos([[maybe_unused]] int pos) {
 	// use backup-power RTC registers to store the data
 #if EFI_PROD_CODE && EFI_BACKUP_SRAM
 	backupRamSave(backup_ram_e::StepperPosition, pos + 1);

--- a/firmware/init/sensor/init_flex.cpp
+++ b/firmware/init/sensor/init_flex.cpp
@@ -19,7 +19,7 @@ static void flexExtiCallback(void*, efitick_t nowNt) {
 
 // https://rusefi.com/forum/viewtopic.php?p=37452#p37452
 
-void initFlexSensor(bool isFirstTime) {
+void initFlexSensor([[maybe_unused]] bool isFirstTime) {
 #if EFI_PROD_CODE
 	if (efiExtiEnablePin("flex", engineConfiguration->flexSensorPin,
 		PAL_EVENT_MODE_BOTH_EDGES, flexExtiCallback, nullptr) < 0) {

--- a/firmware/init/sensor/init_sensors.cpp
+++ b/firmware/init/sensor/init_sensors.cpp
@@ -11,7 +11,7 @@
 
 static void initSensorCli();
 
-void initIfValid(const char* msg, adc_channel_e channel) {
+void initIfValid([[maybe_unused]] const char* msg, adc_channel_e channel) {
 	if (!isAdcChannelValid(channel)) {
 		return;
 	}
@@ -30,7 +30,7 @@ TODO: this code is similar to AdcSubscription::SubscribeSensor, what is the plan
 #endif // EFI_PROD_CODE && HAL_USE_ADC
 }
 
-void deInitIfValid(const char* msg, adc_channel_e channel) {
+void deInitIfValid([[maybe_unused]] const char* msg, adc_channel_e channel) {
 	if (!isAdcChannelValid(channel)) {
 		return;
 	}

--- a/firmware/util/efitime.h
+++ b/firmware/util/efitime.h
@@ -30,6 +30,7 @@ constexpr bool constexpr_isfinite(float f) {
   return std::isfinite(f);
 #elif defined(_WIN32) || defined(__APPLE__) || defined(__CYGWIN__) || defined(__MINGW32__) || defined(__MINGW64__)
   // On Windows and macOS, std::isfinite might not be constexpr pre-C++23
+  (void)f;
   return true;
 #else
   // This is meant to correspond to normal/target platforms


### PR DESCRIPTION
a set of evident fixes to remove annoying red words from compiler's output