### PR TITLE
added startDisabled() to disable starting when not allowed

### DIFF
--- a/firmware/controllers/algo/engine.cpp
+++ b/firmware/controllers/algo/engine.cpp
@@ -360,6 +360,7 @@ void Engine::resetLua() {
 #if EFI_IDLE_CONTROL
 	module<IdleController>().unmock().luaAdd = 0;
 #endif // EFI_IDLE_CONTROL
+	startStopState.startDisabledByLua = false;
 }
 
 /**

--- a/firmware/controllers/lua/lua_hooks.cpp
+++ b/firmware/controllers/lua/lua_hooks.cpp
@@ -1107,6 +1107,10 @@ extern int luaCommandCounters[LUA_BUTTON_COUNT];
 		engine->module<AcController>().unmock().isDisabledByLua = value;
 		return 0;
 	});
+	lua_register(lState, "startDisabled", [](lua_State* l) {
+		engine->startStopState.startDisabledByLua = lua_toboolean(l, 1);
+		return 0;
+	});
 	lua_register(lState, "getTimeSinceAcToggleMs", [](lua_State* l) {
 		float result = engine->module<AcController>().unmock().timeSinceStateChange.getElapsedSeconds() * 1000;
 		lua_pushnumber(l, result);

--- a/firmware/controllers/start_stop.cpp
+++ b/firmware/controllers/start_stop.cpp
@@ -84,6 +84,9 @@ void slowStartStopButtonCallback() {
     if (isCrankingSuppressed()) {
       return;
     }
+    if (engine->startStopState.startDisabledByLua) {
+      return;
+    }
   }
 
 	bool startStopState = engine->startStopState.startStopButtonDebounce.readPinEvent();

--- a/firmware/controllers/start_stop.h
+++ b/firmware/controllers/start_stop.h
@@ -8,6 +8,7 @@ struct StartStopState {
  	Timer startStopStateLastPush;
 
   bool isFirstTime = true;
+  bool startDisabledByLua = false;
 
 };
 


### PR DESCRIPTION
new Lua function startDisabled, since on Mustang I specifically do not want to engage starter until BCM says "ok to start", which only happens after it disables all accesories. If it doesn't wait for that, it could engage the starter while BCM has started shutting down the entire car.