### PR TITLE
feat: Add ExhaustCutoutController with PWM/H-Bridge and auto modes

### DIFF
--- a/firmware/console/binary/live_data.cpp
+++ b/firmware/console/binary/live_data.cpp
@@ -12,6 +12,7 @@
 #include "closed_loop_idle_generated.h"
 #include "vvt_generated.h"
 #include "mc33810_state_generated.h"
+#include "exhaust_cutout.h"
 #include <livedata_board_extra.h>
 
 template<>
@@ -327,4 +328,9 @@ const live_data_rotational_idle_s* getLiveData(size_t) {
 #else
 	return nullptr;
 #endif
+}
+
+template<>
+const exhaust_cutout_s* getLiveData(size_t) {
+	return &engine->module<ExhaustCutoutController>().unmock();
 }

--- a/firmware/controllers/actuators/exhaust_cutout.cpp
+++ b/firmware/controllers/actuators/exhaust_cutout.cpp
@@ -1,0 +1,371 @@
+#include "pch.h"
+#include "exhaust_cutout.h"
+
+static constexpr float VBATT_KEY_ON_TEST_THRESHOLD = 10.0f;
+
+void ExhaustCutoutController::deEnergize() {
+	m_pwmOutput.setSimplePwmDutyCycle(0);
+	m_hbridgePwm.setSimplePwmDutyCycle(0);
+}
+
+void ExhaustCutoutController::initPins() {
+	m_outputPin.deInit();
+	m_hbridgePin2.deInit();
+	m_ledPin.deInit();
+
+	auto& cfg = *engineConfiguration;
+
+	if (!cfg.exhaustCutoutEnabled) {
+		return;
+	}
+
+	bool isHBridge = cfg.exhaustCutoutOutputMode == EXHAUST_CUTOUT_OUTPUT_HBRIDGE;
+	bool isPwm = cfg.exhaustCutoutOutputMode == EXHAUST_CUTOUT_OUTPUT_PWM;
+
+	if (isHBridge) {
+		float freq = cfg.exhaustCutoutHBridgePwmFrequency > 0 ? cfg.exhaustCutoutHBridgePwmFrequency : 1000.0f;
+		if (isBrainPinValid(cfg.exhaustCutoutOutputPin)) {
+			m_outputPin.initPin("cutout-in1", cfg.exhaustCutoutOutputPin, cfg.exhaustCutoutOutputPinMode);
+			startSimplePwm(&m_pwmOutput, "cutout-in1", &engine->scheduler, &m_outputPin, freq, 0);
+		}
+		if (isBrainPinValid(cfg.exhaustCutoutHBridgePin2)) {
+			m_hbridgePin2.initPin("cutout-in2", cfg.exhaustCutoutHBridgePin2, cfg.exhaustCutoutHBridgePin2Mode);
+			startSimplePwm(&m_hbridgePwm, "cutout-in2", &engine->scheduler, &m_hbridgePin2, freq, 0);
+		}
+	} else if (isBrainPinValid(cfg.exhaustCutoutOutputPin)) {
+		m_outputPin.initPin("cutout", cfg.exhaustCutoutOutputPin, cfg.exhaustCutoutOutputPinMode);
+
+		if (isPwm) {
+			float freq = cfg.exhaustCutoutPwmFrequency > 0 ? cfg.exhaustCutoutPwmFrequency : 100.0f;
+			startSimplePwm(&m_pwmOutput, "cutout",
+				&engine->scheduler,
+				&m_outputPin,
+				freq,
+				PERCENT_TO_DUTY(cfg.exhaustCutoutPwmClosedDuty));
+		}
+	}
+
+	if (isBrainPinValid(cfg.exhaustCutoutLedPin)) {
+		m_ledPin.initPin("cutout led", cfg.exhaustCutoutLedPin, cfg.exhaustCutoutLedPinMode);
+	}
+
+	m_tpsHoldTimer.reset();
+	m_state = ExhaustCutoutState::CLOSED;
+
+	// Safe initial output state
+	if (isHBridge) {
+		deEnergize();
+	} else if (isPwm) {
+		m_pwmOutput.setSimplePwmDutyCycle(PERCENT_TO_DUTY(cfg.exhaustCutoutPwmClosedDuty));
+	} else {
+		m_outputPin.setValue(cfg.exhaustCutoutInvertedOutput ? 1 : 0);
+	}
+
+	m_ledPin.setValue(0);
+
+	// Arm key-on test; actual start is deferred until 12V is present (onSlowCallback)
+	if (cfg.exhaustCutoutKeyOnTestEnabled && !m_bootTestDone) {
+		m_keyOnTestPending = true;
+	}
+}
+
+void ExhaustCutoutController::onConfigurationChange(engine_configuration_s const* /*previousConfig*/) {
+	initPins();
+}
+
+bool ExhaustCutoutController::getInputHigh() const {
+	auto& cfg = *engineConfiguration;
+
+	if (cfg.exhaustCutoutActivationMode == EXHAUST_CUTOUT_SWITCH) {
+#if !EFI_SIMULATOR
+		if (isBrainPinValid(cfg.exhaustCutoutSwitchPin)) {
+			return efiReadPin(cfg.exhaustCutoutSwitchPin, cfg.exhaustCutoutSwitchPinMode);
+		}
+#endif
+		return false;
+	}
+
+	if (cfg.exhaustCutoutActivationMode == EXHAUST_CUTOUT_LUA_GAUGE) {
+		SensorType gauge;
+		switch (cfg.exhaustCutoutLuaGauge) {
+			case LUA_GAUGE_2: gauge = SensorType::LuaGauge2; break;
+			case LUA_GAUGE_3: gauge = SensorType::LuaGauge3; break;
+			case LUA_GAUGE_4: gauge = SensorType::LuaGauge4; break;
+			case LUA_GAUGE_5: gauge = SensorType::LuaGauge5; break;
+			case LUA_GAUGE_6: gauge = SensorType::LuaGauge6; break;
+			case LUA_GAUGE_7: gauge = SensorType::LuaGauge7; break;
+			case LUA_GAUGE_8: gauge = SensorType::LuaGauge8; break;
+			default:          gauge = SensorType::LuaGauge1; break;
+		}
+		auto result = Sensor::get(gauge);
+		if (!result.Valid) {
+			return false;
+		}
+		if (cfg.exhaustCutoutLuaGaugeMeaning == LUA_GAUGE_LOWER_BOUND) {
+			return result.Value >= cfg.exhaustCutoutLuaGaugeThreshold;
+		} else {
+			return result.Value <= cfg.exhaustCutoutLuaGaugeThreshold;
+		}
+	}
+
+	return false;
+}
+
+bool ExhaustCutoutController::evaluateAutoTrigger() {
+	auto& cfg = *engineConfiguration;
+
+	float rpm = Sensor::getOrZero(SensorType::Rpm);
+	isTriggerRpm = (cfg.exhaustCutoutOpenRpm > 0) && (rpm > cfg.exhaustCutoutOpenRpm);
+
+	float tps = Sensor::getOrZero(SensorType::Tps1);
+	if (cfg.exhaustCutoutOpenTps > 0 && tps > cfg.exhaustCutoutOpenTps) {
+		isTriggerTps = m_tpsHoldTimer.hasElapsedSec(cfg.exhaustCutoutTpsDelayS);
+	} else {
+		m_tpsHoldTimer.reset();
+		isTriggerTps = false;
+	}
+
+	float map = Sensor::getOrZero(SensorType::MapSlow);
+	isTriggerMap = (cfg.exhaustCutoutOpenMapKpa > 0) && (map > cfg.exhaustCutoutOpenMapKpa);
+
+	bool shouldBeOpen = isTriggerRpm || isTriggerTps || isTriggerMap;
+
+	if (shouldBeOpen) {
+		m_closeDelayTimer.reset();
+		return true;
+	} else {
+		return !m_closeDelayTimer.hasElapsedSec(cfg.exhaustCutoutClosingDelayS);
+	}
+}
+
+void ExhaustCutoutController::setState(ExhaustCutoutState newState) {
+	if (m_state == newState) {
+		return;
+	}
+
+	m_state = newState;
+	m_moveTimer.reset();
+	m_ledTimer.reset();
+
+	auto& cfg = *engineConfiguration;
+	bool isHBridge = cfg.exhaustCutoutOutputMode == EXHAUST_CUTOUT_OUTPUT_HBRIDGE;
+	bool isPwm = cfg.exhaustCutoutOutputMode == EXHAUST_CUTOUT_OUTPUT_PWM;
+
+	switch (newState) {
+		case ExhaustCutoutState::CLOSED:
+			if (isHBridge) {
+				deEnergize();
+			} else if (isPwm) {
+				m_pwmOutput.setSimplePwmDutyCycle(PERCENT_TO_DUTY(cfg.exhaustCutoutPwmClosedDuty));
+			} else {
+				m_outputPin.setValue(cfg.exhaustCutoutInvertedOutput ? 1 : 0);
+			}
+			m_ledPin.setValue(0);
+			break;
+		case ExhaustCutoutState::OPENING:
+			if (isHBridge) {
+				// IN1 = drive duty, IN2 = 0 (open direction)
+				m_hbridgePwm.setSimplePwmDutyCycle(0);
+				m_pwmOutput.setSimplePwmDutyCycle(PERCENT_TO_DUTY(cfg.exhaustCutoutHBridgeDutyCycle));
+			} else if (isPwm) {
+				m_pwmOutput.setSimplePwmDutyCycle(PERCENT_TO_DUTY(cfg.exhaustCutoutPwmOpenDuty));
+			} else {
+				m_outputPin.setValue(cfg.exhaustCutoutInvertedOutput ? 0 : 1);
+			}
+			break;
+		case ExhaustCutoutState::OPEN:
+			if (isHBridge) {
+				deEnergize();
+			}
+			// PWM: duty stays at open level set during OPENING
+			// Digital: pin stays at open logic level set during OPENING
+			break;
+		case ExhaustCutoutState::CLOSING:
+			if (isHBridge) {
+				// IN1 = 0, IN2 = drive duty (close direction)
+				m_pwmOutput.setSimplePwmDutyCycle(0);
+				m_hbridgePwm.setSimplePwmDutyCycle(PERCENT_TO_DUTY(cfg.exhaustCutoutHBridgeDutyCycle));
+			} else if (isPwm) {
+				m_pwmOutput.setSimplePwmDutyCycle(PERCENT_TO_DUTY(cfg.exhaustCutoutPwmClosedDuty));
+			} else {
+				m_outputPin.setValue(cfg.exhaustCutoutInvertedOutput ? 1 : 0);
+			}
+			break;
+	}
+}
+
+void ExhaustCutoutController::updateLed() {
+	switch (m_state) {
+		case ExhaustCutoutState::CLOSED:
+			m_ledPin.setValue(0);
+			break;
+		case ExhaustCutoutState::OPENING: {
+			float phase = fmod(m_ledTimer.getElapsedSeconds() * 3.0f, 1.0f);
+			m_ledPin.setValue(phase < 0.5f ? 1 : 0);
+			break;
+		}
+		case ExhaustCutoutState::OPEN:
+			m_ledPin.setValue(engineConfiguration->exhaustCutoutShowOpenState ? 1 : 0);
+			break;
+		case ExhaustCutoutState::CLOSING: {
+			float phase = fmod(m_ledTimer.getElapsedSeconds() * 1.0f, 1.0f);
+			m_ledPin.setValue(phase < 0.5f ? 1 : 0);
+			break;
+		}
+	}
+}
+
+// Returns the desired open state for the current test step, advancing phase when timer expires.
+bool ExhaustCutoutController::runTestSequence() {
+	auto& cfg = *engineConfiguration;
+	float stepDuration = cfg.exhaustCutoutMoveDurationS;
+	bool stepDone = m_testStepTimer.hasElapsedSec(stepDuration);
+
+	auto advance = [&](ExhaustCutoutTestPhase next) {
+		m_testPhase = next;
+		m_testStepTimer.reset();
+	};
+
+	switch (m_testPhase) {
+		case ExhaustCutoutTestPhase::KEY_ON_OPEN_1:
+			if (stepDone) advance(ExhaustCutoutTestPhase::KEY_ON_CLOSE_1);
+			return true;
+		case ExhaustCutoutTestPhase::KEY_ON_CLOSE_1:
+			if (stepDone) advance(ExhaustCutoutTestPhase::KEY_ON_OPEN_2);
+			return false;
+		case ExhaustCutoutTestPhase::KEY_ON_OPEN_2:
+			if (stepDone) advance(ExhaustCutoutTestPhase::KEY_ON_CLOSE_2);
+			return true;
+		case ExhaustCutoutTestPhase::KEY_ON_CLOSE_2:
+			if (stepDone) {
+				m_testPhase = ExhaustCutoutTestPhase::IDLE;
+				m_bootTestDone = true;
+				m_closeDelayTimer.reset();
+				if (cfg.exhaustCutoutEngineOnTestEnabled) {
+					m_engineOnTestArmed = true;
+				}
+			}
+			return false;
+		case ExhaustCutoutTestPhase::ENGINE_ON_OPEN:
+			if (stepDone) advance(ExhaustCutoutTestPhase::ENGINE_ON_CLOSE);
+			return true;
+		case ExhaustCutoutTestPhase::ENGINE_ON_CLOSE:
+			if (stepDone) {
+				m_testPhase = ExhaustCutoutTestPhase::IDLE;
+				m_closeDelayTimer.reset();
+			}
+			return false;
+		default:
+			return false;
+	}
+}
+
+void ExhaustCutoutController::onSlowCallback() {
+	auto& cfg = *engineConfiguration;
+
+	if (!cfg.exhaustCutoutEnabled || cfg.exhaustCutoutActivationMode == EXHAUST_CUTOUT_OFF) {
+		if (m_state != ExhaustCutoutState::CLOSED) {
+			if (cfg.exhaustCutoutOutputMode == EXHAUST_CUTOUT_OUTPUT_HBRIDGE) {
+				deEnergize();
+			} else if (cfg.exhaustCutoutOutputMode == EXHAUST_CUTOUT_OUTPUT_PWM) {
+				m_pwmOutput.setSimplePwmDutyCycle(PERCENT_TO_DUTY(cfg.exhaustCutoutPwmClosedDuty));
+			} else {
+				m_outputPin.setValue(cfg.exhaustCutoutInvertedOutput ? 1 : 0);
+			}
+			m_ledPin.setValue(0);
+			m_state = ExhaustCutoutState::CLOSED;
+		}
+		isTriggerRpm = false;
+		isTriggerTps = false;
+		isTriggerMap = false;
+		isInputHigh = false;
+		targetOpen = false;
+		isCutoutOpen = false;
+		isCutoutMoving = false;
+		isTestActive = false;
+		m_keyOnTestPending = false;
+		return;
+	}
+
+	float vbatt = Sensor::getOrZero(SensorType::BatteryVoltage);
+
+	// Start key-on test once 12V is present (deferred from initPins)
+	if (m_keyOnTestPending && vbatt >= VBATT_KEY_ON_TEST_THRESHOLD) {
+		m_keyOnTestPending = false;
+		m_testPhase = ExhaustCutoutTestPhase::KEY_ON_OPEN_1;
+		m_testStepTimer.reset();
+	}
+
+	// Engine-on test: fire on first transition from cranking to running
+	bool engineRunning = engine->rpmCalculator.isRunning();
+	if (engineRunning && !m_lastEngineRunning && m_engineOnTestArmed) {
+		m_testPhase = ExhaustCutoutTestPhase::ENGINE_ON_OPEN;
+		m_testStepTimer.reset();
+		m_engineOnTestArmed = false;
+	}
+	m_lastEngineRunning = engineRunning;
+
+	isTestActive = (m_testPhase != ExhaustCutoutTestPhase::IDLE);
+	bool desiredOpen;
+
+	if (isTestActive) {
+		desiredOpen = runTestSequence();
+		isTriggerRpm = false;
+		isTriggerTps = false;
+		isTriggerMap = false;
+		isInputHigh = false;
+	} else {
+		// Normal activation logic
+		isInputHigh = getInputHigh();
+
+		exhaust_cutout_behavior_e behavior = isInputHigh ? cfg.exhaustCutoutBehaviorHigh
+		                                                  : cfg.exhaustCutoutBehaviorLow;
+
+		if (behavior == EXHAUST_CUTOUT_ALWAYS_CLOSED) {
+			desiredOpen = false;
+			isTriggerRpm = false;
+			isTriggerTps = false;
+			isTriggerMap = false;
+			m_tpsHoldTimer.reset();
+		} else if (behavior == EXHAUST_CUTOUT_ALWAYS_OPEN) {
+			desiredOpen = true;
+			isTriggerRpm = false;
+			isTriggerTps = false;
+			isTriggerMap = false;
+		} else {
+			desiredOpen = evaluateAutoTrigger();
+		}
+	}
+
+	targetOpen = desiredOpen;
+
+	// H-Bridge: advance from OPENING to OPEN / CLOSING to CLOSED after motor duration
+	float moveDuration = cfg.exhaustCutoutMoveDurationS;
+	bool moveComplete = m_moveTimer.hasElapsedSec(moveDuration);
+
+	if (m_state == ExhaustCutoutState::OPENING && moveComplete) {
+		setState(ExhaustCutoutState::OPEN);
+	} else if (m_state == ExhaustCutoutState::CLOSING && moveComplete) {
+		setState(ExhaustCutoutState::CLOSED);
+	}
+
+	// State machine transitions
+	if (desiredOpen) {
+		if (m_state == ExhaustCutoutState::CLOSED || m_state == ExhaustCutoutState::CLOSING) {
+			setState(ExhaustCutoutState::OPENING);
+		}
+	} else {
+		if (m_state == ExhaustCutoutState::OPEN || m_state == ExhaustCutoutState::OPENING) {
+			setState(ExhaustCutoutState::CLOSING);
+		}
+	}
+
+	updateLed();
+
+	isCutoutOpen = (m_state == ExhaustCutoutState::OPEN || m_state == ExhaustCutoutState::OPENING);
+	isCutoutMoving = (m_state == ExhaustCutoutState::OPENING || m_state == ExhaustCutoutState::CLOSING);
+}
+
+void initExhaustCutout() {
+	engine->module<ExhaustCutoutController>()->initPins();
+}

