### PR TITLE
LED: blink without stumbling

### DIFF
--- a/firmware/console/binary/tunerstudio.cpp
+++ b/firmware/console/binary/tunerstudio.cpp
@@ -744,6 +744,18 @@ static int tsProcessOne(TsChannelBase* tsChannel) {
 	return 0;
 }
 
+bool TunerstudioThread::isAnyConsoleActive(void) {
+	return (consoleActiveMask != 0);
+}
+
+void TunerstudioThread::onDataArrived(int instance, bool valid) {
+	if (valid) {
+		consoleActiveMask |= (1 << instance);
+	} else {
+		consoleActiveMask &= ~(1 << instance);
+	}
+}
+
 void TunerstudioThread::ThreadTask() {
 	auto channel = setupChannel();
 
@@ -752,12 +764,15 @@ void TunerstudioThread::ThreadTask() {
 		return;
 	}
 
+	// get our instance...
+	int instance = getInstanceCounter();
+
 	// Until the end of time, process incoming messages.
 	while (true) {
 		if (tsProcessOne(channel) == 0) {
-			onDataArrived(true);
+			onDataArrived(instance, true);
 		} else {
-			onDataArrived(false);
+			onDataArrived(instance, false);
 		}
 	}
 }

--- a/firmware/console/binary/tunerstudio.h
+++ b/firmware/console/binary/tunerstudio.h
@@ -88,6 +88,15 @@ public:
 
 	void ThreadTask() override;
 
+	static bool isAnyConsoleActive(void);
+
+private:
+	static int getInstanceCounter() {
+		static int instances = 0;
+		return instances++;
+	}
+	static inline uint32_t consoleActiveMask = 0;
+	static void onDataArrived(int instance, bool valid);
 };
 #endif
 

--- a/firmware/console/console_io.cpp
+++ b/firmware/console/console_io.cpp
@@ -44,12 +44,6 @@
 #include "rusEfiFunctionalTest.h"
 #endif /*EFI_SIMULATOR */
 
-bool consoleByteArrived = false;
-
-void onDataArrived(bool valid) {
-	consoleByteArrived = valid;
-}
-
 CommandHandler console_line_callback;
 
 void startConsole(CommandHandler console_line_callback_p) {

--- a/firmware/console/console_io.h
+++ b/firmware/console/console_io.h
@@ -11,4 +11,3 @@ typedef void (*CommandHandler)(char *);
 
 void consoleOutputBuffer(const uint8_t *buf, int size);
 void startConsole(CommandHandler console_line_callback_p);
-void onDataArrived(bool valid);

--- a/firmware/console/status_loop.cpp
+++ b/firmware/console/status_loop.cpp
@@ -246,8 +246,6 @@ static bool isTriggerErrorNow() {
 #endif /* EFI_ENGINE_CONTROL && EFI_SHAFT_POSITION_INPUT */
 }
 
-extern bool consoleByteArrived;
-
 class CommunicationBlinkingTask : public PeriodicTimerController {
 
 	int getPeriodMs() override {
@@ -292,7 +290,7 @@ class CommunicationBlinkingTask : public PeriodicTimerController {
 				// differentiates software firmware error from critical interrupt error with CPU halt.
 				offTimeMs = 50;
 				onTimeMs = 450;
-			} else if (consoleByteArrived) {
+			} else if (TunerstudioThread::isAnyConsoleActive()) {
 				offTimeMs = 100;
 				onTimeMs = 33;
 #if EFI_CONFIGURATION_STORAGE


### PR DESCRIPTION
consoleByteArrived was set and cleared from several TunerstudioThread instancies. So any of incative TS thread was able to clear global flag and cause fast LED blinking for one period.
Now each thread has its own instance number and assotiated bit in consoleActiveMask. Non zero consoleActiveMask means at least one active connection.
People with pedantism now look at indication without pain.