### PR TITLE
Fail instead of skipping AllTriggersFixture

### DIFF
--- a/unit_tests/tests/trigger/test_all_triggers.cpp
+++ b/unit_tests/tests/trigger/test_all_triggers.cpp
@@ -83,12 +83,12 @@ TEST_P(AllTriggersFixture, TestTrigger) {
 	try {
 		engine->updateTriggerConfiguration();
 	} catch (...) {
-		GTEST_SKIP() << "Trigger type " << (int)tt << " threw exception during initialization (not implemented)";
+		GTEST_FAIL() << "Trigger type " << (int)tt << " threw exception during initialization.";
 	}
 
 	if (shape->shapeDefinitionError) {
 		// Some trigger types are not yet implemented - skip them
-		GTEST_SKIP() << "Trigger type " << (int)tt << " has shapeDefinitionError (not implemented)";
+		GTEST_FAIL() << "Trigger type " << (int)tt << " has shapeDefinitionError.";
 	}
 
 	fprintf(fp, "TRIGGERTYPE %d %d %s %.2f\n", tt, shape->getLength(), getTrigger_type_e(tt), shape->tdcPosition);


### PR DESCRIPTION
fix #9239 
This essentially removes "support" for incompletely implemented triggers, which I reckon is a good thing.