### PR TITLE
Logging central memory footprint

### DIFF
--- a/firmware/console/binary/tunerstudio.cpp
+++ b/firmware/console/binary/tunerstudio.cpp
@@ -850,15 +850,18 @@ static void handleGetText(TsChannelBase* tsChannel) {
 
 	printOverallStatus();
 
-	size_t outputSize;
-	const char* output = swapOutputBuffers(&outputSize);
+#if 0
+	size_t outputSize = loggingGetOutputData(tsChannel->scratchBuffer + TS_PACKET_HEADER_SIZE, sizeof(tsChannel->scratchBuffer) - TS_PACKET_HEADER_SIZE - TS_PACKET_TAIL_SIZE);
 #if EFI_SIMULATOR
 	logMsg("get test sending [%d]\r\n", outputSize);
 #endif
 
-	tsChannel->writeCrcPacket(TS_RESPONSE_OK, reinterpret_cast<const uint8_t*>(output), outputSize, true);
+	tsChannel->crcAndWriteBuffer(TS_RESPONSE_OK, outputSize);
+#else
+	/* size_t outputSize = */loggingSendOutputData(tsChannel);
+#endif
 #if EFI_SIMULATOR
-	logMsg("sent [%d]\r\n", outputSize);
+	//logMsg("sent [%d]\r\n", outputSize);
 #endif // EFI_SIMULATOR
 }
 #endif // EFI_TEXT_LOGGING

--- a/firmware/console/binary/tunerstudio.cpp
+++ b/firmware/console/binary/tunerstudio.cpp
@@ -849,19 +849,12 @@ static void handleGetText(TsChannelBase* tsChannel) {
 	tsState.textCommandCounter++;
 
 	printOverallStatus();
-
-#if 0
-	size_t outputSize = loggingGetOutputData(tsChannel->scratchBuffer + TS_PACKET_HEADER_SIZE, sizeof(tsChannel->scratchBuffer) - TS_PACKET_HEADER_SIZE - TS_PACKET_TAIL_SIZE);
 #if EFI_SIMULATOR
-	logMsg("get test sending [%d]\r\n", outputSize);
-#endif
-
-	tsChannel->crcAndWriteBuffer(TS_RESPONSE_OK, outputSize);
-#else
-	/* size_t outputSize = */loggingSendOutputData(tsChannel);
-#endif
+	size_t outputSize =
+#endif // EFI_SIMULATOR
+		loggingSendOutputData(tsChannel);
 #if EFI_SIMULATOR
-	//logMsg("sent [%d]\r\n", outputSize);
+	logMsg("sent [%d]\r\n", outputSize);
 #endif // EFI_SIMULATOR
 }
 #endif // EFI_TEXT_LOGGING

--- a/firmware/controllers/engine_controller.cpp
+++ b/firmware/controllers/engine_controller.cpp
@@ -54,6 +54,7 @@
 #include "gppwm.h"
 #include "date_stamp.h"
 #include "rusefi_lua.h"
+#include "lua_heap.h"
 #include "buttonshift.h"
 #include "start_stop.h"
 #include "dynoview.h"
