### PR TITLE
Add Clutch Down cranking condition option; fix SwitchedState::operato…

### DIFF
--- a/firmware/controllers/algo/rusefi_enums.h
+++ b/firmware/controllers/algo/rusefi_enums.h
@@ -528,6 +528,7 @@ typedef enum __attribute__ ((__packed__)) {
 	CCNONE = 0,
 	CC_BRAKE = 1,
 	CC_CLUTCH = 2,
+	CC_CLUTCH_DOWN = 3,
 } cranking_condition_e;
 
 /**

--- a/firmware/controllers/start_stop.cpp
+++ b/firmware/controllers/start_stop.cpp
@@ -80,6 +80,9 @@ void slowStartStopButtonCallback() {
     if (engineConfiguration->crankingCondition == CC_CLUTCH && !engine->clutchUpSwitchedState) {
       return;
     }
+    if (engineConfiguration->crankingCondition == CC_CLUTCH_DOWN && !engine->engineState.clutchDownState) {
+      return;
+    }
 
     if (isCrankingSuppressed()) {
       return;

--- a/firmware/controllers/system/efi_output.h
+++ b/firmware/controllers/system/efi_output.h
@@ -23,7 +23,7 @@ public:
     [[nodiscard]] uint16_t getCounter() const;
 
     explicit operator bool() const {
-        return state != nullptr;
+        return state != nullptr && (*state != 0);
     }
 
 private:

--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -1088,8 +1088,8 @@ bit verboseCan2,"Print all","Do not print";Print incoming and outgoing second bu
     custom antiLagActivationMode_e  1 bits, S08, @OFFSET@, [0:1], @@antiLagActivationMode_e_enum@@
     antiLagActivationMode_e antiLagActivationMode;
 
-#define cranking_condition_e_enum "None", "Brake", "Clutch"
-custom cranking_condition_e 1 bits, S08, @OFFSET@, [0:1], @@cranking_condition_e_enum@@
+#define cranking_condition_e_enum "None", "Brake", "Clutch Up", "Clutch Down"
+custom cranking_condition_e 1 bits, S08, @OFFSET@, [0:2], @@cranking_condition_e_enum@@
 cranking_condition_e crankingCondition;
 
 include_file controllers/algo/accel_enrichment.engineConfiguration.txt


### PR DESCRIPTION
…r bool()

- Adds CC_CLUTCH_DOWN = 3 to cranking_condition_e so start/stop can require the clutch-down switch instead of clutch-up
- Renames the existing "Clutch" label to "Clutch Up" (value 2 unchanged, so existing tunes are unaffected)
- Expands the config bits field from [0:1] to [0:2] to fit four values
- Fixes SwitchedState::operator bool() which returned state != nullptr (always true) instead of dereferencing the pointer; this also corrects the previously broken CC_BRAKE and CC_CLUTCH checks in start_stop.cpp ( tested both clutch/brake to work to start the car)

cars like Mustang have two clutch switches, up and down. it is important to distinct between them to make a decision. 