### PR TITLE
H7: ld file with NO_CACHE region in AXI SRAM

### DIFF
--- a/firmware/hw_layer/ports/stm32/stm32h7/STM32H723xG_ITCM64k_AXI_NC.ld
+++ b/firmware/hw_layer/ports/stm32/stm32h7/STM32H723xG_ITCM64k_AXI_NC.ld
@@ -1,0 +1,138 @@
+/*
+    ChibiOS - Copyright (C) 2006..2018 Giovanni Di Sirio
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/*
+ * STM32H723xG (64k ITCM) generic setup.
+ * 
+ * AXI SRAM     - BSS, Data, Heap.
+ * SRAM1+SRAM2  - NOCACHE, ETH.
+ * SRAM4        - None.
+ * DTCM-RAM     - Main Stack, Process Stack.
+ * ITCM-RAM     - None.
+ * BCKP SRAM    - None.
+ */
+MEMORY
+{
+    flash0 (rx) : org = 0x08000000, len = 1M        /* Flash bank1 */
+    flash1 (rx) : org = 0x00000000, len = 0
+    flash2 (rx) : org = 0x00000000, len = 0
+    flash3 (rx) : org = 0x00000000, len = 0
+    flash4 (rx) : org = 0x00000000, len = 0
+    flash5 (rx) : org = 0x00000000, len = 0
+    flash6 (rx) : org = 0x00000000, len = 0
+    flash7 (rx) : org = 0x00000000, len = 0
+    ram0   (wx) : org = 0x24000000, len = 16k       /* AXI SRAM no-cache*/
+    ram1   (wx) : org = 0x24004000, len = 304k      /* AXI SRAM cached */
+    ram2   (wx) : org = 0x30000000, len = 16k       /* AHB SRAM1 */
+    ram3   (wx) : org = 0x30002000, len = 16k       /* AHB SRAM2 */
+    ram4   (wx) : org = 0x38000000, len = 16k       /* AHB SRAM4 */
+    ram5   (wx) : org = 0x20000000, len = 128k      /* DTCM-RAM */
+    ram6   (wx) : org = 0x00000000, len = 64k       /* ITCM-RAM */
+    ram7   (wx) : org = 0x38800000, len = 4k        /* BCKP SRAM */
+}
+
+/* For each data/text section two region are defined, a virtual region
+   and a load region (_LMA suffix).*/
+
+/* Flash region to be used for exception vectors.*/
+REGION_ALIAS("VECTORS_FLASH", flash0);
+REGION_ALIAS("VECTORS_FLASH_LMA", flash0);
+
+/* Flash region to be used for constructors and destructors.*/
+REGION_ALIAS("XTORS_FLASH", flash0);
+REGION_ALIAS("XTORS_FLASH_LMA", flash0);
+
+/* Flash region to be used for code text.*/
+REGION_ALIAS("TEXT_FLASH", flash0);
+REGION_ALIAS("TEXT_FLASH_LMA", flash0);
+
+/* Flash region to be used for read only data.*/
+REGION_ALIAS("RODATA_FLASH", flash0);
+REGION_ALIAS("RODATA_FLASH_LMA", flash0);
+
+/* Flash region to be used for various.*/
+REGION_ALIAS("VARIOUS_FLASH", flash0);
+REGION_ALIAS("VARIOUS_FLASH_LMA", flash0);
+
+/* Flash region to be used for RAM(n) initialization data.*/
+REGION_ALIAS("RAM_INIT_FLASH_LMA", flash0);
+
+/* RAM region to be used for Main stack. This stack accommodates the processing
+   of all exceptions and interrupts.*/
+REGION_ALIAS("MAIN_STACK_RAM", ram5);
+
+/* RAM region to be used for the process stack. This is the stack used by
+   the main() function.*/
+REGION_ALIAS("PROCESS_STACK_RAM", ram5);
+
+/* RAM region to be used for data segment.*/
+REGION_ALIAS("DATA_RAM", ram1);
+REGION_ALIAS("DATA_RAM_LMA", flash0);
+
+/* RAM region to be used for BSS segment.*/
+REGION_ALIAS("BSS_RAM", ram1);
+
+/* RAM region to be used for the default heap.*/
+REGION_ALIAS("HEAP_RAM", ram1);
+
+/* Stack rules inclusion.*/
+INCLUDE rules_stacks.ld
+
+/*===========================================================================*/
+/* Custom sections for STM32H7xx.                                            */
+/* 16k of AXI SRAM are assumed to be non-cacheable using MPU.                */
+/*===========================================================================*/
+
+/* RAM region to be used for nocache segment.*/
+REGION_ALIAS("NOCACHE_RAM", ram0);
+
+/* RAM region to be used for eth segment.*/
+REGION_ALIAS("ETH_RAM", ram0);
+
+SECTIONS
+{
+    /* Special section for non cache-able areas.*/
+    .nocache (NOLOAD) : ALIGN(4)
+    {
+        __nocache_base__ = .;
+        *(.nocache)
+        *(.nocache.*)
+        *(.bss.__nocache_*)
+        . = ALIGN(4);
+        __nocache_end__ = .;
+    } > NOCACHE_RAM
+
+    /* Special section for Ethernet DMA non cache-able areas.*/
+    .eth (NOLOAD) : ALIGN(4)
+    {
+        __eth_base__ = .;
+        *(.eth)
+        *(.eth.*)
+        *(.bss.__eth_*)
+        . = ALIGN(4);
+        __eth_end__ = .;
+    } > ETH_RAM
+}
+
+/* Code rules inclusion.*/
+INCLUDE rules_code.ld
+
+/* Data rules inclusion.*/
+INCLUDE rules_data.ld
+
+/* Memory rules inclusion.*/
+INCLUDE rules_memory.ld
+

