### PR TITLE
9471: CAN baudrate switch

### DIFF
--- a/firmware/controllers/lua/lua_hooks.cpp
+++ b/firmware/controllers/lua/lua_hooks.cpp
@@ -26,6 +26,7 @@
 
 #if EFI_CAN_SUPPORT || EFI_UNIT_TEST
 #include "can_msg_tx.h"
+#include "can_hw.h"
 #endif // EFI_CAN_SUPPORT
 #include "settings.h"
 #include <new>
@@ -242,6 +243,19 @@ static int lua_txCan(lua_State* l) {
 	msg.setDlc(dlc);
 
 	// no return value
+	return 0;
+}
+
+static int lua_canSetBaud(lua_State* l) {
+	int bus = validateCanChannelAndConvertFromHumanIntoZeroIndex(l);
+	int baud = luaL_checkinteger(l, 2);
+
+	int ret = setCanBaud(bus, baud);
+
+	if (ret < 0) {
+		luaL_error(l, "Failed to change CAN%d baudrate to %d", bus + 1, baud);
+	}
+
 	return 0;
 }
 #endif // EFI_CAN_SUPPORT
@@ -1156,6 +1170,7 @@ extern int luaCommandCounters[LUA_BUTTON_COUNT];
 
 #if EFI_CAN_SUPPORT || EFI_UNIT_TEST
 	lua_register(lState, "txCan", lua_txCan);
+	lua_register(lState, "canSetBaud", lua_canSetBaud);
 #endif
 
 #if EFI_PROD_CODE

--- a/firmware/controllers/lua/lua_hooks.cpp
+++ b/firmware/controllers/lua/lua_hooks.cpp
@@ -250,11 +250,13 @@ static int lua_canSetBaud(lua_State* l) {
 	int bus = validateCanChannelAndConvertFromHumanIntoZeroIndex(l);
 	int baud = luaL_checkinteger(l, 2);
 
+#if !EFI_UNIT_TEST
 	int ret = setCanBaud(bus, baud);
 
 	if (ret < 0) {
 		luaL_error(l, "Failed to change CAN%d baudrate to %d", bus + 1, baud);
 	}
+#endif
 
 	return 0;
 }

--- a/firmware/hw_layer/drivers/can/can_hw.cpp
+++ b/firmware/hw_layer/drivers/can/can_hw.cpp
@@ -61,7 +61,7 @@ public:
 	using ThreadController::stop;
 
 	void ThreadTask() override {
-		while (true) {
+		while (!chThdShouldTerminateX()) {
 			// Block until we get a message
 			msg_t result = canReceiveTimeout(m_device, CAN_ANY_MAILBOX, &m_buffer, CAN_RX_TIMEOUT);
 
@@ -75,6 +75,8 @@ public:
 
 			processCanRxMessage(m_index, m_buffer, getTimeNowNt());
 		}
+
+		chThdExit((msg_t)0x0);
 	}
 
 private:

--- a/firmware/hw_layer/drivers/can/can_hw.cpp
+++ b/firmware/hw_layer/drivers/can/can_hw.cpp
@@ -108,6 +108,7 @@ static CANDriver* getCanDevice(size_t index)
 
 	return nullptr;
 }
+#endif // EFI_PROD_CODE
 
 static can_baudrate_e getDefaultCanBaudRate(size_t index) {
 	switch (index) {
@@ -138,7 +139,6 @@ static bool getCanListenOnly(size_t index) {
 
 	return engineConfiguration->can1ListenMode;
 }
-#endif
 
 int txErrorCount[EFI_CAN_BUS_COUNT] = {};
 

--- a/firmware/hw_layer/drivers/can/can_hw.cpp
+++ b/firmware/hw_layer/drivers/can/can_hw.cpp
@@ -58,6 +58,8 @@ public:
 		}
 	}
 
