### PR TITLE
MMC: keep counting unsafe shutdowns

### DIFF
--- a/firmware/console/binary/output_channels.txt
+++ b/firmware/console/binary/output_channels.txt
@@ -75,6 +75,7 @@ int16_t rpmAcceleration;dRPM;"RPM acceleration/Rate of Change/ROC",1, 0, 0, 5, 2
 	uint16_t autoscale lambdaValue;@@GAUGE_NAME_LAMBDA@@;"",{1/@@PACK_MULT_LAMBDA@@}, 0, 0, 0, 3
 
 	uint16_t autoscale VBatt;@@GAUGE_NAME_VBAT@@;"V",{1/@@PACK_MULT_VOLTAGE@@}, 0, 0, 0, 2
+	uint16_t autoscale VIgn;@@GAUGE_NAME_VIGN@@;"V",{1/@@PACK_MULT_VOLTAGE@@}, 0, 0, 0, 2
 
 	uint16_t autoscale oilPressure;@@GAUGE_NAME_OIL_PRESSURE@@;"kPa",{1/@@PACK_MULT_PRESSURE@@}, 0, 0, 0, 0
 	int16_t autoscale vvtPositionB1I;@@GAUGE_NAME_VVT_B1I@@;"deg",{1/@@PACK_MULT_ANGLE@@}, 0, 0, 0, 1

