### PR TITLE
compatibility for older units, IniPreprocessor

### DIFF
--- a/java_console/inifile/src/main/java/com/rusefi/compatibility/ini/IniPreprocessor.java
+++ b/java_console/inifile/src/main/java/com/rusefi/compatibility/ini/IniPreprocessor.java
@@ -1,0 +1,105 @@
+package com.rusefi.compatibility.ini;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.List;
+
+/**
+ * Compatibility preprocessor for INI files containing #if/#else/#endif directives.
+ * <p>
+ * When a #if directive is encountered, only the first (if) branch is kept
+ * <p>
+ * This allows reading older INI files that still contain preprocessor directives
+ * for conditional compilation (e.g., #if LAMBDA).
+ */
+public class IniPreprocessor {
+
+    private IniPreprocessor() {
+    }
+
+    /**
+     * Preprocess raw INI text lines, resolving #if/#else/#endif directives
+     * by always selecting the first (#if) branch.
+     * <p>
+     * Nesting is supported: directives encountered inside a skipped block are
+     * tracked so the correct #endif closes the correct #if.
+     *
+     * @param rawLines list of raw text lines from an INI file (empty lines already stripped)
+     * @return new list with preprocessor directives resolved; directive lines are never emitted
+     */
+    public static List<String> preprocessLines(List<String> rawLines) {
+        List<String> result = new ArrayList<>(rawLines.size());
+
+        // Each entry represents one #if nesting level.
+        // The value is what `currentlyKeeping` was BEFORE entering this level,
+        // so it can be restored on #endif.
+        Deque<Boolean> stack = new ArrayDeque<>();
+
+        // true → we are in an active (first) branch and should emit lines
+        // false → we are inside a skipped branch (#else or nested inside one)
+        boolean currentlyKeeping = true;
+
+        for (String rawLine : rawLines) {
+            String trimmed = rawLine.trim();
+
+            if (isIfDirective(trimmed)) {
+                // Push the current state; take the #if branch, which inherits parent keeping state.
+                stack.push(currentlyKeeping);
+                // currentlyKeeping stays the same: if parent was skipping we stay skipping,
+                // if parent was keeping we keep the if-branch.
+                continue;
+            }
+
+            if (isElseOrElifDirective(trimmed)) {
+                // We already took the #if branch, so always skip the #else/#elif branch.
+                currentlyKeeping = false;
+                continue;
+            }
+
+            if (isEndifDirective(trimmed)) {
+                if (!stack.isEmpty()) {
+                    currentlyKeeping = stack.pop();
+                }
+                continue;
+            }
+
+            if (currentlyKeeping) {
+                result.add(rawLine);
+            }
+        }
+
+        return result;
+    }
+
+    public static final String DIRECTIVE_TYPE = "directive";
+
+    /**
+     * Returns true if the given config-field type name represents a preprocessor directive
+     * (as opposed to a real configuration field type like "int" or "boolean").
+     */
+    public static boolean isDirectiveType(String typeName) {
+        return DIRECTIVE_TYPE.equalsIgnoreCase(typeName);
+    }
+
+    /**
+     * Returns true if the line (already trimmed) is any preprocessor directive:
+     * {@code #if}, {@code #elif}, {@code #else}, or {@code #endif}.
+     */
+    public static boolean isDirectiveLine(String trimmed) {
+        return isIfDirective(trimmed) || isElseOrElifDirective(trimmed) || isEndifDirective(trimmed);
+    }
+
+    private static boolean isIfDirective(String trimmed) {
+        // Require a space after #if to avoid matching #ifdef, #ifndef
+        return trimmed.startsWith("#if ") || trimmed.equals("#if");
+    }
+
+    private static boolean isElseOrElifDirective(String trimmed) {
+        return trimmed.equals("#else") || trimmed.startsWith("#elif ") || trimmed.equals("#elif");
+    }
+
+    private static boolean isEndifDirective(String trimmed) {
+        return trimmed.equals("#endif");
+    }
+}

