### PR TITLE
cli regisry: try to save 3Kb of ram

### DIFF
--- a/firmware/util/cli_registry.cpp
+++ b/firmware/util/cli_registry.cpp
@@ -42,24 +42,24 @@
 using namespace rusefi::stringutil;
 
 static int consoleActionCount = 0;
-static TokenCallback consoleActions[CONSOLE_MAX_ACTIONS];
+static const TokenCallback *consoleActions[CONSOLE_MAX_ACTIONS];
 
 void resetConsoleActions(void) {
 	consoleActionCount = 0;
 }
 
-static void doAddAction(const char *token, action_type_e type, Void callback, void *param) {
 #if !defined(EFI_DISABLE_CONSOLE_ACTIONS)
-	for (uint32_t i = 0; i < std::strlen(token); i++) {
-		char ch = token[i];
+void doAddAction(const TokenCallback *t) {
+	for (uint32_t i = 0; i < std::strlen(t->token); i++) {
+		char ch = t->token[i];
 		if (isupper(ch)) {
-		    onCliCaseError(token);
+		    onCliCaseError(t->token);
 		    return;
 		}
 	}
 	for (int i = 0; i < consoleActionCount; i++) {
-		if (strcmp(token, consoleActions[i].token) == 0 /* zero result means strings are equal */) {
-			onCliDuplicateError(token);
+		if (strcmp(t->token, consoleActions[i]->token) == 0 /* zero result means strings are equal */) {
+			onCliDuplicateError(t->token);
 		    return;
 		}
 	}
@@ -69,98 +69,10 @@ static void doAddAction(const char *token, action_type_e type, Void callback, vo
 		return;
     }
 
-	TokenCallback *current = &consoleActions[consoleActionCount++];
-	current->token = token;
-	current->parameterType = type;
-	current->callback = callback;
-	current->param = param;
+    consoleActions[consoleActionCount] = t;
+    consoleActionCount++;
+}
 #endif /* EFI_DISABLE_CONSOLE_ACTIONS */
-}
-
-void addConsoleActionP(const char *token, VoidPtr callback, void *param) {
-	doAddAction(token, NO_PARAMETER_P, (Void) callback, param);
-}
-
-void addConsoleActionSSP(const char *token, VoidCharPtrCharPtrVoidPtr callback, void *param) {
-	doAddAction(token, STRING2_PARAMETER_P, (Void) callback, param);
-}
-
-/**
- * @brief	Register console action without parameters
- */
-void addConsoleAction(const char *token, Void callback) {
-	doAddAction(token, NO_PARAMETER, callback, NULL);
-}
-
-/**
- * @brief	Register a console command with one Integer parameter
- */
-void addConsoleActionI(const char *token, VoidInt callback) {
-	doAddAction(token, ONE_PARAMETER, (Void) callback, NULL);
-}
-
-void addConsoleActionIP(const char *token, VoidIntVoidPtr callback, void *param) {
-	doAddAction(token, ONE_PARAMETER_P, (Void) callback, param);
-}
-
-/**
- * @brief	Register a console command with two Integer parameters
- */
-void addConsoleActionII(const char *token, VoidIntInt callback) {
-	doAddAction(token, TWO_INTS_PARAMETER, (Void) callback, NULL);
-}
-
-void addConsoleActionIIP(const char *token, VoidIntIntVoidPtr callback, void *param) {
-	doAddAction(token, TWO_INTS_PARAMETER_P, (Void) callback, param);
-}
-
-void addConsoleActionIF(const char *token, VoidIntFloat callback) {
-	doAddAction(token, INT_FLOAT_PARAMETER, (Void) callback, NULL);
-}
-
-void addConsoleActionS(const char *token, VoidCharPtr callback) {
-	doAddAction(token, STRING_PARAMETER, (Void) callback, NULL);
-}
-
-void addConsoleActionSP(const char *token, VoidCharPtrVoidPtr callback, void *param) {
-	doAddAction(token, STRING_PARAMETER_P, (Void) callback, param);
-}
-
-void addConsoleActionSS(const char *token, VoidCharPtrCharPtr callback) {
-	doAddAction(token, STRING2_PARAMETER, (Void) callback, NULL);
-}
-
-void addConsoleActionSSS(const char *token, VoidCharPtrCharPtrCharPtr callback) {
-	doAddAction(token, STRING3_PARAMETER, (Void) callback, NULL);
-}
-
-void addConsoleActionSSSSS(const char *token, VoidCharPtrCharPtrCharPtrCharPtrCharPtr callback) {
-	doAddAction(token, STRING5_PARAMETER, (Void) callback, NULL);
-}
-
-void addConsoleActionNANF(const char *token, VoidFloat callback) {
-	doAddAction(token, FLOAT_PARAMETER_NAN_ALLOWED, (Void) callback, NULL);
-}
-
-void addConsoleActionF(const char *token, VoidFloat callback) {
-	doAddAction(token, FLOAT_PARAMETER, (Void) callback, NULL);
-}
-
-void addConsoleActionFF(const char *token, VoidFloatFloat callback) {
-	doAddAction(token, FLOAT_FLOAT_PARAMETER, (Void) callback, NULL);
-}
-
-void addConsoleActionFFF(const char *token, VoidFloatFloatFloat callback) {
-	doAddAction(token, FLOAT_FLOAT_FLOAT_PARAMETER, (Void) callback, NULL);
-}
-
-void addConsoleActionFFFF(const char *token, VoidFloatFloatFloatFloat callback) {
-	doAddAction(token, FLOAT_FLOAT_FLOAT_FLOAT_PARAMETER, (Void) callback, NULL);
-}
-
-void addConsoleActionFFP(const char *token, VoidFloatFloatVoidPtr callback, void *param) {
-	doAddAction(token, FLOAT_FLOAT_PARAMETER_P, (Void) callback, param);
-}
 
 static int getParameterCount(action_type_e parameterType) {
 	switch (parameterType) {
@@ -198,7 +110,7 @@ static int getParameterCount(action_type_e parameterType) {
 void helpCommand(void) {
 	efiPrintf("%d actions available", consoleActionCount);
 	for (int i = 0; i < consoleActionCount; i++) {
-		TokenCallback *current = &consoleActions[i];
+		const TokenCallback *current = consoleActions[i];
 		efiPrintf("  %s: %d parameters", current->token, getParameterCount(current->parameterType));
 	}
 	efiPrintf("For more visit https://wiki.rusefi.com/Dev-Console-Commands");
@@ -289,13 +201,14 @@ static int setargs(char *args, char **argv, int max_args)
 	return count;
 }
 
-int handleActionWithParameter(TokenCallback *current, char *argv[], int argc) {
+int handleActionWithParameter(const TokenCallback *current, char *argv[], int argc) {
 	(void)argc;
 
 	switch (current->parameterType) {
 	case NO_PARAMETER:
 	{
-		(*current->callback)();
+		Void callbackS = (Void) current->callback;
+		(*callbackS)();
 		return 0;
 	}
 	case NO_PARAMETER_P:
@@ -487,7 +400,7 @@ static int handleConsoleLineInternal(const char *commandLine) {
 	}
 
 	for (int i = 0; i < consoleActionCount; i++) {
-		TokenCallback *current = &consoleActions[i];
+		const TokenCallback *current = consoleActions[i];
 		if (strEqual(argv[0], current->token)) {
 			if ((argc - 1) != getParameterCount(current->parameterType)) {
 				efiPrintf("Incorrect argument count %d, expected %d",

--- a/firmware/util/cli_registry.cpp
+++ b/firmware/util/cli_registry.cpp
@@ -77,19 +77,14 @@ void doAddAction(const TokenCallback *t) {
 static int getParameterCount(action_type_e parameterType) {
 	switch (parameterType) {
 	case NO_PARAMETER:
-	case NO_PARAMETER_P:
 		return 0;
 	case ONE_PARAMETER:
-	case ONE_PARAMETER_P:
 	case FLOAT_PARAMETER:
 	case STRING_PARAMETER:
 		return 1;
 	case FLOAT_FLOAT_PARAMETER:
-	case FLOAT_FLOAT_PARAMETER_P:
 	case STRING2_PARAMETER:
-	case STRING2_PARAMETER_P:
 	case TWO_INTS_PARAMETER:
-	case TWO_INTS_PARAMETER_P:
 	case INT_FLOAT_PARAMETER:
 		return 2;
 	case STRING3_PARAMETER:
@@ -211,34 +206,16 @@ int handleActionWithParameter(const TokenCallback *current, char *argv[], int ar
 		(*callbackS)();
 		return 0;
 	}
-	case NO_PARAMETER_P:
-	{
-		VoidPtr callbackS = (VoidPtr) current->callback;
-		(*callbackS)(current->param);
-		return 0;
-	}
 	case STRING_PARAMETER:
 	{
 		VoidCharPtr callbackS = (VoidCharPtr) current->callback;
 		(*callbackS)(argv[0]);
 		return 0;
 	}
-	case STRING_PARAMETER_P:
-	{
-		VoidCharPtrVoidPtr callbackS = (VoidCharPtrVoidPtr) current->callback;
-		(*callbackS)(argv[0], current->param);
-		return 0;
-	}
 	case STRING2_PARAMETER:
 	{
 		VoidCharPtrCharPtr callbackS = (VoidCharPtrCharPtr) current->callback;
 		(*callbackS)(argv[0], argv[1]);
-		return 0;
-	}
-	case STRING2_PARAMETER_P:
-	{
-		VoidCharPtrCharPtrVoidPtr callbackS = (VoidCharPtrCharPtrVoidPtr) current->callback;
-		(*callbackS)(argv[0], argv[1], current->param);
 		return 0;
 	}
 	case STRING3_PARAMETER:
@@ -290,7 +267,6 @@ int handleActionWithParameter(const TokenCallback *current, char *argv[], int ar
 	}
 
 	case FLOAT_FLOAT_PARAMETER:
-	case FLOAT_FLOAT_PARAMETER_P:
 	{
 		float value[2];
 		for (int i = 0; i < 2; i++) {
@@ -300,13 +276,8 @@ int handleActionWithParameter(const TokenCallback *current, char *argv[], int ar
 				return -1;
 			}
 		}
-		if (current->parameterType == FLOAT_FLOAT_PARAMETER) {
-			VoidFloatFloat callbackS = (VoidFloatFloat) current->callback;
-			(*callbackS)(value[0], value[1]);
-		} else {
-			VoidFloatFloatVoidPtr callbackS = (VoidFloatFloatVoidPtr) current->callback;
-			(*callbackS)(value[0], value[1], current->param);
-		}
+		VoidFloatFloat callbackS = (VoidFloatFloat) current->callback;
+		(*callbackS)(value[0], value[1]);
 		return 0;
 	}
 	case FLOAT_FLOAT_FLOAT_PARAMETER:
@@ -355,7 +326,6 @@ int handleActionWithParameter(const TokenCallback *current, char *argv[], int ar
 		callback(value1, value2);
 		return 0;
 	}
-	case ONE_PARAMETER_P:
 	case ONE_PARAMETER:
 	{
 		int value = atoi(argv[0]);
@@ -365,14 +335,8 @@ int handleActionWithParameter(const TokenCallback *current, char *argv[], int ar
 			#endif
 			return -1;
 		}
-		if (current->parameterType == ONE_PARAMETER_P) {
-			VoidIntVoidPtr callback1 = (VoidIntVoidPtr) current->callback;
-			(*callback1)(value, current->param);
-
-		} else {
-			VoidInt callback1 = (VoidInt) current->callback;
-			(*callback1)(value);
-		}
+		VoidInt callback1 = (VoidInt) current->callback;
+		(*callback1)(value);
 		return 0;
 	}
 	default:

--- a/firmware/util/cli_registry.h
+++ b/firmware/util/cli_registry.h
@@ -10,24 +10,17 @@
 
 typedef enum {
 	NO_PARAMETER,
-	NO_PARAMETER_P,
 	ONE_PARAMETER,
-	ONE_PARAMETER_P,
 	FLOAT_PARAMETER_NAN_ALLOWED,
 	FLOAT_PARAMETER,
-	FLOAT_PARAMETER_P,
 	STRING_PARAMETER,
-	STRING_PARAMETER_P,
 	STRING2_PARAMETER,
-	STRING2_PARAMETER_P,
 	STRING3_PARAMETER,
 	STRING5_PARAMETER,
 	TWO_INTS_PARAMETER,
-	TWO_INTS_PARAMETER_P,
 	FLOAT_FLOAT_PARAMETER,
 	FLOAT_FLOAT_FLOAT_PARAMETER,
 	FLOAT_FLOAT_FLOAT_FLOAT_PARAMETER,
-	FLOAT_FLOAT_PARAMETER_P,
 	INT_FLOAT_PARAMETER,
 } action_type_e;
 
@@ -35,7 +28,6 @@ typedef struct {
 	const char *token;
 	action_type_e parameterType;
 	void *callback;
-	void *param;
 } TokenCallback;
 
 
@@ -52,22 +44,15 @@ extern "C"
 typedef void (*Void)(void);
 typedef void (*VoidPtr)(void*);
 typedef void (*VoidInt)(int);
-typedef void (*VoidIntVoidPtr)(int, void*);
 typedef void (*VoidFloat)(float);
 typedef void (*VoidFloatFloat)(float, float);
 typedef void (*VoidFloatFloatFloat)(float, float, float);
 typedef void (*VoidFloatFloatFloatFloat)(float, float, float, float);
-typedef void (*VoidFloatFloatVoidPtr)(float, float, void*);
 typedef void (*VoidIntInt)(int, int);
-typedef void (*VoidIntIntVoidPtr)(int, int, void*);
 typedef void (*VoidIntFloat)(int, float);
 
 typedef void (*VoidCharPtr)(const char *);
-typedef void (*VoidCharPtrVoidPtr)(const char *, void*);
-
 typedef void (*VoidCharPtrCharPtr)(const char *, const char *);
-typedef void (*VoidCharPtrCharPtrVoidPtr)(const char *, const char *, void*);
-
 typedef void (*VoidCharPtrCharPtrCharPtr)(const char *, const char *, const char *);
 typedef void (*VoidCharPtrCharPtrCharPtrCharPtrCharPtr)(const char *, const char *, const char *, const char *, const char *);
 
@@ -79,9 +64,9 @@ void handleConsoleLine(char *line);
 void doAddAction(const TokenCallback *t);
 
 #if !defined(EFI_DISABLE_CONSOLE_ACTIONS)
-#define addTypedConsoleAction(token, type, callback, param) \
+#define addTypedConsoleAction(token, type, callback) \
 	do { \
-		static const TokenCallback t = { token, type, (void*)+callback, param }; \
+		static const TokenCallback t = { token, type, (void*)+callback }; \
 		doAddAction(&t); \
 	} while(0)
 #else
@@ -93,62 +78,43 @@ void doAddAction(const TokenCallback *t);
 
 #define addConsoleAction(token, callback) \
 	ASSERT_TYPE(Void, callback); \
-	addTypedConsoleAction(token, NO_PARAMETER, callback, nullptr)
+	addTypedConsoleAction(token, NO_PARAMETER, callback)
 #define addConsoleActionI(token, callback) \
 	ASSERT_TYPE(VoidInt, callback); \
-	addTypedConsoleAction(token, ONE_PARAMETER, callback, nullptr)
+	addTypedConsoleAction(token, ONE_PARAMETER, callback)
 #define addConsoleActionII(token, callback) \
 	ASSERT_TYPE(VoidIntInt, callback); \
-	addTypedConsoleAction(token, TWO_INTS_PARAMETER, callback, nullptr)
+	addTypedConsoleAction(token, TWO_INTS_PARAMETER, callback)
 #define addConsoleActionIF(token, callback) \
 	ASSERT_TYPE(VoidIntFloat, callback); \
-	addTypedConsoleAction(token, INT_FLOAT_PARAMETER, callback, nullptr)
+	addTypedConsoleAction(token, INT_FLOAT_PARAMETER, callback)
 #define addConsoleActionF(token, callback) \
 	ASSERT_TYPE(VoidFloat, callback); \
-	addTypedConsoleAction(token, FLOAT_PARAMETER, callback, nullptr)
+	addTypedConsoleAction(token, FLOAT_PARAMETER, callback)
 #define addConsoleActionNANF(token, callback) \
 	ASSERT_TYPE(VoidFloat, callback); \
-	addTypedConsoleAction(token, FLOAT_PARAMETER_NAN_ALLOWED, callback, nullptr)
+	addTypedConsoleAction(token, FLOAT_PARAMETER_NAN_ALLOWED, callback)
 #define addConsoleActionFF(token, callback) \
 	ASSERT_TYPE(VoidFloatFloat, callback); \
-	addTypedConsoleAction(token, FLOAT_FLOAT_PARAMETER, callback, nullptr)
+	addTypedConsoleAction(token, FLOAT_FLOAT_PARAMETER, callback)
 #define addConsoleActionFFF(token, callback) \
 	ASSERT_TYPE(VoidFloatFloatFloat, callback); \
-	addTypedConsoleAction(token, FLOAT_FLOAT_FLOAT_PARAMETER, callback, nullptr)
+	addTypedConsoleAction(token, FLOAT_FLOAT_FLOAT_PARAMETER, callback)
 #define addConsoleActionFFFF(token, callback) \
 	ASSERT_TYPE(VoidFloatFloatFloatFloat, callback); \
-	addTypedConsoleAction(token, FLOAT_FLOAT_FLOAT_FLOAT_PARAMETER, callback, nullptr)
+	addTypedConsoleAction(token, FLOAT_FLOAT_FLOAT_FLOAT_PARAMETER, callback)
 #define addConsoleActionS(token, callback) \
 	ASSERT_TYPE(VoidCharPtr, callback); \
-	addTypedConsoleAction(token, STRING_PARAMETER, callback, nullptr)
+	addTypedConsoleAction(token, STRING_PARAMETER, callback)
 #define addConsoleActionSS(token, callback) \
 	ASSERT_TYPE(VoidCharPtrCharPtr, callback); \
-	addTypedConsoleAction(token, STRING2_PARAMETER, callback, nullptr)
+	addTypedConsoleAction(token, STRING2_PARAMETER, callback)
 #define addConsoleActionSSS(token, callback) \
 	ASSERT_TYPE(VoidCharPtrCharPtrCharPtr, callback); \
-	addTypedConsoleAction(token, STRING3_PARAMETER, callback, nullptr)
+	addTypedConsoleAction(token, STRING3_PARAMETER, callback)
 #define addConsoleActionSSSSS(token, callback) \
 	ASSERT_TYPE(VoidCharPtrCharPtrCharPtrCharPtrCharPtr, callback); \
-	addTypedConsoleAction(token, STRING5_PARAMETER, callback, nullptr)
-
-#define addConsoleActionP(token, callback, param) \
-	ASSERT_TYPE(VoidPtr, callback); \
-	addTypedConsoleAction(token, NO_PARAMETER_P, callback, param)
-#define addConsoleActionIP(token, callback, param) \
-	ASSERT_TYPE(VoidIntVoidPtr, callback); \
-	addTypedConsoleAction(token, ONE_PARAMETER_P, callback, param)
-#define addConsoleActionIIP(token, callback, param) \
-	ASSERT_TYPE(VoidIntIntVoidPtr, callback); \
-	addTypedConsoleAction(token, TWO_INTS_PARAMETER_P, callback, param)
-#define addConsoleActionFFP(token, callback, param) \
-	ASSERT_TYPE(VoidFloatFloatVoidPtr, callback); \
-	addTypedConsoleAction(token, FLOAT_FLOAT_PARAMETER_P, callback, param)
-#define addConsoleActionSP(token, callback, param) \
-	ASSERT_TYPE(VoidCharPtrVoidPtr, callback); \
-	addTypedConsoleAction(token, STRING_PARAMETER_P, callback, param)
-#define addConsoleActionSSP(token, callback, param) \
-	ASSERT_TYPE(VoidCharPtrCharPtrVoidPtr, callback); \
-	addTypedConsoleAction(token, STRING2_PARAMETER_P, callback, param)
+	addTypedConsoleAction(token, STRING5_PARAMETER, callback)
 
 void onCliCaseError(const char *token);
 void onCliDuplicateError(const char *token);

--- a/firmware/util/cli_registry.h
+++ b/firmware/util/cli_registry.h
@@ -34,7 +34,7 @@ typedef enum {
 typedef struct {
 	const char *token;
 	action_type_e parameterType;
-	void (*callback)(void);
+	void *callback;
 	void *param;
 } TokenCallback;
 
@@ -75,33 +75,80 @@ void resetConsoleActions(void);
 void helpCommand(void);
 void initConsoleLogic();
 void handleConsoleLine(char *line);
-void addConsoleAction(const char *token, Void callback);
-void addConsoleActionP(const char *token, VoidPtr callback, void *param);
 
-void addConsoleActionI(const char *token, VoidInt callback);
-void addConsoleActionIP(const char *token, VoidIntVoidPtr callback, void *param);
+void doAddAction(const TokenCallback *t);
 
-void addConsoleActionIF(const char* token, VoidIntFloat callback);
+#if !defined(EFI_DISABLE_CONSOLE_ACTIONS)
+#define addTypedConsoleAction(token, type, callback, param) \
+	do { \
+		static const TokenCallback t = { token, type, (void*)+callback, param }; \
+		doAddAction(&t); \
+	} while(0)
+#else
+#define addTypedConsoleAction(token, type, callback, param)
+#endif
 
-void addConsoleActionII(const char *token, VoidIntInt callback);
-void addConsoleActionIIP(const char *token, VoidIntIntVoidPtr callback, void *param);
+#define ASSERT_TYPE(TYPE, VALUE) \
+	static_assert(std::is_same_v<decltype(+VALUE), TYPE>, "Incorrect action callback")
 
-void addConsoleActionF(const char *token, VoidFloat callback);
-void addConsoleActionNANF(const char *token, VoidFloat callback);
+#define addConsoleAction(token, callback) \
+	ASSERT_TYPE(Void, callback); \
+	addTypedConsoleAction(token, NO_PARAMETER, callback, nullptr)
+#define addConsoleActionI(token, callback) \
+	ASSERT_TYPE(VoidInt, callback); \
+	addTypedConsoleAction(token, ONE_PARAMETER, callback, nullptr)
+#define addConsoleActionII(token, callback) \
+	ASSERT_TYPE(VoidIntInt, callback); \
+	addTypedConsoleAction(token, TWO_INTS_PARAMETER, callback, nullptr)
+#define addConsoleActionIF(token, callback) \
+	ASSERT_TYPE(VoidIntFloat, callback); \
+	addTypedConsoleAction(token, INT_FLOAT_PARAMETER, callback, nullptr)
+#define addConsoleActionF(token, callback) \
+	ASSERT_TYPE(VoidFloat, callback); \
+	addTypedConsoleAction(token, FLOAT_PARAMETER, callback, nullptr)
+#define addConsoleActionNANF(token, callback) \
+	ASSERT_TYPE(VoidFloat, callback); \
+	addTypedConsoleAction(token, FLOAT_PARAMETER_NAN_ALLOWED, callback, nullptr)
+#define addConsoleActionFF(token, callback) \
+	ASSERT_TYPE(VoidFloatFloat, callback); \
+	addTypedConsoleAction(token, FLOAT_FLOAT_PARAMETER, callback, nullptr)
+#define addConsoleActionFFF(token, callback) \
+	ASSERT_TYPE(VoidFloatFloatFloat, callback); \
+	addTypedConsoleAction(token, FLOAT_FLOAT_FLOAT_PARAMETER, callback, nullptr)
+#define addConsoleActionFFFF(token, callback) \
+	ASSERT_TYPE(VoidFloatFloatFloatFloat, callback); \
+	addTypedConsoleAction(token, FLOAT_FLOAT_FLOAT_FLOAT_PARAMETER, callback, nullptr)
+#define addConsoleActionS(token, callback) \
+	ASSERT_TYPE(VoidCharPtr, callback); \
+	addTypedConsoleAction(token, STRING_PARAMETER, callback, nullptr)
+#define addConsoleActionSS(token, callback) \
+	ASSERT_TYPE(VoidCharPtrCharPtr, callback); \
+	addTypedConsoleAction(token, STRING2_PARAMETER, callback, nullptr)
+#define addConsoleActionSSS(token, callback) \
+	ASSERT_TYPE(VoidCharPtrCharPtrCharPtr, callback); \
+	addTypedConsoleAction(token, STRING3_PARAMETER, callback, nullptr)
+#define addConsoleActionSSSSS(token, callback) \
+	ASSERT_TYPE(VoidCharPtrCharPtrCharPtrCharPtrCharPtr, callback); \
+	addTypedConsoleAction(token, STRING5_PARAMETER, callback, nullptr)
 
-void addConsoleActionFF(const char *token, VoidFloatFloat callback);
-void addConsoleActionFFF(const char *token, VoidFloatFloatFloat callback);
-void addConsoleActionFFFF(const char *token, VoidFloatFloatFloatFloat callback);
-void addConsoleActionFFP(const char *token, VoidFloatFloatVoidPtr callback, void *param);
-
-void addConsoleActionS(const char *token, VoidCharPtr callback);
-void addConsoleActionSP(const char *token, VoidCharPtrVoidPtr callback, void *param);
-
-void addConsoleActionSS(const char *token, VoidCharPtrCharPtr callback);
-void addConsoleActionSSP(const char *token, VoidCharPtrCharPtrVoidPtr callback, void *param);
-
-void addConsoleActionSSS(const char *token, VoidCharPtrCharPtrCharPtr callback);
-void addConsoleActionSSSSS(const char *token, VoidCharPtrCharPtrCharPtrCharPtrCharPtr callback);
+#define addConsoleActionP(token, callback, param) \
+	ASSERT_TYPE(VoidPtr, callback); \
+	addTypedConsoleAction(token, NO_PARAMETER_P, callback, param)
+#define addConsoleActionIP(token, callback, param) \
+	ASSERT_TYPE(VoidIntVoidPtr, callback); \
+	addTypedConsoleAction(token, ONE_PARAMETER_P, callback, param)
+#define addConsoleActionIIP(token, callback, param) \
+	ASSERT_TYPE(VoidIntIntVoidPtr, callback); \
+	addTypedConsoleAction(token, TWO_INTS_PARAMETER_P, callback, param)
+#define addConsoleActionFFP(token, callback, param) \
+	ASSERT_TYPE(VoidFloatFloatVoidPtr, callback); \
+	addTypedConsoleAction(token, FLOAT_FLOAT_PARAMETER_P, callback, param)
+#define addConsoleActionSP(token, callback, param) \
+	ASSERT_TYPE(VoidCharPtrVoidPtr, callback); \
+	addTypedConsoleAction(token, STRING_PARAMETER_P, callback, param)
+#define addConsoleActionSSP(token, callback, param) \
+	ASSERT_TYPE(VoidCharPtrCharPtrVoidPtr, callback); \
+	addTypedConsoleAction(token, STRING2_PARAMETER_P, callback, param)
 
 void onCliCaseError(const char *token);
 void onCliDuplicateError(const char *token);


### PR DESCRIPTION
Do not store 16 bytes struct for each command in RAM. Store only pointers in RAM.
Structs should go to flash.

Before:
Lua total heap(s) usage: 0 / 21080 bytes = 0.0%
Lua optional heap usage: 0 / 0
Lua CCM heap usage: 8 / 5264
Common ChibiOS heap: 0 bytes free
ChibiOS memcore usage: 0 / 15816

After:
Lua total heap(s) usage: 0 / 24152 bytes = 0.0%
Lua optional heap usage: 0 / 0
Lua CCM heap usage: 8 / 5264
Common ChibiOS heap: 0 bytes free
ChibiOS memcore usage: 0 / 18888