### PR TITLE
TPS/PPS limits are volatile

### DIFF
--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -2463,12 +2463,12 @@ end_struct
 #define ts_show_stepper_push_pull false
 #define ts_show_live_data true
 #define ts_show_ve_blend true
-#define ts_show_InjectorFlowLinearizationTable false
-#define ts_show_engine_make true
-#define ts_show_engine_code true
 #define ts_show_veBlends2 true
 #define ts_show_veBlends3 true
 #define ts_show_veBlends4 true
+#define ts_show_InjectorFlowLinearizationTable false
+#define ts_show_engine_make true
+#define ts_show_engine_code true
 #define ts_show_FractionDivisor true
 #define ts_show_fuel_threshold true
 #define ts_show_jam_detection true

--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -601,7 +601,7 @@ bit useIdleAdvanceWhileCoasting,"yes","no"
 
 ! note: 0.00489 mult is correct for "faking" 10 bit ADC with 5V Vref - NOPE!
 ! note: see TPS_TS_CONVERSION, this is TS related legacy stuff that should be removed someday. 1000 units for 0..5V range
-custom tps_limit_t 2 scalar, S16, @OFFSET@, "V", @@PACK_MULT_RAW_VOLTAGE@@, 0, 0, 5, 2
+custom tps_limit_t 2 scalar, S16, @OFFSET@, "V", @@PACK_MULT_RAW_VOLTAGE@@, 0, 0, 5, 2, controllerPriority
 tps_limit_t tpsMin;Closed voltage for primary throttle position sensor
 tps_limit_t tpsMax;Fully opened voltage for primary throttle position sensor
 
@@ -1273,8 +1273,8 @@ tps_limit_t tps2Max;Fully opened voltage for primary throttle position sensor
 	switch_input_pin_e tcuUpshiftButtonPin
 	switch_input_pin_e tcuDownshiftButtonPin
 
-	float throttlePedalUpVoltage;;"volts", 1, 0, -6, 6, 2
-	float throttlePedalWOTVoltage;Pedal in the floor;"volts", 1, 0, -6, 6, 2
+	float throttlePedalUpVoltage;;"volts", 1, 0, -6, 6, 2, controllerPriority
+	float throttlePedalWOTVoltage;Pedal in the floor;"volts", 1, 0, -6, 6, 2, controllerPriority
 
 	int16_t startUpFuelPumpDuration;on IGN voltage detection turn fuel pump on to build fuel pressure;"seconds", 1, 0, 0, 6000, 0
 	uint16_t mafFilterParameter;larger value = larger intake manifold volume;"", 1, 0, 0, 10000, 0
@@ -1334,8 +1334,8 @@ tps_limit_t tps2Max;Fully opened voltage for primary throttle position sensor
 	uint32_t uartConsoleSerialSpeed;Band rate for primary TTL;"BPs", 1, 0, 0, 1000000, 0
 
 
-	float throttlePedalSecondaryUpVoltage;;"volts", 1, 0, -6, 6, 2
-	float throttlePedalSecondaryWOTVoltage;Pedal in the floor;"volts", 1, 0, -6, 6, 2
+	float throttlePedalSecondaryUpVoltage;;"volts", 1, 0, -6, 6, 2, controllerPriority
+	float throttlePedalSecondaryWOTVoltage;Pedal in the floor;"volts", 1, 0, -6, 6, 2, controllerPriority
 
 	#define can_baudrate_e_enum "33.33kbps", "50kbps", "83.33kbps", "100kbps", "125kbps", "250kbps", "500kbps", "666kbps", "1Mbps"
 	custom can_baudrate_e 1 bits, U08, @OFFSET@, [0:3], @@can_baudrate_e_enum@@

--- a/firmware/tunerstudio/top_level_menu.ini
+++ b/firmware/tunerstudio/top_level_menu.ini
@@ -38,12 +38,12 @@
 		groupMenu = "VE blend tables"@@if_ts_show_ve_blend
 		groupChildMenu = veBlend1Cfg,		"VE blend 1 settings", 0, {isInjectionEnabled}@@if_ts_show_ve_blend
 		groupChildMenu = veBlend1Table,		"VE blend table 1", 0, { isInjectionEnabled && veBlends1_blendParameter != 0 }@@if_ts_show_ve_blend
