### PR TITLE
flexCranking: interpolate E0->E100 cranking multiplier across full ethanol range

### DIFF
--- a/firmware/controllers/algo/fuel_math.cpp
+++ b/firmware/controllers/algo/fuel_math.cpp
@@ -69,10 +69,10 @@ float getCrankingFuel3(float baseFuel, uint32_t revolutionCounterSinceStart) {
 	}
 
 	if (engineConfiguration->flexCranking && Sensor::hasSensor(SensorType::FuelEthanolPercent)) {
-		auto e85Mult = interpolate2d(clt, config->crankingFuelBins, config->crankingFuelCoefE100);
+		auto e100Mult = interpolate2d(clt, config->crankingFuelBins, config->crankingFuelCoefE100);
 
-		if (e85Mult <= 0.1f) {
-			warning(ObdCode::CUSTOM_ERR_ZERO_E85_MULT, "zero e85 multiplier");
+		if (e100Mult <= 0.1f) {
+			warning(ObdCode::CUSTOM_ERR_ZERO_E85_MULT, "zero e100 multiplier");
 			alreadyWarned = true;
 		}
 
@@ -82,7 +82,7 @@ float getCrankingFuel3(float baseFuel, uint32_t revolutionCounterSinceStart) {
 		engine->engineState.crankingFuel.coolantTemperatureCoefficient =
 			interpolateClamped(
 				0, e0Mult,
-				85, e85Mult,
+				100, e100Mult,
 				flex
 			);
 	} else {

--- a/firmware/tunerstudio/tunerstudio.template.ini
+++ b/firmware/tunerstudio/tunerstudio.template.ini
@@ -736,7 +736,7 @@ include_file controllers/actuators/boost_control.curves.ini
 		yBins		= crankingFuelCoef
 		gauge		= CLTGauge
 
-	curve = crankingCltCurveE100, "Cranking Coolant Temperature Multiplier (Flex Fuel E85)"
+	curve = crankingCltCurveE100, "Cranking Coolant Temperature Multiplier (Flex Fuel E100)"
 		columnLabel = "Coolant", "Multiplier"
 		xAxis		=  -40, { cltHighXaxis }, 9
 		yAxis		=  0,  3, 10

--- a/unit_tests/tests/ignition_injection/test_fuel_math.cpp
+++ b/unit_tests/tests/ignition_injection/test_fuel_math.cpp
@@ -435,6 +435,50 @@ TEST(FuelMath, getCycleFuelMassTest) {
 	EXPECT_NEAR(engine->engineState.crankingFuel.tpsCoefficient, 1, EPS3D);
 }
 
+// flexCranking blends the E0 cranking coolant multiplier (crankingFuelCoef) with the
+// E100 table (crankingFuelCoefE100) based on the flex fuel sensor. The blend endpoint is
+// 100% ethanol, so E85 is genuinely interpolated rather than clamped to the E100 value.
+TEST(FuelMath, flexCrankingE100Interpolation) {
+	EngineTestHelper eth(engine_type_e::TEST_ENGINE);
+
+	// Flat tables across CLT so the coolant axis is a no-op: E0 -> 1.0, E100 -> 3.0
+	setArrayValues(config->crankingFuelCoef, 1.0f);
+	setArrayValues(config->crankingFuelCoefE100, 3.0f);
+
+	engineConfiguration->flexCranking = true;
+	Sensor::setMockValue(SensorType::Clt, 20);
+
+	auto coolantCoef = []() {
+		getCrankingFuel3(/*baseFuel*/1, /*revolutionCounterSinceStart*/0);
+		return engine->engineState.crankingFuel.coolantTemperatureCoefficient;
+	};
+
+	// No flex sensor -> E0 table only
+	Sensor::resetMockValue(SensorType::FuelEthanolPercent);
+	EXPECT_NEAR(1.0f, coolantCoef(), EPS3D);
+
+	// E0 -> E0 table
+	Sensor::setMockValue(SensorType::FuelEthanolPercent, 0);
+	EXPECT_NEAR(1.0f, coolantCoef(), EPS3D);
+
+	// E50 -> halfway: 1.0 + 0.50 * (3.0 - 1.0) = 2.0
+	Sensor::setMockValue(SensorType::FuelEthanolPercent, 50);
+	EXPECT_NEAR(2.0f, coolantCoef(), EPS3D);
+
+	// E85 -> genuinely interpolated (previously clamped to the E100 value):
+	// 1.0 + 0.85 * (3.0 - 1.0) = 2.7
+	Sensor::setMockValue(SensorType::FuelEthanolPercent, 85);
+	EXPECT_NEAR(2.7f, coolantCoef(), EPS3D);
+
+	// E100 -> full E100 table value
+	Sensor::setMockValue(SensorType::FuelEthanolPercent, 100);
+	EXPECT_NEAR(3.0f, coolantCoef(), EPS3D);
+
+	// E110 -> clamp to E100 table value
+	Sensor::setMockValue(SensorType::FuelEthanolPercent, 110);
+	EXPECT_NEAR(3.0f, coolantCoef(), EPS3D);
+}
+
 TEST(FuelMath, postCrankingFactorAxis){
 	EngineTestHelper eth(engine_type_e::TEST_ENGINE);
 	setupSimpleTestEngineWithMafAndTT_ONE_trigger(&eth);


### PR DESCRIPTION
## Summary

The second cranking coolant-temperature multiplier table is named `crankingFuelCoefE100` and is described as **E100** in `rusefi_config.txt`, but the firmware blended it in at an **85% (E85)** endpoint. Because `interpolateClamped()` clamps at its endpoints, any flex-fuel reading between 85% and 100% ethanol was pinned to the E100 table value, and the E85→E100 range was never actually interpolated. The TunerStudio label ("Flex Fuel E85") also disagreed with the field name.

This made the behavior inconsistent across three layers:

| Layer | Said it was |
|-------|-------------|
| Config field name | `crankingFuelCoefE100` → **E100** |
| `flexCranking` bit description | **E100** |
| Firmware interpolation endpoint | **85 (E85)** |
| TunerStudio curve label | **E85** |

## Change

Move the blend endpoint to **100%** so the table matches its name:

- E0 uses `crankingFuelCoef`
- E100 uses `crankingFuelCoefE100`
- Intermediate ethanol content (including E85) is now genuinely interpolated between the two

Also renames the local `e85Mult` → `e100Mult` and updates the TunerStudio curve label from "Flex Fuel E85" to "Flex Fuel E100". The persisted config field name is **unchanged**, so tune compatibility/migration is preserved.

## Tests

Adds `FuelMath.flexCrankingE100Interpolation`, covering the no-sensor, E0, E50, E85, E100, and >E100 clamp cases.

## Compatibility note

This changes the meaning of existing tunes that calibrated the second table assuming an 85% endpoint: at E85 they will now receive a slightly lower (interpolated) value rather than the full second-table value. Since the field has always been named `E100`, this aligns behavior with the documented/named semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
