### PR TITLE
Enable ethernet on one or both nucleo boards: allow custom ip for nucleo F767 board

### DIFF
--- a/firmware/config/boards/nucleo_f767/readme.md
+++ b/firmware/config/boards/nucleo_f767/readme.md
@@ -21,3 +21,11 @@ Subnet mask: 255.255.255.0
 Default gateway: 192.168.10.1
 
 Preferred DNS server: 8.8.8.8 (don't care).
+
+
+for local dev you maybe want to connect the PC and the ecu on the same LAN with another devices, for that you need to update:
+firmware/console/lwipopts.h
+
+LWIP_IPADDR with the preffered IP adress for the ecu
+
+LWIP_GATEWAY with the LAN gateway


### PR DESCRIPTION
related #4665

working over real LAN :D

<img width="459" height="386" alt="image" src="https://github.com/user-attachments/assets/93857665-02dd-4b18-929b-68206bcb10a0" />
