### PR TITLE
PortScanner should not change global LinkManager status on closing ports

### DIFF
--- a/java_console/io/src/main/java/com/rusefi/io/LinkManager.java
+++ b/java_console/io/src/main/java/com/rusefi/io/LinkManager.java
@@ -59,6 +59,7 @@ public class LinkManager implements Closeable {
     private boolean needPullLiveData = true;
     public final MessagesListener messageListener = (source, message) -> log.info(source + ": " + message);
     private boolean isDisconnectedByUser;
+    private boolean notifyGlobalStatusOnClose = true;
 
     public LinkManager() {
         engineState = new EngineState(new EngineState.EngineStateListenerImpl() {
@@ -178,6 +179,16 @@ public class LinkManager implements Closeable {
 
     public LinkManager setNeedPullText(boolean needPullText) {
         this.needPullText = needPullText;
+        return this;
+    }
+
+    /**
+     * When false, {@link #close()} does not push {@link ConnectionStatusValue#NOT_CONNECTED} to the
+     * global {@link ConnectionStatusLogic#INSTANCE}.  Set this on short-lived scanner probes so they
+     * do not evict the splash-screen auto-connect or any other persistent connection.
+     */
+    public LinkManager setNotifyGlobalStatusOnClose(boolean notify) {
+        this.notifyGlobalStatusOnClose = notify;
         return this;
     }
 
@@ -358,7 +369,9 @@ public class LinkManager implements Closeable {
 
     @Override
     public void close() {
-        ConnectionStatusLogic.INSTANCE.setValue(ConnectionStatusValue.NOT_CONNECTED);
+        if (notifyGlobalStatusOnClose) {
+            ConnectionStatusLogic.INSTANCE.setValue(ConnectionStatusValue.NOT_CONNECTED);
+        }
         if (connector != null) {
             connector.stop();
         }

--- a/java_console/io/src/main/java/com/rusefi/updater/PlainSerialPortScanner.java
+++ b/java_console/io/src/main/java/com/rusefi/updater/PlainSerialPortScanner.java
@@ -31,6 +31,7 @@ public class PlainSerialPortScanner {
                 try (LinkManager linkManager = new LinkManager()
                     .setNeedPullText(false)
                     .setNeedPullLiveData(false)
+                    .setNotifyGlobalStatusOnClose(false)
                 ) {
                     linkManager.start(port, ConnectionStatusLogic.Listener.VOID);
                     linkManager.getConnector().connectAndReadConfiguration(new BinaryProtocol.Arguments(false, false),

--- a/java_console/ui/src/main/java/com/rusefi/maintenance/BinaryProtocolExecutor.java
+++ b/java_console/ui/src/main/java/com/rusefi/maintenance/BinaryProtocolExecutor.java
@@ -38,6 +38,7 @@ public class BinaryProtocolExecutor {
         try (LinkManager linkManager = new LinkManager()
             .setNeedPullText(false)
             .setNeedPullLiveData(true)
+            .setNotifyGlobalStatusOnClose(false)
         ) {
             callbacks.logLine(String.format(msg + ": Connecting to port `%s`...", port));
 


### PR DESCRIPTION
otherwise we are breaking existing connection in another ports!!

ie: ecu on COM31 auto connected, scanner fails on COM3, both connections were dropped