### PR TITLE
Fix broken links in 55 pin breakout PCB readme

### DIFF
--- a/hardware/Breakout_55pin_963063-15-Connector/readme.md
+++ b/hardware/Breakout_55pin_963063-15-Connector/readme.md
@@ -6,9 +6,6 @@
 
 https://rusefi.com/forum/viewtopic.php?f=4&t=616
 
-See [here](../breakout_55_pin) for a similar Motronic connector
+See [here](../Breakout_55pin-motronic-Connector) for a similar Motronic connector
 
-
-[For sale](https://www.ebay.com/itm/333553816490)
-
-[For sale with connector](https://www.ebay.com/itm/333553815170)
+[For sale](https://www.ebay.com/itm/336387912094)


### PR DESCRIPTION
2 of the links in the readme for the 55 pin breakout PCB were broken. Both should be fine now.