### PR TITLE
refactor: extract stepper motors from ETB hardware pool DC

### DIFF
--- a/firmware/controllers/actuators/dc_motors.cpp
+++ b/firmware/controllers/actuators/dc_motors.cpp
@@ -81,7 +81,8 @@
 		}
 	}
 
-static DcHardware dcHardware[ETB_COUNT + DC_PER_STEPPER];
+static DcHardware dcHardware[ETB_COUNT];
+static DcHardware stepperDcHardware[DC_PER_STEPPER];
 
 DcHardware *getPrimaryDCHardwareForLogging() {
 	return &dcHardware[0];
@@ -119,6 +120,42 @@ DcMotor* initDcMotor(brain_pin_e coil_p, brain_pin_e coil_m, size_t index) {
 		engineConfiguration->stepperDcInvertedPins,
 		&engine->scheduler,
 		engineConfiguration->etbFreq /* same in case of stepper? */
+	);
+
+	return &hw.dcMotor;
+}
+
+DcMotor* initStepperDcMotor(const char *disPinMsg, const dc_io& io, size_t index, bool useTwoWires) {
+	auto& hw = stepperDcHardware[index];
+
+	hw.start(
+		useTwoWires,
+		io.controlPin,
+		io.directionPin1,
+		io.directionPin2,
+		disPinMsg,
+		io.disablePin,
+		engineConfiguration->stepperDcInvertedPins,
+		&engine->scheduler,
+		engineConfiguration->etbFreq
+	);
+
+	return &hw.dcMotor;
+}
+
+DcMotor* initStepperDcMotor(brain_pin_e coil_p, brain_pin_e coil_m, size_t index) {
+	auto& hw = stepperDcHardware[index];
+
+	hw.start(
+		true, /* useTwoWires */
+		Gpio::Unassigned, /* pinEnable */
+		coil_p,
+		coil_m,
+		nullptr,
+		Gpio::Unassigned, /* pinDisable */
+		engineConfiguration->stepperDcInvertedPins,
+		&engine->scheduler,
+		engineConfiguration->etbFreq
 	);
 
 	return &hw.dcMotor;

--- a/firmware/controllers/actuators/dc_motors.h
+++ b/firmware/controllers/actuators/dc_motors.h
@@ -14,6 +14,10 @@
 DcMotor* initDcMotor(const char *disPinMsg, const dc_io& io, size_t index, bool useTwoWires);
 DcMotor* initDcMotor(brain_pin_e coil_p, brain_pin_e coil_m, size_t index);
 
+// Stepper coil motor initialization - uses a separate hardware pool from the ETB/DC-actuator pool
+DcMotor* initStepperDcMotor(const char *disPinMsg, const dc_io& io, size_t index, bool useTwoWires);
+DcMotor* initStepperDcMotor(brain_pin_e coil_p, brain_pin_e coil_m, size_t index);
+
 // Manual control of motors for use by console commands
 void setDcMotorFrequency(size_t index, int hz);
 void setDcMotorDuty(size_t index, float duty);

--- a/firmware/controllers/actuators/electronic_throttle.cpp
+++ b/firmware/controllers/actuators/electronic_throttle.cpp
@@ -1091,14 +1091,4 @@ const electronic_throttle_s* getLiveData(size_t idx) {
 #endif
 }
 
-// root cause: we have poor usability around DC function and h-bridge stepper
-void pickEtbOrStepper() {
-  if (!engineConfiguration->useHbridgesToDriveIdleStepper) {
-    return;
-  }
-  for (size_t i = 0;i<ETB_COUNT;i++) {
-	  if (engineConfiguration->etbFunctions[i] != DC_None) {
-      criticalError("Cannot use H-bridge for stepper while DC function is selected");
-	  }
-	}
-}
+

--- a/firmware/controllers/actuators/electronic_throttle.h
+++ b/firmware/controllers/actuators/electronic_throttle.h
@@ -20,8 +20,6 @@ void setEtbLuaAdjustment(percent_t adjustment);
 void setEwgLuaAdjustment(percent_t pos);
 void setHitachiEtbCalibration();
 
-void pickEtbOrStepper();
-
 void blinkEtbErrorCodes(bool blinkPhase);
 
 // same plug as 18919 AM810 but have different calibrations

--- a/firmware/controllers/actuators/idle_hardware.cpp
+++ b/firmware/controllers/actuators/idle_hardware.cpp
@@ -102,10 +102,10 @@ void initIdleHardware() {
 
 		if (engineConfiguration->useRawOutputToDriveIdleStepper) {
 		  // four Push-Pull outputs to directly drive stepper idle air valve coils
-			auto motorA = initDcMotor(engineConfiguration->stepper_raw_output[0],
-				engineConfiguration->stepper_raw_output[1], ETB_COUNT + 0);
-			auto motorB = initDcMotor(engineConfiguration->stepper_raw_output[2],
-				engineConfiguration->stepper_raw_output[3], ETB_COUNT + 1);
+			auto motorA = initStepperDcMotor(engineConfiguration->stepper_raw_output[0],
+				engineConfiguration->stepper_raw_output[1], 0);
+			auto motorB = initStepperDcMotor(engineConfiguration->stepper_raw_output[2],
+				engineConfiguration->stepper_raw_output[3], 1);
 
 			iacHbridgeHw.initialize(
 				motorA,
@@ -115,10 +115,10 @@ void initIdleHardware() {
 
 			hw = &iacHbridgeHw;
 		} else if (engineConfiguration->useHbridgesToDriveIdleStepper) {
-			auto motorA = initDcMotor("DC dis-1", engineConfiguration->stepperDcIo[0],
-				ETB_COUNT + 0, engineConfiguration->stepper_dc_use_two_wires);
-			auto motorB = initDcMotor("DC dis-2", engineConfiguration->stepperDcIo[1],
-				ETB_COUNT + 1, engineConfiguration->stepper_dc_use_two_wires);
+			auto motorA = initStepperDcMotor("DC dis-1", engineConfiguration->stepperDcIo[0],
+				0, engineConfiguration->stepper_dc_use_two_wires);
+			auto motorB = initStepperDcMotor("DC dis-2", engineConfiguration->stepperDcIo[1],
+				1, engineConfiguration->stepper_dc_use_two_wires);
 
 			iacHbridgeHw.initialize(
 				motorA,

--- a/firmware/controllers/engine_controller.cpp
+++ b/firmware/controllers/engine_controller.cpp
@@ -522,10 +522,6 @@ bool validateConfigOnStartUpOrBurn() {
   if (!validateBoardConfig()) {
     return false;
   }
-#if defined(HW_HELLEN_UAEFI)
-  // todo: make this board-specific validation callback!
-  pickEtbOrStepper();
-#endif
   if (!validateGdi()) {
     return false;
   }


### PR DESCRIPTION
## Problem

The `DcHardware` pool was shared between ETB/DC-actuator motors and the
H-bridge stepper coil drivers:

```cpp
static DcHardware dcHardware[ETB_COUNT + DC_PER_STEPPER];
//  indices 0-1 → ETB/EWG/DC-idle
//  indices 2-3 → stepper coils A/B
```
This caused a real conflict: using an H-bridge stepper idle valve while
any DC motor function was assigned was silently unsafe. A runtime guard
pickEtbOrStepper() existed only to detect and block this combination.
Additionally, the stepper occupying ETB slots was the root cause of the
hard limit of just 2 DC motor actuators.

## Result
Stepper and DC-actuator motors now use fully independent hardware pools. No behavior change. This is a prerequisite for lifting the 2-slot DC motor limit (allowing ETB + wastegate + DC idle valve simultaneously).