### PR TITLE
back-port script: also sync resources and test data

### DIFF
--- a/bin/_back_port_all_java.sh
+++ b/bin/_back_port_all_java.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 
-# this script is helps to back-port complete master java into some very old branch by just dumping it there
+# this script helps to back-port complete master java into some very old branch by just dumping it there
+# NOTE: build.gradle files are intentionally NOT synced — LTS uses different module aliases
+#       (e.g. :core_io instead of :shared_io) and different rootDir-relative paths.
+#       If the backported code requires new gradle dependencies, add them manually
+#       following the pattern from commit 9bb90de.
 
 TARGET_DIR=${1:-../rusefi.2}
 
@@ -17,6 +21,19 @@ find "$TARGET_DIR/java_console" "$TARGET_DIR/java_tools" -name "*.java" -type f 
 
 # copy all java
 echo "Copying new Java files..."
-find java_console java_tools -name "*.java" | rsync -avR --files-from=- . "$TARGET_DIR/"
+find java_console java_tools -name "*.java" -not -path "*/build/*" | rsync -avR --files-from=- . "$TARGET_DIR/"
 
-echo "Done!"
+# copy resource files (images, test data, properties) that accompany the java code
+echo "Copying resource files..."
+find java_console java_tools \
+  \( -path "*/src/main/resources/*" -o -path "*/src/test/resources/*" \) \
+  -not -path "*/build/*" -type f | rsync -avR --files-from=- . "$TARGET_DIR/"
+
+# copy non-java test data files (ini, msq, xml, etc. under src/test/java)
+echo "Copying test data files..."
+find java_console java_tools -path "*/src/test/java/*" \
+  \( -name "*.ini" -o -name "*.msq" -o -name "*.xml" -o -name "*.json" \) \
+  -not -path "*/build/*" -type f | rsync -avR --files-from=- . "$TARGET_DIR/"
+
+echo "Done! Verify the build compiles with: cd $TARGET_DIR/java_tools && ./gradlew :ui:compileJava"
+echo "If new gradle module dependencies are missing, see commit 9bb90de for the repair pattern."


### PR DESCRIPTION
Extend _back_port_all_java.sh to copy files that accompany Java source:
- Files under src/main/resources/ and src/test/resources/
- Non-java test data (ini, msq, xml, json) under src/test/java/

Also exclude build/ directories from all find commands so compiled artifacts are never accidentally synced to the target.

related #9516