### PR TITLE
removed idle ramp and dashpot, preparation for better idle control

### DIFF
--- a/firmware/config/engines/canam.cpp
+++ b/firmware/config/engines/canam.cpp
@@ -30,9 +30,6 @@ void setMaverickX3() {
     engineConfiguration->injector.flow = 320;
     engineConfiguration->etbIdleThrottleRange = 10;
 
-    engineConfiguration->iacByTpsHoldTime = 2;
-    engineConfiguration->iacByTpsDecayTime = 2;
-    engineConfiguration->iacByTpsTaper = 5;
     engineConfiguration->useIdleTimingPidControl = true;
     engineConfiguration->idleTimingSoftEntryTime = 1;
 

--- a/firmware/config/engines/hyundai.cpp
+++ b/firmware/config/engines/hyundai.cpp
@@ -315,10 +315,6 @@ static void commonGenesisCoupe() {
     engineConfiguration->tpsAccelFractionDivisor = 3;
     // default "false"
     engineConfiguration->useSeparateAdvanceForIdle = true;
-    // default 0.0
-    engineConfiguration->iacByTpsHoldTime = 2;
-    // default 0.0
-    engineConfiguration->iacByTpsDecayTime = 3;
     // default "false"
     engineConfiguration->useIdleTimingPidControl = true;
     // default "false"

--- a/firmware/config/engines/mazda/mazda_miata_na8.cpp
+++ b/firmware/config/engines/mazda/mazda_miata_na8.cpp
@@ -36,7 +36,6 @@ void setMazdaMiata96() {
 	engineConfiguration->idlePidRpmDeadZone = 100;
 	engineConfiguration->idlePidRpmUpperLimit = 350;
 
-	engineConfiguration->iacByTpsTaper = 6;
 	engineConfiguration->useIdleTimingPidControl = true;
 
 	engineConfiguration->wwaeTau = 0.1;

--- a/firmware/config/engines/mazda/mazda_miata_vvt.cpp
+++ b/firmware/config/engines/mazda/mazda_miata_vvt.cpp
@@ -275,7 +275,6 @@ static void setCommonMazdaNB() {
 
 	// Idle
 	engineConfiguration->idleMode = idle_mode_e::IM_AUTO;
-	engineConfiguration->iacByTpsTaper = 6;
 	engineConfiguration->acIdleExtraOffset = 15;
 
 	engineConfiguration->useIdleTimingPidControl = true;

--- a/firmware/controllers/actuators/idle_state.txt
+++ b/firmware/controllers/actuators/idle_state.txt
@@ -5,8 +5,7 @@ custom idle_state_e 4 bits, S32, @OFFSET@, [0:2], "not important"
 
 	custom percent_t 4 scalar, F32, @OFFSET@, "", 1, 0, 0, 100, 2
 
-    percent_t baseIdlePosition;"idle: base value\ncurrent position without adjustments (iacByTpsTaper, afterCrankingIACtaperDuration)"
-	  percent_t iacByTpsTaper;idle: iacByTpsTaper portion
+    percent_t baseIdlePosition;"idle: base value\ncurrent position without adjustments (afterCrankingIACtaperDuration)"
 
     bit mightResetPid;idle: mightResetPid\nThe idea of 'mightResetPid' is to reset PID only once - each time when TPS > idlePidDeactivationTpsThreshold.\nThe throttle pedal can be pressed for a long time, making the PID data obsolete (thus the reset is required).\nWe set 'mightResetPid' to true only if PID was actually used (i.e. idlePid.getOutput() was called) to save some CPU resources.\nSee automaticIdleController().
 

--- a/firmware/controllers/actuators/idle_thread.cpp
+++ b/firmware/controllers/actuators/idle_thread.cpp
@@ -41,17 +41,6 @@ IIdleController::TargetInfo IdleController::getTargetRpm(float clt) {
   // Higher exit than entry to add some hysteresis to avoid bouncing around upper threshold
  	float exitRpm = target + 1.5 * rpmUpperLimit;
 
- 	// Ramp the target down from the transition RPM to normal over a few seconds
-  if (engineConfiguration->idleReturnTargetRamp) {
- 		// Ramp the target down from the transition RPM to normal over a few seconds
- 		float timeSinceIdleEntry = m_timeInIdlePhase.getElapsedSeconds();
- 		target += interpolateClamped(
- 			0, rpmUpperLimit,
- 			engineConfiguration->idleReturnTargetRampDuration, 0,
- 			timeSinceIdleEntry
- 		);
- 	}
-
  	idleTarget = target;
 	idleEntryRpm = entryRpm;
 	idleExitRpm = exitRpm;
@@ -142,31 +131,6 @@ if (engine->antilagController.isAntilagCondition) {
 	running += engineConfiguration->ALSIdleAdd;
 }
 #endif /* EFI_ANTILAG_SYSTEM */
-
-	// 'dashpot' (hold+decay) logic for coasting->idle
-	float tpsForTaper = tps.value_or(0);
-	efitimeus_t nowUs = getTimeNowUs();
-	if (phase == Phase::Running) {
-		lastTimeRunningUs = nowUs;
-	}
-	// imitate a slow pedal release for TPS taper (to avoid engine stalls)
-	if (tpsForTaper <= engineConfiguration->idlePidDeactivationTpsThreshold) {
-		// make sure the time is not zero
-		float timeSinceRunningPhaseSecs = (nowUs - lastTimeRunningUs + 1) / US_PER_SECOND_F;
-		// we shift the time to implement the hold correction (time can be negative)
-		float timeSinceRunningAfterHoldSecs = timeSinceRunningPhaseSecs - engineConfiguration->iacByTpsHoldTime;
-		// implement the decay correction (from tpsForTaper to 0)
-		tpsForTaper = interpolateClamped(0, engineConfiguration->idlePidDeactivationTpsThreshold, engineConfiguration->iacByTpsDecayTime, tpsForTaper, timeSinceRunningAfterHoldSecs);
-	}
-
-	// Now bump it by the specified amount when the throttle is opened (if configured)
-	// nb: invalid tps will make no change, no explicit check required
-	iacByTpsTaper = interpolateClamped(
-		0, 0,
-		engineConfiguration->idlePidDeactivationTpsThreshold, engineConfiguration->iacByTpsTaper,
-		tpsForTaper);
-
-	running += iacByTpsTaper;
 
 	float airTaperRpmUpperLimit = engineConfiguration->idlePidRpmUpperLimit;
 	iacByRpmTaper = interpolateClamped(

--- a/firmware/controllers/actuators/idle_thread.h
+++ b/firmware/controllers/actuators/idle_thread.h
@@ -121,8 +121,6 @@ private:
 	// These are stored by getIdlePosition() and used by getIdleTimingAdjustment()
 	Phase m_lastPhase = Phase::Cranking;
 	efitimeus_t restoreAfterPidResetTimeUs = 0;
-	// used by 'dashpot' (hold+decay) logic for iacByTpsTaper
-	efitimeus_t lastTimeRunningUs = 0;
 	// used by "soft" idle entry
 	float m_crankTaperEndTime = 0.0f;
 	float m_idleTimingSoftEntryEndTime = 0.0f;

--- a/firmware/controllers/actuators/idle_thread_io.cpp
+++ b/firmware/controllers/actuators/idle_thread_io.cpp
@@ -126,7 +126,6 @@ void setDefaultIdleParameters() {
 	engineConfiguration->idlePidRpmUpperLimit = 300;
 
 	engineConfiguration->idlePidRpmDeadZone = 50;
-	engineConfiguration->idleReturnTargetRampDuration = 3;
 }
 
 void startIdleThread() {

--- a/firmware/controllers/algo/defaults/default_base_engine.cpp
+++ b/firmware/controllers/algo/defaults/default_base_engine.cpp
@@ -171,10 +171,6 @@ void defaultsOrFixOnBurn() {
 	if (engineConfiguration->alternator_iTermMax == 0) {
   	engineConfiguration->alternator_iTermMax = 1000;
 	}
-	if (engineConfiguration->idleReturnTargetRampDuration <= 0.1){
-		engineConfiguration->idleReturnTargetRampDuration = 3;
-	}
-
 	if (engineConfiguration->vvtControlMinRpm < engineConfiguration->cranking.rpm) {
 		engineConfiguration->vvtControlMinRpm = engineConfiguration->cranking.rpm;
 	}
@@ -393,7 +389,6 @@ void setDefaultBaseEngine() {
 	engineConfiguration->idleStepperReactionTime = 3;
 	engineConfiguration->idleStepperTotalSteps = 200;
 	engineConfiguration->stepperForceParkingEveryRestart = true;
-	engineConfiguration->iacByTpsTaper = 2;
 
     engineConfiguration->etbSplit = MAX_TPS_PPS_DISCREPANCY;
 

--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -1026,7 +1026,7 @@ custom script_setting_t 4 scalar, F32, @OFFSET@, 		"",	   1,	   0, 0, 18000,	  2
 	custom vehicle_info_t @@VEHICLE_INFO_SIZE@@ string, ASCII, @OFFSET@, @@VEHICLE_INFO_SIZE@@
 	custom gppwm_note_t @@GPPWM_NOTE_SIZE@@ string, ASCII, @OFFSET@, @@GPPWM_NOTE_SIZE@@
 
-	bit idleReturnTargetRamp,"yes","no";Ramp the idle target down from the entry threshold over N seconds when returning to idle. Helps prevent overshooting (below) the idle target while returning to idle from coasting.
+	bit unusedBit_idleReturnTargetRamp,"yes","no"
 	bit useInjectorFlowLinearizationTable,"yes","no"
 	bit useHbridgesToDriveIdleStepper,"yes","no";If enabled we use two H-bridges to drive stepper idle air valve
 	bit multisparkEnable,"yes","no"
@@ -1305,7 +1305,7 @@ tps_limit_t tps2Max;Fully opened voltage for primary throttle position sensor
 	bit enableKnockSpectrogram,"yes","no";"Available via TS Plugin see https://rusefi.com/s/knock"
 	bit enableKnockSpectrogramFilter,"yes","no"
 
-	int16_t iacByTpsTaper;This value is an added for base idle value. Idle Value added when coasting and transitioning into idle.;"percent", 1, 0, 0, 500, 0
+	int16_t unusedIacByTpsTaper
 
 	Gpio accelerometerCsPin;
 	uint8_t coastingFuelCutVssLow;Below this speed, disable DFCO. Use this to prevent jerkiness from fuel enable/disable in low gears.;{bitStringValue(velocityUnitsLabels, useMetricOnInterface)}, {useMetricOnInterface ? 1 : @@UNITS_KMH_TO_MPH@@}, 0, {useMetricOnInterface ? 0 : 0}, {useMetricOnInterface ? 255 : 158}, 0
@@ -1684,8 +1684,7 @@ pin_input_mode_e[LUA_DIGITAL_INPUT_COUNT iterate] luaDigitalInputPinModes;
 	int8_t[TCU_GEAR_COUNT] autoscale gearBasedOpenLoopBoostAdder;Boost duty cycle modified by gear;"%", 0.5, 0, -63, 63, 1
 
 	uint32_t benchTestCount;How many test bench pulses do you want;"", 1, 0, 1, 10000000, 0
-	uint8_t autoscale iacByTpsHoldTime;How long initial idle adder is held before starting to decay.;"seconds", 0.1, 0, 0, 25, 1
-	uint8_t autoscale iacByTpsDecayTime;How long it takes to remove initial IAC adder to return to normal idle.;"seconds", 0.1, 0, 0, 25, 1
+	uint8_t[2] unusedIacByTpsHoldDecay
 
 	switch_input_pin_e[RANGE_INPUT_COUNT iterate] tcu_rangeInput;
 	pin_input_mode_e[RANGE_INPUT_COUNT iterate] tcu_rangeInputMode;
@@ -1886,7 +1885,7 @@ uint8_t autoscale knockFuelTrim;Maximum Amount of Fuel trim when knock;"%", 1, 0
 
 	int8_t[8] airmassToTimingBins;;"mg", 1, 0, -100, 100, 0
 	int8_t[8] airmassToTimingValues;;"deg", 1, 0, -30, 30, 0
-	uint8_t autoscale idleReturnTargetRampDuration;idle return target ramp duration;"seconds", 0.1, 0, 0.1, 15, 1
+	uint8_t unusedIdleReturnTargetRampDuration
 
 	float wastegatePositionOpenedVoltage;Voltage when the wastegate is fully open;"v", 1, 0, 0, 10, 2
 	float wastegatePositionClosedVoltage;Voltage when the wastegate is closed;"v", 1, 0, 0, 10, 2

--- a/firmware/tunerstudio/tunerstudio.template.ini
+++ b/firmware/tunerstudio/tunerstudio.template.ini
@@ -3568,13 +3568,8 @@ dialog = allPinsOutputs_1_and_2, "", xAxis
 		field = "Use idle ignition table while coasting", useIdleAdvanceWhileCoasting, { useSeparateAdvanceForIdle == 1 }
 		field = "Separate idle VE table",		useSeparateVeForIdle@@if_ts_show_useSeparateVeForIdle
 		field = "Override Idle VE table load axis", idleVeOverrideMode, { useSeparateVeForIdle == 1 }
-		field = "Ramp target on return to idle",	idleReturnTargetRamp, { idleMode == @@idle_mode_e_IM_AUTO@@ }
-		field = "Ramp target duration",	idleReturnTargetRampDuration, { idleMode == @@idle_mode_e_IM_AUTO@@ && idleReturnTargetRamp }
 		field = "Separate idle tables for cranking taper",		useSeparateIdleTablesForCrankingTaper
 		field = "Separate coasting idle table",	useIacTableForCoasting
-		field = "Dashpot coasting-to-idle Initial idle Adder",	    iacByTpsTaper
-		field = "Dashpot coasting-to-idle Hold time", iacByTpsHoldTime
-		field = "Dashpot coasting-to-idle Decay time", iacByTpsDecayTime
 
 	dialog = idleSettings, "", yAxis
 		field = "Idle control mode",					idleMode, { !modeledFlowIdle }

--- a/unit_tests/tests/test_idle_controller.cpp
+++ b/unit_tests/tests/test_idle_controller.cpp
@@ -213,66 +213,6 @@ TEST(idle_v2, idleAdderShouldNotAffectNonIdleAreas) {
 	EXPECT_FLOAT_EQ(50 + 9, dut.getRunningOpenLoop(IIdleController::Phase::Idling, 0, 10, 0));
 }
 
-TEST(idle_v2, runningOpenLoopTpsTaper) {
-	EngineTestHelper eth(engine_type_e::TEST_ENGINE);
-	IdleController dut;
-
-	// Zero out base tempco table
-	setTable(config->cltIdleCorrTable, 0.0f);
-
-	// Add 50% idle position
-	engineConfiguration->iacByTpsTaper = 50;
-	// At 10% TPS
-	engineConfiguration->idlePidDeactivationTpsThreshold = 10;
-
-	// Check in-bounds points
-	EXPECT_FLOAT_EQ(0, dut.getRunningOpenLoop(IIdleController::Phase::Cranking, 0, 0, 0));
-	EXPECT_FLOAT_EQ(25, dut.getRunningOpenLoop(IIdleController::Phase::Cranking, 0, 0, 5));
-	EXPECT_FLOAT_EQ(50, dut.getRunningOpenLoop(IIdleController::Phase::Cranking, 0, 0, 10));
-
-	// Check out of bounds - shouldn't leave the interval [0, 10]
-	EXPECT_FLOAT_EQ(0, dut.getRunningOpenLoop(IIdleController::Phase::Cranking, 0, 0, -5));
-	EXPECT_FLOAT_EQ(50, dut.getRunningOpenLoop(IIdleController::Phase::Cranking, 0, 0, 20));
-}
-
-TEST(idle_v2, runningOpenLoopTpsTaperWithDashpot) {
-	EngineTestHelper eth(engine_type_e::TEST_ENGINE);
-	IdleController dut;
-
-	// Zero out base tempco table
-	setTable(config->cltIdleCorrTable, 0.0f);
-
-	// Add 50% idle position
-	engineConfiguration->iacByTpsTaper = 50;
-	// At 10% TPS
-	engineConfiguration->idlePidDeactivationTpsThreshold = 10;
-
-	// set hold and decay time
-	engineConfiguration->iacByTpsHoldTime = 10;	// 10 secs
-	engineConfiguration->iacByTpsDecayTime = 10;	// 10 secs
-
-	// save the lastTimeRunningUs time - let it be the start of the hold phase
-	advanceTimeUs(5'000'000);
-	// full throttle = max.iac
-	EXPECT_FLOAT_EQ(50, dut.getRunningOpenLoop(ICP::Running, 0, 0, 100));
-
-	// jump to the end of the 'hold' phase of dashpot
-	advanceTimeUs(10'000'000);
-
-	// change the state to idle (release the pedal) - but still 100% max.iac!
-    EXPECT_FLOAT_EQ(50, dut.getRunningOpenLoop(ICP::Idling, 0, 0, 0));
-    // now we're in the middle of decay
-    advanceTimeUs(5'000'000);
-    // 50% decay (50% of 50 is 25)
-    EXPECT_FLOAT_EQ(25, dut.getRunningOpenLoop(ICP::Idling, 0, 0, 0));
-    // now the decay is finished
-    advanceTimeUs(5'000'000);
-    // no correction
-    EXPECT_FLOAT_EQ(0, dut.getRunningOpenLoop(ICP::Idling, 0, 0, 0));
-    // still react to the pedal
-    EXPECT_FLOAT_EQ(50, dut.getRunningOpenLoop(ICP::Idling, 0, 0, 10));
-}
-
 struct MockOpenLoopIdler : public IdleController {
 	MOCK_METHOD(float, getCrankingOpenLoop, (float clt), (const, override));
 	MOCK_METHOD(float, getRunningOpenLoop, (IIdleController::Phase phase, float rpm, float clt, SensorResult tps), (override));


### PR DESCRIPTION
adding random dashpot air does not make sense, why are we randomly adding air because we're returning to idle? We should be adding an RPM target, to the ramp to idle. This way all our idle modeling would be consistent (no idle aire being added because the engine needs more air because ?, we should add target RPM and then grab the air from the already-calibrated idle duty vs target rpm table)

ramp RPM was removed since this should not just start at whatever upper bound ofidle control we are, we should specifically set an RPM as we arrive at idle (base RPM target + off idle adder), then ramp down to base idle