### PR TITLE
Calibration restore: add failure handling and partial merge support

### DIFF
--- a/java_console/core_ui/src/main/java/com/rusefi/core/ui/CalibrationBackupFailureAction.java
+++ b/java_console/core_ui/src/main/java/com/rusefi/core/ui/CalibrationBackupFailureAction.java
@@ -1,0 +1,8 @@
+package com.rusefi.core.ui;
+
+public enum CalibrationBackupFailureAction {
+    RETRY,
+    SKIP_FAILED_FIELDS,
+    RESET_ALL,
+    CANCEL
+}

--- a/java_console/core_ui/src/main/java/com/rusefi/core/ui/CalibrationBackupFailureDialog.java
+++ b/java_console/core_ui/src/main/java/com/rusefi/core/ui/CalibrationBackupFailureDialog.java
@@ -1,0 +1,85 @@
+package com.rusefi.core.ui;
+
+import javax.swing.*;
+import java.awt.*;
+import java.util.List;
+
+public class CalibrationBackupFailureDialog {
+
+    private static final String TITLE = "Calibration Backup Failed";
+    private static final String BUTTON_RETRY = "Retry Calibration";
+    private static final String BUTTON_SKIP = "Skip Failed Fields";
+    private static final String BUTTON_RESET = "Reset All Configuration";
+    private static final String BUTTON_CANCEL = "Cancel Update";
+
+    public static CalibrationBackupFailureAction showDialog(
+        JComponent parent,
+        String failureMessage,
+        List<String> failedFields,
+        boolean hasBackupData
+    ) {
+        StringBuilder message = new StringBuilder();
+        message.append("<html><body style='width: 350px'>");
+        message.append("<h3>Calibration Backup/Restore Failed</h3>");
+        message.append(failureMessage);
+        message.append("<br><br>");
+
+        if (failedFields != null && !failedFields.isEmpty()) {
+            message.append("<b>Failed fields:</b><br>");
+            for (String field : failedFields) {
+                message.append("&bull; ").append(field).append("<br>");
+            }
+            message.append("<br>");
+        }
+
+        if (!hasBackupData) {
+            message.append("<i>No calibration backup available. You can retry or proceed with ECU defaults.</i>");
+        }
+
+        message.append("<br>What would you like to do?</body></html>");
+
+        Object[] options;
+        if (hasBackupData) {
+            options = new Object[]{BUTTON_RETRY, BUTTON_SKIP, BUTTON_RESET};
+        } else {
+            options = new Object[]{BUTTON_RETRY, BUTTON_RESET, BUTTON_CANCEL};
+        }
+
+        Window owner = findOwnerWindow(parent);
+        int choice = JOptionPane.showOptionDialog(
+            owner,
+            message.toString(),
+            TITLE,
+            JOptionPane.DEFAULT_OPTION,
+            JOptionPane.WARNING_MESSAGE,
+            null,
+            options,
+            options[0]
+        );
+
+        if (choice == 0) {
+            return CalibrationBackupFailureAction.RETRY;
+        } else if (choice == 1) {
+            return hasBackupData ? CalibrationBackupFailureAction.SKIP_FAILED_FIELDS : CalibrationBackupFailureAction.RESET_ALL;
+        } else if (choice == 2 && hasBackupData) {
+            return CalibrationBackupFailureAction.RESET_ALL;
+        } else {
+            return CalibrationBackupFailureAction.CANCEL;
+        }
+    }
+
+    private static Window findOwnerWindow(JComponent parent) {
+        if (parent != null) {
+            Window window = SwingUtilities.getWindowAncestor(parent);
+            if (window != null && window.isShowing()) {
+                return window;
+            }
+        }
+        JFrame fallback = new JFrame();
+        fallback.setAlwaysOnTop(true);
+        fallback.setLocationRelativeTo(null);
+        fallback.setSize(1, 1);
+        fallback.setVisible(true);
+        return fallback;
+    }
+}

--- a/java_console/ui/src/main/java/com/rusefi/maintenance/CalibrationsHelper.java
+++ b/java_console/ui/src/main/java/com/rusefi/maintenance/CalibrationsHelper.java
@@ -11,6 +11,8 @@ import com.rusefi.binaryprotocol.BinaryProtocol;
 import com.rusefi.binaryprotocol.BinaryProtocolLocalCache;
 import com.rusefi.binaryprotocol.IniNotFoundException;
 import com.rusefi.core.ui.AutoupdateUtil;
