### PR TITLE
boards: super-uaefi: fix A16 pin

### DIFF
--- a/firmware/config/boards/hellen/super-uaefi/connectors/60pin.yaml
+++ b/firmware/config/boards/hellen/super-uaefi/connectors/60pin.yaml
@@ -102,10 +102,11 @@ pins:
     color: blue
 
   - pin: 16A
-    meta: MM100_MEGA_UAEFI_IN_AUX3
-    class: switch_inputs
+    id: [MM100_IN_AUX3, MM100_IN_AUX3_ANALOG]
+    class: [switch_inputs, analog_inputs]
     ts_name: ___ Digital input signal
     function: Digital input signal
+    type: av
 
   - pin: 17A
     id: [MM100_IN_D2, MM100_IN_D2]

--- a/firmware/config/boards/hellen/super-uaefi/connectors/60pin.yaml
+++ b/firmware/config/boards/hellen/super-uaefi/connectors/60pin.yaml
@@ -104,8 +104,8 @@ pins:
   - pin: 16A
     id: [MM100_IN_AUX3, MM100_IN_AUX3_ANALOG]
     class: [switch_inputs, analog_inputs]
-    ts_name: ___ Digital input signal
-    function: Digital input signal
+    ts_name: ___ AIN 2 / Digital input (no pull)
+    function: Analog / Digital input
     type: av
 
   - pin: 17A


### PR DESCRIPTION
MM100_IN_AUX3 != MM100_MEGA_UAEFI_IN_AUX3
Also add analog function

Fixes conflict of CAN TX pin and IN_DIN A16.
2026-06-16_17_24_22_454: EngineState: pin PD1 **(16A Digital input signal)**: CAN TX Mode AF9 Push-Pull No pull Speed Low IN 1 OUT 0

only: super-uaefi