### PR TITLE
fix: suzuki g16b trigger error

### DIFF
--- a/firmware/controllers/trigger/decoders/trigger_suzuki.cpp
+++ b/firmware/controllers/trigger/decoders/trigger_suzuki.cpp
@@ -37,28 +37,19 @@ void initializeSuzukiG13B(TriggerWaveform *s) {
 void initializeSuzukiG16B(TriggerWaveform *s) {
 	s->initialize(FOUR_STROKE_CAM_SENSOR, SyncEdge::RiseOnly);
 	
-	float w = 5.754; // width of tooth in degrees
+	float w = 5.754; // width of tooth in degrees (measured)
 	
-	s->addToothRiseFall(15, w);
-	s->addToothRiseFall(55, w);
-	s->addToothRiseFall(90, w);
-	s->addToothRiseFall(130, w);
-	s->addToothRiseFall(145, w);
-	s->addToothRiseFall(180, w);
-	s->addToothRiseFall(235, w);
-	s->addToothRiseFall(270, w);
-	s->addToothRiseFall(310, w);
-	s->addToothRiseFall(325, w);
-	s->addToothRiseFall(360, w);
-	
-	/*
-	angle_t teethAngles[] = { 0, 15, 55, 90, 130, 145, 180, 235, 270, 310, 325 }; // angle center of tooth
+	angle_t teethAngles[] = { 15, 55, 90, 130, 145, 180, 235, 270, 310, 325, 360 }; // angle center of tooth
 	for(angle_t pos : teethAngles) {  // Range-based for: no indices, auto-type safe
 		s->addToothRiseFall(pos, w);
-	} */
-	 
-	s->setTriggerSynchronizationGap(2.667); // unique gap ratio
-	s->setSecondTriggerSynchronizationGap(0.875); // gap ratio that follows a unique gap ratio
+	}
+	
+	// Set sync gap based on largest gap between teeth
+	// Calculate gaps: 15,40,35,40,15,35,55,35,40,15,35 (degrees)
+	// Largest is 55° between 180-235, one before is 35°
+	// Ratio largest/previous 1.57
+	s->setTriggerSynchronizationGap(1.571); // unique gap ratio
+	s->setSecondTriggerSynchronizationGap(0.636); // gap ratio that follows a unique gap ratio
 	
 }
 


### PR DESCRIPTION
Fix for suzuki g16b trigger error.

![error_suzuki_g16b](https://github.com/user-attachments/assets/4b7d9402-41e0-4499-a45b-069f86b67a21)

Continuation form: https://github.com/rusefi/rusefi/pull/9218

We have measured again the teeth width in degrees.
We also recalculated the gaps.