--- a/firmware/controllers/actuators/exhaust_cutout.h
+++ b/firmware/controllers/actuators/exhaust_cutout.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include "exhaust_cutout_generated.h"
+#include <rusefi/timer.h>
+#include "efi_output.h"
+#include "pwm_generator_logic.h"
+
+enum class ExhaustCutoutState : uint8_t {
+	CLOSED = 0,
+	OPENING = 1,
+	OPEN = 2,
+	CLOSING = 3,
+};
+
+enum class ExhaustCutoutTestPhase : uint8_t {
+	IDLE = 0,
+	KEY_ON_OPEN_1,
+	KEY_ON_CLOSE_1,
+	KEY_ON_OPEN_2,
+	KEY_ON_CLOSE_2,
+	ENGINE_ON_OPEN,
+	ENGINE_ON_CLOSE,
+};
+
+class ExhaustCutoutController : public exhaust_cutout_s, public EngineModule {
+public:
+	void onSlowCallback() override;
+	void onConfigurationChange(engine_configuration_s const* previousConfig) override;
+
+	void initPins();
+
+private:
+	bool getInputHigh() const;
+	bool evaluateAutoTrigger();
+	void setState(ExhaustCutoutState newState);
+	void updateLed();
+	void deEnergize();
+	bool runTestSequence();
+
+	OutputPin m_outputPin;    // Digital output, single PWM output, or H-Bridge IN1
+	OutputPin m_hbridgePin2;  // H-Bridge IN2
+	OutputPin m_ledPin;
+	SimplePwm m_pwmOutput{"cutout"};     // used in PWM mode or H-Bridge IN1
+	SimplePwm m_hbridgePwm{"cutout-in2"}; // H-Bridge IN2 PWM
+
+	Timer m_tpsHoldTimer;
+	Timer m_closeDelayTimer;
+	Timer m_moveTimer;
+	Timer m_ledTimer;
+	Timer m_testStepTimer;
+
+	ExhaustCutoutState m_state = ExhaustCutoutState::CLOSED;
+
+	ExhaustCutoutTestPhase m_testPhase = ExhaustCutoutTestPhase::IDLE;
+	bool m_bootTestDone = false;
+	bool m_keyOnTestPending = false;
+	bool m_engineOnTestArmed = false;
+	bool m_lastEngineRunning = false;
+};
+
+void initExhaustCutout();

