### PR TITLE
fuel: flex fuel transient compensation (accel enrichment + wall wetting)

### DIFF
--- a/firmware/console/binary/output_channels.txt
+++ b/firmware/console/binary/output_channels.txt
@@ -96,6 +96,11 @@ int16_t rpmAcceleration;dRPM;"RPM acceleration/Rate of Change/ROC",1, 0, 0, 5, 2
 	uint16_t autoscale wallFuelAmount;@@GAUGE_NAME_FUEL_WALL_AMOUNT@@;"mg",{1/@@PACK_MULT_FUEL_MASS@@}, 0, 0, 0, 3
 	int16_t autoscale wallFuelCorrectionValue;@@GAUGE_NAME_FUEL_WALL_CORRECTION@@;"mg",{1/@@PACK_MULT_FUEL_MASS@@}, 0, 0, 0, 3
 
+! Flex fuel transient compensation multipliers (1.0 = neutral)
+	uint16_t autoscale flexAeMultiplier;Flex: AE multiplier;"mult", 0.001, 0, 0, 5, 3
+	uint16_t autoscale flexWwTauMultiplier;Flex: WW tau multiplier;"mult", 0.001, 0, 0, 5, 3
+	uint16_t autoscale flexWwBetaMultiplier;Flex: WW beta multiplier;"mult", 0.001, 0, 0, 5, 3
+
 	uint16_t revolutionCounterSinceStart;;"",1, 0, 0, 0, 0
 
 	uint16_t canReadCounter;@@GAUGE_NAME_CAN_READ_OK@@;"",1, 0, 0, 64000, 0

--- a/firmware/controllers/algo/accel_enrichment.cpp
+++ b/firmware/controllers/algo/accel_enrichment.cpp
@@ -23,6 +23,7 @@
 
 #include "pch.h"
 #include "accel_enrichment.h"
+#include "flex_transient.h"
 #include "tunerstudio.h"
 
 
@@ -93,7 +94,11 @@ float TpsAccelEnrichment::getTpsEnrichment() {
 		mult = 1;
 	}
 
