### PR TITLE
ISO-TP frames usually use 8 bytes, even if payload is shorter

### DIFF
--- a/firmware/controllers/can/isotp/isotp.cpp
+++ b/firmware/controllers/can/isotp/isotp.cpp
@@ -36,7 +36,7 @@ int IsoTpBase::sendFrame(const IsoTpFrameHeader &header, const uint8_t *data, in
 		return 0;
 	}
 
-	int dlc = offset + numBytes;
+	int dlc = 8;
 	CanTxMessage txmsg(CanCategory::SERIAL, txFrameId, dlc, busIndex, IS_EXT_RANGE_ID(txFrameId));
 
 	// fill the frame data according to the CAN-TP protocol (ISO 15765-2)


### PR DESCRIPTION
some units may ignore short frames

current version should work well in both cases 