### PR TITLE
fix "console exception diff defect"

### DIFF
--- a/java_console/io/src/main/java/com/rusefi/binaryprotocol/BinaryProtocol.java
+++ b/java_console/io/src/main/java/com/rusefi/binaryprotocol/BinaryProtocol.java
@@ -120,6 +120,14 @@ public class BinaryProtocol {
 
         binaryProtocolLogger = new BinaryProtocolLogger(linkManager);
         stream.addCloseListener(binaryProtocolLogger::close);
+        // When the stream dies (cable yank, ECU reboot, etc.) mark NOT_CONNECTED and purge
+        // stale sensor data so a subsequent ECU doesn't inherit values from this one.
+        // This is the only mechanism that fires NOT_CONNECTED on the splash screen — the
+        // ConnectionWatchdog exists only inside ConsoleUI and is not created during splash.
+        stream.addCloseListener(() -> {
+            ConnectionStatusLogic.INSTANCE.setValue(ConnectionStatusValue.NOT_CONNECTED);
+            SensorCentral.getInstance().reset();
+        });
     }
 
     public boolean isClosed() {

--- a/java_console/io/src/main/java/com/rusefi/core/SensorCentral.java
+++ b/java_console/io/src/main/java/com/rusefi/core/SensorCentral.java
@@ -88,7 +88,7 @@ public class SensorCentral implements ISensorCentral {
         }
     }
     private volatile Map<String, ResolvedGaugeLabels> resolvedGaugeLabels = Collections.emptyMap();
-    private byte[] response;
+    private volatile byte[] response;
 
     // Sliding window of recent frame arrival timestamps (System.nanoTime), used to compute
     // the synthetic 'runtimeDataRateGauge' value (frames-per-second) once per ECU frame.
@@ -246,6 +246,28 @@ public class SensorCentral implements ISensorCentral {
         }
         if (listeners != null)
             listeners.remove(listener);
+    }
+
+    /**
+     * Clears all accumulated sensor state. Called on ECU disconnect so stale values from the
+     * old board do not linger into the next connection (especially critical when ECU A and B
+     * have different output-channel layouts / firmware signatures).
+     * <p>
+     * Thread-safety: this method may race with the pull thread's {@link #grabSensorValues} call.
+     * {@code sensorsHolder} uses its own internal lock so {@code reset()} and
+     * {@code getValue}/{@code setValue} are mutually exclusive.
+     * {@code response} and {@code resolvedGaugeLabels} are {@code volatile}, so their
+     * null/empty assignments are immediately visible to any concurrent reader.
+     * {@code frameTimestampsNanos} is guarded by its own {@code synchronized} block here and
+     * in {@link #updateRuntimeDataRate}.
+     */
+    public void reset() {
+        sensorsHolder.reset();
+        response = null;
+        resolvedGaugeLabels = Collections.emptyMap();
+        synchronized (frameTimestampsNanos) {
+            frameTimestampsNanos.clear();
+        }
     }
 
     @Override

--- a/java_console/io/src/main/java/com/rusefi/core/SensorsHolder.java
+++ b/java_console/io/src/main/java/com/rusefi/core/SensorsHolder.java
@@ -1,6 +1,7 @@
 package com.rusefi.core;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