--- a/java_console/inifile/src/test/java/com/opensr5/ini/test/IniPreprocessorTest.java
+++ b/java_console/inifile/src/test/java/com/opensr5/ini/test/IniPreprocessorTest.java
@@ -1,0 +1,181 @@
+package com.opensr5.ini.test;
+
+import com.rusefi.compatibility.ini.IniPreprocessor;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class IniPreprocessorTest {
+
+    @Test
+    public void noDirectives_passesThrough() {
+        List<String> input = Arrays.asList("line1", "line2", "line3");
+        assertEquals(input, IniPreprocessor.preprocessLines(input));
+    }
+
+    @Test
+    public void emptyInput_returnsEmpty() {
+        assertEquals(Collections.emptyList(), IniPreprocessor.preprocessLines(Collections.emptyList()));
+    }
+
+    @Test
+    public void simpleIf_keepsIfBranch() {
+        List<String> input = Arrays.asList(
+                "#if LAMBDA",
+                "kept",
+                "#endif"
+        );
+        assertEquals(List.of("kept"), IniPreprocessor.preprocessLines(input));
+    }
+
+    @Test
+    public void simpleIfElse_keepsIfBranch_dropsElse() {
+        List<String> input = Arrays.asList(
+                "#if LAMBDA",
+                "if-branch",
+                "#else",
+                "else-branch",
+                "#endif"
+        );
+        assertEquals(List.of("if-branch"), IniPreprocessor.preprocessLines(input));
+    }
+
+    @Test
+    public void elseWithMultipleLines_allDropped() {
+        List<String> input = Arrays.asList(
+                "before",
+                "#if FOO",
+                "if-line1",
+                "if-line2",
+                "#else",
+                "else-line1",
+                "else-line2",
+                "#endif",
+                "after"
+        );
+        assertEquals(List.of("before", "if-line1", "if-line2", "after"),
+                IniPreprocessor.preprocessLines(input));
+    }
+
+    @Test
+    public void elif_treatedLikeElse_skipped() {
+        List<String> input = Arrays.asList(
+                "#if FOO",
+                "if-branch",
+                "#elif BAR",
+                "elif-branch",
+                "#endif"
+        );
+        assertEquals(List.of("if-branch"), IniPreprocessor.preprocessLines(input));
+    }
+
+    @Test
+    public void nestedIf_insideKeepingBranch() {
+        List<String> input = Arrays.asList(
+                "#if OUTER",
+                "outer-if",
+                "#if INNER",
+                "inner-if",
+                "#else",
+                "inner-else",
+                "#endif",
+                "outer-if-after",
+                "#else",
+                "outer-else",
+                "#endif"
+        );
+        assertEquals(List.of("outer-if", "inner-if", "outer-if-after"),
+                IniPreprocessor.preprocessLines(input));
+    }
+
+    @Test
+    public void nestedIf_insideSkippedBranch_fullySkipped() {
+        List<String> input = Arrays.asList(
+                "#if OUTER",
+                "outer-if",
+                "#else",
+                "outer-else",
+                "#if INNER",
+                "inner-if",
+                "#else",
+                "inner-else",
+                "#endif",
+                "#endif"
+        );
+        assertEquals(List.of("outer-if"), IniPreprocessor.preprocessLines(input));
+    }
+
+    @Test
+    public void multipleTopLevelIfs() {
+        List<String> input = Arrays.asList(
+                "#if A",
+                "a-if",
+                "#else",
+                "a-else",
+                "#endif",
+                "middle",
+                "#if B",
+                "b-if",
+                "#else",
+                "b-else",
+                "#endif"
+        );
+        assertEquals(List.of("a-if", "middle", "b-if"),
+                IniPreprocessor.preprocessLines(input));
+    }
+
+    @Test
+    public void directiveLinesNotEmitted() {
+        List<String> input = Arrays.asList(
+                "#if X",
+                "content",
+                "#endif"
+        );
+        List<String> result = IniPreprocessor.preprocessLines(input);
+        assertFalse(result.stream().anyMatch(l -> l.startsWith("#")));
+    }
+
+    @Test
+    public void isDirectiveLine_recognizesAllDirectives() {
+        assertTrue(IniPreprocessor.isDirectiveLine("#if FOO"));
+        assertTrue(IniPreprocessor.isDirectiveLine("#if"));
+        assertTrue(IniPreprocessor.isDirectiveLine("#else"));
+        assertTrue(IniPreprocessor.isDirectiveLine("#elif BAR"));
+        assertTrue(IniPreprocessor.isDirectiveLine("#elif"));
+        assertTrue(IniPreprocessor.isDirectiveLine("#endif"));
+    }
+
+    @Test
+    public void isDirectiveLine_doesNotMatchNonDirectives() {
+        assertFalse(IniPreprocessor.isDirectiveLine("someKey = value"));
+        assertFalse(IniPreprocessor.isDirectiveLine("; comment"));
+        assertFalse(IniPreprocessor.isDirectiveLine("#ifdef X")); // not supported
+        assertFalse(IniPreprocessor.isDirectiveLine("#ifndef X")); // not supported
+    }
+
+    @Test
+    public void isDirectiveType_caseInsensitive() {
+        assertTrue(IniPreprocessor.isDirectiveType("directive"));
+        assertTrue(IniPreprocessor.isDirectiveType("DIRECTIVE"));
+        assertTrue(IniPreprocessor.isDirectiveType("Directive"));
+        assertFalse(IniPreprocessor.isDirectiveType("int"));
+        assertFalse(IniPreprocessor.isDirectiveType("boolean"));
+    }
+
+    @Test
+    public void ifWithLeadingWhitespace_stillRecognized() {
+        // rawLines already have whitespace; IniPreprocessor trims internally
+        List<String> input = Arrays.asList(
+                "   #if X",
+                "  kept",
+                "   #else",
+                "  dropped",
+                "   #endif"
+        );
+        assertEquals(List.of("  kept"), IniPreprocessor.preprocessLines(input));
+    }
+}

