### PR TITLE
VariableRegistry: fix escape handling with `quoteReplacement`

### DIFF
--- a/java_tools/configuration_definition/src/test/java/com/rusefi/test/VariableRegistryTest.java
+++ b/java_tools/configuration_definition/src/test/java/com/rusefi/test/VariableRegistryTest.java
@@ -25,6 +25,14 @@ public class VariableRegistryTest {
     }
 
     @Test
+    public void testDollarSignInValue() {
+        VariableRegistry registry = new VariableRegistry();
+        registry.register("content", "bits, U16, 0, [0:8], $switch_input_pin_e_list");
+        assertEquals("bits, U16, 0, [0:8], $switch_input_pin_e_list",
+                registry.applyVariables("@@content@@"));
+    }
+
+    @Test
     public void testReplace() {
         VariableRegistry registry = new VariableRegistry();
         registry.register("var", 256);

--- a/java_tools/enum_to_string/src/main/java/com/rusefi/VariableRegistry.java
+++ b/java_tools/enum_to_string/src/main/java/com/rusefi/VariableRegistry.java
@@ -212,8 +212,7 @@ public class VariableRegistry {
                 throw new IllegalStateException("Something broken in: [" + line + "]");
             String key = m.group(2);
             String newValue = function.apply(key);
-            newValue = newValue.replace("\\", "\\\\"); // hack out symbol escaping
-            line = m.replaceFirst(newValue);
+            line = m.replaceFirst(Matcher.quoteReplacement(newValue));
         }
         return line;
     }


### PR DESCRIPTION
related #9335 