--- a/firmware/hw_layer/ports/stm32/stm32h7/STM32H723xG_ITCM64k_AXI_NC.ld
+++ b/firmware/hw_layer/ports/stm32/stm32h7/STM32H723xG_ITCM64k_AXI_NC.ld
@@ -14,6 +14,16 @@
     limitations under the License.
 */
 
+/* change address & length if bootloader */
+/* H743 has all sectors 128K size */
+bootloader_size = 128k;
+flash_start = 0x08000000 + (DEFINED(HAS_BOOTLOADER) ? bootloader_size : 0);
+flash_size = DEFINED(IS_BOOTLOADER) ? bootloader_size : 1M;
+image_size = DEFINED(HAS_BOOTLOADER) ? (flash_size - bootloader_size) : flash_size;
+
+/* OpenBLT <-> main FW shared area */
+_OpenBLT_Shared_Params_Size = DEFINED(HAS_BOOTLOADER) || DEFINED(IS_BOOTLOADER) ? 16 : 0;
+
 /*
  * STM32H723xG (64k ITCM) generic setup.
  * 
@@ -26,7 +36,7 @@
  */
 MEMORY
 {
-    flash0 (rx) : org = 0x08000000, len = 1M        /* Flash bank1 */
+    flash0 (rx) : org = flash_start, len = image_size    /* Flash bank1 */
     flash1 (rx) : org = 0x00000000, len = 0
     flash2 (rx) : org = 0x00000000, len = 0
     flash3 (rx) : org = 0x00000000, len = 0
@@ -34,7 +44,8 @@ MEMORY
     flash5 (rx) : org = 0x00000000, len = 0
     flash6 (rx) : org = 0x00000000, len = 0
     flash7 (rx) : org = 0x00000000, len = 0
-    ram0   (wx) : org = 0x24000000, len = 16k       /* AXI SRAM no-cache*/
+    shared      : org = 0x24000000, len = _OpenBLT_Shared_Params_Size
+    ram0   (wx) : org = 0x24000000 + _OpenBLT_Shared_Params_Size, len = 16k - _OpenBLT_Shared_Params_Size       /* AXI SRAM no-cache*/
     ram1   (wx) : org = 0x24004000, len = 304k      /* AXI SRAM cached */
     ram2   (wx) : org = 0x30000000, len = 16k       /* AHB SRAM1 */
     ram3   (wx) : org = 0x30002000, len = 16k       /* AHB SRAM2 */

--- a/firmware/hw_layer/ports/stm32/stm32h7/cfg/mcuconf_stm32h723.h
+++ b/firmware/hw_layer/ports/stm32/stm32h7/cfg/mcuconf_stm32h723.h
@@ -4,9 +4,20 @@
 #ifndef STM32_NOCACHE_ENABLE
 #define STM32_NOCACHE_ENABLE                TRUE
 #endif
+
+#if STM32_NOCACHE_IN_AXI
+// first 16 Kb in AXI SRAM.
+#define STM32_NOCACHE_MPU_REGION            MPU_REGION_6
+#define STM32_NOCACHE_RBAR                  0x24000000U
+#define STM32_NOCACHE_RASR                  MPU_RASR_SIZE_16K
+#else
+// whole SRAM2 region.
+// NOTE: this region is not accesable by some bus master
+// For example by SDMMC1 !!!
 #define STM32_NOCACHE_MPU_REGION            MPU_REGION_6
 #define STM32_NOCACHE_RBAR                  0x30002000U
 #define STM32_NOCACHE_RASR                  MPU_RASR_SIZE_16K
+#endif
 
 /*
  * PWR system settings.

--- a/firmware/hw_layer/ports/stm32/stm32h7/global_port.h
+++ b/firmware/hw_layer/ports/stm32/stm32h7/global_port.h
@@ -2,7 +2,11 @@
 #define CCM_OPTIONAL __attribute__((section(".ram5")))
 //TODO: update LD file!
 #define SDRAM_OPTIONAL __attribute__((section(".ram8")))
-// SRAM3 is 32k and set to disable dcache
-#define NO_CACHE __attribute__((aligned(4))) __attribute__((section(".ram3")))
+#if STM32_NOCACHE_IN_AXI
+	#define NO_CACHE __attribute__((aligned(4))) __attribute__((section(".ram0")))
+#else
+	// SRAM3 is 32k and set to disable dcache
+	#define NO_CACHE __attribute__((aligned(4))) __attribute__((section(".ram3")))
+#endif
 
 #define BKUP_RAM_NOINIT __attribute__((section(".bkup_ram_noinit")))


### PR DESCRIPTION
Some bus masters have no access to SRAM2 where we have no cache region on H7.
For example SDMMC1 has no access to SRAM2.
Add another linker file where no cache region is located in first 16K of AXI SRAM.
<img width="973" height="880" alt="Screenshot from 2026-06-02 16-20-52" src="https://github.com/user-attachments/assets/d8e6177b-f018-4532-b5a7-1160274fdbe2" />


only:uaefi_pro_h7