--- a/java_tools/configuration_definition_base/src/main/java/com/rusefi/compatibility/ini/ConfigDirective.java
+++ b/java_tools/configuration_definition_base/src/main/java/com/rusefi/compatibility/ini/ConfigDirective.java
@@ -1,0 +1,42 @@
+package com.rusefi.compatibility.ini;
+
+import com.rusefi.ConfigField;
+import com.rusefi.ConfigFieldImpl;
+import com.rusefi.ReaderState;
+import org.jetbrains.annotations.Nullable;
+
+public class ConfigDirective {
+
+    private ConfigDirective() {
+    }
+
+    /**
+     * Returns true if the given field represents a preprocessor directive
+     */
+    public static boolean isDirective(ConfigField field) {
+        return IniPreprocessor.isDirectiveType(field.getTypeName());
+    }
+
+    /**
+     * @param state the current reader state
+     * @param line  the raw directive line
+     * @return a new {@link ConfigFieldImpl} tagged as a directive
+     */
+    public static ConfigFieldImpl makeDirectiveField(ReaderState state, String line) {
+        return new ConfigFieldImpl(state, "", line, null,
+                IniPreprocessor.DIRECTIVE_TYPE, new int[0], null, false, false,
+                null, null);
+    }
+
+    /**
+     * Returns the text that should be emitted verbatim into the TunerStudio
+     * output for a directive field, or {@code null} if the field is not a
+     * directive (or has no comment).
+     */
+    @Nullable
+    public static String getDirectiveOutput(ConfigField field) {
+        if (!isDirective(field))
+            return null;
+        return field.getComment();
+    }
+}


### PR DESCRIPTION
replaces #9213
progress to https://github.com/rusefi/rusefi/issues/9211

general idea is having a new java package (rusefi.compatibility) so we can move all the relative deadcode from #9027 mantening the compatiblity with older units (evaluating on a simpler way the #if directives), so we can also solve #9028 issue making  `ConfigField`, `IniFileReader`, etc a bit simpler

first PR with the new evaluator without any wiring to actual Ini file read flow