### PR TITLE
sd: conditional SD logging triggers

### DIFF
--- a/firmware/console/binary/output_channels.txt
+++ b/firmware/console/binary/output_channels.txt
@@ -453,6 +453,8 @@ float mapFast
 
   uint8_t sd_error;
 
+	uint8_t sdLoggingState;SD: Logging state;"code", 1, 0, 0, 0, 0
+
 	uint8_t fastAdcOverrunCount;ECU: Fast ADC overruns;"", 1, 0, 0, 255, 0
 	uint8_t slowAdcOverrunCount;ECU: Slow ADC overruns;"", 1, 0, 0, 255, 0
 	uint8_t fastAdcLastError;ECU: Fast ADC error type;"", 1, 0, 0, 255, 0

--- a/firmware/controllers/algo/engine_configuration.cpp
+++ b/firmware/controllers/algo/engine_configuration.cpp
@@ -247,6 +247,15 @@ void setDefaultBasePins() {
 // at the moment bootloader does NOT really need SD card, this is a step towards future bootloader SD card usage
 void setDefaultSdCardParameters() {
 	engineConfiguration->isSdCardEnabled = true;
+
+	// Conditional logging defaults to off -> SD logs unconditionally (current behavior)
+	engineConfiguration->sdCardConditionalLogging = false;
+	engineConfiguration->sdLogStartRpm = 0;
+	engineConfiguration->sdLogStopRpm = 0;
+	engineConfiguration->sdLogStopDelay = 5;
+	engineConfiguration->sdLogMinTps = 0;
+	engineConfiguration->sdLogMinMap = 0;
+	engineConfiguration->sdLogMinVss = 0;
 }
 
 #if EFI_ENGINE_CONTROL

--- a/firmware/controllers/algo/engine_types.h
+++ b/firmware/controllers/algo/engine_types.h
@@ -409,3 +409,16 @@ typedef enum {
 	LUA_COMMAND_9,
 	LUA_COMMAND_10,
 } bench_mode_e;
+
+// Reason why SD logging is or is not currently writing (for the SD: Logging state indicator)
+typedef enum __attribute__ ((__packed__)) {
+	SD_LOG_DISABLED = 0,      // SD not in ECU logging mode
+	SD_LOG_SUPPRESSED = 1,    // paused via console (sdsuppresslogging)
+	SD_LOG_FAILED = 2,        // logger died
+	SD_LOG_UNCONDITIONAL = 3, // logging, conditional trigger disabled
+	SD_LOG_ACTIVE = 4,        // logging, trigger condition met
+	SD_LOG_STOP_DELAY = 5,    // logging, RPM below stop, within stop delay
+	SD_LOG_WAIT_RPM = 6,      // not logging: RPM below start threshold
+	SD_LOG_WAIT_COND = 7,     // not logging: TPS/MAP/VSS condition not met
+	SD_LOG_BUTTON_OFF = 8,    // not logging: trigger button toggled off
+} sd_log_state_e;

--- a/firmware/controllers/modules/generated/engine_modules_generated.h
+++ b/firmware/controllers/modules/generated/engine_modules_generated.h
@@ -8,6 +8,7 @@
 #include "example_module.h"
 #include "vvl_controller.h"
 #include "configuration_wizard.h"
+#include "sd_log_trigger.h"
 
 // Board-specific extra modules. Upstream ships an empty stub;
 // custom boards override this header via their include path.

--- a/firmware/controllers/modules/generated/modules_list_generated.h
+++ b/firmware/controllers/modules/generated/modules_list_generated.h
@@ -6,6 +6,7 @@ TripOdometer,
 FanControl1,FanControl2,
 MapAveragingModule,
 ExampleModule,
+SdLogTrigger,
 
 #if EFI_ETHERNET
 EthernetConsoleModule,

--- a/firmware/controllers/modules/modules.mk
+++ b/firmware/controllers/modules/modules.mk
@@ -15,4 +15,5 @@ include $(PROJECT_DIR)/controllers/modules/ethernet_console/ethernet_console.mk
 include $(PROJECT_DIR)/controllers/modules/example_module/example_module.mk
 include $(PROJECT_DIR)/controllers/modules/vvl_controller/vvl_controller.mk
 include $(PROJECT_DIR)/controllers/modules/check_engine_light/check_engine_light.mk
+include $(PROJECT_DIR)/controllers/modules/sd_log_trigger/sd_log_trigger.mk
 include $(PROJECT_DIR)/controllers/modules/configuration_wizard/configuration_wizard.mk

--- a/firmware/controllers/modules/sd_log_trigger/sd_log_trigger.cpp
+++ b/firmware/controllers/modules/sd_log_trigger/sd_log_trigger.cpp
@@ -10,6 +10,18 @@
 // button debounce window
 #define SD_LOG_BUTTON_DEBOUNCE_MS 100
 
+void SdLogTrigger::onConfigurationChange(engine_configuration_s const* /*previousConfig*/) {
+	// Register the toggle button so its pin is configured through efiSetPadMode by
+	// ButtonDebounce::startConfigurationList(), which reports a pin conflict
+	// (criticalError "Pin X required by ... but is used by Y") if the pin is
+	// already used by another feature - same protection as the start/stop button.
+	if (!m_buttonInited) {
+		m_button.init(SD_LOG_BUTTON_DEBOUNCE_MS, engineConfiguration->sdLogTriggerPin,
+			engineConfiguration->sdLogTriggerPinMode);
+		m_buttonInited = true;
+	}
+}
+
 void SdLogTrigger::onSlowCallback() {
 	// Conditional logging disabled -> always log (current/default behavior)
 	if (!engineConfiguration->sdCardConditionalLogging) {
@@ -19,13 +31,7 @@ void SdLogTrigger::onSlowCallback() {
 	}
 
 	// A configured toggle button takes precedence over the sensor conditions
-	if (isBrainPinValid(engineConfiguration->sdLogTriggerPin)) {
-		if (!m_buttonInited) {
-			m_button.init(SD_LOG_BUTTON_DEBOUNCE_MS, engineConfiguration->sdLogTriggerPin,
-				engineConfiguration->sdLogTriggerPinMode);
-			m_buttonInited = true;
-		}
-
+	if (m_buttonInited && isBrainPinValid(engineConfiguration->sdLogTriggerPin)) {
 		bool level = m_button.readPinEvent();
 		// toggle on the rising edge (press): on->off->on...
 		if (level && !m_lastButtonLevel) {

--- a/firmware/controllers/modules/sd_log_trigger/sd_log_trigger.cpp
+++ b/firmware/controllers/modules/sd_log_trigger/sd_log_trigger.cpp
@@ -1,0 +1,74 @@
+/*
+ * @file sd_log_trigger.cpp
+ *
+ * See sd_log_trigger.h and test_sd_log_trigger.cpp
+ */
+
+#include "pch.h"
+#include "sd_log_trigger.h"
+
+// button debounce window
+#define SD_LOG_BUTTON_DEBOUNCE_MS 100
+
+void SdLogTrigger::onSlowCallback() {
+	// Conditional logging disabled -> always log (current/default behavior)
+	if (!engineConfiguration->sdCardConditionalLogging) {
+		m_logging = true;
+		m_state = SD_LOG_UNCONDITIONAL;
+		return;
+	}
+
+	// A configured toggle button takes precedence over the sensor conditions
+	if (isBrainPinValid(engineConfiguration->sdLogTriggerPin)) {
+		if (!m_buttonInited) {
+			m_button.init(SD_LOG_BUTTON_DEBOUNCE_MS, engineConfiguration->sdLogTriggerPin,
+				engineConfiguration->sdLogTriggerPinMode);
+			m_buttonInited = true;
+		}
+
+		bool level = m_button.readPinEvent();
+		// toggle on the rising edge (press): on->off->on...
+		if (level && !m_lastButtonLevel) {
+			m_logging = !m_logging;
+		}
+		m_lastButtonLevel = level;
+
+		m_state = m_logging ? SD_LOG_ACTIVE : SD_LOG_BUTTON_OFF;
+		return;
+	}
+
+	// Sensor based trigger with RPM hysteresis
+	float rpm = Sensor::getOrZero(SensorType::Rpm);
+
+	uint16_t startRpm = engineConfiguration->sdLogStartRpm;
+	uint16_t stopRpm = engineConfiguration->sdLogStopRpm;
+	// guard against an invalid (non-hysteresis) config: fall back to a single threshold
+	if (stopRpm >= startRpm) {
+		stopRpm = startRpm;
+	}
+
+	// Secondary conditions gate the START only (0 = ignore that condition)
+	bool secondaryOk =
+		(engineConfiguration->sdLogMinTps == 0 || Sensor::getOrZero(SensorType::Tps1)         >= engineConfiguration->sdLogMinTps) &&
+		(engineConfiguration->sdLogMinMap == 0 || Sensor::getOrZero(SensorType::Map)          >= engineConfiguration->sdLogMinMap) &&
+		(engineConfiguration->sdLogMinVss == 0 || Sensor::getOrZero(SensorType::VehicleSpeed) >= engineConfiguration->sdLogMinVss);
+
+	// Start once RPM crosses the start threshold (and secondary conditions are met)
+	if (rpm >= startRpm && secondaryOk) {
+		m_logging = true;
+	}
+
+	// The stop delay starts counting once RPM drops below the stop threshold
+	if (rpm >= stopRpm) {
+		m_stopTimer.reset();
+	} else if (m_stopTimer.hasElapsedSec(engineConfiguration->sdLogStopDelay)) {
+		m_logging = false;
+	}
+
+	// Reason for the indicator
+	if (m_logging) {
+		m_state = (rpm < stopRpm) ? SD_LOG_STOP_DELAY : SD_LOG_ACTIVE;
+	} else {
+		m_state = (rpm >= startRpm && !secondaryOk) ? SD_LOG_WAIT_COND : SD_LOG_WAIT_RPM;
+	}
+}

--- a/firmware/controllers/modules/sd_log_trigger/sd_log_trigger.cpp
+++ b/firmware/controllers/modules/sd_log_trigger/sd_log_trigger.cpp
@@ -23,9 +23,11 @@ void SdLogTrigger::onConfigurationChange(engine_configuration_s const* /*previou
 }
 
 void SdLogTrigger::onSlowCallback() {
-	// Conditional logging disabled -> always log (current/default behavior)
+	// Conditional logging disabled -> always log (current/default behavior).
+	// Reset the conditional latch so that switching into conditional mode (or the
+	// boot-time default->tune transition) starts fresh instead of inheriting "on".
 	if (!engineConfiguration->sdCardConditionalLogging) {
-		m_logging = true;
+		m_logging = false;
 		m_state = SD_LOG_UNCONDITIONAL;
 		return;
 	}

--- a/firmware/controllers/modules/sd_log_trigger/sd_log_trigger.h
+++ b/firmware/controllers/modules/sd_log_trigger/sd_log_trigger.h
@@ -15,6 +15,8 @@
 class SdLogTrigger : public EngineModule {
 public:
 	void onSlowCallback() override;
+	// registers the toggle button pin so it takes part in pin-conflict detection
+	void onConfigurationChange(engine_configuration_s const* previousConfig) override;
 
 	// Should the SD logger be writing right now?
 	bool shouldLog() const {

--- a/firmware/controllers/modules/sd_log_trigger/sd_log_trigger.h
+++ b/firmware/controllers/modules/sd_log_trigger/sd_log_trigger.h
@@ -1,0 +1,40 @@
+/*
+ * @file sd_log_trigger.h
+ *
+ * Conditional SD logging (phase 1): start/stop SD card logging based on trigger
+ * conditions (RPM with hysteresis + optional TPS/MAP/VSS, or a toggle button),
+ * so we avoid huge idle/cruise logs and capture only the interesting events.
+ *
+ * See also test_sd_log_trigger.cpp
+ */
+
+#pragma once
+
+#include "debounce.h"
+
+class SdLogTrigger : public EngineModule {
+public:
+	void onSlowCallback() override;
+
+	// Should the SD logger be writing right now?
+	bool shouldLog() const {
+		return m_logging;
+	}
+
+	// Why it is or is not logging - drives the "SD: Logging state" indicator
+	sd_log_state_e getState() const {
+		return m_state;
+	}
+
+private:
+	bool m_logging = false;
+	sd_log_state_e m_state = SD_LOG_DISABLED;
+
+	// counts time since RPM dropped below the stop threshold
+	Timer m_stopTimer;
+
+	// toggle button (press to start, press again to stop)
+	ButtonDebounce m_button{"sd_log"};
+	bool m_buttonInited = false;
+	bool m_lastButtonLevel = false;
+};

--- a/firmware/controllers/modules/sd_log_trigger/sd_log_trigger.h
+++ b/firmware/controllers/modules/sd_log_trigger/sd_log_trigger.h
@@ -20,7 +20,7 @@ public:
 
 	// Should the SD logger be writing right now?
 	bool shouldLog() const {
-		return m_logging;
+		return m_state == SD_LOG_UNCONDITIONAL || m_state == SD_LOG_ACTIVE || m_state == SD_LOG_STOP_DELAY;
 	}
 
 	// Why it is or is not logging - drives the "SD: Logging state" indicator

--- a/firmware/controllers/modules/sd_log_trigger/sd_log_trigger.mk
+++ b/firmware/controllers/modules/sd_log_trigger/sd_log_trigger.mk
@@ -1,0 +1,4 @@
+MODULES_INC += $(PROJECT_DIR)/controllers/modules/sd_log_trigger
+MODULES_CPPSRC += $(PROJECT_DIR)/controllers/modules/sd_log_trigger/sd_log_trigger.cpp
+MODULES_INCLUDE += \#include "sd_log_trigger.h"\n
+MODULES_LIST += SdLogTrigger,

--- a/firmware/hw_layer/mmc_card.cpp
+++ b/firmware/hw_layer/mmc_card.cpp
@@ -19,6 +19,7 @@
 #include "file_writer.h"
 #include "status_loop.h"
 #include "binary_mlg_logging.h"
+#include "sd_log_trigger.h"
 
 // Divide logs into 32Mb chunks.
 // With this opstion defined SW will pre-allocate file with given size and
@@ -916,8 +917,27 @@ static int sdModeExecuter(SD_MODE mode)
 
 		if ((sdLoggedSuppressed) || (sdLoggerFailed)) {
 			// logger is dead or paused, do not waste CPU
+			engine->outputChannels.sdLoggingState = (uint8_t)(sdLoggerFailed ? SD_LOG_FAILED : SD_LOG_SUPPRESSED);
+			engine->outputChannels.sd_logging_internal = false;
 			chThdSleepMilliseconds(100);
 			return 0;
+		}
+
+		// Conditional logging: only write while the trigger conditions are met (phase 1)
+		{
+			auto trigger = engine->module<SdLogTrigger>();
+			engine->outputChannels.sdLoggingState = (uint8_t)trigger->getState();
+			if (!trigger->shouldLog()) {
+				engine->outputChannels.sd_logging_internal = false;
+				// close the current file so each logging session is its own file
+				if (sdLoggerInitDone) {
+					sdLoggerStop();
+					sdLoggerInitDone = false;
+				}
+				chThdSleepMilliseconds(100);
+				return 0;
+			}
+			engine->outputChannels.sd_logging_internal = true;
 		}
 
 		// execute one of logger

--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -1212,6 +1212,15 @@ bit sdTriggerLog,"Trigger","Full MLG";'Trigger' mode will write a high speed log
 bit stepper_dc_use_two_wires,"yes","no"
 bit watchOutForLinearTime,"yes","no"
 bit sdTriggerLogCsv,"CSV","Binary"
+bit sdCardConditionalLogging,"enabled","disabled";Only write the SD log while trigger conditions are met (start/stop). Off = always log, the current behavior.
+uint16_t sdLogStartRpm;Start logging at/above this RPM;"rpm", 1, 0, 0, 30000, 0
+uint16_t sdLogStopRpm;Stop logging below this RPM. Set below 'start' for hysteresis;"rpm", 1, 0, 0, 30000, 0
+uint8_t sdLogStopDelay;Keep logging this many seconds after RPM drops below the stop threshold;"sec", 1, 0, 0, 255, 0
+uint8_t sdLogMinTps;Also require TPS at/above this to start logging (0 = ignore);"%", 1, 0, 0, 100, 0
+uint16_t sdLogMinMap;Also require MAP at/above this to start logging (0 = ignore);"kPa", 1, 0, 0, 1000, 0
+uint8_t sdLogMinVss;Also require vehicle speed at/above this to start logging (0 = ignore);"kph", 1, 0, 0, 255, 0
+switch_input_pin_e sdLogTriggerPin;Optional toggle button to start/stop logging (press on, press off)
+pin_input_mode_e sdLogTriggerPinMode;
 
 	uint32_t engineChartSize;;"count", 1, 0, 0, 300, 0
 

--- a/firmware/tunerstudio/tunerstudio.template.ini
+++ b/firmware/tunerstudio/tunerstudio.template.ini
@@ -4012,6 +4012,20 @@ include_file @@SECONDARY_PANELS_FILE@@
 		field = "MLG logger rate",						sdCardLogFrequency, { isSdCardEnabled && !sdTriggerLog }
 		field = "Trigger logger foramt",				sdTriggerLogCsv, { isSdCardEnabled && sdTriggerLog }
 
+	dialog = sdConditionalLogging, "SD Conditional Logging"
+		field = "#Only log while conditions are met, e.g. for dyno pulls / launches"
+		field = "Conditional logging",					sdCardConditionalLogging, { isSdCardEnabled }
+		field = "Start RPM",							sdLogStartRpm, { isSdCardEnabled && sdCardConditionalLogging }
+		field = "Stop RPM (hysteresis, < start)",		sdLogStopRpm, { isSdCardEnabled && sdCardConditionalLogging }
+		field = "Stop delay",							sdLogStopDelay, { isSdCardEnabled && sdCardConditionalLogging }
+		field = "Also require TPS above (0 = ignore)",	sdLogMinTps, { isSdCardEnabled && sdCardConditionalLogging }
+		field = "Also require MAP above (0 = ignore)",	sdLogMinMap, { isSdCardEnabled && sdCardConditionalLogging }
+		field = "Also require speed above (0 = ignore)",	sdLogMinVss, { isSdCardEnabled && sdCardConditionalLogging }
+		field = "Toggle button pin (overrides RPM)",	sdLogTriggerPin, { isSdCardEnabled && sdCardConditionalLogging }
+		field = "Toggle button mode",					sdLogTriggerPinMode, { isSdCardEnabled && sdCardConditionalLogging && sdLogTriggerPin != 0 }
+		field = "#State codes: 3=uncond 4=active 5=stop delay 6=wait RPM 7=wait cond 8=button off"
+		readout = sdLoggingState, "Logging state", "", 0, 8, 0, 0, 1, 1, 0, 0
+
 	dialog = sdCardCommands, "SD commands"
 		commandButton = "Mount to PC",					cmd_mount_pc
 		commandButton = "Mount to ECU",					cmd_mount_ecu
@@ -4040,6 +4054,7 @@ include_file @@SECONDARY_PANELS_FILE@@
 		panel = sdPresentIndicators
 		panel = sdCardActivityIndicators
 		panel = sdCardLogging
+		panel = sdConditionalLogging
 		panel = sdCardStateIndicators
 		panel = sdCardErrorPanel
 		panel = sdCardCommands

--- a/unit_tests/tests/test_sd_log_trigger.cpp
+++ b/unit_tests/tests/test_sd_log_trigger.cpp
@@ -1,0 +1,88 @@
+/*
+ * @file test_sd_log_trigger.cpp
+ *
+ * Conditional SD logging trigger (phase 1) state machine tests.
+ */
+
+#include "pch.h"
+#include "sd_log_trigger.h"
+
+TEST(sdLog, unconditionalWhenDisabled) {
+	EngineTestHelper eth(engine_type_e::TEST_ENGINE);
+	engineConfiguration->sdCardConditionalLogging = false;
+
+	auto m = engine->module<SdLogTrigger>();
+	m->onSlowCallback();
+
+	EXPECT_TRUE(m->shouldLog());
+	EXPECT_EQ(SD_LOG_UNCONDITIONAL, m->getState());
+}
+
+TEST(sdLog, rpmHysteresisAndStopDelay) {
+	EngineTestHelper eth(engine_type_e::TEST_ENGINE);
+	engineConfiguration->sdCardConditionalLogging = true;
+	engineConfiguration->sdLogStartRpm = 4000;
+	engineConfiguration->sdLogStopRpm = 3000;
+	engineConfiguration->sdLogStopDelay = 2;
+
+	auto m = engine->module<SdLogTrigger>();
+
+	// below start -> not logging
+	Sensor::setMockValue(SensorType::Rpm, 1000);
+	m->onSlowCallback();
+	EXPECT_FALSE(m->shouldLog());
+	EXPECT_EQ(SD_LOG_WAIT_RPM, m->getState());
+
+	// at/above start -> logging
+	Sensor::setMockValue(SensorType::Rpm, 5000);
+	m->onSlowCallback();
+	EXPECT_TRUE(m->shouldLog());
+	EXPECT_EQ(SD_LOG_ACTIVE, m->getState());
+
+	// dead zone (stop <= rpm < start) -> keep logging (hysteresis)
+	Sensor::setMockValue(SensorType::Rpm, 3500);
+	m->onSlowCallback();
+	EXPECT_TRUE(m->shouldLog());
+	EXPECT_EQ(SD_LOG_ACTIVE, m->getState());
+
+	// below stop but within the delay -> still logging
+	Sensor::setMockValue(SensorType::Rpm, 1000);
+	m->onSlowCallback();
+	EXPECT_TRUE(m->shouldLog());
+	EXPECT_EQ(SD_LOG_STOP_DELAY, m->getState());
+
+	// still below stop after the delay -> stop logging
+	eth.moveTimeForwardSec(3);
+	m->onSlowCallback();
+	EXPECT_FALSE(m->shouldLog());
+	EXPECT_EQ(SD_LOG_WAIT_RPM, m->getState());
+}
+
+TEST(sdLog, secondaryConditionGatesEntry) {
+	EngineTestHelper eth(engine_type_e::TEST_ENGINE);
+	engineConfiguration->sdCardConditionalLogging = true;
+	engineConfiguration->sdLogStartRpm = 4000;
+	engineConfiguration->sdLogStopRpm = 3000;
+	engineConfiguration->sdLogMinTps = 50;
+
+	auto m = engine->module<SdLogTrigger>();
+
+	// RPM ok but TPS below the minimum -> does not start
+	Sensor::setMockValue(SensorType::Rpm, 5000);
+	Sensor::setMockValue(SensorType::Tps1, 10);
+	m->onSlowCallback();
+	EXPECT_FALSE(m->shouldLog());
+	EXPECT_EQ(SD_LOG_WAIT_COND, m->getState());
+
+	// TPS now above the minimum -> starts
+	Sensor::setMockValue(SensorType::Tps1, 80);
+	m->onSlowCallback();
+	EXPECT_TRUE(m->shouldLog());
+	EXPECT_EQ(SD_LOG_ACTIVE, m->getState());
+
+	// secondary conditions gate ENTRY only: TPS dropping does not stop logging while RPM stays up
+	Sensor::setMockValue(SensorType::Tps1, 0);
+	m->onSlowCallback();
+	EXPECT_TRUE(m->shouldLog());
+	EXPECT_EQ(SD_LOG_ACTIVE, m->getState());
+}

--- a/unit_tests/tests/tests.mk
+++ b/unit_tests/tests/tests.mk
@@ -148,6 +148,7 @@ TESTS_SRC_CPP = \
 	tests/test_cpp_memory_layout.cpp \
 	tests/test_pid.cpp \
 	tests/test_accel_enrichment.cpp \
+	tests/test_sd_log_trigger.cpp \
 	tests/test_gpiochip.cpp \
 	tests/test_deadband.cpp \
 	tests/test_sticky_pps.cpp \


### PR DESCRIPTION
## Summary

Adds **conditional SD card logging triggers** (phase 1) so a card captures the interesting events — dyno pulls, launches, intermittent issues — instead of hours of idle/cruise. Today rusEFI logs to SD continuously whenever in ECU logging mode; this lets the log start/stop on configurable conditions.

Default **off**, so existing tunes keep logging unconditionally exactly as before.

## Behavior

A new `SdLogTrigger` module (`controllers/modules/sd_log_trigger`), evaluated in `onSlowCallback`, decides whether to log:

- **RPM start/stop with hysteresis** — start at/above `sdLogStartRpm`; once started, keep logging until RPM stays **below** `sdLogStopRpm` for `sdLogStopDelay` seconds. The dead zone between stop and start holds the current state.
- **Optional secondary conditions** (`sdLogMinTps` / `sdLogMinMap` / `sdLogMinVss`) that gate the **start only** — each ignored when set to `0`. Once logging, only RPM stops it (so a pull that briefly lifts throttle keeps recording).
- **Optional toggle button** (`sdLogTriggerPin`, press on / press off) via `ButtonDebounce`, which takes precedence over the sensor conditions when configured. Its pin is registered in `onConfigurationChange`, so an already-used pin reports the standard pin conflict (`criticalError`), same as the start/stop button.

`mmc_card.cpp` gates the `SD_MODE_ECU` logger on the module: while not logging it closes the current file (so **each session is its own file**) and idles.

## Observability

A new `sdLoggingState` output channel reports **why** logging is or isn't active — `disabled / suppressed / failed / unconditional / active / stop-delay / wait-rpm / wait-cond / button-off` — alongside the existing `sd_logging_internal` bit, and is shown as a readout in the new "SD Conditional Logging" dialog.

## Tests

`test_sd_log_trigger.cpp` covers the state machine: unconditional, RPM hysteresis + stop delay, and entry-gating (secondary condition blocks start but does not stop an active log).

## Validation

- Unit Tests CI: **green** (build + all three `sdLog.*` tests pass).
- Firmware compile/link confirmed on a real STM32 board: module symbols + vtable present in the ELF, `rusefi.bin` produced.



🤖 Generated with [Claude Code](https://claude.com/claude-code)
