### PR TITLE
Set Renix sync gaps

### DIFF
--- a/firmware/controllers/trigger/decoders/trigger_renix.cpp
+++ b/firmware/controllers/trigger/decoders/trigger_renix.cpp
@@ -28,6 +28,9 @@ static void commonRenix(TriggerWaveform *s) {
 
 	// float math error accumulates at this point so we have to spell out 180
 	s->addEventAngle(s->getCycleDuration(), TriggerValue::FALL);
+
+	s->setTriggerSynchronizationGap3(/*gapIndex*/0, 1.25, 2.25);
+	s->setTriggerSynchronizationGap3(/*gapIndex*/1, 0.75, 1.25);
 }
 
 // TT_RENIX_44_2_2


### PR DESCRIPTION
Problem:

- No gaps were set
- When no gaps were set, 1.5 - 2.5 is used
- The gap on these triggers is exactly 1.5
- The check is "measured ratio" > from, so in theory this wouldn't pass unit tests
- However, some floating point shenanigans mean that the calculated ratio is actually something like 1.500001, so it passes

I can't imagine that actually works reliably IRL.
I went ahead and set a second gap.