### PR TITLE
Improve HW CI

### DIFF
--- a/.github/workflows/hardware-ci.yaml
+++ b/.github/workflows/hardware-ci.yaml
@@ -130,8 +130,8 @@ jobs:
 # (cat .github/workflows/openocd_ci_proteus_f7.cfg ) | .github/workflows/hw-ci/openocd_wipe_and_flash.sh
     - name: st-flash wipe & flash STM32
       run: |
-        st-flash --area=main erase
-        st-flash --format=binary --reset --connect-under-reset write firmware/deliver/rusefi.bin 0x08000000
+        st-flash $([ -n "$HARDWARE_CI_STLINK_SERIAL" ] && echo "--serial") $HARDWARE_CI_STLINK_SERIAL --area=main erase
+        st-flash $([ -n "$HARDWARE_CI_STLINK_SERIAL" ] && echo "--serial") $HARDWARE_CI_STLINK_SERIAL --format=binary --reset --connect-under-reset write firmware/deliver/rusefi.bin 0x08000000
 
     - name: Upload build bin artifact
       uses: actions/upload-artifact@v7


### PR DESCRIPTION
Set environment variables from a file which can be mounted on the docker image at run time. This is used for setting STLink and ECU serials.

Specify STLink serial if it is set in an environment variable, so multiple STLinks can be used on a single computer.