### PR TITLE
fix efiPrintfInternal ISR crash under windows

### DIFF
--- a/firmware/util/loggingcentral.cpp
+++ b/firmware/util/loggingcentral.cpp
@@ -181,6 +181,8 @@ void efiPrintfInternal(const char *format, ...) {
 	 * can have large stack frames that overflow
 	 * the ChibiOS thread working area into adjacent static globals, corrupting
 	 * scheduler data structures
+	 * ChibiOS suggested patch: https://github.com/rusefi/ChibiOS/pull/66
+	 * ChibiOS issue: https://sourceforge.net/p/chibios/bugs/1305/
 	 */
 	if (verboseMode
 #if EFI_SIMULATOR

--- a/firmware/util/loggingcentral.cpp
+++ b/firmware/util/loggingcentral.cpp
@@ -200,22 +200,21 @@ void efiPrintfInternal(const char *format, ...) {
 	msg_t msg;
 
 	/*
-	 * efiPrintfInternal can be called from both thread context and ISR
-	 * context (e.g. timer callbacks fired by chVTDoTickI — note that
-	 * ChibiOS releases the lock around callbacks: chSysUnlockFromISR →
-	 * callback → chSysLockFromISR).
-	 *
-	 * In the thread context we use S-class chSysLock/chSysUnlock.
-	 * In ISR context we must use I-class chSysLockFromISR/chSysUnlockFromISR
-	 * — using S-class would corrupt lock_cnt (SV#6) and drop the ISR lock.
+	 * On the win32 simulator port, S-class chSysLock/chSysUnlock from ISR
+	 * context corrupts the cooperative scheduler state (ready-list / delta-list)
+	 * because port_unlock() resets port_irq_sts, breaking the lock invariant.
+	 * On real ARM hardware the S-class and I-class locks are functionally
+	 * identical (both just raise BASEPRI), so the S-class pattern works
 	 */
+#if EFI_SIMULATOR
 	const bool isIsr = port_is_isr_context();
-
 	if (isIsr) {
 		chSysLockFromISR();
 		msg = freeBuffers.fetchI(&lineBuffer);
 		chSysUnlockFromISR();
-	} else {
+	} else
+#endif
+	{
 		chibios_rt::CriticalSectionLocker csl;
 		msg = freeBuffers.fetchI(&lineBuffer);
 	}
@@ -243,11 +242,15 @@ void efiPrintfInternal(const char *format, ...) {
 			lineBuffer->buffer[i] = ' ';
 	}
 
+#if EFI_SIMULATOR
 	if (isIsr) {
 		chSysLockFromISR();
 		filledBuffers.postI(lineBuffer);
 		chSysUnlockFromISR();
-	} else {
+	} else
+#endif
+	{
+		// Push the buffer in to the written list so it can be written back
 		chibios_rt::CriticalSectionLocker csl;
 		filledBuffers.postI(lineBuffer);
 	}

--- a/firmware/util/loggingcentral.cpp
+++ b/firmware/util/loggingcentral.cpp
@@ -176,7 +176,17 @@ namespace priv
 {
 void efiPrintfInternal(const char *format, ...) {
 #if EFI_UNIT_TEST || EFI_SIMULATOR
-	if (verboseMode) {
+	/*
+	 * Skip printf to stdout from ISR context — the C runtime's printf/vprintf
+	 * can have large stack frames that overflow
+	 * the ChibiOS thread working area into adjacent static globals, corrupting
+	 * scheduler data structures
+	 */
+	if (verboseMode
+#if EFI_SIMULATOR
+		&& !port_is_isr_context()
+#endif
+	) {
 		printf("[%dus]efiPrintfInternal:", time2print(getTimeNowUs()));
 		va_list ap;
 		va_start(ap, format);
@@ -189,8 +199,23 @@ void efiPrintfInternal(const char *format, ...) {
 	LogLineBuffer* lineBuffer;
 	msg_t msg;
 
-	{
-		// Acquire a buffer we can write to
+	/*
+	 * efiPrintfInternal can be called from both thread context and ISR
+	 * context (e.g. timer callbacks fired by chVTDoTickI — note that
+	 * ChibiOS releases the lock around callbacks: chSysUnlockFromISR →
+	 * callback → chSysLockFromISR).
+	 *
+	 * In the thread context we use S-class chSysLock/chSysUnlock.
+	 * In ISR context we must use I-class chSysLockFromISR/chSysUnlockFromISR
+	 * — using S-class would corrupt lock_cnt (SV#6) and drop the ISR lock.
+	 */
+	const bool isIsr = port_is_isr_context();
+
+	if (isIsr) {
+		chSysLockFromISR();
+		msg = freeBuffers.fetchI(&lineBuffer);
+		chSysUnlockFromISR();
+	} else {
 		chibios_rt::CriticalSectionLocker csl;
 		msg = freeBuffers.fetchI(&lineBuffer);
 	}
@@ -218,10 +243,12 @@ void efiPrintfInternal(const char *format, ...) {
 			lineBuffer->buffer[i] = ' ';
 	}
 
-	{
-		// Push the buffer in to the written list so it can be written back
+	if (isIsr) {
+		chSysLockFromISR();
+		filledBuffers.postI(lineBuffer);
+		chSysUnlockFromISR();
+	} else {
 		chibios_rt::CriticalSectionLocker csl;
-
 		filledBuffers.postI(lineBuffer);
 	}
 #endif

--- a/simulator/Makefile
+++ b/simulator/Makefile
@@ -31,6 +31,15 @@ $(info OS is [${OS}])
 # CH_DBG_SYSTEM_STATE_CHECK) apply on Cygwin builds too.
 IS_CYGWIN = $(if $(findstring CYGWIN,$(OS)),yes,no)
 
+# Windows flag: true for both native Windows_NT and Cygwin.
+ifeq ($(OS),Windows_NT)
+  IS_WIN = yes
+else ifeq ($(IS_CYGWIN),yes)
+  IS_WIN = yes
+else
+  IS_WIN = no
+endif
+
 include ../firmware/rusefi.mk
 include ../firmware/rusefi_rules.mk
 -include ${BOARD_DIR}/firmware/firmware.mk
@@ -43,14 +52,10 @@ PCHSUB = simulator
 # used by USE_SMART_BUILD
 CONFDIR = .
 
-ifneq ($(OS),Windows_NT)
-  ifeq ($(IS_CYGWIN),yes)
-    SANITIZE = no
-  else
-    SANITIZE = yes
-  endif
-else
+ifeq ($(IS_WIN),yes)
   SANITIZE = no
+else
+  SANITIZE = yes
 endif
 
 ifeq ($(SIMULATOR_DEBUG_LEVEL_OPT),)
@@ -63,9 +68,7 @@ ifeq ($(USE_OPT),)
   USE_OPT = -Wall -Wno-error=implicit-fallthrough -Wno-error=write-strings -Wno-error=strict-aliasing -Werror=nonnull
   USE_OPT += -D US_TO_NT_MULTIPLIER=$(US_TO_NT_MULTIPLIER)
 
-  ifeq ($(OS),Windows_NT)
-    USE_OPT += -DEFI_SIM_IS_WINDOWS=1 -DIS_WINDOWS_COMPILER=1
-  else ifeq ($(IS_CYGWIN),yes)
+  ifeq ($(IS_WIN),yes)
     USE_OPT += -DEFI_SIM_IS_WINDOWS=1 -DIS_WINDOWS_COMPILER=1
   else
     USE_OPT += -m32 -DEFI_SIM_IS_WINDOWS=0 -DIS_WINDOWS_COMPILER=0
@@ -147,7 +150,7 @@ endif
 #
 
 # Define project name here
-ifeq ($(OS),Windows_NT)
+ifeq ($(IS_WIN),yes)
   PROJECT = rusefi_simulator.exe
 else
   PROJECT = rusefi_simulator
@@ -172,7 +175,7 @@ include $(CHIBIOS)/os/common/ports/SIMIA32/compilers/GCC/port.mk
 include $(CHIBIOS)/os/hal/lib/streams/streams.mk
 #include $(CHIBIOS)/os/various/cpp_wrappers/chcpp.mk
 
-ifeq ($(OS),Windows_NT)
+ifeq ($(IS_WIN),yes)
   include ${CHIBIOS}/os/hal/ports/simulator/win32/platform.mk
 else
   include ${CHIBIOS}/os/hal/ports/simulator/posix/platform.mk
@@ -247,7 +250,7 @@ ASMXSRC = $(STARTUPASM) $(PORTASM) $(OSALASM)
 # Compiler settings
 #
 
-ifeq ($(OS),Windows_NT)
+ifeq ($(IS_WIN),yes)
   # ChibiOS seem to require 32 bit compiler at least on Windows
   # base 32-bit Cygwin is needed with mingw64 32-bit version
   # Cygwin64 would not debug if used with mingw64 32-bit version
@@ -302,7 +305,7 @@ UINCDIR =
 ULIBDIR =
 
 # List all user libraries here
-ifeq ($(OS),Windows_NT)
+ifeq ($(IS_WIN),yes)
 ULIBS = -lws2_32 -static
 else
 ULIBS =

--- a/simulator/chconf.h
+++ b/simulator/chconf.h
@@ -549,14 +549,8 @@
  * @note    The default is @p FALSE.
  */
 
-// as 2026, the simulator is broken if we are on Windows and we have this check enable (triggers SV#6), for now is only disabled for windows
-// see #8247
 #if !defined(CH_DBG_SYSTEM_STATE_CHECK)
-#if EFI_SIM_IS_WINDOWS
-#define CH_DBG_SYSTEM_STATE_CHECK           FALSE
-#else
 #define CH_DBG_SYSTEM_STATE_CHECK           TRUE
-#endif
 #endif
 
   #define ON_LOCK_HOOK


### PR DESCRIPTION
no crash on windows, no more hack on windows for SV#6 :D

resolves https://github.com/rusefi/rusefi/issues/8992
related #9345


now happy output on windows:

```
Simulator: reading config from flash1.bin
[5000us]efiPrintfInternal:msg`Flash: Reading done`
[5000us]efiPrintfInternal:msg`Flash: Reading storage ID 2 @0x2 ... 24220 bytes`
Simulator: reading config from flash2.bin
[5000us]efiPrintfInternal:msg`Flash: Reading done`
commonInitEngineController
initSettings
[5000us]efiPrintfInternal:msg`setTpsAccelLen: Length should be positive [0]`
[5000us]efiPrintfInternal:msg`initMapAveraging...`
[5000us]efiPrintfInternal:msg`initHardware() OK!`
[5000us]efiPrintfInternal:msg`Emulating position sensor(s). RPM=1200`
[5000us]efiPrintfInternal:msg`Stimulator: updating trigger shape for ch0: 106/0 5`
[5000us]efiPrintfInternal:msg`Stimulator: updating trigger shape for ch1: 106/0 5`
[5000us]efiPrintfInternal:msg`Stimulator: updating trigger shape for ch2: 7/0 5`
[5000us]efiPrintfInternal:msg`Emulating position sensor(s). RPM=1200`
Full Duplex Channel SD1 listening on port 29001
Full Duplex Channel SD2 listening on port 29002
[5000us]efiPrintfInternal:msg`LUA loading script length: 614...`
[5000us]efiPrintfInternal:msg`LUA script loaded successfully!`
Init: connection on SD1
Init: disconnection on SD1
Init: connection on SD1
Init: disconnection on SD1
Init: connection on SD1
``` 