### PR TITLE
sd: default migration for conditional logging thresholds (closes #9650)

### DIFF
--- a/firmware/controllers/algo/defaults/default_base_engine.cpp
+++ b/firmware/controllers/algo/defaults/default_base_engine.cpp
@@ -182,6 +182,15 @@ void defaultsOrFixOnBurn() {
 	if (engineConfiguration->vvtControlMinRpm < engineConfiguration->cranking.rpm) {
 		engineConfiguration->vvtControlMinRpm = engineConfiguration->cranking.rpm;
 	}
+
+	// Conditional SD logging: seed sensible start/stop/delay for tunes that predate the
+	// feature (a zero start RPM means it was never configured), so enabling conditional
+	// logging does not start from a degenerate "always on, never off" state.
+	if (engineConfiguration->sdLogStartRpm == 0) {
+		engineConfiguration->sdLogStartRpm = 800;
+		engineConfiguration->sdLogStopRpm = 700;
+		engineConfiguration->sdLogStopDelay = 30;
+	}
 }
 
 void setDefaultBaseEngine() {

--- a/firmware/controllers/algo/engine_configuration.cpp
+++ b/firmware/controllers/algo/engine_configuration.cpp
@@ -248,11 +248,12 @@ void setDefaultBasePins() {
 void setDefaultSdCardParameters() {
 	engineConfiguration->isSdCardEnabled = true;
 
-	// Conditional logging defaults to off -> SD logs unconditionally (current behavior)
+	// Conditional logging defaults to off -> SD logs unconditionally (current behavior).
+	// The thresholds below are only used once the user enables conditional logging.
 	engineConfiguration->sdCardConditionalLogging = false;
-	engineConfiguration->sdLogStartRpm = 0;
-	engineConfiguration->sdLogStopRpm = 0;
-	engineConfiguration->sdLogStopDelay = 5;
+	engineConfiguration->sdLogStartRpm = 800;
+	engineConfiguration->sdLogStopRpm = 700;
+	engineConfiguration->sdLogStopDelay = 30;
 	engineConfiguration->sdLogMinTps = 0;
 	engineConfiguration->sdLogMinMap = 0;
 	engineConfiguration->sdLogMinVss = 0;


### PR DESCRIPTION
## Summary

Follow-up to #9646, addresses #9650 (Conditional SD default migration).

The conditional SD logging RPM thresholds defaulted to `0/0`, which is a degenerate "always start, never stop" state, and older tunes that predate the feature carried `0` for the new parameters. Per the [calibration-compatibility guidance](docs/calibration-compatibility.md), this seeds sensible values:

- **`setDefaultSdCardParameters()`** — start **800** rpm / stop **700** rpm, **30 s** stop delay.
- **`defaultsOrFixOnBurn()`** — seed the same on tunes that predate the feature (detected via a zero start RPM), so enabling conditional logging on an updated tune behaves sensibly instead of starting from `0/0`.

Conditional logging still **defaults off** (`sdCardConditionalLogging = false`), so existing tunes keep logging unconditionally exactly as before — only the thresholds used once a user enables the feature are affected.

Closes #9650

🤖 Generated with [Claude Code](https://claude.com/claude-code)
