### PR TITLE
add PulseWidthSensor for PWM duty cycle input

### DIFF
--- a/firmware/controllers/sensors/pulse_width_sensor.cpp
+++ b/firmware/controllers/sensors/pulse_width_sensor.cpp
@@ -1,0 +1,118 @@
+/**
+ * @file pulse_width_sensor.cpp
+ *
+ * Captures duty cycle from a fixed-frequency PWM signal using EXTI interrupts on
+ * both edges.  The duty cycle [0, 1] is passed through a SensorConverter so callers
+ * can linearise it to any physical unit.
+ *
+ * Both "always-low" (no edges) and "always-high" (rising but never falling) failure
+ * modes result in no valid readings being posted, which causes FunctionalSensor's
+ * built-in timeout to invalidate the sensor automatically.
+ */
+
+#include "pch.h"
+
+#include "pulse_width_sensor.h"
+
+#if EFI_PROD_CODE
+#include "digital_input_exti.h"
+
+static void pulseWidthSensorExtiCallback(void* arg, efitick_t nowNt) {
+	reinterpret_cast<PulseWidthSensor*>(arg)->onEdge(nowNt);
+}
+#endif // EFI_PROD_CODE
+
+void PulseWidthSensor::initIfValid(brain_pin_e pin, SensorConverter &converter) {
+	if (!isBrainPinValid(pin)) {
+		return;
+	}
+
+	setFunction(converter);
+
+#if EFI_PROD_CODE
+	if (efiExtiEnablePin(getSensorName(), pin, PAL_EVENT_MODE_BOTH_EDGES,
+			pulseWidthSensorExtiCallback, reinterpret_cast<void*>(this)) < 0) {
+		return;
+	}
+#endif // EFI_PROD_CODE
+
+	m_pin = pin;
+
+	Register();
+}
+
+void PulseWidthSensor::deInit() {
+	if (!isBrainPinValid(m_pin)) {
+		return;
+	}
+
+#if EFI_PROD_CODE
+	efiExtiDisablePin(m_pin);
+#endif
+
+	m_pin = Gpio::Unassigned;
+}
+
+void PulseWidthSensor::onEdge(efitick_t nowNt) {
+	eventCounter++;
+
+#if EFI_PROD_CODE
+	bool isHigh = efiReadPin(m_pin);
+#else
+	// In simulator / unit-test builds the real pin cannot be read; track the
+	// edge direction with a simple toggle so tests can drive onEdge() manually.
+	m_lastWasHigh = !m_lastWasHigh;
+	bool isHigh = m_lastWasHigh;
+#endif
+
+	if (isHigh) {
+		// ---- Rising edge -------------------------------------------------------
+		// Capture the period from the previous rising edge (= full signal period).
+		// On the very first edge we just initialise the timer and wait for the next
+		// cycle before we trust the period value.
+		if (m_seenRisingEdge) {
+			m_lastPeriodSec = m_periodTimer.getElapsedSecondsAndReset(nowNt);
+		} else {
+			m_periodTimer.reset(nowNt);
+			m_seenRisingEdge = true;
+		}
+
+		// Begin timing the high portion of the pulse
+		m_pulseWidthTimer.reset(nowNt);
+	} else {
+		// ---- Falling edge -------------------------------------------------------
+		if (!m_seenRisingEdge) {
+			// Signal started low before we saw the first rising edge – ignore.
+			return;
+		}
+
+		float pulseWidthSec = m_pulseWidthTimer.getElapsedSeconds(nowNt);
+		float periodSec     = m_lastPeriodSec;
+
+		// Require at least one complete cycle to have elapsed (period > 0) and
+		// that the period falls within the configured frequency window.
+		if (periodSec <= 0.0f
+		    || periodSec < m_minPeriodSec
+		    || periodSec > m_maxPeriodSec) {
+			// Frequency out of range or no previous rising edge yet – discard this
+			// reading but keep the timers running so we recover automatically.
+			return;
+		}
+
+		// Duty cycle is defined as high-time / period.
+		float dutyCycle = pulseWidthSec / periodSec;
+
+		// Clamp to [0, 1] to absorb jitter at the extremes.
+		dutyCycle = clampF(0.0f, dutyCycle, 1.0f);
+
+		postRawValue(dutyCycle, nowNt);
+	}
+}
+
+void PulseWidthSensor::showInfo(const char* sensorName) const {
+	efiPrintf("PWM duty sensor \"%s\": pin=%s events=%d lastPeriod=%.4fs",
+	          sensorName,
+	          hwPortname(m_pin),
+	          eventCounter,
+	          m_lastPeriodSec);
+}