+	using ThreadController::stop;
+
 	void ThreadTask() override {
 		while (true) {
 			// Block until we get a message
@@ -306,6 +308,40 @@ void initCan() {
 
 bool getIsCanEnabled(void) {
 	return isCanEnabled;
+}
+
+void setCanBaud(size_t index, can_baudrate_e rate) {
+	if (index >= EFI_CAN_BUS_COUNT)
+		return;
+
+	auto device = getCanDevice(index);
+	if (device == nullptr)
+		return;
+
+	// Stop listener
+	canRead[index].stop();
+
+	// Remove CAN device from tx system
+	CanTxMessage::removeDevice(index);
+
+	// Actually stop HW
+	canStop(device);
+
+	// Get config for new baudrate
+	CANConfig canConfig;
+	memcpy(&canConfig, findCanConfig(rate), sizeof(canConfig));
+	applyListenOnly(&canConfig, getCanListenOnly(index));
+
+	// Start HW
+	canStart(device, &canConfig);
+
+	// Plumb CAN devices to tx system
+	CanTxMessage::setDevice(index, device);
+
+	// Start listener
+	if (engineConfiguration->canReadEnabled) {
+		canRead[index].start();
+	}
 }
 
 #endif /* EFI_CAN_SUPPORT */

--- a/firmware/hw_layer/drivers/can/can_hw.cpp
+++ b/firmware/hw_layer/drivers/can/can_hw.cpp
@@ -310,13 +310,13 @@ bool getIsCanEnabled(void) {
 	return isCanEnabled;
 }
 
-void setCanBaud(size_t index, can_baudrate_e rate) {
+int setCanBaud(size_t index, can_baudrate_e rate) {
 	if (index >= EFI_CAN_BUS_COUNT)
-		return;
+		return -1;
 
 	auto device = getCanDevice(index);
 	if (device == nullptr)
-		return;
+		return -2;
 
 	// Stop listener
 	canRead[index].stop();
@@ -342,6 +342,48 @@ void setCanBaud(size_t index, can_baudrate_e rate) {
 	if (engineConfiguration->canReadEnabled) {
 		canRead[index].start();
 	}
+
+	return 0;
+}
+
+int setCanBaud(size_t index, int baudrate) {
+	can_baudrate_e rate;
+
+	switch (baudrate) {
+	case 33000:
+		rate = B33KBPS;
+		break;
+	case 50000:
+		rate = B50KBPS;
+		break;
+	case 83000:
+	case 83333:
+		rate = B83KBPS;
+		break;
+	case 100000:
+		rate = B100KBPS;
+		break;
+	case 125000:
+		rate = B125KBPS;
+		break;
+	case 250000:
+		rate = B250KBPS;
+		break;
+	case 666000:
+	case 666666:
+		rate = B666KBPS;
+		break;
+	case 1000000:
+		rate = B1MBPS;
+		break;
+	case 500000:
+		rate = B500KBPS;
+		break;
+	default:
+		return -3;
+	}
+
+	return setCanBaud(index, rate);
 }
 
 #endif /* EFI_CAN_SUPPORT */

--- a/firmware/hw_layer/drivers/can/can_hw.cpp
+++ b/firmware/hw_layer/drivers/can/can_hw.cpp
@@ -48,10 +48,12 @@ public:
 	{
 	}
 
-	void start(CANDriver* device) {
+	void setDevice(CANDriver* device) {
 		m_device = device;
+	}
 
-		if (device) {
+	void start(void) {
+		if (m_device) {
 			ThreadController::start();
 		}
 	}
@@ -79,11 +81,11 @@ private:
 	CANDriver* m_device;
 };
 
-CCM_OPTIONAL static CanRead canRead1(0);
-CCM_OPTIONAL static CanRead canRead2(1);
+CCM_OPTIONAL static CanRead canRead[EFI_CAN_BUS_COUNT] = { CanRead(0), CanRead(1)
 #if (EFI_CAN_BUS_COUNT >= 3)
-CCM_OPTIONAL static CanRead canRead3(2);
+	, CanRead(2)
 #endif
+	};
 static CanWrite canWrite CCM_OPTIONAL;
 
 #if EFI_PROD_CODE
@@ -101,6 +103,36 @@ static CANDriver* getCanDevice(size_t index)
 	}
 
 	return nullptr;
+}
+
+static can_baudrate_e getDefaultCanBaudRate(size_t index) {
+	switch (index) {
+	case 0:
+		return engineConfiguration->canBaudRate;
+	case 1:
+		return engineConfiguration->can2BaudRate;
+#if (EFI_CAN_BUS_COUNT >= 3)
+	case 2:
+		return engineConfiguration->can3BaudRate;
+#endif
+	}
+
+	return engineConfiguration->canBaudRate;
+}
+
+static bool getCanListenOnly(size_t index) {
+	switch (index) {
+	case 0:
+		return engineConfiguration->can1ListenMode;
+	case 1:
+		return engineConfiguration->can2ListenMode;
+#if (EFI_CAN_BUS_COUNT >= 3)
+	case 2:
+		return engineConfiguration->can3ListenMode;
+#endif
+	}
+
+	return engineConfiguration->can1ListenMode;
 }
 #endif
 
@@ -221,66 +253,41 @@ void initCan() {
 	}
 
 	// Determine physical CAN peripherals based on selected pins
-	auto device1 = getCanDevice(0);
-	auto device2 = getCanDevice(1);
-#if (EFI_CAN_BUS_COUNT >= 3)
-	auto device3 = getCanDevice(2);
-#endif
+	CANDriver *device[EFI_CAN_BUS_COUNT];
+	bool anyCan = false;
+	for (size_t index = 0; index < EFI_CAN_BUS_COUNT; index++) {
+		device[index] = getCanDevice(index);
 
-	// If all devices are null, a firmware error was already thrown by detectCanDevice, but we shouldn't continue
-	if (!device1 && !device2) {
-#if (EFI_CAN_BUS_COUNT >= 3)
-		if (!device3)
-#endif
+		// Check for same devie select
+		for (size_t j = 0; j < index; j++) {
+			if ((device[index] != nullptr) && (device[index] == device[j])) {
+				criticalError("CAN%d and CAN%d pins must be set to different devices", index + 1, j + 1);
 				return;
+			}
+		}
+		anyCan |= (device[index] != nullptr);
 	}
 
-	// Devices can't be the same!
-	if (((device1 == device2) && device1) ||
-#if (EFI_CAN_BUS_COUNT >= 3)
-		((device2 == device3) && device2) ||
-		((device3 == device1) && device3) ||
-#endif
-		0) {
-		criticalError("CAN pins must be set to different devices");
+	// If all devices are null, a firmware error was already thrown by detectCanDevice, but we shouldn't continue
+	if (!anyCan) {
 		return;
 	}
 
 	// Initialize peripherals
-	if (device1) {
-	    // Config based on baud rate
-	    // Pointer to this local canConfig is stored inside CANDriver
-	    // even it is used only during canStart this is wierd
-	    CANConfig canConfig;
-	    memcpy(&canConfig, findCanConfig(engineConfiguration->canBaudRate), sizeof(canConfig));
-	    applyListenOnly(&canConfig, engineConfiguration->can1ListenMode);
-		canStart(device1, &canConfig);
+	for (size_t index = 0; index < EFI_CAN_BUS_COUNT; index++) {
+		if (device[index]) {
+			// Config based on baud rate
+			// Pointer to this local canConfig is stored inside CANDriver
+			// even it is used only during canStart this is wierd
+			CANConfig canConfig;
+			memcpy(&canConfig, findCanConfig(getDefaultCanBaudRate(index)), sizeof(canConfig));
+			applyListenOnly(&canConfig, getCanListenOnly(index));
+			canStart(device[index], &canConfig);
 
-		// Plumb CAN devices to tx system
-		CanTxMessage::setDevice(0, device1);
+			// Plumb CAN devices to tx system
+			CanTxMessage::setDevice(index, device[index]);
+		}
 	}
-
-	if (device2) {
-	    CANConfig canConfig;
-	    memcpy(&canConfig, findCanConfig(engineConfiguration->can2BaudRate), sizeof(canConfig));
-	    applyListenOnly(&canConfig, engineConfiguration->can2ListenMode);
-		canStart(device2, &canConfig);
-
-		// Plumb CAN devices to tx system
-		CanTxMessage::setDevice(1, device2);
-	}
-
-#if (EFI_CAN_BUS_COUNT >= 3)
-	if (device3) {
-	    CANConfig canConfig;
-	    memcpy(&canConfig, findCanConfig(engineConfiguration->can3BaudRate), sizeof(canConfig));
-	    applyListenOnly(&canConfig, engineConfiguration->can3ListenMode);
-		canStart(device3, &canConfig);
-
-		// Plumb CAN devices to tx system
-		CanTxMessage::setDevice(2, device3);
-	}
-#endif
 
 	// fire up threads, as necessary
 	if (engineConfiguration->canWriteEnabled) {
@@ -288,11 +295,10 @@ void initCan() {
 	}
 
 	if (engineConfiguration->canReadEnabled) {
-		canRead1.start(device1);
-		canRead2.start(device2);
-#if (EFI_CAN_BUS_COUNT >= 3)
-		canRead3.start(device3);
-#endif
+		for (size_t index = 0; index < EFI_CAN_BUS_COUNT; index++) {
+			canRead[index].setDevice(device[index]);
+			canRead[index].start();
+		}
 	}
 
 	isCanEnabled = true;

--- a/firmware/hw_layer/drivers/can/can_hw.h
+++ b/firmware/hw_layer/drivers/can/can_hw.h
@@ -18,5 +18,6 @@ void setCanVss(int type);
 void stopCanPins();
 void startCanPins();
 bool getIsCanEnabled(void);
+void setCanBaud(size_t index, can_baudrate_e rate);
 
 #endif /* EFI_CAN_SUPPORT */

--- a/firmware/hw_layer/drivers/can/can_hw.h
+++ b/firmware/hw_layer/drivers/can/can_hw.h
@@ -18,6 +18,7 @@ void setCanVss(int type);
 void stopCanPins();
 void startCanPins();
 bool getIsCanEnabled(void);
-void setCanBaud(size_t index, can_baudrate_e rate);
+int setCanBaud(size_t index, can_baudrate_e rate);
+int setCanBaud(size_t index, int baud);
 
 #endif /* EFI_CAN_SUPPORT */

--- a/firmware/hw_layer/drivers/can/can_msg_tx.h
+++ b/firmware/hw_layer/drivers/can/can_msg_tx.h
@@ -63,6 +63,12 @@ public:
 	 * Configures the device for all messages to transmit from.
 	 */
 	static void setDevice(size_t idx, CANDriver* device);
+	/**
+	 * Removes device from interface list
+	 */
+	static void removeDevice(size_t idx) {
+		setDevice(idx, nullptr);
+	}
 #endif // EFI_CAN_SUPPORT
 
 	size_t busIndex = 0;


### PR DESCRIPTION
Known issue:
Can cause "device not configured" critical error because CAN interface is removed and then re-installed into CanTxMessage interfaces list when changing baudrate.