--- a/firmware/console/status_loop.cpp
+++ b/firmware/console/status_loop.cpp
@@ -534,6 +534,7 @@ static void updatePressures() {
 
 static void updateMiscSensors() {
 	engine->outputChannels.VBatt = Sensor::getOrZero(SensorType::BatteryVoltage);
+	engine->outputChannels.VIgn = Sensor::getOrZero(SensorType::IgnKeyVoltage);
 
 	engine->outputChannels.idlePositionSensor = Sensor::getOrZero(SensorType::IdlePosition);
 

--- a/firmware/hw_layer/backup_ram.h
+++ b/firmware/hw_layer/backup_ram.h
@@ -26,6 +26,12 @@ enum class backup_ram_e {
 	 */
 	IgnCounter,
 
+	/**
+	 * MMC card status
+	 * 32 bits value, see mmc_card.c for details
+	 */
+	MccStatus,
+
 	/* The number of stored backup variables */
 	BACKUP_RAM_NUM,
 };

--- a/firmware/hw_layer/mmc_card.cpp
+++ b/firmware/hw_layer/mmc_card.cpp
@@ -40,6 +40,7 @@
 #include "hellen_meta.h"
 
 #include "rtc_helper.h"
+#include "backup_ram.h"
 
 #if EFI_STORAGE_SD == TRUE
 #include "storage_sd.h"
@@ -59,7 +60,7 @@ extern int errorHandlerCheckReportFiles();
 extern void errorHandlerDeleteReports();
 
 // see also SD_MODE
-typedef enum {
+typedef enum : uint8_t {
 	SD_STATUS_INIT = 0,
 	SD_STATUS_MOUNTED,
 	SD_STATUS_MOUNT_FAILED,
@@ -86,7 +87,10 @@ static const char *sdStatusNames[] =
 };
 
 static const char *sdStatusName(SD_STATUS status) {
-	return sdStatusNames[status];
+	if ((uint8_t)status < efi::size(sdStatusNames)) {
+		return sdStatusNames[status];
+	}
+	return "INVALID";
 }
 
 static const char *sdModeNames[] =
@@ -99,7 +103,10 @@ static const char *sdModeNames[] =
 };
 
 static const char *sdModeName(SD_MODE mode) {
-	return sdModeNames[mode];
+	if ((uint8_t)mode < efi::size(sdModeNames)) {
+		return sdModeNames[mode];
+	}
+	return "INVALID";
 }
 
 static bool sdLoggerReady = false;
@@ -152,6 +159,70 @@ static MMCConfig mmccfg = {
  * fatfs MMC/SPI
  */
 static NO_CACHE FATFS MMC_FS;
+
+union SdBackupState {
+	struct {
+		SD_MODE mode;
+		SD_STATUS status;
+		uint8_t unsafeUnmountCnt;
+		uint8_t valid;
+	} __attribute__((packed));
+	uint32_t x;
+};
+
+static_assert(sizeof(SdBackupState) == sizeof(uint32_t));
+
+static void sdCardUpdateBackupState() {
+	SdBackupState state;
+	state.x = backupRamLoad(backup_ram_e::MccStatus);
+	state.mode = sdMode;
+	state.status = sdStatus;
+	state.valid = 0x5A;
+	backupRamSave(backup_ram_e::MccStatus, state.x);
+}
+
+static void sdCardShowBackupState() {
+	SdBackupState state;
+	state.x = backupRamLoad(backup_ram_e::MccStatus);
+
+	efiPrintf("SD state at last power off %s / %s", sdModeName(state.mode), sdStatusName(state.status));
+	efiPrintf("total unsafe power offs %d", state.unsafeUnmountCnt);
+}
+
+static bool sdCardInitBackupState() {
+	SdBackupState state;
+	state.x = backupRamLoad(backup_ram_e::MccStatus);
+
+	bool valid = state.valid == 0x5A;
+	if (valid) {
+		if ((state.mode != SD_MODE_IDLE) && (state.mode != SD_MODE_UNMOUNT)) {
+			if (state.unsafeUnmountCnt < 255) {
+				state.unsafeUnmountCnt++;
+			}
+		}
+	} else {
+		state.mode = SD_MODE_IDLE;
+		state.status = SD_STATUS_INIT;
+		state.unsafeUnmountCnt = 0;
+		state.valid = 0x5A;
+	}
+
+	backupRamSave(backup_ram_e::MccStatus, state.x);
+
+	return valid;
+}
+
+static void sdCardSetCurrentMode(SD_MODE mode) {
+	sdMode = mode;
+
+	sdCardUpdateBackupState();
+}
+
+static void sdSetCurrentStatus(SD_STATUS status) {
+	sdStatus = status;
+
+	sdCardUpdateBackupState();
+}
 
 static void sdLoggerSetReady(bool value) {
 #if EFI_TUNER_STUDIO
@@ -304,7 +375,7 @@ static int sdLoggerCreateFile(FIL *fd) {
 	engine->outputChannels.sd_error = (uint8_t)err;
 #endif
 	if (err != FR_OK) {
-		sdStatus = SD_STATUS_OPEN_FAILED;
+		sdSetCurrentStatus(SD_STATUS_OPEN_FAILED);
 		warning(ObdCode::CUSTOM_ERR_SD_MOUNT_FAILED, "SD: file open failed");
 		printFatFsError("log file create", err);
 		return -1;
@@ -396,7 +467,7 @@ static BaseBlockDevice* initializeMmcBlockDevice() {
 	// Performs the initialization procedure on the inserted card.
 	LOCK_SD_SPI();
 	if (blkConnect(&MMCD1) != HAL_SUCCESS) {
-		sdStatus = SD_STATUS_MMC_FAILED;
+		sdSetCurrentStatus(SD_STATUS_MMC_FAILED);
 		UNLOCK_SD_SPI();
 		return nullptr;
 	}
@@ -726,7 +797,7 @@ static int sdModeSwitchToIdle(SD_MODE from)
 	case SD_MODE_ECU:
 		sdLoggerStop();
 		unmountMmc();
-		sdStatus = SD_STATUS_INIT;
+		sdSetCurrentStatus(SD_STATUS_INIT);
 		return 0;
 	case SD_MODE_PC:
 		deattachMsdSdCard();
@@ -799,23 +870,23 @@ static SD_MODE sdModeSwitcher(SD_MODE mode, SD_MODE target) {
 		return target;
 	case SD_MODE_ECU:
 		if (mountMmc()) {
-			sdStatus = SD_STATUS_MOUNTED;
+			sdSetCurrentStatus(SD_STATUS_MOUNTED);
 			sdLoggerStart();
 			return SD_MODE_ECU;
 		} else {
-			sdStatus = SD_STATUS_MOUNT_FAILED;
+			sdSetCurrentStatus(SD_STATUS_MOUNT_FAILED);
 			// failed to mount SD card to ECU, go to idle
 			return SD_MODE_IDLE;
 		}
 	case SD_MODE_PC:
 		attachMsdSdCard(cardBlockDevice, resources.blkbuf, sizeof(resources.blkbuf));
-		sdStatus = SD_STATUS_MSD;
+		sdSetCurrentStatus(SD_STATUS_MSD);
 		return SD_MODE_PC;
 	case SD_MODE_FORMAT:
 		if (sdFormat()) {
 			// formated ok
 		}
-		sdStatus = SD_STATUS_INIT;
+		sdSetCurrentStatus(SD_STATUS_INIT);
 		return SD_MODE_IDLE;
 	}
 
@@ -890,10 +961,16 @@ static THD_FUNCTION(MMCmonThread, arg) {
 		chThdSleepMilliseconds(100);
 	}
 
-	sdStatus = SD_STATUS_CONNECTING;
+	if (sdCardInitBackupState()) {
+		sdCardShowBackupState();
+	} else {
+		efiPrintf("SD backup RAM state is not valid");
+	}
+
+	sdSetCurrentStatus(SD_STATUS_CONNECTING);
 	if (!initMmc()) {
 		efiPrintf("Card is not preset/failed to init");
-		sdStatus = SD_STATUS_NOT_INSERTED;
+		sdSetCurrentStatus(SD_STATUS_NOT_INSERTED);
 		// give up until next boot
 		goto die;
 	}
@@ -924,11 +1001,11 @@ static THD_FUNCTION(MMCmonThread, arg) {
 				efiPrintf("SD: failed to switch from %s to %s", sdModeName(sdMode), sdModeName(target));
 				// TODO: handle
 				chThdSleepMilliseconds(1000);
-				sdMode = SD_MODE_IDLE;
+				sdCardSetCurrentMode(SD_MODE_IDLE);
 			} else {
 				efiPrintf("SD: switched from %s to %s", sdModeName(sdMode), sdModeName(target));
 			}
-			sdMode = target;
+			sdCardSetCurrentMode(target);
 		}
 
 		if (sdModeExecuter(sdMode) == 0) {

--- a/firmware/hw_layer/mmc_card.h
+++ b/firmware/hw_layer/mmc_card.h
@@ -14,7 +14,7 @@
 #define DOT_MLG ".mlg"
 
 // see also SD_STATUS
-typedef enum {
+typedef enum : uint8_t {
 	SD_MODE_IDLE = 0,
 	SD_MODE_ECU,
 	SD_MODE_PC,

--- a/firmware/hw_layer/ports/stm32/backup_ram.cpp
+++ b/firmware/hw_layer/ports/stm32/backup_ram.cpp
@@ -13,6 +13,8 @@ uint32_t backupRamLoad(backup_ram_e idx) {
 		return RTCD1.rtc->BKP0R & 0xffff;
 	case backup_ram_e::IgnCounter:
 		return (RTCD1.rtc->BKP0R >> 16) & 0xff;
+	case backup_ram_e::MccStatus:
+		return RTCD1.rtc->BKP1R;
 	default:
 		criticalError("Invalid backup ram idx %d", (int)idx);
 		return 0;
@@ -30,6 +32,9 @@ void backupRamSave(backup_ram_e idx, uint32_t value) {
 		break;
 	case backup_ram_e::IgnCounter:
 		RTCD1.rtc->BKP0R = (RTCD1.rtc->BKP0R & ~0x00ff0000) | ((value & 0xff) << 16);
+		break;
+	case backup_ram_e::MccStatus:
+		RTCD1.rtc->BKP1R = value;
 		break;
 	default:
 		criticalError("Invalid backup ram idx %d, value %lx", (int)idx, value);

--- a/firmware/integration/rusefi_config_shared.txt
+++ b/firmware/integration/rusefi_config_shared.txt
@@ -98,6 +98,7 @@
 #define GAUGE_NAME_DETECTED_GEAR "Detected Gear"
 #define GAUGE_NAME_TURBO_SPEED "Turbocharger Speed"
 #define GAUGE_NAME_VBAT "VBatt"
+#define GAUGE_NAME_VIGN "VIgn"
 #define GAUGE_NAME_TIME "Time"
 #define GAUGE_NAME_RPM "RPM"
 #define GAUGE_NAME_CLT "CLT"


### PR DESCRIPTION
Keep MMC state in backup RAM. Check if card was properly unmounted during power off on next start.