### PR TITLE
Rotational idle: skip fuel

### DIFF
--- a/firmware/controllers/engine_cycle/main_trigger_callback.cpp
+++ b/firmware/controllers/engine_cycle/main_trigger_callback.cpp
@@ -83,6 +83,12 @@ void InjectionEvent::onTriggerTooth(efitick_t nowNt, float currentPhase, float n
 		return;
 	}
 
+#if ROTATIONAL_IDLE_CONTROLLER
+	if (engine->rotationalIdleController.shouldSkipFuelRotationalIdle()) {
+		return;
+	}
+#endif // ROTATIONAL_IDLE_CONTROLLER
+
 	// Select fuel mass from the correct cylinder
 	auto injectionMassGrams = getEngineState()->injectionMass[this->cylinderNumber];
 


### PR DESCRIPTION
on `InjectionEvent::onTriggerTooth`

related #9233