### PR TITLE
BasicUpdaterPanel: fix null check for calibrations field in popup menu refresh

### DIFF
--- a/java_console/ui/src/main/java/com/rusefi/SerialPortScanner.java
+++ b/java_console/ui/src/main/java/com/rusefi/SerialPortScanner.java
@@ -189,14 +189,34 @@ public enum SerialPortScanner {
             portCache.put(p);
         }
 
-        portCache.retainAll(serialPorts);
+        final Collection<String> tcpPorts = includeSlowLookup
+            ? TcpConnector.getAvailablePorts()
+            : Collections.emptyList();
+
+        final Set<String> livePortNames = new HashSet<>(serialPorts);
+        livePortNames.addAll(tcpPorts);
+        portCache.retainAll(livePortNames);
 
         // Sort ports by their type to put your ECU at the top
         ports.sort(Comparator.comparingInt(a -> a.type.sortOrder));
 
         if (includeSlowLookup) {
-            for (String tcpPort : TcpConnector.getAvailablePorts()) {
-                ports.add(new PortResult(tcpPort, SerialPortType.Ecu));
+            for (String tcpPort : tcpPorts) {
+                final Optional<PortResult> cachedPort = portCache.get(tcpPort);
+                if (cachedPort.isPresent()) {
+                    ports.add(cachedPort.get());
+                } else {
+                    final Optional<CalibrationsInfo> tcpCalibrations = getEcuCalibrations(tcpPort);
+                    final PortResult tcpResult = tcpCalibrations
+                        .map(c -> new PortResult(tcpPort, SerialPortType.Ecu, c))
+                        .orElseGet(() -> new PortResult(tcpPort, SerialPortType.Ecu));
+                    ports.add(tcpResult);
+
+                    // cache port + calibrations
+                    if (tcpCalibrations.isPresent()) {
+                        portCache.put(tcpResult);
+                    }
+                }
             }
             dfuConnected = DfuFlasher.detectSTM32BootloaderDriverState(UpdateOperationCallbacks.DUMMY);
             stLinkConnected = StLinkFlasher.detectStLink(UpdateOperationCallbacks.DUMMY);

--- a/java_console/ui/src/main/java/com/rusefi/ui/basic/BasicUpdaterPanel.java
+++ b/java_console/ui/src/main/java/com/rusefi/ui/basic/BasicUpdaterPanel.java
@@ -336,6 +336,8 @@ never used?
         importTuneButton.setEnabled(isEcuPortJobPossible);
 //        updateCalibrationsButton.setEnabled(isEcuPortJobPossible);
         if (logoLabelPopupMenu != null) {
+            // getCalibrations() can be null for TCP ports (typically the simulator)
+            // are added in SerialPortScanner.findAllAvailablePorts which leaves calibrations null
             logoLabelPopupMenu.refreshUploadTuneAndPrintUnitLabelsMenuItems(
                 isEcuPortJobPossible,
                 ecuPort.map(port -> port.getCalibrations() != null && existsAnyOfUnitIdentifierFields(port.getCalibrations().getIniFile())).orElse(false)

--- a/java_console/ui/src/main/java/com/rusefi/ui/basic/BasicUpdaterPanel.java
+++ b/java_console/ui/src/main/java/com/rusefi/ui/basic/BasicUpdaterPanel.java
@@ -338,7 +338,7 @@ never used?
         if (logoLabelPopupMenu != null) {
             logoLabelPopupMenu.refreshUploadTuneAndPrintUnitLabelsMenuItems(
                 isEcuPortJobPossible,
-                ecuPort.map(port -> existsAnyOfUnitIdentifierFields(port.getCalibrations().getIniFile())).orElse(false)
+                ecuPort.map(port -> port.getCalibrations() != null && existsAnyOfUnitIdentifierFields(port.getCalibrations().getIniFile())).orElse(false)
             );
         }
     }


### PR DESCRIPTION
calibrations are null if the connected ecu is the simulator

resolves #9368