### PR TITLE
bench test: add boost control solenoid bench test command

### DIFF
--- a/firmware/controllers/algo/engine_types.h
+++ b/firmware/controllers/algo/engine_types.h
@@ -408,4 +408,5 @@ typedef enum {
 	LUA_COMMAND_8,
 	LUA_COMMAND_9,
 	LUA_COMMAND_10,
+	BENCH_BOOST_VALVE,
 } bench_mode_e;

--- a/firmware/controllers/bench_test.cpp
+++ b/firmware/controllers/bench_test.cpp
@@ -299,6 +299,11 @@ static void hpfpValveBench() {
 		&enginePins.hpfpValve);
 }
 
+static void boostValveBench() {
+	pinbench(engineConfiguration->benchTestOnTime, engineConfiguration->benchTestOffTime, engineConfiguration->benchTestCount,
+		&enginePins.boostPin);
+}
+
 void fuelPumpBench() {
 	fuelPumpBenchExt(BENCH_FUEL_PUMP_DURATION);
 }
@@ -437,6 +442,9 @@ void handleBenchCategory(uint16_t index) {
 #endif // EFI_HD_ACR
 	case BENCH_HPFP_VALVE:
 		hpfpValveBench();
+		return;
+	case BENCH_BOOST_VALVE:
+		boostValveBench();
 		return;
 	case BENCH_FUEL_PUMP:
 		// cmd_test_fuel_pump
@@ -910,6 +918,7 @@ void initBenchTest() {
 	addConsoleAction(CMD_STARTER_BENCH, starterRelayBench);
 	addConsoleAction(CMD_MIL_BENCH, milBench);
 	addConsoleAction(CMD_HPFP_BENCH, hpfpValveBench);
+	addConsoleAction(CMD_BOOST_BENCH, boostValveBench);
 
 #if EFI_CAN_SUPPORT
   addConsoleActionI("ping_wideband", [](int index) {

--- a/firmware/integration/ts_protocol.txt
+++ b/firmware/integration/ts_protocol.txt
@@ -109,6 +109,7 @@
 #define CMD_SPARK_BENCH "sparkbench"
 #define CMD_STARTER_BENCH "starterbench"
 #define CMD_HPFP_BENCH "hpfpbench"
+#define CMD_BOOST_BENCH "boostbench"
 #define CMD_AC_RELAY_BENCH "acrelaybench"
 #define CMD_FAN_BENCH "fanbench"
 #define CMD_FAN2_BENCH "fan2bench"

--- a/firmware/tunerstudio/tunerstudio.template.ini
+++ b/firmware/tunerstudio/tunerstudio.template.ini
@@ -2095,6 +2095,7 @@ cmd_test_check_engine_light	= "@@TS_IO_TEST_COMMAND_char@@@@ts_command_e_TS_BENC
 cmd_test_idle_valve				= "@@TS_IO_TEST_COMMAND_char@@@@ts_command_e_TS_BENCH_CATEGORY_16_hex@@@@bench_mode_e_BENCH_IDLE_VALVE_16_hex@@"
 cmd_test_second_idle_valve		= "@@TS_IO_TEST_COMMAND_char@@@@ts_command_e_TS_BENCH_CATEGORY_16_hex@@@@bench_mode_e_BENCH_SECOND_IDLE_VALVE_16_hex@@"
 cmd_test_hpfp_valve				= "@@TS_IO_TEST_COMMAND_char@@@@ts_command_e_TS_BENCH_CATEGORY_16_hex@@@@bench_mode_e_BENCH_HPFP_VALVE_16_hex@@"
+cmd_test_boost_valve			= "@@TS_IO_TEST_COMMAND_char@@@@ts_command_e_TS_BENCH_CATEGORY_16_hex@@@@bench_mode_e_BENCH_BOOST_VALVE_16_hex@@"
 cmd_test_lua_command_1				= "@@TS_IO_TEST_COMMAND_char@@@@ts_command_e_TS_BENCH_CATEGORY_16_hex@@@@bench_mode_e_LUA_COMMAND_1_16_hex@@"
 cmd_test_lua_command_2				= "@@TS_IO_TEST_COMMAND_char@@@@ts_command_e_TS_BENCH_CATEGORY_16_hex@@@@bench_mode_e_LUA_COMMAND_2_16_hex@@"
 cmd_test_lua_command_3				= "@@TS_IO_TEST_COMMAND_char@@@@ts_command_e_TS_BENCH_CATEGORY_16_hex@@@@bench_mode_e_LUA_COMMAND_3_16_hex@@"
@@ -4401,6 +4402,7 @@ dialog = tcuControls, "Transmission Settings"
 		field = "Control Mode",							boostType, { isBoostControlEnabled }
 		field = "Output",							boostControlPin, { boostControlPin != 0 || isBoostControlEnabled }
 		field = "Output Mode",							boostControlPinMode, { isBoostControlEnabled }
+		commandButton = "Bench Test Boost Solenoid", cmd_test_boost_valve, { boostControlPin != 0 }
 		field = "Frequency",						boostPwmFrequency, { isBoostControlEnabled }
 		field = "Safe duty cycle",					boostControlSafeDutyCycle, { isBoostControlEnabled }
 		field = "No boost control below RPM",	boostControlMinRpm, { isBoostControlEnabled }


### PR DESCRIPTION
## Summary

rusEFI has bench test commands for injectors, ignition, fuel pump, idle valve, fan, HPFP, etc., but there was no dedicated bench test for the **boost control solenoid**. This adds one.

The new test drives the already-existing `enginePins.boostPin` output, which is registered against `boostControlPin` / `boostControlPinMode`, so it uses exactly the configured pin and pin mode. As requested, it reuses the existing `benchTestOnTime` / `benchTestOffTime` / `benchTestCount` settings (identical to the HPFP valve bench test).

## Changes

- **`bench_mode_e`** (`engine_types.h`): append `BENCH_BOOST_VALVE`. It is appended at the **end** of the enum so the wire-protocol indices of all existing bench/CAN commands are preserved.
- **`bench_test.cpp`**:
  - `boostValveBench()` mirrors `hpfpValveBench()` and calls `pinbench(benchTestOnTime, benchTestOffTime, benchTestCount, &enginePins.boostPin)`.
  - wired into `handleBenchCategory()` (`case BENCH_BOOST_VALVE`).
  - registered as the `boostbench` console command (`CMD_BOOST_BENCH`).
- **TunerStudio** (`tunerstudio.template.ini` + `ts_protocol.txt`):
  - `CMD_BOOST_BENCH "boostbench"` console command string.
  - `cmd_test_boost_valve` TS command.
  - a **"Bench Test Boost Solenoid"** `commandButton` in the boost dialog, shown when `boostControlPin` is configured.

## Usage

- TunerStudio: button in the Boost dialog, next to the boost output pin config.
- Console: `boostbench` (uses the configured on/off time and count).

## Notes

- No unit/autotest coverage was added: the bench logic lives under `#if !EFI_UNIT_TEST`, and the simulator autotest (`SimulatorFunctionalTest`) models single-shot pins with a fixed duration, whereas this test (like HPFP) is multi-iteration via `benchTestCount` and depends on `boostControlPin` being assigned. This matches the existing HPFP valve bench test, which is also not in the autotest. Verified via TunerStudio / simulator instead.
- As with the other `BENCH_*` outputs, this is intended to be used with the engine stopped; the boost PWM controller and the bench test would otherwise contend for the same pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