-	return extraFuel * mult;
+	// Flex fuel transient compensation (CLT x ethanol). Neutral (1.0) without a flex sensor.
+	// Note: AE_MODE_PREDICTIVE_MAP returns earlier, so this does not apply in that mode.
+	float flexMult = getFlexTransientMult(config->flexAeMult);
+	engine->outputChannels.flexAeMultiplier = flexMult;
+	return extraFuel * mult * flexMult;
 }
 
 void TpsAccelEnrichment::onEngineCycleTps() {

--- a/firmware/controllers/algo/defaults/default_base_engine.cpp
+++ b/firmware/controllers/algo/defaults/default_base_engine.cpp
@@ -191,6 +191,14 @@ void defaultsOrFixOnBurn() {
 		engineConfiguration->sdLogStopRpm = 700;
 		engineConfiguration->sdLogStopDelay = 30;
 	}
+
+	// Flex fuel transient compensation: give tunes that predate the feature sensible
+	// CLT x ethanol axis bins so the tables aren't degenerate when enabled (values stay
+	// neutral via the helper guard until the user fills them in).
+	if (config->flexTransientCltBins[FLEX_TRANSIENT_CLT_SIZE - 1] == 0) {
+		setLinearCurve(config->flexTransientCltBins, -40, 100, 1);
+		setLinearCurve(config->flexTransientEthanolBins, 0, 100, 1);
+	}
 }
 
 void setDefaultBaseEngine() {

--- a/firmware/controllers/algo/defaults/default_fuel.cpp
+++ b/firmware/controllers/algo/defaults/default_fuel.cpp
@@ -282,6 +282,16 @@ void setDefaultWallWetting() {
 	copyArray(config->wwBetaMapValues, betaMap);
 }
 
+static void setDefaultFlexTransientComp() {
+	setLinearCurve(config->flexTransientCltBins, -40, 100, 1);
+	setLinearCurve(config->flexTransientEthanolBins, 0, 100, 1);
+
+	// Default to neutral (1.0) so transient fueling is unchanged until the user tunes these
+	setTable(config->flexAeMult, 1.0f);
+	setTable(config->flexWwTauMult, 1.0f);
+	setTable(config->flexWwBetaMult, 1.0f);
+}
+
 static void setDefaultWboSettings() {
 	for (size_t i = 0; i < CAN_WBO_COUNT; i++) {
 		engineConfiguration->canWbo[i].type = RUSEFI;
@@ -381,6 +391,9 @@ void setDefaultFuel() {
 	engineConfiguration->tpsAccelEnrichmentThreshold = 40; // TPS % change, per engine cycle
 
 	setDefaultWallWetting();
+
+	// Flex fuel transient compensation (CLT x ethanol) - neutral by default
+	setDefaultFlexTransientComp();
 
 	// TPS/TPS AE curve
 	setMazdaMiataNbTpsTps();

--- a/firmware/controllers/algo/flex_transient.h
+++ b/firmware/controllers/algo/flex_transient.h
@@ -1,0 +1,37 @@
+/*
+ * @file flex_transient.h
+ *
+ * Flex-fuel transient fueling compensation: CLT x Ethanol% multiplier tables
+ * applied to acceleration enrichment and wall wetting (tau/beta).
+ *
+ * Gasoline and ethanol behave very differently during transient throttle, especially
+ * when cold, so these tables allow extra enrichment when ethanol content is high and
+ * the engine is cold, while staying neutral (1.0) when warm or on gasoline.
+ */
+
+#pragma once
+
+/**
+ * Look up a flex-fuel transient compensation multiplier from a CLT (X) x Ethanol% (Y) table.
+ *
+ * Returns 1.0 (neutral) when there is no flex fuel sensor, or when the table is left
+ * un-initialized (all zero), so existing tunes and gasoline operation are unchanged.
+ */
+template <typename TTable>
+float getFlexTransientMult(const TTable& table) {
+	if (!engineConfiguration->flexFuelTransientComp || !Sensor::hasSensor(SensorType::FuelEthanolPercent)) {
+		return 1.0f;
+	}
+
+	// Default to normal operating temperature in case of CLT sensor failure
+	float clt = Sensor::get(SensorType::Clt).value_or(90);
+	// If failed flex sensor, default to 50% E (matches cranking behavior)
+	float ethanol = Sensor::get(SensorType::FuelEthanolPercent).value_or(50);
+
+	float mult = interpolate3d(table,
+		config->flexTransientEthanolBins, ethanol,
+		config->flexTransientCltBins, clt);
+
+	// An un-initialized (all-zero) table means "no compensation"
+	return mult > 0.01f ? mult : 1.0f;
+}

--- a/firmware/controllers/algo/wall_fuel.cpp
+++ b/firmware/controllers/algo/wall_fuel.cpp
@@ -6,6 +6,7 @@
 
 #include "pch.h"
 #include "wall_fuel.h"
+#include "flex_transient.h"
 
 void WallFuel::resetWF() {
 	wallFuel = 0;
@@ -74,59 +75,71 @@ float WallFuel::getWallFuel() const {
 }
 
 float WallFuelController::computeTau() const {
-	if (!engineConfiguration->complexWallModel) {
-		return engineConfiguration->wwaeTau;
-	}
-
 	// Default to normal operating temperature in case of
 	// CLT failure, this is not critical to get perfect
 	float clt = Sensor::get(SensorType::Clt).value_or(90);
 
-	float tau = interpolate2d(
-		clt,
-		config->wwCltBins,
-		config->wwTauCltValues
-	);
-
-	// If you have a MAP sensor, apply MAP correction
-	if (Sensor::hasSensor(SensorType::Map)) {
-		auto map = Sensor::get(SensorType::Map).value_or(60);
-
-		tau *= interpolate2d(
-			map,
-			config->wwMapBins,
-			config->wwTauMapValues
+	float tau;
+	if (!engineConfiguration->complexWallModel) {
+		tau = engineConfiguration->wwaeTau;
+	} else {
+		tau = interpolate2d(
+			clt,
+			config->wwCltBins,
+			config->wwTauCltValues
 		);
+
+		// If you have a MAP sensor, apply MAP correction
+		if (Sensor::hasSensor(SensorType::Map)) {
+			auto map = Sensor::get(SensorType::Map).value_or(60);
+
+			tau *= interpolate2d(
+				map,
+				config->wwMapBins,
+				config->wwTauMapValues
+			);
+		}
 	}
+
+	// Flex fuel transient compensation (CLT x ethanol). Neutral (1.0) without a flex sensor.
+	float flexMult = getFlexTransientMult(config->flexWwTauMult);
+	engine->outputChannels.flexWwTauMultiplier = flexMult;
+	tau *= flexMult;
 
 	return tau;
 }
 
 float WallFuelController::computeBeta() const {
-	if (!engineConfiguration->complexWallModel) {
-		return engineConfiguration->wwaeBeta;
-	}
-
 	// Default to normal operating temperature in case of
 	// CLT failure, this is not critical to get perfect
 	float clt = Sensor::get(SensorType::Clt).value_or(90);
 
-	float beta = interpolate2d(
-		clt,
-		config->wwCltBins,
-		config->wwBetaCltValues
-	);
-
-	// If you have a MAP sensor, apply MAP correction
-	if (Sensor::hasSensor(SensorType::Map)) {
-		auto map = Sensor::get(SensorType::Map).value_or(60);
-
-		beta *= interpolate2d(
-			map,
-			config->wwMapBins,
-			config->wwBetaMapValues
+	float beta;
+	if (!engineConfiguration->complexWallModel) {
+		beta = engineConfiguration->wwaeBeta;
+	} else {
+		beta = interpolate2d(
+			clt,
+			config->wwCltBins,
+			config->wwBetaCltValues
 		);
+
+		// If you have a MAP sensor, apply MAP correction
+		if (Sensor::hasSensor(SensorType::Map)) {
+			auto map = Sensor::get(SensorType::Map).value_or(60);
+
+			beta *= interpolate2d(
+				map,
+				config->wwMapBins,
+				config->wwBetaMapValues
+			);
+		}
 	}
+
+	// Flex fuel transient compensation (CLT x ethanol). Neutral (1.0) without a flex sensor.
+	float flexMult = getFlexTransientMult(config->flexWwBetaMult);
+	engine->outputChannels.flexWwBetaMultiplier = flexMult;
+	beta *= flexMult;
 
 	// Clamp to 0..1 (you can't have more than 100% of the fuel hit the wall!)
 	return clampF(0, beta, 1);

--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -1198,6 +1198,7 @@ bit useFixedBaroCorrFromMap,"yes","no";Read MAP sensor on ECU start-up to use as
 bit useSeparateAdvanceForCranking,"Table","Fixed (auto taper)";In Constant mode, timing is automatically tapered to running as RPM increases.\nIn Table mode, the "Cranking ignition advance" table is used directly.
 bit useAdvanceCorrectionsForCranking,"yes","no";This enables the various ignition corrections during cranking (IAT, CLT and PID idle).\nYou probably don't need this.
 bit flexCranking,"enabled","disabled";Enable a second cranking table to use for E100 flex fuel, interpolating between the two based on flex fuel sensor.
+bit flexFuelTransientComp,"enabled","disabled";Enable flex-fuel transient fueling compensation (acceleration enrichment and wall wetting tau/beta) based on ethanol content and coolant temperature.
 bit useIacPidMultTable,"yes","no";This flag allows to use a special 'PID Multiplier' table (0.0-1.0) to compensate for nonlinear nature of IAC-RPM controller
 bit isBoostControlEnabled,"enabled","disabled"
 bit launchSmoothRetard,"enabled","disabled";Gradually interpolates the ignition timing from the base timing table value down to the target "Absolute Timing at Launch" value, starting from the beginning of the launch window.
@@ -2329,6 +2330,16 @@ uint8_t[TPS_TPS_ACCEL_CLT_CORR_TABLE] autoscale tpsTspCorrValues;;"multiplier", 
 
 uint8_t[TPS_TPS_ACCEL_CLT_CORR_TABLE] autoscale predictiveMapBlendDurationBins;;"RPM", 50, 0, 0, 12500, 0
 uint8_t[TPS_TPS_ACCEL_CLT_CORR_TABLE] autoscale predictiveMapBlendDurationValues;;"second", 0.02, 0, 0, 5, 2
+
+! Flex-fuel transient fueling compensation: CLT (X) x Ethanol% (Y) multiplier tables
+#define FLEX_TRANSIENT_CLT_SIZE 8
+#define FLEX_TRANSIENT_ETH_SIZE 8
+
+int16_t[FLEX_TRANSIENT_CLT_SIZE] flexTransientCltBins;Coolant temperature axis for the flex-fuel transient compensation tables;"C", 1, 0, -40, 200, 0
+uint8_t[FLEX_TRANSIENT_ETH_SIZE] flexTransientEthanolBins;Ethanol percentage axis for the flex-fuel transient compensation tables;"%", 1, 0, 0, 100, 0
+uint8_t[FLEX_TRANSIENT_ETH_SIZE x FLEX_TRANSIENT_CLT_SIZE] autoscale flexAeMult;Acceleration enrichment multiplier as a function of CLT (X) and ethanol % (Y);"mult", 0.02, 0, 0, 5, 2
+uint8_t[FLEX_TRANSIENT_ETH_SIZE x FLEX_TRANSIENT_CLT_SIZE] autoscale flexWwTauMult;Wall wetting tau multiplier as a function of CLT (X) and ethanol % (Y);"mult", 0.02, 0, 0, 5, 2
+uint8_t[FLEX_TRANSIENT_ETH_SIZE x FLEX_TRANSIENT_CLT_SIZE] autoscale flexWwBetaMult;Wall wetting beta multiplier as a function of CLT (X) and ethanol % (Y);"mult", 0.02, 0, 0, 5, 2
 
 ! yes, 200C region is legit for some air-cooled engines
 int16_t[CLT_LIMITER_CURVE_SIZE] autoscale cltRevLimitRpmBins;;{bitStringValue(unitsLabels, useMetricOnInterface)}, {useMetricOnInterface ? 1 : 1.8}, {useMetricOnInterface ? 0 : 17.77777}, {useMetricOnInterface ? -40 : -40}, {useMetricOnInterface ? 200 : 392}, 0

--- a/firmware/tunerstudio/top_level_menu.ini
+++ b/firmware/tunerstudio/top_level_menu.ini
@@ -83,6 +83,11 @@
 		groupChildMenu = mapEstimateTableTbl,		"MAP estimate table", {isInjectionEnabled == 1 && fuelAlgorithm == @@engine_load_mode_e_LM_SPEED_DENSITY@@}, { uiMode == @@UiMode_FULL@@ || uiMode == @@UiMode_INSTALLATION@@ }@@if_ts_show_map_estimate
 		groupChildMenu = predictiveMapBlendDuration,      "Predictive Map Blend Duration", 0, {isInjectionEnabled == 1}
 
+		# Flex fuel transient compensation (CLT x ethanol)
+		groupChildMenu = flexAeMultDialog,     "Flex fuel: accel enrichment multiplier", 0, {isInjectionEnabled == 1 && flexFuelTransientComp == 1}
+		groupChildMenu = flexWwTauMultDialog,  "Flex fuel: wall wetting tau multiplier", 0, {isInjectionEnabled == 1 && flexFuelTransientComp == 1}
+		groupChildMenu = flexWwBetaMultDialog, "Flex fuel: wall wetting beta multiplier", 0, {isInjectionEnabled == 1 && flexFuelTransientComp == 1}
+
 		groupMenu = "Wall wetting AE"@@if_ts_show_adv_wall_wetting
 		groupChildMenu = wwTauCurves, "Evap time", 0, { complexWallModel != 0 }@@if_ts_show_adv_wall_wetting
 		groupChildMenu = wwBetaCurves, "Impact fraction", 0, { complexWallModel != 0 }@@if_ts_show_adv_wall_wetting

--- a/firmware/tunerstudio/tunerstudio.template.ini
+++ b/firmware/tunerstudio/tunerstudio.template.ini
@@ -1173,17 +1173,17 @@ curve = rangeMatrix, "Range Switch Input Matrix"
 
 	table = flexAeMultTbl,  tpsTpsAccelMap,  "Accel Enrichment Flex Multiplier",	1
 		xBins		= flexTransientCltBins, coolantTemperature
-		yBins		= flexTransientEthanolBins
+		yBins		= flexTransientEthanolBins, flexPercent
 		zBins		= flexAeMult
 
 	table = flexWwTauMultTbl,  tpsTpsAccelMap,  "Wall Wetting Tau Flex Multiplier",	1
 		xBins		= flexTransientCltBins, coolantTemperature
-		yBins		= flexTransientEthanolBins
+		yBins		= flexTransientEthanolBins, flexPercent
 		zBins		= flexWwTauMult
 
 	table = flexWwBetaMultTbl,  tpsTpsAccelMap,  "Wall Wetting Beta Flex Multiplier",	1
 		xBins		= flexTransientCltBins, coolantTemperature
-		yBins		= flexTransientEthanolBins
+		yBins		= flexTransientEthanolBins, flexPercent
 		zBins		= flexWwBetaMult
 
 		table = tractionEtbTableTbl,  tractionEtb,  "Traction Control ETB drop",	1

--- a/firmware/tunerstudio/tunerstudio.template.ini
+++ b/firmware/tunerstudio/tunerstudio.template.ini
@@ -1171,6 +1171,21 @@ curve = rangeMatrix, "Range Switch Input Matrix"
 		yBins		= tpsTpsAccelToRpmBins,  tpsTo
 		zBins		= tpsTpsAccelTable
 
+	table = flexAeMultTbl,  tpsTpsAccelMap,  "Accel Enrichment Flex Multiplier",	1
+		xBins		= flexTransientCltBins, coolantTemperature
+		yBins		= flexTransientEthanolBins
+		zBins		= flexAeMult
+
+	table = flexWwTauMultTbl,  tpsTpsAccelMap,  "Wall Wetting Tau Flex Multiplier",	1
+		xBins		= flexTransientCltBins, coolantTemperature
+		yBins		= flexTransientEthanolBins
+		zBins		= flexWwTauMult
+
+	table = flexWwBetaMultTbl,  tpsTpsAccelMap,  "Wall Wetting Beta Flex Multiplier",	1
+		xBins		= flexTransientCltBins, coolantTemperature
+		yBins		= flexTransientEthanolBins
+		zBins		= flexWwBetaMult
+
 		table = tractionEtbTableTbl,  tractionEtb,  "Traction Control ETB drop",	1
 		xBins		= tractionControlSpeedBins,  vehicleSpeedKph
 		yBins		= tractionControlSlipBins,  wheelSlipRatio
@@ -4216,6 +4231,7 @@ include_file @@SECONDARY_PANELS_FILE@@
 		field = "Wall fueling model type",				complexWallModel@@if_ts_show_complexWallModel
 		field = "evaporation time constant / tau",		wwaeTau, { complexWallModel == 0 }
 		field = "added to wall coef / beta",			wwaeBeta, { complexWallModel == 0 }
+		field = "Flex fuel transient compensation",		flexFuelTransientComp
 
 	indicatorPanel = AccelEnfichIndicatorsPanel
 		indicator = { isTuningNow }, "No tuning happening", "Tuning Detected",  white,  black,  green,  black
@@ -4225,6 +4241,15 @@ include_file @@SECONDARY_PANELS_FILE@@
 		panel = TpsAccelPanel
 		panel = WallWettingAccelPanel
 		panel = AccelEnfichIndicatorsPanel
+
+	dialog = flexAeMultDialog, "", border
+		panel = flexAeMultTbl, Center
+
+	dialog = flexWwTauMultDialog, "", border
+		panel = flexWwTauMultTbl, Center
+
+	dialog = flexWwBetaMultDialog, "", border
+		panel = flexWwBetaMultTbl, Center
 
 	dialog = wwTauCurves, "Wall wetting AE evaporation time"
 		field = "#Set a base evaporation time based on coolant temperature, and a multiplier based on MAP."

--- a/unit_tests/tests/ignition_injection/test_fuel_wall_wetting.cpp
+++ b/unit_tests/tests/ignition_injection/test_fuel_wall_wetting.cpp
@@ -15,6 +15,47 @@ struct MockWallController : public IWallFuelController {
 	MOCK_METHOD(float, getBeta, (), (const, override));
 };
 
+// Exposes the protected tau/beta computation for direct testing
+struct TestWallFuelController : public WallFuelController {
+	using WallFuelController::computeTau;
+	using WallFuelController::computeBeta;
+};
+
+TEST(fuel, wallWettingFlexFuelCompensation) {
+	EngineTestHelper eth(engine_type_e::TEST_ENGINE);
+
+	// Basic (constant) wall model so the base tau/beta are known scalars
+	engineConfiguration->complexWallModel = false;
+	engineConfiguration->wwaeTau = 0.4f;
+	engineConfiguration->wwaeBeta = 0.3f;
+
+	// Flex transient tables: tau x2, beta x1.5 everywhere
+	setLinearCurve(config->flexTransientCltBins, -40, 100, 1);
+	setLinearCurve(config->flexTransientEthanolBins, 0, 100, 1);
+	setTable(config->flexWwTauMult, 2.0f);
+	setTable(config->flexWwBetaMult, 1.5f);
+
+	engineConfiguration->flexFuelTransientComp = true;
+	Sensor::setMockValue(SensorType::Clt, 20);
+
+	TestWallFuelController dut;
+
+	// No flex sensor -> compensation neutral, base values pass through
+	Sensor::resetMockValue(SensorType::FuelEthanolPercent);
+	EXPECT_NEAR(0.4f, dut.computeTau(), EPS4D);
+	EXPECT_NEAR(0.3f, dut.computeBeta(), EPS4D);
+
+	// E100 with compensation enabled -> tau and beta scaled by the tables
+	Sensor::setMockValue(SensorType::FuelEthanolPercent, 100);
+	EXPECT_NEAR(0.8f, dut.computeTau(), EPS4D);
+	EXPECT_NEAR(0.45f, dut.computeBeta(), EPS4D);
+
+	// Disable flag -> back to neutral even with a flex sensor present
+	engineConfiguration->flexFuelTransientComp = false;
+	EXPECT_NEAR(0.4f, dut.computeTau(), EPS4D);
+	EXPECT_NEAR(0.3f, dut.computeBeta(), EPS4D);
+}
+
 TEST(fuel, testWallWettingEnrichmentMath) {
 	EngineTestHelper eth(engine_type_e::TEST_ENGINE);
 

--- a/unit_tests/tests/test_accel_enrichment.cpp
+++ b/unit_tests/tests/test_accel_enrichment.cpp
@@ -151,3 +151,52 @@ TEST(fuel, testTpsAccelEnrichment) {
 	// should return 0 if we are using predictive map
 	EXPECT_EQ(0, engine->module<TpsAccelEnrichment>()->getTpsEnrichment());
 }
+
+TEST(fuel, tpsAccelFlexFuelCompensation) {
+	EngineTestHelper eth(engine_type_e::TEST_ENGINE);
+
+	engineConfiguration->tpsAccelEnrichmentThreshold = 5;
+	engineConfiguration->tpsAccelLookback = 2;
+	// non-fractional so the raw enrichment is the table value directly
+	engineConfiguration->tpsAccelFractionPeriod = 1;
+	engineConfiguration->tpsAccelFractionDivisor = 1;
+
+	// Constant AE table (1.0) and flat RPM correction so the base enrichment is a known 1.0
+	setTable(config->tpsTpsAccelTable, 1.0f);
+	setRpmTableBin(config->tpsTspCorrValuesBins);
+	setLinearCurve(config->tpsTspCorrValues, 1, 1);
+
+	// Flex transient AE table = 2.0 everywhere
+	setLinearCurve(config->flexTransientCltBins, -40, 100, 1);
+	setLinearCurve(config->flexTransientEthanolBins, 0, 100, 1);
+	setTable(config->flexAeMult, 2.0f);
+
+	engineConfiguration->flexFuelTransientComp = true;
+	Sensor::setMockValue(SensorType::Clt, 20);
+
+	initAccelEnrichment();
+	engine->rpmCalculator.setRpmValue(600);
+	engine->periodicFastCallback();
+
+	auto ae = engine->module<TpsAccelEnrichment>();
+	ae->setLength(2);
+
+	auto triggerAccel = [&]() {
+		ae->resetAE();
+		ae->onNewValue(0);
+		ae->onNewValue(10); // delta 10 > threshold 5 -> table value 1.0
+		return ae->getTpsEnrichment();
+	};
+
+	// No flex sensor -> compensation neutral, enrichment = base 1.0
+	Sensor::resetMockValue(SensorType::FuelEthanolPercent);
+	EXPECT_NEAR(1.0f, triggerAccel(), EPS4D);
+
+	// E100 with compensation enabled -> enrichment doubles
+	Sensor::setMockValue(SensorType::FuelEthanolPercent, 100);
+	EXPECT_NEAR(2.0f, triggerAccel(), EPS4D);
+
+	// Disable flag -> back to neutral even with a flex sensor present
+	engineConfiguration->flexFuelTransientComp = false;
+	EXPECT_NEAR(1.0f, triggerAccel(), EPS4D);
+}


### PR DESCRIPTION
## Summary

Adds optional **flex-fuel compensation for transient fueling** (acceleration enrichment and wall wetting), driven by **CLT × Ethanol%** tables. Gasoline and ethanol behave very differently during transient throttle — especially when cold — so this allows extra enrichment when ethanol content is high and the engine is cold, while staying neutral when warm or on gasoline.

Today the base fuel is compensated for ethanol (`stoichRatioPrimary/Secondary`) and there is `flexCranking`, but transient fueling has no direct `FuelEthanolPercent` compensation.

## What it adds

Three **8×8 CLT (X) × Ethanol% (Y)** multiplier tables with shared axes (`rusefi_config.txt`):

| Table | Applies to |
|-------|------------|
| `flexAeMult` | acceleration enrichment |
| `flexWwTauMult` | wall wetting tau |
| `flexWwBetaMult` | wall wetting beta |

A single helper `getFlexTransientMult()` (`flex_transient.h`) centralizes the gating + lookup:
- returns **1.0 (neutral)** when the new `flexFuelTransientComp` enable bit is off, or when no flex sensor is present;
- treats an **un-initialized (all-zero) table as neutral**;
- a **failed flex sensor defaults to 50% ethanol**, matching `flexCranking`.

### Hooks (3)
- **`accel_enrichment.cpp` `getTpsEnrichment()`** — scales the AE adder. Because the value is unit-agnostic, this covers **both ms-adder and percent-adder** modes with one multiply. `AE_MODE_PREDICTIVE_MAP` returns earlier (AE = 0), so it is unaffected there and relies on the wall-wetting comp instead.
- **`wall_fuel.cpp` `computeTau()` / `computeBeta()`** — scales tau/beta in **both** the basic (constant) and advanced (`complexWallModel`) modes.

### Observability
Output channels `flexAeMultiplier` / `flexWwTauMultiplier` / `flexWwBetaMultiplier` expose the applied multiplier for real-time logging (1.0 = neutral).

### TunerStudio
3 tables + a dedicated dialog/menu under TPS Acceleration Enrichment / Wall Wetting AE, plus the enable checkbox in the Accel/Decel Enrichment dialog.

## Compatibility

- Enable bit **defaults off** and all tables **default to 1.0**, so existing tunes are unchanged.
- `computeBeta()` now clamps to 0..1 in **both** modes (previously advanced-only). `wwaeBeta` is already a 0..1 fraction, so this is a no-op for valid tunes.

## Tests

`unit_tests` cover all three hooks (`test_fuel_wall_wetting.cpp`, `test_accel_enrichment.cpp`): no sensor → neutral, E100 → scaled, **disabled → neutral**. The wall test exposes the protected `computeTau`/`computeBeta` via a small `using`-subclass.

## Validation

Config / `.ini` / output-channel generation was validated locally (config_definition + LiveDataProcessor run clean; the generated struct/`.ini`/output-channels contain the new fields with correct types/scale). C++ compile + unit-test execution rely on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