--- a/firmware/controllers/sensors/pulse_width_sensor.h
+++ b/firmware/controllers/sensors/pulse_width_sensor.h
@@ -1,0 +1,85 @@
+/**
+ * @file pulse_width_sensor.h
+ *
+ * Sensor that reads duty cycle from a fixed-frequency PWM signal (e.g. 100–200 Hz).
+ * The raw value posted to the FunctionalSensor pipeline is the duty cycle in the
+ * range [0, 1]. A SensorConverter then maps it to the desired physical quantity.
+ *
+ * Failure modes handled:
+ *  - Signal always LOW  – no edges arrive, FunctionalSensor timeout invalidates the sensor.
+ *  - Signal always HIGH – a rising edge is recorded but no falling edge follows within
+ *                         the expected period window, so no valid reading is ever posted
+ *                         and the FunctionalSensor timeout invalidates the sensor.
+ *  - Frequency out of range – readings from cycles whose period falls outside
+ *                              [minFreqHz, maxFreqHz] are silently discarded.
+ */
+#pragma once
+
+#include "functional_sensor.h"
+#include <rusefi/timer.h>
+
+class PulseWidthSensor : public FunctionalSensor {
+public:
+	/**
+	 * @param type          sensor type
+	 * @param timeoutPeriod how long without a valid reading before the sensor is
+	 *                      considered failed (passed straight to FunctionalSensor)
+	 * @param minFreqHz     minimum expected signal frequency [Hz] – cycles slower than
+	 *                      this are discarded as out-of-range
+	 * @param maxFreqHz     maximum expected signal frequency [Hz] – cycles faster than
+	 *                      this are discarded as out-of-range
+	 */
+	PulseWidthSensor(SensorType type, efidur_t timeoutPeriod,
+	                 float minFreqHz = 50.0f, float maxFreqHz = 500.0f)
+		: FunctionalSensor(type, timeoutPeriod)
+		, m_minPeriodSec(1.0f / maxFreqHz)
+		, m_maxPeriodSec(1.0f / minFreqHz)
+	{ }
+
+	/**
+	 * Configure and register the sensor. Does nothing if @p pin is not valid.
+	 *
+	 * @param pin       brain pin wired to the PWM signal
+	 * @param converter maps raw duty cycle (0–1) to the physical sensor value
+	 */
+	void initIfValid(brain_pin_e pin, SensorConverter &converter);
+
+	/** Disable the EXTI interrupt and unregister the sensor. */
+	void deInit();
+
+	void showInfo(const char* sensorName) const override;
+
+	/**
+	 * Called by the EXTI interrupt on every edge (both rising and falling).
+	 * Public so the static trampoline callback can reach it.
+	 */
+	void onEdge(efitick_t nowNt);
+
+	/** Diagnostic: total edge count since init. */
+	int eventCounter = 0;
+
+private:
+	// Reciprocal frequency limits stored as period limits for faster comparison
+	const float m_minPeriodSec;
+	const float m_maxPeriodSec;
+
+	brain_pin_e m_pin = Gpio::Unassigned;
+
+	// Measures elapsed time from the rising edge to the falling edge (= high pulse width)
+	Timer m_pulseWidthTimer;
+
+	// Measures elapsed time from rising edge to rising edge (= signal period)
+	Timer m_periodTimer;
+
+	// Period of the most-recently completed full cycle (rising→rising), seconds
+	float m_lastPeriodSec = 0;
+
+	// True once at least one rising edge has been observed
+	bool m_seenRisingEdge = false;
+
+#if !EFI_PROD_CODE
+	// Simulator / unit-test: tracks simulated edge direction since efiReadPin
+	// is unavailable in those builds.
+	bool m_lastWasHigh = false;
+#endif
+};


### PR DESCRIPTION
Adds support for sensors that encode values using PWM pulse width
(e.g. throttle pedals).

Captures fixed-frequency PWM signals (typically 100–200 Hz) and reports
the duty cycle [0.0, 1.0] via the FunctionalSensor pipeline.

Failure handling:
- Always low / always high → sensor timeout invalidates the value
- Frequency out of range → cycle is discarded, sensor automatically recovers

Implementation uses EXTI both-edge interrupts, following the same pattern
as FrequencySensor.