### PR TITLE
EnumIniField.getValue to use real size fix #7738

### DIFF
--- a/firmware/config/boards/f407-discovery/board_config.txt
+++ b/firmware/config/boards/f407-discovery/board_config.txt
@@ -1,2 +1,1 @@
 Gpio communityCommsLedPin
-int technicalDebt7738


### PR DESCRIPTION
only:hw