### PR TITLE
Makefile: linker: show memory statistic

### DIFF
--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -117,7 +117,7 @@ endif
 
 # Linker extra options here.
 ifeq ($(USE_LDOPT),)
-  USE_LDOPT =
+  USE_LDOPT = --print-memory-usage
 endif
 
 # Enable this if you want link time optimizations (LTO)


### PR DESCRIPTION
Ask linker for stat like this:

```
Memory region         Used Size  Region Size  %age Used
              bl:           0 B        32 KB      0.00%
          flash0:      543524 B       736 KB     72.12%
          flash1:      439556 B       736 KB     58.32%
          flash2:           0 B          0 B
          flash3:           0 B          0 B
          flash4:           0 B          0 B
          flash5:           0 B          0 B
          flash6:           0 B          0 B
          flash7:           0 B          0 B
          shared:          16 B         16 B    100.00%
            ram0:      376816 B     376816 B    100.00%
            ram1:           0 B     376816 B      0.00%
            ram2:         440 B        16 KB      2.69%
            ram3:       70316 B       128 KB     53.65%
            ram4:           0 B        16 KB      0.00%
            ram5:         760 B         4 KB     18.55%
            ram6:           0 B          0 B
            ram7:           0 B          0 B
```