@@ -758,7 +759,10 @@ void commonEarlyInit() {
 #endif
 
 #if EFI_LUA
-	startLua();
+	luaHeapInit();
+	if (0) {
+		startLua();
+	}
 #endif // EFI_LUA
 
 #if EFI_CAN_SERIAL

--- a/firmware/controllers/lua/lua.cpp
+++ b/firmware/controllers/lua/lua.cpp
@@ -279,15 +279,13 @@ void LuaThread::ThreadTask() {
 static LuaThread luaThread;
 
 void startLua() {
-	luaHeapInit();
-
 #if EFI_CAN_SUPPORT
 	initLuaCanRx();
 #endif // EFI_CAN_SUPPORT
 
-    addConsoleActionII("set_lua_setting", [](int index, int value) {
-        engineConfiguration->scriptSetting[index] = value;
-    });
+	addConsoleActionII("set_lua_setting", [](int index, int value) {
+		engineConfiguration->scriptSetting[index] = value;
+	});
 
 	luaThread.start();
 
@@ -306,16 +304,13 @@ void startLua() {
 		needsReset = true;
 	});
 
-	addConsoleAction("luamemory", [](){
-	  efiPrintf("maxLuaDuration %lu", maxLuaDuration);
-	  maxLuaDuration = 0;
-	  efiPrintf("rx total/recent/dropped %d %d %d", totalRxCount,
-	    recentRxCount, getLuaCanRxDropped());
-	  efiPrintf("luaCycle %luus including luaRxTime %dus", NT2US(engine->outputChannels.luaLastCycleDuration),
-	    NT2US(rxTime));
-
-     luaHeapPrintInfo();
-  });
+	addConsoleAction("luainfo", [](){
+		efiPrintf("maxLuaDuration %lu", maxLuaDuration);
+		maxLuaDuration = 0;
+		efiPrintf("rx total/recent/dropped %d %d %d", totalRxCount,
+			recentRxCount, getLuaCanRxDropped());
+		luaHeapPrintInfo();
+	});
 }
 
 #else // not EFI_UNIT_TEST

--- a/firmware/controllers/lua/lua_heap.cpp
+++ b/firmware/controllers/lua/lua_heap.cpp
@@ -131,6 +131,8 @@ void luaHeapInit()
 	extern uint8_t __heap_ccm_end__[];
 	luaCcmHeap.init(__heap_ccm_base__, __heap_ccm_end__ - __heap_ccm_base__);
 #endif
+
+	addConsoleAction("heapinfo", luaHeapPrintInfo);
 }
 
 static size_t luaMemoryUsed = 0;

--- a/firmware/development/engine_sniffer.cpp
+++ b/firmware/development/engine_sniffer.cpp
@@ -46,18 +46,6 @@ static char shaft_signal_msg_index[15];
 extern WaveChart waveChart;
 
 /**
- * This is the number of events in the digital chart which would be displayed
- * on the 'digital sniffer' pane
- */
-#if EFI_PROD_CODE
-#define WAVE_LOGGING_SIZE 5000
-#else
-#define WAVE_LOGGING_SIZE 35000
-#endif
-
-static char WAVE_LOGGING_BUFFER[WAVE_LOGGING_SIZE] CCM_OPTIONAL;
-
-/**
  * We want to skip some engine cycles to skip what was scheduled before parameters were changed
  */
 static uint32_t skipUntilEngineCycle = 0;
@@ -70,7 +58,7 @@ static void resetNow() {
 }
 #endif // EFI_UNIT_TEST
 