-		groupChildMenu = veBlend2Cfg,		"VE blend 2 settings", 0, {isInjectionEnabled}@@if_ts_show_ve_blend
-		groupChildMenu = veBlend2Table,		"VE blend table 2", 0, { isInjectionEnabled && veBlends2_blendParameter != 0 }@@if_ts_show_ve_blend
-		groupChildMenu = veBlend3Cfg,		"VE blend 3 settings", 0, {isInjectionEnabled}@@if_ts_show_ve_blend
-		groupChildMenu = veBlend3Table,		"VE blend table 3", 0, { isInjectionEnabled && veBlends3_blendParameter != 0 }@@if_ts_show_ve_blend
-		groupChildMenu = veBlend4Cfg,		"VE blend 4 settings", 0, {isInjectionEnabled}@@if_ts_show_ve_blend
-		groupChildMenu = veBlend4Table,		"VE blend table 4", 0, { isInjectionEnabled && veBlends4_blendParameter != 0 }@@if_ts_show_ve_blend
+		groupChildMenu = veBlend2Cfg,		"VE blend 2 settings", 0, {isInjectionEnabled}@@if_ts_show_veBlends2
+		groupChildMenu = veBlend2Table,		"VE blend table 2", 0, { isInjectionEnabled && veBlends2_blendParameter != 0 }@@if_ts_show_veBlends2
+		groupChildMenu = veBlend3Cfg,		"VE blend 3 settings", 0, {isInjectionEnabled}@@if_ts_show_veBlends3
+		groupChildMenu = veBlend3Table,		"VE blend table 3", 0, { isInjectionEnabled && veBlends3_blendParameter != 0 }@@if_ts_show_veBlends3
+		groupChildMenu = veBlend4Cfg,		"VE blend 4 settings", 0, {isInjectionEnabled}@@if_ts_show_veBlends4
+		groupChildMenu = veBlend4Table,		"VE blend table 4", 0, { isInjectionEnabled && veBlends4_blendParameter != 0 }@@if_ts_show_veBlends4
 
 		subMenu = lambdaTableDialog,			"Target lambda", 0, {isInjectionEnabled == 1 && useLambdaOnInterface}
 		subMenu = afrTableDialog,				"Target AFR", 0, {isInjectionEnabled == 1 && !useLambdaOnInterface}


### PR DESCRIPTION
Also fix ini file generation with some VE Blend tables disabled:
```
Warning: Unknown Menu Target: veBlend3Cfg, Problem at:
[mainController.ini]:[Line:7406]: 		groupChildMenu = veBlend3Cfg,		"VE blend 3 settings", 0, {isInjectionEnabled}

Warning: Variable 'veBlends3_blendParameter' used in expression, but not defined as OutputChannel or Setting Parameter in hd-test, Problem at:
[mainController.ini]:[Line:7407]: 		groupChildMenu = veBlend3Table,		"VE blend table 3", 0, { isInjectionEnabled && veBlends3_blendParameter != 0 }

Warning: Unknown Menu Target: veBlend3Table, Problem at:
[mainController.ini]:[Line:7407]: 		groupChildMenu = veBlend3Table,		"VE blend table 3", 0, { isInjectionEnabled && veBlends3_blendParameter != 0 }

Warning: Unknown Menu Target: veBlend4Cfg, Problem at:
[mainController.ini]:[Line:7408]: 		groupChildMenu = veBlend4Cfg,		"VE blend 4 settings", 0, {isInjectionEnabled}

Warning: Variable 'veBlends4_blendParameter' used in expression, but not defined as OutputChannel or Setting Parameter in hd-test, Problem at:
[mainController.ini]:[Line:7409]: 		groupChildMenu = veBlend4Table,		"VE blend table 4", 0, { isInjectionEnabled && veBlends4_blendParameter != 0 }

Warning: Unknown Menu Target: veBlend4Table, Problem at:
[mainController.ini]:[Line:7409]: 		groupChildMenu = veBlend4Table,		"VE blend table 4", 0, { isInjectionEnabled && veBlends4_blendParameter != 0 }
```