@@ -11,10 +12,13 @@ public class SensorsHolder {
     // Values stored as single-element double[] to avoid boxing on every update.
     // The array is allocated once per channel name and mutated in place thereafter.
     // todo: probably not worth migrating to AtomicDouble with longBitsToDouble
+    private final Object lock = new Object();
     private final Map<String, double[]> values = new HashMap<>();
 
     public Set<String> getSensorNames() {
-        return values.keySet();
+        synchronized (lock) {
+            return new HashSet<>(values.keySet());
+        }
     }
 
     public double getValue(Sensor sensor) {
@@ -22,8 +26,10 @@ public class SensorsHolder {
     }
 
     public double getValue(String sensorName) {
-        double[] cell = values.get(sensorName.toLowerCase(Locale.US));
-        return cell == null ? Double.NaN : cell[0];
+        synchronized (lock) {
+            double[] cell = values.get(sensorName.toLowerCase(Locale.US));
+            return cell == null ? Double.NaN : cell[0];
+        }
     }
 
     public boolean setValue(double value, final Sensor sensor) {
@@ -33,13 +39,21 @@ public class SensorsHolder {
 
     public boolean setValue(double value, String sensorName) {
         String key = sensorName.toLowerCase(Locale.US);
-        double[] cell = values.get(key);
-        if (cell == null) {
-            values.put(key, new double[]{value});
-            return true;
+        synchronized (lock) {
+            double[] cell = values.get(key);
+            if (cell == null) {
+                values.put(key, new double[]{value});
+                return true;
+            }
+            boolean isUpdated = cell[0] != value;
+            cell[0] = value;
+            return isUpdated;
         }
-        boolean isUpdated = cell[0] != value;
-        cell[0] = value;
-        return isUpdated;
+    }
+
+    public void reset() {
+        synchronized (lock) {
+            values.clear();
+        }
     }
 }

--- a/java_console/ui/src/main/java/com/rusefi/SerialPortScanner.java
+++ b/java_console/ui/src/main/java/com/rusefi/SerialPortScanner.java
@@ -64,6 +64,10 @@ public enum SerialPortScanner {
             startTimer();
     }
 
+    // Number of ECU-detection attempts before giving up and labelling a port Unknown.
+    // A freshly rebooted or reconnected ECU may not respond on the first try.
+    private static final int DETECT_MAX_ATTEMPTS = 3;
+
     private static PortResult inspectPort(String serialPort) {
         log.info("Determining type of serial port: " + serialPort);
 
@@ -71,24 +75,34 @@ public enum SerialPortScanner {
         log.info("Port " + serialPort + (isOpenblt ? " looks like" : " does not look like") + " an OpenBLT bootloader");
         if (isOpenblt) {
             return new PortResult(serialPort, SerialPortType.OpenBlt);
-        } else {
-            // See if this looks like an ECU
+        }
+
+        for (int attempt = 1; attempt <= DETECT_MAX_ATTEMPTS; attempt++) {
             final Optional<CalibrationsInfo> ecuCalibrations = getEcuCalibrations(serialPort);
             final boolean isEcu = ecuCalibrations.isPresent();
-            log.info("Port " + serialPort + (isEcu ? " looks like" : " does not look like") + " an ECU");
+            log.info("Port " + serialPort + " ECU detection attempt " + attempt + "/" + DETECT_MAX_ATTEMPTS
+                + ": " + (isEcu ? "found" : "not found"));
             if (isEcu) {
-                final boolean ecuHasOpenblt = ecuHasOpenblt(serialPort);
-                log.info("ECU at " + serialPort + (ecuHasOpenblt ? " has" : " does not have") + " an OpenBLT bootloader");
+                final boolean hasOpenblt = ecuHasOpenblt(serialPort);
+                log.info("ECU at " + serialPort + (hasOpenblt ? " has" : " does not have") + " an OpenBLT bootloader");
                 return new PortResult(
                     serialPort,
-                    ecuHasOpenblt ? SerialPortType.EcuWithOpenblt : SerialPortType.Ecu,
+                    hasOpenblt ? SerialPortType.EcuWithOpenblt : SerialPortType.Ecu,
                     ecuCalibrations.get()
                 );
-            } else {
-                // Dunno what this is, leave it in the list anyway
-                return new PortResult(serialPort, SerialPortType.Unknown);
+            }
+            if (attempt < DETECT_MAX_ATTEMPTS) {
+                try {
+                    Thread.sleep(200);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    break;
+                }
             }
         }
+
+        log.info("Port " + serialPort + " does not look like an ECU after " + DETECT_MAX_ATTEMPTS + " attempts");
+        return new PortResult(serialPort, SerialPortType.Unknown);
     }
 
     private static List<PortResult> inspectPorts(final List<String> ports) {
@@ -188,9 +202,12 @@ public enum SerialPortScanner {
 
         for (PortResult p : inspectPorts(portsToInspect)) {
             log.info("Port " + p.port + " detected as: " + p.type.friendlyString);
-
             ports.add(p);
-            portCache.put(p);
+            // Do not cache Unknown — keep the port uninspected so the next scan cycle retries
+            // detection automatically without waiting for the port to disappear and reappear.
+            if (p.type != SerialPortType.Unknown) {
+                portCache.put(p);
+            }
         }
 
         final Collection<String> tcpPorts = includeSlowLookup

--- a/java_console/ui/src/main/java/com/rusefi/StartupFrame.java
+++ b/java_console/ui/src/main/java/com/rusefi/StartupFrame.java
@@ -702,6 +702,8 @@ public class StartupFrame {
             splashListener = null;
         }
         // Per design: keep auto-connect gate closed for the rest of the session.
+        // the idea here is "if the user is connecting and desconecting multiple boards,
+        // user is updating a large batch of units, so we don't bother with calibration data pre-read, since it is done on the update job"
         uiContext.getLinkManager().close();
         autoConnectedPort = null;
         autoConnectThread = null;

--- a/java_console/ui/src/main/java/com/rusefi/StartupFrame.java
+++ b/java_console/ui/src/main/java/com/rusefi/StartupFrame.java
@@ -558,7 +558,10 @@ public class StartupFrame {
         splashListener = new ConnectionStatusLogic.Listener() {
             @Override
             public void onConnectionStatus(boolean isConnected) {
-                if (!isConnected) return;
+                if (!isConnected) {
+                    SwingUtilities.invokeLater(() -> onSplashDisconnected());
+                    return;
+                }
                 SwingUtilities.invokeLater(() -> {
                     if (!ConnectionStatusLogic.INSTANCE.isConnected()) return;
                     if (uiContext.getBinaryProtocol() == null) return;
@@ -671,14 +674,35 @@ public class StartupFrame {
         });
     }
 
-    private void onSplashConnectFailed(String msg) {
-        log.warn("Splash auto-connect failed: " + msg);
-        // Per design: keep auto-connect gate closed for the rest of the session.
-        uiContext.getLinkManager().close();
+    /**
+     * Called on the EDT when the ECU drops the connection while still on the splash screen
+     * lears splash-owned state so the port combo is repopulated
+     * on the next scanner tick and the user can manually pick a port or wait for ECU B.
+     */
+    private void onSplashDisconnected() {
         if (splashListener != null) {
             ConnectionStatusLogic.INSTANCE.removeListener(splashListener);
             splashListener = null;
         }
+        // Sets isStarted=false so the next connect() can create a new LinkManager connector.
+        uiContext.getLinkManager().close();
+        autoConnectedPort = null;
+        autoConnectThread = null;
+        connectButton.setText("Connect");
+        connectButton.setEnabled(true);
+        portsComboBox.getComboPorts().setEnabled(true);
+    }
+
+    private void onSplashConnectFailed(String msg) {
+        log.warn("Splash auto-connect failed: " + msg);
+        // Remove the listener before calling close() so the NOT_CONNECTED event it emits does
+        // not re-trigger onSplashDisconnected() and overwrite the failure message below.
+        if (splashListener != null) {
+            ConnectionStatusLogic.INSTANCE.removeListener(splashListener);
+            splashListener = null;
+        }
+        // Per design: keep auto-connect gate closed for the rest of the session.
+        uiContext.getLinkManager().close();
         autoConnectedPort = null;
         autoConnectThread = null;
         connectButton.setEnabled(true);

--- a/java_console/ui/src/main/java/com/rusefi/ini/IniFileState.java
+++ b/java_console/ui/src/main/java/com/rusefi/ini/IniFileState.java
@@ -10,6 +10,7 @@ import com.rusefi.ini.reader.IniFileReaderUtil;
 import com.rusefi.ui.UIContext;
 
 import java.io.FileNotFoundException;
+import java.util.Objects;
 
 import static com.devexperts.logging.Logging.getLogging;
 
@@ -23,6 +24,8 @@ public class IniFileState {
     private final UIContext uiContext;
 
     private IniFileModel iniFileModel;
+    // Signature of the ECU whose INI model is currently cached. Null means local fallback.
+    private String lastSignature;
 
     public IniFileState(UIContext uiContext) {
         this.uiContext = uiContext;
@@ -45,10 +48,25 @@ public class IniFileState {
     public IniFileModel getIniFileModel() {
         BinaryProtocol bp = uiContext.getBinaryProtocol();
         if (bp != null) {
-            // do not lose reference on disconnect
+            String currentSignature = bp.signature;
             IniFileModel current = bp.getIniFileNullable();
-            if (current != null)
+            if (current != null) {
+                // bp has a fully-loaded model — always take it and track the signature.
+                if (!Objects.equals(currentSignature, lastSignature)) {
+                    log.info("ECU signature changed [" + lastSignature + "] -> [" + currentSignature + "], updating INI model");
+                    lastSignature = currentSignature;
+                }
                 iniFileModel = current;
+            } else if (currentSignature != null && !Objects.equals(currentSignature, lastSignature)) {
+                // bp is connected, but the INI hasn't loaded yet, and the ECU signature differs
+                // from the last cached one — discard the stale model so callers don't use wrong
+                // field offsets from the old firmware while waiting for the new INI to load.
+                log.info("ECU signature changed [" + lastSignature + "] -> [" + currentSignature + "], invalidating stale INI model");
+                lastSignature = currentSignature;
+                iniFileModel = null;
+            }
+            // else: same-ECU reconnect (signature unchanged or not yet known) — keep cached model
+            // so the UI stays populated during a transient drop, matching original intent.
         }
         return iniFileModel;
     }


### PR DESCRIPTION
- Add retry logic for ECU detection
- Avoid caching unknown ports to enable re-detection during the next scan.
- Enhance INI model handling by cleaning up stale states on ECU signature changes.
- Reset sensor data and connection status on ECU disconnects to prevent stale data.
- Synchronize sensor value access and clearing to ensure thread safety.

resolves #9144 and similar techdebt (mainly the thread issue on sensor values)