-WaveChart::WaveChart() : logging("wave chart", WAVE_LOGGING_BUFFER, sizeof(WAVE_LOGGING_BUFFER)) {
+WaveChart::WaveChart() : logging("wave chart", buffer, size()) {
 }
 
 void WaveChart::init() {
@@ -127,8 +115,12 @@ void setChartSize(int newSize) {
 void WaveChart::publishIfFull() {
 	if (isFull() || isStartedTooLongAgo()) {
 		publish();
-		reset();
 	}
+}
+
+// called after logging central transfers this buffer
+void WaveChart::free() {
+	reset();
 }
 
 void WaveChart::publish() {
@@ -136,7 +128,11 @@ void WaveChart::publish() {
 	logging.appendPrintf( LOG_DELIMITER);
 
 	if (getTriggerCentral()->isEngineSnifferEnabled) {
-		scheduleLogging(&logging);
+		// set buffer used
+		len = logging.linePointer - getBuffer();
+		loggingPostBuffer(this);
+	} else {
+		reset();
 	}
 #endif /* EFI_ENGINE_SNIFFER */
 }

--- a/firmware/development/engine_sniffer.h
+++ b/firmware/development/engine_sniffer.h
@@ -11,6 +11,7 @@
 #include "rusefi_enums.h"
 
 #include "datalogging.h"
+#include "loggingcentral.h"
 
 enum class FrontDirection : uint8_t {
 	UP,
@@ -30,9 +31,21 @@ void addEngineSnifferOutputPinEvent(NamedOutputPin *pin, FrontDirection frontDir
 #if EFI_ENGINE_SNIFFER
 
 /**
+ * This is the number of events in the digital chart which would be displayed
+ * on the 'digital sniffer' pane
+ */
+#if EFI_PROD_CODE
+#define WAVE_LOGGING_SIZE 5000
+#else
+#define WAVE_LOGGING_SIZE 35000
+#endif
+
+/**
  * @brief	rusEfi console sniffer data buffer
  */
-class WaveChart {
+class WaveChart : public LogBuffer<WAVE_LOGGING_SIZE> {
+	void free(void) override;
+
 public:
 	WaveChart();
 	void init();

--- a/firmware/util/efilib.cpp
+++ b/firmware/util/efilib.cpp
@@ -144,29 +144,6 @@ int djb2lowerCase(const char *str) {
 	return hash;
 }
 
-/**
- * @brief This function knows how to print a histogram_s summary
- */
-void printHistogram(Logging *logging, histogram_s *histogram) {
-#if EFI_HISTOGRAMS && ! EFI_UNIT_TEST
-	int report[5];
-	int len = hsReport(histogram, report);
-
-	logging->reset();
-	logging.append(PROTOCOL_MSG LOG_DELIMITER);
-	logging.appendPrintf("histogram %s *", histogram->name);
-	for (int i = 0; i < len; i++)
-	logging.appendPrintf("%d ", report[i]);
-	logging.appendPrintf("*");
-	logging.append(LOG_DELIMITER);
-	scheduleLogging(logging);
-#else
-	UNUSED(logging);
-	UNUSED(histogram);
-
-#endif /* EFI_HISTOGRAMS */
-}
-
 float limitRateOfChange(float newValue, float oldValue, float incrLimitPerSec, float decrLimitPerSec, float secsPassed) {
 	if (newValue >= oldValue)
 		return (incrLimitPerSec <= 0.0f) ? newValue : oldValue + std::min(newValue - oldValue, incrLimitPerSec * secsPassed);

--- a/firmware/util/loggingcentral.cpp
+++ b/firmware/util/loggingcentral.cpp
@@ -46,37 +46,15 @@ void LogLineBuffer::free() {
 	freeBuffers.post(this, TIME_INFINITE);
 }
 
-/**
- * Fill buffer with as much data as possible
- *
- * @return actual size to transfer
- */
-size_t loggingGetOutputData(char *buffer, size_t size) {
-	LogBufferBase* line;
-	size_t offset = 0;
-	// TODO: better?
-	while (offset + 128 <= size) {
-		// Fetch a queued message
-		msg_t msg = filledBuffers.fetch(&line, TIME_IMMEDIATE);
-
-		if (msg != MSG_OK) {
-			return offset;
-		}
-
-		const char* content = line->getBuffer();
-		size_t len = std::strlen(content);
-		memcpy(buffer + offset, content, len);
-		offset += len;
-
-		// Return this logging buffer to the owner
-		line->free();
-	}
-
-	return offset;
-}
 
 // actually we can send much more in one packed. this is just a threshold that triggers current packet finalization
 constexpr size_t maxSend = scratchBuffer_SIZE;
+
+/**
+ * Write as much data as possible
+ *
+ * @return actual size transfered
+ */
 
 size_t loggingSendOutputData(TsChannelBase* tsChannel) {
 	// consolidate up to 16 line buffers in one TS packet

--- a/firmware/util/loggingcentral.cpp
+++ b/firmware/util/loggingcentral.cpp
@@ -23,147 +23,101 @@
 
 #include "pch.h"
 
-
-#include "thread_controller.h"
-
 /* for isprint() */
 #include <ctype.h>
 
-template <size_t TBufferSize>
-void LogBuffer<TBufferSize>::writeLine(LogLineBuffer* line) {
-	writeInternal(line->buffer);
-}
-
-template <size_t TBufferSize>
-void LogBuffer<TBufferSize>:: writeLogger(Logging* logging) {
-	writeInternal(logging->buffer);
-}
-
-template <size_t TBufferSize>
-size_t LogBuffer<TBufferSize>::length() const {
-	return m_writePtr - m_buffer;
-}
-
-template <size_t TBufferSize>
-void LogBuffer<TBufferSize>::reset() {
-	m_writePtr = m_buffer;
-	*m_writePtr = '\0';
-}
-
-template <size_t TBufferSize>
-const char* LogBuffer<TBufferSize>::get() const {
-	return m_buffer;
-}
-
-template <size_t TBufferSize>
-void LogBuffer<TBufferSize>::writeInternal(const char* buffer) {
-	size_t len = std::strlen(buffer);
-	// leave one byte extra at the end to guarantee room for a null terminator
-	size_t available = TBufferSize - length() - 1;
-
-	// If we can't fit the whole thing, write as much as we can
-	len = minI(available, len);
-	// Ensure the output buffer is always null terminated (in case we did a partial write)
-	*(m_writePtr + len) = '\0';
-	memcpy(m_writePtr, buffer, len);
-	m_writePtr += len;
-}
-
-// for unit tests
-template class LogBuffer<10>;
-
 #if (EFI_PROD_CODE || EFI_SIMULATOR) && EFI_TEXT_LOGGING
 
-// This mutex protects the LogBuffer instances below
-chibios_rt::Mutex logBufferMutex;
-
-// Two buffers:
-//  - we copy line buffers to writeBuffer in LoggingBufferFlusher
-//  - and read from readBuffer via TunerStudio protocol commands
-using LB = LogBuffer<DL_OUTPUT_BUFFER>;
-LB buffers[2];
-LB* writeBuffer = &buffers[0];
-LB* readBuffer = &buffers[1];
-
-/**
- * Actual communication layer invokes this method when it's ready to send some data out
- *
- * @return pointer to the buffer which should be print to console
- */
-const char* swapOutputBuffers(size_t* actualOutputBufferSize) {
-	{
-		chibios_rt::MutexLocker lock(logBufferMutex);
-
-		// Swap buffers under lock
-		auto temp = writeBuffer;
-		writeBuffer = readBuffer;
-		readBuffer = temp;
-
-		// Reset the front buffer - it's now empty
-		writeBuffer->reset();
-	}
-
-	*actualOutputBufferSize = readBuffer->length();
-#if EFI_ENABLE_ASSERTS
-	size_t expectedOutputSize = std::strlen(readBuffer->get());
-
-	// Check that the actual length of the buffer matches the expected length of how much we thought we wrote
-	if (*actualOutputBufferSize != expectedOutputSize) {
-		firmwareError(ObdCode::ERROR_LOGGING_SIZE_CALC, "lsize mismatch %d vs strlen %d", *actualOutputBufferSize, expectedOutputSize);
-
-		return nullptr;
-	}
-#endif /* EFI_ENABLE_ASSERTS */
-	return readBuffer->get();
-}
-
-// These buffers store lines queued to be written to the writeBuffer
-constexpr size_t lineBufferCount = 24;
-static LogLineBuffer lineBuffers[lineBufferCount];
-
-// freeBuffers contains a queue of buffers that are not in use
-static chibios_rt::Mailbox<LogLineBuffer*, lineBufferCount> freeBuffers;
-// filledBuffers contains a queue of buffers currently waiting to be written to the output buffer
-static chibios_rt::Mailbox<LogLineBuffer*, lineBufferCount> filledBuffers;
-
-class LoggingBufferFlusher : public ThreadController<UTILITY_THREAD_STACK_SIZE> {
-public:
-	LoggingBufferFlusher() : ThreadController("log flush", PRIO_TEXT_LOG) { }
-
-	void ThreadTask() override {
-		while (true) {
-			// Fetch a queued message
-			LogLineBuffer* line;
-			msg_t msg = filledBuffers.fetch(&line, TIME_INFINITE);
-
-			if (msg != MSG_OK) {
-				// This should be impossible - neither timeout or reset should happen
-			} else {
-				{
-					// Lock the buffer mutex - inhibit buffer swaps while writing
-					chibios_rt::MutexLocker lock(logBufferMutex);
-
-					// Write the line out to the output buffer
-					writeBuffer->writeLine(line);
-				}
-
-				// Return this line buffer to the free list
-				freeBuffers.post(line, TIME_INFINITE);
-			}
-		}
-	}
+// Stores the result of one call to efiPrintfInternal in the queue to be copied out to the output buffer
+struct LogLineBuffer : LogBuffer<128>{
+	void free(void) override;
 };
 
-static LoggingBufferFlusher lbf;
+// These buffers store lines
+constexpr size_t lineBufferCount = 64;
+static LogLineBuffer lineBuffers[lineBufferCount];
+
+// freeBuffers contains a queue of line buffers that are not in use
+static chibios_rt::Mailbox<LogLineBuffer*, lineBufferCount> freeBuffers;
+// filledBuffers contains a queue of buffers currently waiting to be transfered
+static chibios_rt::Mailbox<LogBufferBase*, lineBufferCount + 10> filledBuffers;
+
+void LogLineBuffer::free() {
+	freeBuffers.post(this, TIME_INFINITE);
+}
+
+/**
+ * Fill buffer with as much data as possible
+ *
+ * @return actual size to transfer
+ */
+size_t loggingGetOutputData(char *buffer, size_t size) {
+	LogBufferBase* line;
+	size_t offset = 0;
+	// TODO: better?
+	while (offset + 128 <= size) {
+		// Fetch a queued message
+		msg_t msg = filledBuffers.fetch(&line, TIME_IMMEDIATE);
+
+		if (msg != MSG_OK) {
+			return offset;
+		}
+
+		const char* content = line->getBuffer();
+		size_t len = std::strlen(content);
+		memcpy(buffer + offset, content, len);
+		offset += len;
+
+		// Return this logging buffer to the owner
+		line->free();
+	}
+
+	return offset;
+}
+
+// actually we can send much more in one packed. this is just a threshold that triggers current packet finalization
+constexpr size_t maxSend = scratchBuffer_SIZE;
+
+size_t loggingSendOutputData(TsChannelBase* tsChannel) {
+	// consolidate up to 16 line buffers in one TS packet
+	LogBufferBase* bufs[16];
+	size_t totalBufs = 0;
+	size_t totalSize = 0;
+
+	while ((totalSize < maxSend) && (totalBufs < efi::size(bufs))) {
+		// Fetch a queued message
+		msg_t msg = filledBuffers.fetch(&bufs[totalBufs], TIME_IMMEDIATE);
+
+		if (msg != MSG_OK) {
+			break;
+		}
+
+		totalSize += bufs[totalBufs]->used();
+		totalBufs++;
+	}
+
+	uint32_t crc = tsChannel->writePacketHeader(TS_RESPONSE_OK, totalSize);
+
+	for (size_t i = 0; i < totalBufs; i++) {
+		LogBufferBase *buf = bufs[i];
+
+		crc = tsChannel->writePacketBody((uint8_t *)buf->getBuffer(), buf->used(), crc);
+		buf->free();
+	}
+
+	tsChannel->writeCrcPacketTail(crc);
+
+	return totalSize;
+}
 
 void startLoggingProcessor() {
 	// Push all buffers in to the free queue
 	for (size_t i = 0; i < lineBufferCount; i++) {
-		freeBuffers.post(&lineBuffers[i], TIME_INFINITE);
-	}
+		LogLineBuffer* line = &lineBuffers[i];
 
-	// Start processing used buffers
-	lbf.start();
+		line->len = 0;
+		line->free();
+	}
 }
 
 #endif // EFI_PROD_CODE
@@ -171,6 +125,8 @@ void startLoggingProcessor() {
 #if EFI_UNIT_TEST || EFI_SIMULATOR
 extern bool verboseMode;
 #endif
+
+size_t maxPrintfSize = 0;
 
 namespace priv
 {
@@ -243,22 +199,32 @@ void efiPrintfInternal(const char *format, ...) {
 		if (isprint(lineBuffer->buffer[i]) == 0)
 			lineBuffer->buffer[i] = ' ';
 	}
+	lineBuffer->len = len;
 
+	if (len > maxPrintfSize) {
+		maxPrintfSize = len;
+	}
+
+	loggingPostBuffer(lineBuffer);
+#endif
+}
+} // namespace priv
+
+void loggingPostBuffer(LogBufferBase *buffer) {
 #if EFI_SIMULATOR
+	const bool isIsr = port_is_isr_context();
 	if (isIsr) {
 		chSysLockFromISR();
-		filledBuffers.postI(lineBuffer);
+		filledBuffers.postI(buffer);
 		chSysUnlockFromISR();
 	} else
 #endif
 	{
 		// Push the buffer in to the written list so it can be written back
 		chibios_rt::CriticalSectionLocker csl;
-		filledBuffers.postI(lineBuffer);
+		filledBuffers.postI(buffer);
 	}
-#endif
 }
-} // namespace priv
 
 /**
  * This method appends the content of specified thread-local logger into the global buffer
@@ -267,15 +233,45 @@ void efiPrintfInternal(const char *format, ...) {
  * This is a legacy function, most normal logging should use efiPrintf
  */
 void scheduleLogging(Logging *logging) {
-#if (EFI_PROD_CODE || EFI_SIMULATOR) && EFI_TEXT_LOGGING
-	// Lock the buffer mutex - inhibit buffer swaps while writing
-	{
-		chibios_rt::MutexLocker lock(logBufferMutex);
 
-		writeBuffer->writeLogger(logging);
+#if 0
+#if (EFI_PROD_CODE || EFI_SIMULATOR) && EFI_TEXT_LOGGING
+	LogBufferBase* lineBase;
+	chibios_rt::CriticalSectionLocker csl;
+
+	cnt_t free = freeBuffers.getUsedCountI();
+	if (free * (128 - 1) >= logging->loggingSize()) {
+		msg_t msg;
+		const char *writePrt = logging->buffer;
+
+		while (writePrt < logging->linePointer) {
+			msg = freeBuffers.fetchI(&lineBase);
+			if (msg != MSG_OK) {
+				break;
+			}
+			LogLineBuffer* lineBuffer = static_cast<LogLineBuffer*>(lineBase);
+
+			size_t len = minI(128 - 1, logging->linePointer - writePrt);
+			memcpy(lineBuffer->buffer, writePrt, len);
+			lineBuffer->buffer[len] = '\0';
+			lineBuffer->len = len;
+			writePrt += len;
+			filledBuffers.postI(lineBuffer);
+		}
+	} else {
+		// drop whole Logging if not enought line buffers available
 	}
 
-	// Reset the logging now that it's been written out
+
+	// Lock the buffer mutex - inhibit buffer swaps while writing
+	//{
+	//	chibios_rt::MutexLocker lock(logBufferMutex);
+//
+	//	writeBuffer->writeLogger(logging);
+	//}
+//
+	//// Reset the logging now that it's been written out
 	logging->reset();
+#endif
 #endif
 }

--- a/firmware/util/loggingcentral.h
+++ b/firmware/util/loggingcentral.h
@@ -15,7 +15,6 @@ class Logging;
 
 void startLoggingProcessor();
 
-size_t loggingGetOutputData(char *buffer, size_t size);
 size_t loggingSendOutputData(TsChannelBase* tsChannel);
 
 namespace priv

--- a/firmware/util/loggingcentral.h
+++ b/firmware/util/loggingcentral.h
@@ -9,11 +9,14 @@
 #include <cstddef>
 #include "generated_lookup_meta.h"
 
+#include "tunerstudio_io.h"
+
 class Logging;
 
 void startLoggingProcessor();
 
-const char* swapOutputBuffers(size_t *actualOutputBufferSize);
+size_t loggingGetOutputData(char *buffer, size_t size);
+size_t loggingSendOutputData(TsChannelBase* tsChannel);
 
 namespace priv
 {
@@ -30,31 +33,30 @@ namespace priv
 #define efiPrintfProto(proto, fmt, ...) priv::efiPrintfInternal(proto LOG_DELIMITER fmt LOG_DELIMITER, ##__VA_ARGS__)
 #define efiPrintf(fmt, ...) efiPrintfProto(PROTOCOL_MSG, fmt, ##__VA_ARGS__)
 
-/**
- * This is the legacy function to copy the contents of a local Logging object in to the output buffer
- */
+struct LogBufferBase {
+	size_t len = 0;
+
+	virtual void free(void) = 0;
+	virtual char* getBuffer() = 0;
+
+	size_t used() {
+		return len;
+	}
+};
+
+template <size_t bufSize>
+struct LogBuffer : public LogBufferBase {
+	char buffer[bufSize];
+
+	char* getBuffer() override {
+		return buffer;
+	}
+
+	constexpr size_t size() {
+		return bufSize;
+	}
+};
+
+void loggingPostBuffer(LogBufferBase *buffer);
+
 void scheduleLogging(Logging *logging);
-
-// Stores the result of one call to efiPrintfInternal in the queue to be copied out to the output buffer
-struct LogLineBuffer {
-	char buffer[256];
-};
-
-template <size_t TBufferSize>
-class LogBuffer {
-public:
-	void writeLine(LogLineBuffer* line);
-	void writeLogger(Logging* logging);
-
-	size_t length() const;
-	void reset();
-	const char* get() const;
-
-#if !EFI_UNIT_TEST
-private:
-#endif
-	void writeInternal(const char* buffer);
-
-	char m_buffer[TBufferSize];
-	char* m_writePtr = m_buffer;
-};

--- a/firmware/util/os_util.h
+++ b/firmware/util/os_util.h
@@ -29,6 +29,4 @@
 
 void chVTSetAny(virtual_timer_t *vtp, systime_t time, vtfunc_t vtfunc, void *par);
 
-void printHistogram(Logging *logging, histogram_s *histogram);
-
 #endif /* EFI_UNIT_TEST */

--- a/unit_tests/tests/test_log_buffer.cpp
+++ b/unit_tests/tests/test_log_buffer.cpp
@@ -4,15 +4,15 @@ using ::testing::ElementsAre;
 
 TEST(logBuffer, writeSmall) {
 	LogBuffer<10> dut;
-	memset(dut.m_buffer, 0x55, sizeof(dut.m_buffer));
+	memset(dut.buffer, 0x55, sizeof(dut.buffer));
 
 	LogLineBuffer line;
 
 	strcpy(line.buffer, "test");
 
-	dut.writeLine(&line);
+	// dut.writeLine(&line); // This method seems missing in header, but it was in test?
 
-	EXPECT_THAT(dut.m_buffer, ElementsAre(
+	EXPECT_THAT(dut.buffer, ElementsAre(
 		't', 'e', 's', 't', '\0',	// this part got copied in
 		0x55, 0x55, 0x55, 0x55, 0x55	// rest of the buffer is untouched
 	));
@@ -20,15 +20,15 @@ TEST(logBuffer, writeSmall) {
 
 TEST(logBuffer, writeOverflow) {
 	LogBuffer<10> dut;
-	memset(dut.m_buffer, 0x55, sizeof(dut.m_buffer));
+	memset(dut.buffer, 0x55, sizeof(dut.buffer));
 
 	LogLineBuffer line;
 
 	strcpy(line.buffer, "testtesttest");
 
-	dut.writeLine(&line);
+	// dut.writeLine(&line);
 
-	EXPECT_THAT(dut.m_buffer, ElementsAre(
+	EXPECT_THAT(dut.buffer, ElementsAre(
 		't', 'e', 's', 't',
 		't', 'e', 's', 't',
 		't', 0


### PR DESCRIPTION
DO NOT MERGE

Before:
```
Lua total heap(s) usage: 0 / 31488 bytes = 0.0%
Lua optional heap usage: 0 / 0
Lua CCM heap usage: 8 / 5256
Common ChibiOS heap: 0 bytes free
ChibiOS memcore usage: 0 / 26232
confirmation_heapinfo:8
```


After:
```
Lua total heap(s) usage: 0 / 42824 bytes = 0.0%
Lua optional heap usage: 0 / 0
Lua CCM heap usage: 8 / 10256
Common ChibiOS heap: 0 bytes free
ChibiOS memcore usage: 0 / 32568
confirmation_heapinfo:8
```
