### PR TITLE
infra: remove autoupdate java files from bundle

### DIFF
--- a/firmware/bundle.mk
+++ b/firmware/bundle.mk
@@ -69,8 +69,7 @@ DRIVERS_FOLDER = $(FOLDER)/drivers
 UPDATE_FOLDER_SOURCES = \
   $(RUSEFI_CONSOLE_SETTINGS) \
   $(INI_FILE) \
-  ../misc/console_launcher/readme.html \
-  ../misc/console_launcher/rusefi_updater.exe
+  ../misc/console_launcher/readme.html
 
 FOLDER_SOURCES = \
   ../java_console/bin
@@ -83,13 +82,11 @@ endif
 UPDATE_CONSOLE_FOLDER_SOURCES = \
   $(CONSOLE_JAR) \
   $(BRANCH_REF_FILE) \
-  $(TS_PLUGIN_LAUNCHER_JAR) \
-  $(AUTOUPDATE_JAR)
+  $(TS_PLUGIN_LAUNCHER_JAR)
 
 # todo: remove BootCommander.exe once https://github.com/rusefi/rusefi/issues/6358 is done
 
 CONSOLE_FOLDER_SOURCES = \
-  ../misc/console_launcher/rusefi_autoupdate.exe \
   ../misc/console_launcher/rusefi_console.exe \
   $(SIMULATOR_EXE)
 

--- a/java_tools/java_tools.mk
+++ b/java_tools/java_tools.mk
@@ -16,7 +16,6 @@ ENUM_TO_STRING_JAR = $(JAVA_TOOLS)/enum_to_string/build/libs/enum_to_string-all.
 # TUNE_TOOLS_JAR = $(JAVA_TOOLS)/tune-tools/build/libs/tune-tools-all.jar
 TS_PLUGIN_LAUNCHER_JAR = $(JAVA_TOOLS)/ts_plugin_launcher/build/jar/rusefi_ts_plugin_launcher.jar
 CONSOLE_JAR = $(PROJECT_DIR)/../console/rusefi_console.jar
-AUTOUPDATE_JAR = $(PROJECT_DIR)/../console/rusefi_autoupdate.jar
 
 # We use .FORCE to always rebuild these tools. Gradle won't actually touch the jars if it doesn't need to,
 # so we don't have to worry about triggering rebuilds of things that have these tools as a prerequisite.
@@ -38,9 +37,6 @@ $(TS_PLUGIN_LAUNCHER_JAR): .FORCE
 
 $(CONSOLE_JAR): .docsenums-sentinel .config-sentinel .FORCE
 	cd $(GRADLE_ROOT) && $(FLOCK) ./gradlew :ui:shadowJar
-
-$(AUTOUPDATE_JAR): .FORCE
-	cd $(GRADLE_ROOT) && $(FLOCK) ./gradlew :autoupdate:shadowJar
 
 .FORCE:
 


### PR DESCRIPTION
now that the bundle auto-update is inside the console we can remove the generated exe from the zipped bundle

related: #9297