--- a/firmware/controllers/actuators/exhaust_cutout.txt
+++ b/firmware/controllers/actuators/exhaust_cutout.txt
@@ -1,0 +1,10 @@
+struct_no_prefix exhaust_cutout_s
+	bit isTriggerRpm;RPM trigger active
+	bit isTriggerTps;TPS trigger active, anti-blip OK
+	bit isTriggerMap;MAP/boost trigger active
+	bit isInputHigh;Activation input in HIGH state
+	bit targetOpen;Control logic requests cutout open
+	bit isCutoutOpen;Cutout is fully open
+	bit isCutoutMoving;H-Bridge motor is running
+	bit isTestActive;Actuator test sequence is running
+end_struct

--- a/firmware/controllers/algo/engine.h
+++ b/firmware/controllers/algo/engine.h
@@ -39,6 +39,7 @@
 #include "trigger_scheduler.h"
 #include "fuel_pump.h"
 #include "main_relay.h"
+#include "exhaust_cutout.h"
 #include "ac_control.h"
 #include "type_list.h"
 #include "boost_control.h"
@@ -161,6 +162,7 @@ public:
         AlternatorController,
 #endif /* EFI_ALTERNATOR_CONTROL */
         MainRelayController,
+        ExhaustCutoutController,
         Mockable<IgnitionController>,
         Mockable<AcController>,
         PrimeController,

