### PR TITLE
editable main relay wait time

### DIFF
--- a/firmware/controllers/actuators/main_relay.cpp
+++ b/firmware/controllers/actuators/main_relay.cpp
@@ -28,8 +28,8 @@ void MainRelayController::onSlowCallback() {
 }
 
 bool MainRelayController::needsDelayedShutoff() {
-	// Prevent main relay from turning off if we had ignition voltage in the past 1 second
+	// Prevent main relay from turning off if we had ignition voltage in the past N seconds.
 	// This avoids accidentally killing the car during a transient, for example
 	// right when the starter is engaged.
-	return !m_lastIgnitionTime.hasElapsedSec(1);
+	return !m_lastIgnitionTime.hasElapsedSec(engineConfiguration->mainRelayDisableTime);
 }

--- a/firmware/controllers/algo/defaults/default_base_engine.cpp
+++ b/firmware/controllers/algo/defaults/default_base_engine.cpp
@@ -135,6 +135,10 @@ void defaultsOrFixOnBurn() {
     engineConfiguration->engineShutDownPeriod = 5;
   }
 
+  if (engineConfiguration->mainRelayDisableTime == 0) {
+    engineConfiguration->mainRelayDisableTime = 1;
+  }
+
 #if HW_PROTEUS && defined(STM32F4XX)
   // should have been proteus per-board validation
   engineConfiguration->is_enabled_spi_5 = false;

--- a/firmware/controllers/algo/engine_configuration.cpp
+++ b/firmware/controllers/algo/engine_configuration.cpp
@@ -428,6 +428,7 @@ static void setDefaultEngineConfiguration() {
 	engineConfiguration->vvtActivationDelayMs = 6000;
 
 	engineConfiguration->startCrankingDuration = 3;
+	engineConfiguration->mainRelayDisableTime = 1;
 
 	engineConfiguration->maxAcRpm = 5000;
 	engineConfiguration->maxAcClt = 100;

--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -930,6 +930,7 @@ spi_device_e digitalPotentiometerSpiDevice;Digital Potentiometer is used by stoc
 
 	brain_input_pin_e[LOGIC_ANALYZER_CHANNEL_COUNT iterate] logicAnalyzerPins;
 	pin_output_mode_e mainRelayPinMode;
+	uint8_t mainRelayDisableTime;Time after ignition turn-off before the main relay is disabled.;"s", 1, 0, 1, 60, 0
 
 	! 536870911 = 2^29-1, the maximum valid extended ID
 	uint32_t verboseCanBaseAddress;;"", 1, 0, 0, 536870911, 0

--- a/firmware/tunerstudio/tunerstudio.template.ini
+++ b/firmware/tunerstudio/tunerstudio.template.ini
@@ -3639,6 +3639,7 @@ include_file @@SECONDARY_PANELS_FILE@@
 		field = "microRusEFI main relay control is hard wired on pin #29"@@if_ts_show_main_relay_microRusEFI_message
 		field = "Output",						mainRelayPin
 		field = "Output mode",					mainRelayPinMode
+		field = "Main Relay Disable Time",		mainRelayDisableTime
 		commandButton = "Test Main Relay", cmd_test_main_relay
 
 	dialog = starterRelayDialog, "Starter Disable"


### PR DESCRIPTION
Some cars, like Mustang S550 and 2015 Camaro need to hold main relay for more than one second while CANBUS devices shut down. This change makes the time until the main relay turns off editable from the outputs settings