### PR TITLE
F767 ethernet_console: TCP Settings and flush changes

### DIFF
--- a/firmware/console/lwipopts.h
+++ b/firmware/console/lwipopts.h
@@ -70,7 +70,18 @@
 
 #include "generated_lookup_meta.h"
 
-// Ensure that one TCP segment can always fit an entire response to TS - we never need to split a TS packet across multiple frames.
-#define TCP_MSS (BLOCKING_FACTOR + 10)
+// Full Ethernet MTU per TCP segment.  TS responses that exceed the MTU get split
+// across multiple segments; EthernetChannel coalesces its own multi-part writes
+// so this does not cause per-TS-frame fragmentation overhead.
+#define TCP_MSS 1460
+
+// Widen the send window and give lwIP a heap large enough to actually use it.
+// MEMP_NUM_TCP_SEG must be >= derived TCP_SND_QUEUELEN or the lwIP sanity check
+// will fail the build.  Costs ~30 KB static RAM on ethernet-enabled boards.
+#define TCP_SND_BUF         (8 * TCP_MSS)
+#define TCP_WND             (8 * TCP_MSS)
+#define TCP_SND_QUEUELEN    32
+#define MEMP_NUM_TCP_SEG    40
+#define MEM_SIZE            (24 * 1024)
 
 #endif /* LWIP_HDR_LWIPOPTS_H__ */

--- a/firmware/controllers/modules/ethernet_console/ethernet_console.cpp
+++ b/firmware/controllers/modules/ethernet_console/ethernet_console.cpp
@@ -23,6 +23,11 @@ static void do_connection() {
 	sockaddr_in remote;
 	socklen_t size = sizeof(remote);
 	connectionSocket = lwip_accept(listenerSocket, (sockaddr*)&remote, &size);
+
+	if (connectionSocket != -1) {
+		int one = 1;
+		lwip_setsockopt(connectionSocket, IPPROTO_TCP, TCP_NODELAY, &one, sizeof(one));
+	}
 }
 
 class EthernetChannel final : public TsChannelBase {
@@ -37,11 +42,39 @@ public:
 	}
 
 	void write(const uint8_t* buffer, size_t size, bool isEndOfPacket) override {
-		// If not the end of a packet, set the MSG_MORE flag to indicate to the transport
-		// that we have more to add to the buffer before queuing a flush.
-		auto flags = isEndOfPacket ? 0 : MSG_MORE;
-		lwip_send(connectionSocket, buffer, size, flags);
+		// lwIP's MSG_MORE only sets PSH, it does not coalesce sends.  Buffer locally so
+		// multi-part TS responses (header + body + tail) leave as a single TCP segment.
+		// Without this, small leading writes trigger delayed-ACK + Nagle on the peer
+		// pair and add ~40 ms per transaction.
+		size_t remaining = size;
+		const uint8_t* src = buffer;
+		while (remaining > 0) {
+			size_t free = sizeof(txBuffer) - txPos;
+			size_t chunk = remaining < free ? remaining : free;
+			memcpy(txBuffer + txPos, src, chunk);
+			txPos += chunk;
+			src += chunk;
+			remaining -= chunk;
+			if (txPos == sizeof(txBuffer)) {
+				flush();
+			}
+		}
+		if (isEndOfPacket) {
+			flush();
+		}
 	}
+
+	void flush() override {
+		if (txPos > 0) {
+			lwip_send(connectionSocket, txBuffer, txPos, 0);
+			txPos = 0;
+		}
+	}
+
+private:
+	uint8_t txBuffer[1536];
+	size_t txPos = 0;
+public:
 
 	size_t readTimeout(uint8_t* buffer, size_t size, int /*timeout*/) override {
 		auto result = lwip_recv(connectionSocket, buffer, size, /*flags =*/ 0);


### PR DESCRIPTION
old data rate:
<img width="459" height="386" alt="image" src="https://github.com/user-attachments/assets/5916467d-9c02-47d0-be01-09d085e7c645" />


data rate: yes
<img width="422" height="400" alt="image" src="https://github.com/user-attachments/assets/26478fb8-0fee-49f3-ab8f-cdcc2ea08e29" />


`+30 KB lwIP static RAM, ~+1.5 KB BSS + ~+120 B text from the coalescer`

related #9418