+import com.rusefi.core.ui.CalibrationBackupFailureAction;
+import com.rusefi.core.ui.CalibrationBackupFailureDialog;
 import com.rusefi.io.LinkManager;
 import com.rusefi.io.UpdateOperationCallbacks;
 import org.jetbrains.annotations.Nullable;
@@ -31,6 +33,9 @@ import java.util.concurrent.ExecutionException;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import javax.swing.JComponent;
+import javax.swing.SwingUtilities;
+
 import static com.devexperts.logging.Logging.getLogging;
 import static com.rusefi.maintenance.CallbacksWaitingUtil.waitForPredicate;
 import static com.rusefi.util.TuneBackupUtil.saveConfigurationImageToFiles;
@@ -42,6 +47,17 @@ public class CalibrationsHelper {
 
     static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd-HH.mm.ss");
     private static final String RUSEFI_FORCE_CALIBRATIONS_RESTORE = System.getenv("RUSEFI_FORCE_CALIBRATIONS_RESTORE");
+    private static final int MAX_CALIBRATION_RETRIES = 3;
+
+    public static class MergeResult {
+        public final Optional<CalibrationsInfo> mergedCalibrations;
+        public final List<String> failedFields;
+
+        public MergeResult(Optional<CalibrationsInfo> mergedCalibrations, List<String> failedFields) {
+            this.mergedCalibrations = mergedCalibrations;
+            this.failedFields = failedFields;
+        }
+    }
 
     public static void main(String[] args) {
 //        args = new String[] {"destinationFileName.xml", "COM34"};
@@ -93,6 +109,7 @@ public class CalibrationsHelper {
     }
 
     public static boolean updateFirmwareAndRestorePreviousCalibrations(
+        final JComponent parent,
         final PortResult originalEcuPort,
         @Nullable final BinaryProtocol bp,
         @Nullable final LinkManager lm,
@@ -106,25 +123,74 @@ public class CalibrationsHelper {
         final String backupName = getFileNameWithoutExtension(timestampFileNameComponent, "backup_from_ecu");
 
         final Optional<CalibrationsInfo> prevCalibrations;
-        if (bp != null && lm != null) {
-            // Reuse the live connection — no new port-open needed.
-            final Optional<CalibrationsInfo>[] holder = new Optional[]{Optional.empty()};
-            try {
-                lm.submit(() -> holder[0] = readAndBackupCurrentCalibrations(bp, callbacks, backupName)).get();
-            } catch (ExecutionException | InterruptedException e) {
-                if (e instanceof InterruptedException) Thread.currentThread().interrupt();
-                callbacks.logLine("Failed to read current calibrations: " + e.getMessage());
-                lm.disconnect();
-                return false;
+        boolean skipCalibrationRestore = false;
+        boolean usePartialMerge = false;
+
+        int retryCount = 0;
+        Optional<CalibrationsInfo> calibrations = Optional.empty();
+        List<String> backupFailedFields = new ArrayList<>();
+
+        while (retryCount <= MAX_CALIBRATION_RETRIES) {
+            if (retryCount > 0) {
+                callbacks.logLine("Retrying calibration backup (attempt " + retryCount + " of " + MAX_CALIBRATION_RETRIES + ")...");
+                BinaryProtocol.sleep(5_000);
             }
-            prevCalibrations = holder[0];
-            lm.disconnect(); // release port so the flash can proceed
-        } else {
-            prevCalibrations = readAndBackupCurrentCalibrationsWithSuspendedPortScanner(
-                originalEcuPort.port, callbacks, backupName, connectivityContext);
+
+            if (bp != null && lm != null) {
+                final Optional<CalibrationsInfo>[] holder = new Optional[]{Optional.empty()};
+                try {
+                    lm.submit(() -> holder[0] = readAndBackupCurrentCalibrations(bp, callbacks, backupName)).get();
+                } catch (ExecutionException | InterruptedException e) {
+                    if (e instanceof InterruptedException) Thread.currentThread().interrupt();
+                    callbacks.logLine("Failed to read current calibrations: " + e.getMessage());
+                    holder[0] = Optional.empty();
+                }
+                calibrations = holder[0];
+            } else {
+                calibrations = readAndBackupCurrentCalibrationsWithSuspendedPortScanner(
+                    originalEcuPort.port, callbacks, backupName, connectivityContext);
+            }
+
+            if (calibrations.isPresent()) {
+                break;
+            }
+
+            retryCount++;
+            if (retryCount > MAX_CALIBRATION_RETRIES) {
+                if (isUiContext(callbacks)) {
+                    CalibrationBackupFailureAction action = showCalibrationFailureDialog(
+                        parent,
+                        "Failed to back up current tune from ECU after " + MAX_CALIBRATION_RETRIES + " attempts.",
+                        backupFailedFields,
+                        false
+                    );
+                    if (action == CalibrationBackupFailureAction.RETRY) {
+                        retryCount = 1;
+                        continue;
+                    } else if (action == CalibrationBackupFailureAction.CANCEL) {
+                        callbacks.logLine("Firmware update cancelled by user.");
+                        return false;
+                    } else if (action == CalibrationBackupFailureAction.RESET_ALL) {
+                        skipCalibrationRestore = true;
+                    } else {
+                        skipCalibrationRestore = true;
+                        usePartialMerge = true;
+                    }
+                } else {
+                    callbacks.logLine("Failed to back up current tune from ECU...");
+                    return false;
+                }
+            }
         }
 
-        if (!prevCalibrations.isPresent()) {
+        prevCalibrations = calibrations;
+
+        // Always disconnect before flashing - the port must be free for ECU reboot to OpenBLT
+        if (bp != null && lm != null) {
+            lm.disconnect();
+        }
+
+        if (!skipCalibrationRestore && !prevCalibrations.isPresent()) {
             callbacks.logLine("Failed to back up current tune from ECU...");
             return false;
         }
@@ -150,6 +216,21 @@ public class CalibrationsHelper {
                     newEcuPort.port
                 ));
 
+                if (skipCalibrationRestore) {
+                    callbacks.logLine("Skipping calibration restore - ECU will use default configuration.");
+                    final Optional<CalibrationsInfo> freshCalibrations = readAndBackupCurrentCalibrationsWithSuspendedPortScanner(
+                        newEcuPort.port,
+                        callbacks,
+                        getFileNameWithoutExtension(timestampFileNameComponent, "fresh_from_ecu"),
+                        connectivityContext
+                    );
+                    if (!freshCalibrations.isPresent()) {
+                        callbacks.logLine("WARNING: Failed to read fresh configuration from ECU after flash.");
+                    } else {
+                        callbacks.logLine("Fresh configuration read from ECU for console refresh.");
+                    }
+                    return true;
+                }
                 // The ECU's USB can briefly drop and re-enumerate right after the
                 // scanner's probe. Retry a few times to ride out that transient window.
                 Optional<CalibrationsInfo> updatedCalibrations = Optional.empty();
@@ -166,18 +247,64 @@ public class CalibrationsHelper {
                 }
                 if (!updatedCalibrations.isPresent()) {
                     callbacks.logLine("Failed to back up tune from ECU after firmware update...");
-                    return false;
+
+                    if (isUiContext(callbacks)) {
+                        CalibrationBackupFailureAction action = showCalibrationFailureDialog(
+                            parent,
+                            "Failed to read calibration from ECU after firmware update.",
+                            new ArrayList<>(),
+                            true
+                        );
+                        if (action == CalibrationBackupFailureAction.RESET_ALL) {
+                            callbacks.logLine("Skipping calibration restore - ECU will use default configuration.");
+                            return true;
+                        } else if (action == CalibrationBackupFailureAction.CANCEL) {
+                            callbacks.logLine("Firmware update cancelled by user.");
+                            return false;
+                        } else if (action == CalibrationBackupFailureAction.RETRY) {
+                            updatedCalibrations = readAndBackupCurrentCalibrationsWithSuspendedPortScanner(
+                                newEcuPort.port,
+                                callbacks,
+                                getFileNameWithoutExtension(timestampFileNameComponent, "after_firmware_update_retry"),
+                                connectivityContext
+                            );
+                            if (!updatedCalibrations.isPresent()) {
+                                return false;
+                            }
+                        } else {
+                            usePartialMerge = true;
+                        }
+                    } else {
+                        return false;
+                    }
                 }
-                final Optional<CalibrationsInfo> mergedCalibrations = mergeCalibrations(
-                    prevCalibrations.get().getIniFile(),
-                    prevCalibrations.get().generateMsq(),
-                    updatedCalibrations.get(),
-                    callbacks,
-                    emptySet()
-                );
-                if (mergedCalibrations.isPresent() && MigrateSettingsCheckboxState.isMigrationNeeded) {
+
+                final MergeResult mergeResult;
+                if (usePartialMerge) {
+                    mergeResult = mergeCalibrationsWithPartialFailure(
+                        prevCalibrations.get().getIniFile(),
+                        prevCalibrations.get().generateMsq(),
+                        updatedCalibrations.get(),
+                        callbacks,
+                        emptySet()
+                    );
+                    if (!mergeResult.failedFields.isEmpty()) {
+                        callbacks.logLine("WARNING: " + mergeResult.failedFields.size() + " field(s) failed to migrate and were skipped.");
+                    }
+                } else {
+                    final Optional<CalibrationsInfo> mergedOpt = mergeCalibrations(
+                        prevCalibrations.get().getIniFile(),
+                        prevCalibrations.get().generateMsq(),
+                        updatedCalibrations.get(),
+                        callbacks,
+                        emptySet()
+                    );
+                    mergeResult = new MergeResult(mergedOpt, new ArrayList<>());
+                }
+
+                if (mergeResult.mergedCalibrations.isPresent() && MigrateSettingsCheckboxState.isMigrationNeeded) {
                     if (!backUpCalibrationsInfo(
-                        mergedCalibrations.get(),
+                        mergeResult.mergedCalibrations.get(),
                         getFileNameWithoutExtension(timestampFileNameComponent, "merged_to_write"),
                         callbacks
                     )) {
@@ -186,7 +313,7 @@ public class CalibrationsHelper {
                     }
                     if (!CalibrationsUpdater.INSTANCE.updateCalibrations(
                         newEcuPort.port,
-                        mergedCalibrations.get().getImage().getConfigurationImage(),
+                        mergeResult.mergedCalibrations.get().getImage().getConfigurationImage(),
                         callbacks,
                         connectivityContext
                     )) {
@@ -586,5 +713,116 @@ public class CalibrationsHelper {
             callbacks.logLine("It looks like we do not need to update any fields to restore previous calibrations.");
         }
         return result;
+    }
+
+    public static MergeResult mergeCalibrationsWithPartialFailure(
+        final IniFileModel prevIniFile,
+        final Msq prevMsq,
+        final CalibrationsInfo newCalibrations,
+        final UpdateOperationCallbacks callbacks,
+        final Set<String> additionalIniFieldsToIgnore
+    ) {
+        final List<String> failedFields = new ArrayList<>();
+        final IniFileModel newIniFile = newCalibrations.getIniFile();
+        final Msq newMsq = newCalibrations.generateMsq();
+
+        final TuneMigrationContext context = new TuneMigrationContext(
+            prevIniFile,
+            prevMsq,
+            newIniFile,
+            newMsq,
+            callbacks,
+            additionalIniFieldsToIgnore
+        );
+        ComposedTuneMigrator.INSTANCE.migrateTune(context);
+        final Set<Map.Entry<String, Constant>> valuesToUpdate = context.getMigratedConstants().entrySet();
+
+        if (valuesToUpdate.isEmpty() && !"true".equalsIgnoreCase(RUSEFI_FORCE_CALIBRATIONS_RESTORE)) {
+            callbacks.logLine("It looks like we do not need to update any fields to restore previous calibrations.");
+            return new MergeResult(Optional.empty(), failedFields);
+        }
+
+        final ConfigurationImage mergedImage = newCalibrations.getImage().getConfigurationImage().clone();
+        for (final Map.Entry<String, Constant> valueToUpdate : valuesToUpdate) {
+            final String migratedFieldName = valueToUpdate.getKey();
+            final Constant migratedValue = valueToUpdate.getValue();
+            final Optional<IniField> fieldToUpdate = newIniFile.findIniField(migratedFieldName);
+            if (fieldToUpdate.isPresent()) {
+                try {
+                    ConfigurationImageGetterSetter2.setValue(fieldToUpdate.get(), mergedImage, migratedValue);
+                    callbacks.logLine(String.format(
+                        "To restore previous calibrations we are going to update the field `%s` with a value `%s`",
+                        migratedFieldName,
+                        migratedValue.getValue()
+                    ));
+                } catch (Throwable e) {
+                    log.error(
+                        String.format("Failed to set value %s for ini-field %s", migratedValue, fieldToUpdate),
+                        e
+                    );
+                    callbacks.logLine(String.format(
+                        "WARNING: Failed to migrate field `%s`, skipping: %s",
+                        migratedFieldName,
+                        e.getMessage()
+                    ));
+                    failedFields.add(migratedFieldName);
+                }
+            } else if (null == migratedValue) {
+                log.info(String.format(
+                    "Disappeared `%s` field has been already migrated by one of migrators",
+                    migratedFieldName
+                ));
+            } else {
+                callbacks.logLine(String.format(
+                    "WARNING!!! To restore previous calibrations we want to update the field `%s` with a value " +
+                        "`%s`, but this field has disappeared in updated .ini file",
+                    migratedFieldName,
+                    migratedValue.getValue()
+                ));
+                failedFields.add(migratedFieldName);
+            }
+        }
+
+        if (failedFields.isEmpty() && valuesToUpdate.isEmpty() && "true".equalsIgnoreCase(RUSEFI_FORCE_CALIBRATIONS_RESTORE)) {
+            callbacks.logLine("It looks like we do not need to update previous calibrations, but for debugging we are going to rewrite to ECU new calibrations again.");
+            return new MergeResult(Optional.of(newCalibrations), failedFields);
+        }
+
+        if (failedFields.isEmpty() && valuesToUpdate.isEmpty()) {
+            return new MergeResult(Optional.empty(), failedFields);
+        }
+
+        return new MergeResult(Optional.of(new CalibrationsInfo(
+            newIniFile,
+            new ConfigurationImageWithMeta(newCalibrations.getImage().getMeta(), mergedImage.getContent())
+        )), failedFields);
+    }
+
+    private static boolean isUiContext(final UpdateOperationCallbacks callbacks) {
+        return callbacks != UpdateOperationCallbacks.DUMMY &&
+               callbacks != UpdateOperationCallbacks.LOGGER;
+    }
+
+    private static CalibrationBackupFailureAction showCalibrationFailureDialog(
+        final JComponent parent,
+        final String failureMessage,
+        final List<String> failedFields,
+        final boolean hasBackupData
+    ) {
+        final CalibrationBackupFailureAction[] result = new CalibrationBackupFailureAction[1];
+        try {
+            SwingUtilities.invokeAndWait(() -> {
+                result[0] = CalibrationBackupFailureDialog.showDialog(
+                    parent,
+                    failureMessage,
+                    failedFields,
+                    hasBackupData
+                );
+            });
+        } catch (Exception e) {
+            log.error("Failed to show calibration failure dialog:", e);
+            return CalibrationBackupFailureAction.RESET_ALL;
+        }
+        return result[0];
     }
 }

--- a/java_console/ui/src/main/java/com/rusefi/maintenance/DfuFlasher.java
+++ b/java_console/ui/src/main/java/com/rusefi/maintenance/DfuFlasher.java
@@ -55,7 +55,7 @@ public class DfuFlasher {
         final ConnectivityContext connectivityContext
     ) {
         return CalibrationsHelper.updateFirmwareAndRestorePreviousCalibrations(
-            port, bp, lm, callbacks, () -> dfuUpdateFirmware(parent, port.port, callbacks), connectivityContext);
+            parent, port, bp, lm, callbacks, () -> dfuUpdateFirmware(parent, port.port, callbacks), connectivityContext);
     }
 
     private static boolean dfuUpdateFirmware(

--- a/java_console/ui/src/main/java/com/rusefi/maintenance/ProgramSelector.java
+++ b/java_console/ui/src/main/java/com/rusefi/maintenance/ProgramSelector.java
@@ -239,7 +239,7 @@ public class ProgramSelector {
         ConnectivityContext connectivityContext
     ) {
         return updateFirmwareAndRestorePreviousCalibrations(
-            ecuPort, bp, lm, callbacks, () -> bltUpdateFirmware(parent, ecuPort, callbacks, connectivityContext), connectivityContext);
+            parent, ecuPort, bp, lm, callbacks, () -> bltUpdateFirmware(parent, ecuPort, callbacks, connectivityContext), connectivityContext);
     }
 
     private static boolean bltUpdateFirmware(JComponent parent, PortResult ecuPort, UpdateOperationCallbacks callbacks, ConnectivityContext connectivityContext) {

--- a/java_console/ui/src/test/java/com/rusefi/maintenance/CalibrationsHelperContextTest.java
+++ b/java_console/ui/src/test/java/com/rusefi/maintenance/CalibrationsHelperContextTest.java
@@ -1,0 +1,69 @@
+package com.rusefi.maintenance;
+
+import com.rusefi.io.UpdateOperationCallbacks;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class CalibrationsHelperContextTest {
+
+    @Test
+    public void testIsUiContext_withDummyCallbacks() throws Exception {
+        Method method = CalibrationsHelper.class.getDeclaredMethod("isUiContext", UpdateOperationCallbacks.class);
+        method.setAccessible(true);
+
+        boolean result = (boolean) method.invoke(null, UpdateOperationCallbacks.DUMMY);
+        assertFalse(result, "DUMMY callbacks should not be considered UI context");
+    }
+
+    @Test
+    public void testIsUiContext_withLoggerCallbacks() throws Exception {
+        Method method = CalibrationsHelper.class.getDeclaredMethod("isUiContext", UpdateOperationCallbacks.class);
+        method.setAccessible(true);
+
+        boolean result = (boolean) method.invoke(null, UpdateOperationCallbacks.LOGGER);
+        assertFalse(result, "LOGGER callbacks should not be considered UI context");
+    }
+
+    @Test
+    public void testIsUiContext_withConsoleCallbacks() throws Exception {
+        Method method = CalibrationsHelper.class.getDeclaredMethod("isUiContext", UpdateOperationCallbacks.class);
+        method.setAccessible(true);
+
+        boolean result = (boolean) method.invoke(null, UpdateOperationCallbacks.CONSOLE);
+        assertTrue(result, "CONSOLE callbacks should be considered UI context");
+    }
+
+    @Test
+    public void testIsUiContext_withCustomCallbacks() throws Exception {
+        Method method = CalibrationsHelper.class.getDeclaredMethod("isUiContext", UpdateOperationCallbacks.class);
+        method.setAccessible(true);
+
+        UpdateOperationCallbacks customCallbacks = new UpdateOperationCallbacks() {
+            @Override
+            public void log(String message, boolean breakLineOnTextArea, boolean sendToLogger) {
+            }
+
+            @Override
+            public void done() {
+            }
+
+            @Override
+            public void warning() {
+            }
+
+            @Override
+            public void error() {
+            }
+
+            @Override
+            public void clear() {
+            }
+        };
+
+        boolean result = (boolean) method.invoke(null, customCallbacks);
+        assertTrue(result, "Custom callbacks should be considered UI context");
+    }
+}

--- a/java_console/ui/src/test/java/com/rusefi/maintenance/CalibrationsHelperPartialMergeTest.java
+++ b/java_console/ui/src/test/java/com/rusefi/maintenance/CalibrationsHelperPartialMergeTest.java
@@ -1,0 +1,71 @@
+package com.rusefi.maintenance;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import jakarta.xml.bind.JAXBException;
+import java.util.HashSet;
+import java.util.Set;
+
+import static com.rusefi.maintenance.migration.default_migration.DefaultTestTuneMigrationContext.*;
+import static com.rusefi.maintenance.migration.migrators.TableAddColumnsMigrator.VE_TABLE_FIELD_NAME;
+import static java.util.Collections.emptySet;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class CalibrationsHelperPartialMergeTest {
+    private PartialMergeTestContext testContext;
+
+    @BeforeEach
+    public void setUp() throws JAXBException {
+        testContext = PartialMergeTestContext.load();
+    }
+
+    @Test
+    public void testMergeCalibrationsWithPartialFailure_returnsNonNullResult() {
+        CalibrationsHelper.MergeResult result = CalibrationsHelper.mergeCalibrationsWithPartialFailure(
+            testContext.getPrevIniFile(),
+            testContext.getPrevTune(),
+            testContext.getUpdatedCalibrationsInfo(),
+            testContext.getCallbacks(),
+            emptySet()
+        );
+
+        assertNotNull(result);
+        assertNotNull(result.failedFields);
+    }
+
+    @Test
+    public void testMergeCalibrationsWithPartialFailure_tracksFailedFields() {
+        Set<String> simulatedFailures = new HashSet<>();
+        simulatedFailures.add(IGNITION_TABLE_FIELD_NAME);
+
+        CalibrationsHelper.MergeResult result = testContext.mergeWithSimulatedFailures(simulatedFailures);
+
+        assertNotNull(result);
+        assertTrue(result.mergedCalibrations.isPresent());
+        assertEquals(1, result.failedFields.size());
+        assertTrue(result.failedFields.contains(IGNITION_TABLE_FIELD_NAME));
+
+        String logText = testContext.getTestCallbacks().getContent();
+        assertTrue(logText.contains("Failed to migrate field `" + IGNITION_TABLE_FIELD_NAME + "`"));
+    }
+
+    @Test
+    public void testMergeCalibrationsWithPartialFailure_multipleFieldsFail() {
+        Set<String> simulatedFailures = new HashSet<>();
+        simulatedFailures.add(IGNITION_TABLE_FIELD_NAME);
+        simulatedFailures.add(VE_TABLE_FIELD_NAME);
+
+        CalibrationsHelper.MergeResult result = testContext.mergeWithSimulatedFailures(simulatedFailures);
+
+        assertNotNull(result);
+        assertTrue(result.mergedCalibrations.isPresent());
+        assertEquals(2, result.failedFields.size());
+        assertTrue(result.failedFields.contains(IGNITION_TABLE_FIELD_NAME));
+        assertTrue(result.failedFields.contains(VE_TABLE_FIELD_NAME));
+
+        String logText = testContext.getTestCallbacks().getContent();
+        assertTrue(logText.contains("Failed to migrate field `" + IGNITION_TABLE_FIELD_NAME + "`"));
+        assertTrue(logText.contains("Failed to migrate field `" + VE_TABLE_FIELD_NAME + "`"));
+    }
+}

--- a/java_console/ui/src/test/java/com/rusefi/maintenance/PartialMergeTestContext.java
+++ b/java_console/ui/src/test/java/com/rusefi/maintenance/PartialMergeTestContext.java
@@ -1,0 +1,118 @@
+package com.rusefi.maintenance;
+
+import com.opensr5.ConfigurationImage;
+import com.opensr5.ConfigurationImageWithMeta;
+import com.opensr5.ini.IniFileModel;
+import com.opensr5.ini.field.IniField;
+import com.rusefi.ini.reader.IniFileReaderUtil;
+import com.rusefi.io.UpdateOperationCallbacks;
+import com.rusefi.maintenance.migration.TuneMigrationContext;
+import com.rusefi.tune.ConfigurationImageGetterSetter2;
+import com.rusefi.tune.xml.Constant;
+import com.rusefi.tune.xml.Msq;
+
+import jakarta.xml.bind.JAXBException;
+import java.io.FileNotFoundException;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+
+public class PartialMergeTestContext extends TuneMigrationContext {
+    public static final String TEST_DATA_FOLDER = "src/test/java/com/rusefi/maintenance/migration/default_migration/test_data";
+
+    public static PartialMergeTestContext load() throws JAXBException {
+        try {
+            return new PartialMergeTestContext(
+                Msq.readTune(TEST_DATA_FOLDER + "/prev_calibrations.msq"),
+                IniFileReaderUtil.readIniFile(TEST_DATA_FOLDER + "/prev_calibrations.ini"),
+                Msq.readTune(TEST_DATA_FOLDER + "/updated_calibrations.msq"),
+                IniFileReaderUtil.readIniFile(TEST_DATA_FOLDER + "/updated_calibrations.ini"),
+                new TestCallbacks()
+            );
+        } catch (FileNotFoundException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public PartialMergeTestContext(
+        final Msq prevMsq,
+        final IniFileModel prevIni,
+        final Msq updatedMsq,
+        final IniFileModel updatedIni,
+        final UpdateOperationCallbacks callbacks
+    ) {
+        super(prevIni, prevMsq, updatedIni, updatedMsq, callbacks, Collections.emptySet());
+    }
+
+    public TestCallbacks getTestCallbacks() {
+        return (TestCallbacks) getCallbacks();
+    }
+
+    public CalibrationsInfo getPrevCalibrationsInfo() {
+        return getCalibrationsInfo(getPrevTune(), getPrevIniFile());
+    }
+
+    public CalibrationsInfo getUpdatedCalibrationsInfo() {
+        return getCalibrationsInfo(getUpdatedTune(), getUpdatedIniFile());
+    }
+
+    private static CalibrationsInfo getCalibrationsInfo(final Msq msq, final IniFileModel ini) {
+        final ConfigurationImage image = msq.asImage(ini);
+        ConfigurationImageWithMeta imageWithMeta = ConfigurationImageWithMeta.valueOf(ini, image);
+        return new CalibrationsInfo(ini, imageWithMeta);
+    }
+
+    public CalibrationsHelper.MergeResult mergeWithSimulatedFailures(Set<String> simulatedFailures) {
+        TestCallbacks callbacks = getTestCallbacks();
+        IniFileModel prevIniFile = getPrevIniFile();
+        Msq prevMsq = getPrevTune();
+        CalibrationsInfo newCalibrations = getUpdatedCalibrationsInfo();
+        Set<String> additionalIniFieldsToIgnore = Collections.emptySet();
+
+        TuneMigrationContext context = new TuneMigrationContext(
+            prevIniFile,
+            prevMsq,
+            newCalibrations.getIniFile(),
+            newCalibrations.generateMsq(),
+            callbacks,
+            additionalIniFieldsToIgnore
+        );
+        com.rusefi.maintenance.migration.migrators.ComposedTuneMigrator.INSTANCE.migrateTune(context);
+        Set<Map.Entry<String, Constant>> valuesToUpdate = context.getMigratedConstants().entrySet();
+
+        if (valuesToUpdate.isEmpty()) {
+            return new CalibrationsHelper.MergeResult(java.util.Optional.empty(), new java.util.ArrayList<>());
+        }
+
+        java.util.List<String> failedFields = new java.util.ArrayList<>();
+        ConfigurationImage mergedImage = newCalibrations.getImage().getConfigurationImage().clone();
+        for (Map.Entry<String, Constant> valueToUpdate : valuesToUpdate) {
+            String migratedFieldName = valueToUpdate.getKey();
+            Constant migratedValue = valueToUpdate.getValue();
+            java.util.Optional<IniField> fieldToUpdate = newCalibrations.getIniFile().findIniField(migratedFieldName);
+
+            if (fieldToUpdate.isPresent()) {
+                if (simulatedFailures.contains(migratedFieldName)) {
+                    callbacks.log("WARNING: Failed to migrate field `" + migratedFieldName + "`, skipping: Simulated failure", true, false);
+                    failedFields.add(migratedFieldName);
+                    continue;
+                }
+
+                try {
+                    ConfigurationImageGetterSetter2.setValue(fieldToUpdate.get(), mergedImage, migratedValue);
+                } catch (Throwable e) {
+                    callbacks.log("WARNING: Failed to migrate field `" + migratedFieldName + "`, skipping: " + e.getMessage(), true, false);
+                    failedFields.add(migratedFieldName);
+                }
+            }
+        }
+
+        return new CalibrationsHelper.MergeResult(
+            java.util.Optional.of(new CalibrationsInfo(
+                newCalibrations.getIniFile(),
+                new ConfigurationImageWithMeta(newCalibrations.getImage().getMeta(), mergedImage.getContent())
+            )),
+            failedFields
+        );
+    }
+}


### PR DESCRIPTION
we can rescue some calibration:

<img width="585" height="439" alt="image" src="https://github.com/user-attachments/assets/18d0f04b-fde5-4789-a6be-56697c6d9e5b" />



we cant save anything:

<img width="591" height="391" alt="image" src="https://github.com/user-attachments/assets/cdd48b5c-d281-4b45-87a6-3b012ce6fa07" />


resolves #9563
