### PR TITLE
Add EFI_SLOW_ADC and ADC_FAST_DEVICE configurable macros

### DIFF
--- a/firmware/hw_layer/ports/stm32/stm32_adc_v2.cpp
+++ b/firmware/hw_layer/ports/stm32/stm32_adc_v2.cpp
@@ -8,6 +8,14 @@
 
 #include "pch.h"
 
+#ifndef EFI_SLOW_ADC
+#define EFI_SLOW_ADC ADCD1
+#endif
+
+#ifndef ADC_FAST_DEVICE
+#define ADC_FAST_DEVICE ADCD2
+#endif
+
 #ifdef EFI_SOFTWARE_KNOCK
 #include "knock_config.h"
 #endif
@@ -270,22 +278,22 @@ static void slowAdcEndCB(ADCDriver *adcp) {
 			#ifdef ADC_MUX_PIN
 			muxControl.setValue(0, /*force*/true);
 			#endif
-			adcStartConversionI(adcp, &convGroupSlow, (adcsample_t *)slowSampleBuffer, SLOW_ADC_OVERSAMPLE);
+			adcStartConversionI(&EFI_SLOW_ADC, &convGroupSlow, (adcsample_t *)slowSampleBuffer, SLOW_ADC_OVERSAMPLE);
 			break;
 		#ifdef ADC_MUX_PIN
 		case convertMuxed:
 			muxControl.setValue(1, /*force*/true);
 			// convert second half
-			adcStartConversionI(adcp, &convGroupSlow, (adcsample_t *)slowSampleBufferMuxed, SLOW_ADC_OVERSAMPLE);
+			adcStartConversionI(&EFI_SLOW_ADC, &convGroupSlow, (adcsample_t *)slowSampleBufferMuxed, SLOW_ADC_OVERSAMPLE);
 			break;
 		#endif
 		case convertAux:
 			adcSTM32DisableVBATE();
-			adcStartConversionI(adcp, &aux1ConvGroup, (adcsample_t *)aux1SensorSamples, auxSensorOversample);
+			adcStartConversionI(&EFI_SLOW_ADC, &aux1ConvGroup, (adcsample_t *)aux1SensorSamples, auxSensorOversample);
 			break;
 		case convertAux2:
 			adcSTM32EnableVBATE();
-			adcStartConversionI(adcp, &aux2ConvGroup, (adcsample_t *)aux2SensorSamples, auxSensorOversample);
+			adcStartConversionI(&EFI_SLOW_ADC, &aux2ConvGroup, (adcsample_t *)aux2SensorSamples, auxSensorOversample);
 			break;
 		}
 		chSysUnlockFromISR();
@@ -295,7 +303,7 @@ static void slowAdcEndCB(ADCDriver *adcp) {
 
 static bool readBatch(adcsample_t* convertedSamples, adcsample_t* b) {
 #if (EFI_INTERNAL_SLOW_ADC_BACKGROUND == FALSE)
-	msg_t result = adcConvert(&ADCD1, &convGroupSlow, b, SLOW_ADC_OVERSAMPLE);
+	msg_t result = adcConvert(&EFI_SLOW_ADC, &convGroupSlow, b, SLOW_ADC_OVERSAMPLE);
 
 	// If something went wrong - try again later
 	if (result != MSG_OK) {
@@ -303,7 +311,7 @@ static bool readBatch(adcsample_t* convertedSamples, adcsample_t* b) {
 	}
 
 	// Temperature sensor is only physically wired to ADC1
-	adcConvert(&ADCD1, &auxConvGroup, (adcsample_t *)auxSensorSamples, auxSensorOversample);
+	adcConvert(&EFI_SLOW_ADC, &auxConvGroup, (adcsample_t *)auxSensorSamples, auxSensorOversample);
 
 	// Switch IN18 input to Vbat
 	adcSTM32EnableVBATE();
@@ -486,18 +494,18 @@ void portInitAdc() {
 #endif //ADC_MUX_PIN
 
 	// Init slow ADC
-	adcStart(&ADCD1, NULL);
+	adcStart(&EFI_SLOW_ADC, NULL);
 
 	// Enable internal temperature reference
 	adcSTM32EnableTSVREFE(); // Internal temperature sensor
 
 #if (EFI_INTERNAL_SLOW_ADC_BACKGROUND == TRUE)
-	adcStartConversion(&ADCD1, &convGroupSlow, (adcsample_t *)slowSampleBuffer, SLOW_ADC_OVERSAMPLE);
+	adcStartConversion(&EFI_SLOW_ADC, &convGroupSlow, (adcsample_t *)slowSampleBuffer, SLOW_ADC_OVERSAMPLE);
 #endif
 
 #if EFI_USE_FAST_ADC
 	// Init fast ADC (MAP sensor)
-	adcStart(&ADCD2, NULL);
+	adcStart(&ADC_FAST_DEVICE, NULL);
 #endif
 
 #if defined(STM32F7XX)

--- a/firmware/hw_layer/ports/stm32/stm32_adc_v4.cpp
+++ b/firmware/hw_layer/ports/stm32/stm32_adc_v4.cpp
@@ -8,6 +8,10 @@
 
 #include "pch.h"
 
+#ifndef EFI_SLOW_ADC
+#define EFI_SLOW_ADC ADCD1
+#endif
+
 #if HAL_USE_ADC
 
 #include "mpu_util.h"
@@ -42,7 +46,7 @@ static constexpr int H7_ADC_SHIFT_BITS = log2_int(H7_ADC_OVERSAMPLE);
 
 void portInitAdc() {
 	// Init slow ADC
-	adcStart(&ADCD1, NULL);
+	adcStart(&EFI_SLOW_ADC, NULL);
 
 #if STM32_ADC_USE_ADC3
 	// Knock/trigger scope ADC
@@ -168,7 +172,7 @@ bool readSlowAnalogInputs(adcsample_t* convertedSamples) {
 	{
 		chibios_rt::CriticalSectionLocker csl;
 		// Oversampling and right-shift happen in hardware, so we can sample directly to the output buffer
-		adcStartConversionI(&ADCD1, &convGroupSlow, convertedSamples, 1);
+		adcStartConversionI(&EFI_SLOW_ADC, &convGroupSlow, convertedSamples, 1);
 	}
 
 	constexpr uint32_t samplingRate = H7_ADC_SPEED;


### PR DESCRIPTION
Replace hardcoded ADCD1/ADCD2 references in stm32_adc_v2 and stm32_adc_v4 with EFI_SLOW_ADC/ADC_FAST_DEVICE macros (defaulting to the same values), allowing boards to redirect slow/fast ADC to a different peripheral. 

The ADC upgrades have been split into three branches, this one allows ADC peripherals to be assigned to different pins.

BTW, Claude compained about there being a bug in readBatch, and then spoke a lot of things that are considerably over my pay grade:
The bug is that readBatch in stm32_adc_v2.cpp uses three variable names that don't exist (auxConvGroup,
  auxSensorSamples, adcp). If anyone tried to compile with a specific flag set differently, it would just refuse to
  build.

  The TDB rule says: before fixing a bug, first write a test that proves the bug exists — so that when you apply the
  fix, the test changing from "fail" to "pass" is proof the fix actually did something real.

  The problem here is that this bug is a typo in variable names — it's not a logic bug you can observe at runtime, it's
  a "won't compile" bug. You can't really write a Google Test that says "hey, this variable name is wrong."

@dron0gus @FDSoftware ?