--- a/firmware/controllers/algo/rusefi_enums.h
+++ b/firmware/controllers/algo/rusefi_enums.h
@@ -611,6 +611,24 @@ typedef enum __attribute__ ((__packed__)) {
 	LUA_GAUGE_UPPER_BOUND = 1,
 } lua_gauge_meaning_e;
 
+typedef enum __attribute__ ((__packed__)) {
+	EXHAUST_CUTOUT_OFF = 0,
+	EXHAUST_CUTOUT_SWITCH = 1,
+	EXHAUST_CUTOUT_LUA_GAUGE = 2,
+} exhaust_cutout_activation_e;
+
+typedef enum __attribute__ ((__packed__)) {
+	EXHAUST_CUTOUT_ALWAYS_CLOSED = 0,
+	EXHAUST_CUTOUT_ALWAYS_OPEN = 1,
+	EXHAUST_CUTOUT_AUTO = 2,
+} exhaust_cutout_behavior_e;
+
+typedef enum __attribute__ ((__packed__)) {
+	EXHAUST_CUTOUT_OUTPUT_DIGITAL = 0,
+	EXHAUST_CUTOUT_OUTPUT_PWM = 1,
+	EXHAUST_CUTOUT_OUTPUT_HBRIDGE = 2,
+} exhaust_cutout_output_mode_e;
+
 // this one is "Rotational Idle", it's a naming mess https://github.com/rusefi/rusefi/issues/8435
 typedef enum __attribute__ ((__packed__)) {
 	SWITCH_INPUT_ANTILAG = 0,

--- a/firmware/controllers/controllers.mk
+++ b/firmware/controllers/controllers.mk
@@ -19,6 +19,7 @@ CONTROLLERS_SRC_CPP = \
 	$(CONTROLLERS_DIR)/actuators/idle_thread.cpp \
 	$(CONTROLLERS_DIR)/actuators/ignition_controller.cpp \
 	$(CONTROLLERS_DIR)/actuators/main_relay.cpp \
+	$(CONTROLLERS_DIR)/actuators/exhaust_cutout.cpp \
 	$(CONTROLLERS_DIR)/actuators/vvt.cpp \
 	$(CONTROLLERS_DIR)/actuators/gppwm_channel_reader.cpp \
 	$(CONTROLLERS_DIR)/actuators/gppwm/gppwm_channel.cpp \

--- a/firmware/controllers/engine_controller.cpp
+++ b/firmware/controllers/engine_controller.cpp
@@ -448,6 +448,7 @@ void commonInitEngineController() {
 	initScriptImpl();
 
 	initGpPwm();
+	initExhaustCutout();
 
 #if EFI_IDLE_CONTROL
 	startIdleThread();

--- a/firmware/docs_enums.mk
+++ b/firmware/docs_enums.mk
@@ -16,6 +16,7 @@ DOCS_ENUMS_INPUTS = \
   $(PROJECT_DIR)/controllers/engine_cycle/high_pressure_fuel_pump.txt \
   $(PROJECT_DIR)/controllers/actuators/idle_state.txt \
   $(PROJECT_DIR)/controllers/actuators/electronic_throttle.txt \
+  $(PROJECT_DIR)/controllers/actuators/exhaust_cutout.txt \
   $(PROJECT_DIR)/hw_layer/drivers/gpio/mc33810_state.txt \
   $(PROJECT_DIR)/integration/LiveData.yaml \
   $(PROJECT_DIR)/controllers/sensors/sensor_type.h \

--- a/firmware/integration/LiveData.yaml
+++ b/firmware/integration/LiveData.yaml
@@ -141,6 +141,13 @@ Usages:
     folder: controllers/actuators
     output_name: mainRelay
 
+  - name: exhaust_cutout
+    java: ExhaustCutout.java
+    folder: controllers/actuators
+    prepend: integration/rusefi_config_shared.txt
+    output_name: exhaustCutout
+    engineModule: ExhaustCutoutController
+
   #todo: handle ETB pid and Idle pid which point at same pid_state.txt
   # - name: pid_state
   #   java: PidState.java

--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -93,7 +93,7 @@
 ! This is the version of the data stored in flash configuration
 ! Any time an incompatible change is made to the configuration format stored in flash,
 ! update this string to the current date!
-#define FLASH_DATA_VERSION 260407
+#define FLASH_DATA_VERSION 260501
 
 ! Remove next line when Java toolset gets adjusted to load those from json config into VariablesRegistry
 ! Also remove file integration/generated/rusefi_config_generated_enums.txt
@@ -579,6 +579,8 @@ bit useSeparateIdleTablesForCrankingTaper,"enabled","disabled";This uses separat
 bit launchControlEnabled,"enabled","disabled"
 bit antiLagEnabled,"enabled","disabled"
 bit useRunningMathForCranking,"Fuel Map","Fixed";For cranking either use the specified fixed base fuel mass, or use the normal running math (VE table).
+bit crankingAirAmountEnabled,"enabled","disabled";Enable CLT-based cranking air amount table. During cranking, open-loop valve position is taken from this table instead of the running idle tables.
+bit crankingIdleRpmFlareEnabled,"enabled","disabled";Enable CLT-based cranking idle RPM flare. An RPM adder from the table is applied during cranking, tapering to zero as the engine transitions to idle.
 bit displayLogicLevelsInEngineSniffer,"yes","no";Shall we display real life signal or just the part consumed by trigger decoder.\nApplies to both trigger and cam/vvt input.
 bit useTLE8888_stepper,"yes","no"
 bit usescriptTableForCanSniffingFiltering,"yes","no"
@@ -1800,13 +1802,13 @@ uint8_t autoscale knockFuelTrim;Maximum Amount of Fuel trim when knock;"%", 1, 0
 
 	bit nitrousControlEnabled,"enabled","disabled"
 	bit vvlControlEnabled,"enabled","disabled"
-	bit unusedBit_Fancy3
-	bit unusedBit_Fancy4
-	bit unusedBit_Fancy5
-	bit unusedBit_Fancy6
-	bit unusedBit_Fancy7
-	bit unusedBit_Fancy8
-	bit unusedBit_Fancy9
+	bit exhaustCutoutEnabled,"enabled","disabled"
+	bit exhaustCutoutShowOpenState,"LED on when open","LED off when open"
+	bit unusedBit_CutoutWasHBridge
+	bit exhaustCutoutInvertedOutput,"INVERTED","NORMAL"
+	bit exhaustCutoutKeyOnTestEnabled,"Key-on test","disabled"
+	bit exhaustCutoutEngineOnTestEnabled,"Engine-on test","disabled"
+	bit unusedBit_CutoutWasPwm
 	bit unusedBit_Fancy10
 	bit unusedBit_Fancy11
 	bit unusedBit_Fancy12
@@ -1932,7 +1934,51 @@ end_struct
 
     rotational_idle_s rotationalIdleController;
 
-! historically 'unusedOftenChangesDuringFirmwareUpdate' was here - now that's just an anchor reminding where to insert new fields
+! Exhaust Cutout Control
+	#define exhaust_cutout_activation_e_enum "OFF", "Switch", "LuaGauge"
+	custom exhaust_cutout_activation_e 1 bits, U08, @OFFSET@, [0:1], @@exhaust_cutout_activation_e_enum@@
+
+	#define exhaust_cutout_behavior_e_enum "Always Closed", "Always Open", "Auto"
+	custom exhaust_cutout_behavior_e 1 bits, U08, @OFFSET@, [0:1], @@exhaust_cutout_behavior_e_enum@@
+
+	#define exhaust_cutout_output_mode_e_enum "Digital", "PWM", "H-Bridge"
+	custom exhaust_cutout_output_mode_e 1 bits, U08, @OFFSET@, [0:1], @@exhaust_cutout_output_mode_e_enum@@
+
+	exhaust_cutout_output_mode_e exhaustCutoutOutputMode;Exhaust cutout output type: Digital on/off, PWM, or H-Bridge motor
+	exhaust_cutout_activation_e exhaustCutoutActivationMode;Exhaust cutout activation mode
+	exhaust_cutout_behavior_e exhaustCutoutBehaviorLow;Cutout behavior when switch is OFF or gauge is below threshold
+	exhaust_cutout_behavior_e exhaustCutoutBehaviorHigh;Cutout behavior when switch is ON or gauge is above threshold
+	lua_gauge_e exhaustCutoutLuaGauge;Lua gauge index for activation
+	lua_gauge_meaning_e exhaustCutoutLuaGaugeMeaning;Lua gauge comparison direction
+
+	switch_input_pin_e exhaustCutoutSwitchPin;Hardware switch input pin
+	pin_input_mode_e exhaustCutoutSwitchPinMode;
+
+	output_pin_e exhaustCutoutOutputPin;Cutout output pin (digital) or H-Bridge IN1 (Open direction)
+	pin_output_mode_e exhaustCutoutOutputPinMode;
+
+	output_pin_e exhaustCutoutHBridgePin2;H-Bridge IN2 pin (Close direction)
+	pin_output_mode_e exhaustCutoutHBridgePin2Mode;
+
+	output_pin_e exhaustCutoutLedPin;Status LED output pin
+	pin_output_mode_e exhaustCutoutLedPinMode;
+
+	float exhaustCutoutLuaGaugeThreshold;Lua gauge activation threshold;"", 1, 0, -30000, 30000, 3
+
+	uint16_t exhaustCutoutOpenRpm;RPM threshold to open cutout (0 to disable);"rpm", 1, 0, 0, 20000, 0
+	uint8_t exhaustCutoutOpenTps;TPS threshold to open cutout (0 to disable);"%", 1, 0, 0, 100, 0
+	uint8_t autoscale exhaustCutoutTpsDelayS;Anti-blip: TPS must exceed threshold for this long before opening;"s", 0.1, 0, 0, 25, 1
+	float exhaustCutoutOpenMapKpa;MAP/Boost threshold to open cutout (0 to disable);"kPa", 1, 0, 0, 500, 1
+	uint8_t autoscale exhaustCutoutClosingDelayS;Hold-open time after triggers clear;"s", 0.1, 0, 0, 25, 1
+	uint8_t autoscale exhaustCutoutMoveDurationS;H-Bridge motor drive time (de-energizes after). Also controls LED blink duration and actuator test step duration.;"s", 0.1, 0, 0, 5, 1
+
+	uint16_t exhaustCutoutPwmFrequency;PWM output frequency (PWM mode only);"Hz", 1, 0, 1, 10000, 0
+	uint8_t autoscale exhaustCutoutPwmOpenDuty;PWM duty when cutout is OPEN (PWM mode only);"%", 1, 0, 0, 100, 0
+	uint8_t autoscale exhaustCutoutPwmClosedDuty;PWM duty when cutout is CLOSED (PWM mode only);"%", 1, 0, 0, 100, 0
+
+	uint16_t exhaustCutoutHBridgePwmFrequency;H-Bridge IN1/IN2 PWM frequency (H-Bridge mode only);"Hz", 1, 0, 1, 10000, 0
+	uint8_t autoscale exhaustCutoutHBridgeDutyCycle;H-Bridge motor drive duty cycle (H-Bridge mode only);"%", 1, 0, 0, 100, 0
+	uint8_t[3] exhaustCutoutHBridgeAlignmentPad;unused
 
 ! end of engine_configuration_s
 end_struct
@@ -2017,7 +2063,8 @@ uint8_t[PEDAL_TO_TPS_SIZE] pedalToTpsPedalBins;;"%", 1, 0, 0, 120, 0
 uint8_t[PEDAL_TO_TPS_RPM_SIZE] autoscale pedalToTpsRpmBins;;"RPM", @@RPM_AS_BYTE_SCALE@@, 0, 0, @@RPM_AS_BYTE_LIMIT@@, 0
 
 float[CLT_CRANKING_CURVE_SIZE] cltCrankingCorrBins;CLT-based cranking position %. The values in this curve represent a percentage of the ETB Maximum angle. e.g. If "ETB Idle Maximum Angle" is 10, a value of 70 means 7% ETB Position.;{bitStringValue(unitsLabels, useMetricOnInterface)}, {useMetricOnInterface ? 1 : 1.8}, {useMetricOnInterface ? 0 : 17.77777}, {useMetricOnInterface ? -100 : -148}, {useMetricOnInterface ? @@CLT_UPPER_LIMIT@@ : @@CLT_UPPER_LIMIT@@ * 1.8 + 32}, 2
-float[CLT_CRANKING_CURVE_SIZE] cltCrankingCorr    ;CLT-based cranking position %. The values in this curve represent a percentage of the ETB Maximum angle. e.g. If "ETB Idle Maximum Angle" is 10, a value of 70 means 7% ETB Position.;"percent", 1, 0, 0, 100, 2
+float[CLT_CRANKING_CURVE_SIZE] cltCrankingCorr    ;Cranking idle valve position by coolant temperature (Duty mode only). 0-100% open-loop valve duty during cranking.;"value", 1, 0, 0, 100, 0
+float[CLT_CRANKING_CURVE_SIZE] cltCrankingRpmAdder;Cranking idle RPM adder by coolant temperature (RPM mode only). Added on top of the normal CLT-based idle RPM target during cranking, tapering to zero as the engine warms into idle.;"RPM", 1, 0, 0, 2000, 0
 
 float[CLT_CRANKING_TAPER_CURVE_SIZE] afterCrankingIACtaperDurationBins;;{bitStringValue(unitsLabels, useMetricOnInterface)}, {useMetricOnInterface ? 1 : 1.8}, {useMetricOnInterface ? 0 : 17.77777}, {useMetricOnInterface ? -100 : -148}, {useMetricOnInterface ? @@CLT_UPPER_LIMIT@@ : @@CLT_UPPER_LIMIT@@ * 1.8 + 32}, 2
 uint16_t[CLT_CRANKING_TAPER_CURVE_SIZE] afterCrankingIACtaperDuration;This is the duration in cycles that the IAC will take to reach its normal idle position, it can be used to hold the idle higher for a few seconds after cranking to improve startup.\nShould be 100 once tune is better;"cycles", 1, 0, 0, 500, 1

--- a/java_console/io/src/main/java/com/rusefi/enums/StateDictionaryFactory.java
+++ b/java_console/io/src/main/java/com/rusefi/enums/StateDictionaryFactory.java
@@ -1,5 +1,5 @@
 package com.rusefi.enums;
-//was generated automatically by rusEFI tool config_definition_base-all.jar based on StateDictionaryGenerator integration/LiveData.yaml on Tue Jan 20 22:49:13 UTC 2026
+//was generated automatically by rusEFI tool config_definition_base-all.jar based on StateDictionaryGenerator integration/LiveData.yaml on Sat May 30 17:31:22 AST 2026
 
 import com.rusefi.config.generated.*;
 import com.rusefi.ldmp.StateDictionary;
@@ -25,6 +25,7 @@ public class StateDictionaryFactory {
         stateDictionary.register(live_data_e.LDS_fan_control1, "fan_control");
         stateDictionary.register(live_data_e.LDS_fuel_pump_control, "fuel_pump");
         stateDictionary.register(live_data_e.LDS_main_relay, "main_relay");
+        stateDictionary.register(live_data_e.LDS_exhaust_cutout, "exhaust_cutout");
         stateDictionary.register(live_data_e.LDS_engine_state, "engine");
         stateDictionary.register(live_data_e.LDS_tps_accel_state, "accel_enrichment");
         stateDictionary.register(live_data_e.LDS_trigger_central, "trigger_central");

--- a/java_console/io/src/main/java/com/rusefi/enums/live_data_e.java
+++ b/java_console/io/src/main/java/com/rusefi/enums/live_data_e.java
@@ -24,6 +24,7 @@ public enum live_data_e {
 	LDS_fan_control1,
 	LDS_fuel_pump_control,
 	LDS_main_relay,
+	LDS_exhaust_cutout,
 	LDS_engine_state,
 	LDS_tps_accel_state,
 	LDS_trigger_central,


### PR DESCRIPTION
New engine module controlling exhaust cutout actuators with:
- Three output modes: digital, PWM, and H-Bridge (motor-driven)
- Auto open/close triggers: RPM, TPS (with anti-blip delay), MAP/boost
- Activation via switch input or Lua gauge threshold
- Actuator test sequence on key-on (deferred until 12V present) and engine start
- Live data for all state flags (trigger conditions, open/moving/test state)
tested on GT350 with factry cutouts