### PR TITLE
SerialPortScanner: mark tcp ecu has "unknown" if we can't get calibration data (ie, same as serial ports)

### DIFF
--- a/java_console/ui/src/main/java/com/rusefi/SerialPortScanner.java
+++ b/java_console/ui/src/main/java/com/rusefi/SerialPortScanner.java
@@ -213,7 +213,7 @@ public enum SerialPortScanner {
                     final Optional<CalibrationsInfo> tcpCalibrations = getEcuCalibrations(tcpPort);
                     final PortResult tcpResult = tcpCalibrations
                         .map(c -> new PortResult(tcpPort, SerialPortType.Ecu, c))
-                        .orElseGet(() -> new PortResult(tcpPort, SerialPortType.Ecu));
+                        .orElseGet(() -> new PortResult(tcpPort, SerialPortType.Unknown));
                     ports.add(tcpResult);
 
                     // cache port + calibrations

--- a/java_console/ui/src/main/java/com/rusefi/ui/basic/BasicUpdaterPanel.java
+++ b/java_console/ui/src/main/java/com/rusefi/ui/basic/BasicUpdaterPanel.java
@@ -338,7 +338,7 @@ never used?
         if (logoLabelPopupMenu != null) {
             logoLabelPopupMenu.refreshUploadTuneAndPrintUnitLabelsMenuItems(
                 isEcuPortJobPossible,
-                ecuPort.map(port -> existsAnyOfUnitIdentifierFields(port.getCalibrations().getIniFile())).orElse(false)
+                ecuPort.map(port -> port.getCalibrations() != null && existsAnyOfUnitIdentifierFields(port.getCalibrations().getIniFile())).orElse(false)
             );
         }
     }


### PR DESCRIPTION
resolves #9465