### PR TITLE
PortHolder: fix reconnection over race condition between device restart

### DIFF
--- a/java_console/io/src/main/java/com/rusefi/io/serial/PortHolder.java
+++ b/java_console/io/src/main/java/com/rusefi/io/serial/PortHolder.java
@@ -42,9 +42,20 @@ public class PortHolder {
      */
     void connectAndReadConfiguration(BinaryProtocol.Arguments arguments) {
         Objects.requireNonNull(arguments);
-        IoStream stream = ioStreamFactory.call();
+        IoStream stream;
+        try {
+            stream = ioStreamFactory.call();
+        } catch (RuntimeException e) {
+            log.error("Exception opening port: " + e.getMessage());
+            if (listener != null) {
+                listener.onConnectionFailed("Exception opening port: " + e.getMessage());
+            }
+            return;
+        }
         if (stream == null) {
-            // error already reported
+            if (listener != null) {
+                listener.onConnectionFailed("Failed to open port");
+            }
             return;
         }
         synchronized (portLock) {

--- a/java_console/ui/src/main/java/com/rusefi/maintenance/BinaryProtocolExecutor.java
+++ b/java_console/ui/src/main/java/com/rusefi/maintenance/BinaryProtocolExecutor.java
@@ -5,6 +5,7 @@ import com.fazecast.jSerialComm.SerialPort;
 import com.rusefi.ConnectivityContext;
 import com.rusefi.Timeouts;
 import com.rusefi.binaryprotocol.BinaryProtocol;
+import com.rusefi.io.ConnectionStatusLogic;
 import com.rusefi.io.LinkManager;
 import com.rusefi.io.UpdateOperationCallbacks;
 
@@ -12,6 +13,7 @@ import java.util.Arrays;
 import java.util.Objects;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static com.fazecast.jSerialComm.SerialPort.getCommPorts;
@@ -38,19 +40,40 @@ public class BinaryProtocolExecutor {
             .setNeedPullLiveData(true)
         ) {
             callbacks.logLine(String.format(msg + ": Connecting to port `%s`...", port));
+
+            final CountDownLatch connectionLatch = new CountDownLatch(1);
+            final AtomicBoolean connectionSuccess = new AtomicBoolean(false);
+
+            linkManager.startAndConnect(port, new ConnectionStatusLogic.Listener() {
+                @Override
+                public void onConnectionStatus(boolean isConnected) {}
+
+                @Override
+                public void onConnectionFailed(String s) {
+                    callbacks.logLine(String.format(msg + ": Connection failed: %s", s));
+                    connectionLatch.countDown();
+                }
+
+                @Override
+                public void onConnectionEstablished() {
+                    connectionSuccess.set(true);
+                    connectionLatch.countDown();
+                }
+            });
+
             try {
-                if (linkManager.connect(port, isScanningForEcu).await(1, TimeUnit.MINUTES)) {
-                    final CountDownLatch latch = new CountDownLatch(1);
+                if (connectionLatch.await(1, TimeUnit.MINUTES) && connectionSuccess.get()) {
+                    final CountDownLatch actionLatch = new CountDownLatch(1);
                     callbacks.logLine(String.format(msg + ": Performing action on port %s...", port));
                     linkManager.execute(() -> {
                         try {
                             executionResult.set(bpAction.doWithBinaryProtocol(linkManager.getBinaryProtocol()));
                         } finally {
-                            latch.countDown();
+                            actionLatch.countDown();
                         }
                     });
                     try {
-                        if (!latch.await(1, TimeUnit.MINUTES)) {
+                        if (!actionLatch.await(1, TimeUnit.MINUTES)) {
                             callbacks.logLine(String.format("Failed perform action on port %s in a minute", port));
                         }
                     } catch (final InterruptedException e) {

--- a/java_console/ui/src/main/java/com/rusefi/maintenance/CalibrationsHelper.java
+++ b/java_console/ui/src/main/java/com/rusefi/maintenance/CalibrationsHelper.java
@@ -131,11 +131,20 @@ public class CalibrationsHelper {
                     newEcuPort.port
                 ));
 
-                final Optional<CalibrationsInfo> updatedCalibrations = readAndBackupCurrentCalibrationsWithSuspendedPortScanner(
-                    newEcuPort.port,
-                    callbacks,
-                    getFileNameWithoutExtension(timestampFileNameComponent, "after_firmware_update"), connectivityContext
-                );
+                // The ECU's USB can briefly drop and re-enumerate right after the
+                // scanner's probe. Retry a few times to ride out that transient window.
+                Optional<CalibrationsInfo> updatedCalibrations = Optional.empty();
+                for (int attempt = 1; attempt <= 3 && !updatedCalibrations.isPresent(); attempt++) {
+                    if (attempt > 1) {
+                        callbacks.logLine("Retrying calibration read after firmware update (attempt " + attempt + ")...");
+                        BinaryProtocol.sleep(5_000);
+                    }
+                    updatedCalibrations = readAndBackupCurrentCalibrationsWithSuspendedPortScanner(
+                        newEcuPort.port,
+                        callbacks,
+                        getFileNameWithoutExtension(timestampFileNameComponent, "after_firmware_update"), connectivityContext
+                    );
+                }
                 if (!updatedCalibrations.isPresent()) {
                     callbacks.logLine("Failed to back up tune from ECU after firmware update...");
                     return false;


### PR DESCRIPTION
… and scanner port probe (mainly linux console, can happen on windows also)

usually the bug manifests itself as update fails on port calibrations, we retry after some random time manually and same update payload /firmware bin success