### PR TITLE
fuel: fix STFT correction channel scaling (read 99% at neutral)

### DIFF
--- a/firmware/controllers/algo/engine_state.txt
+++ b/firmware/controllers/algo/engine_state.txt
@@ -85,7 +85,7 @@ struct_no_prefix engine_state_s
 	float dwellActualRatio;"Ignition: Dwell deviation";"%", 100, -1.0, 80, 120, 1
 
 	! todo: extract to injection.txt?
-	float[FT_BANK_COUNT iterate] stftCorrection;STFT: Bank; "%", 100, -1.0, 50, 150, 1
+	float[FT_BANK_COUNT iterate] stftCorrection;STFT: Bank; "%", 100, -100, -50, 50, 1
 
 ! engine_state_s
 end_struct


### PR DESCRIPTION
## Problem

The `stftCorrection` output channel stores a fuel multiplier where `1.0` = no correction. Its TunerStudio scaling is declared in `engine_state.txt` as:

    float[FT_BANK_COUNT iterate] stftCorrection;STFT: Bank; "%", 100, -1.0, 50, 150, 1

TunerStudio applies `display = raw*scale + offset`, so at the neutral multiplier (`1.0`) the channel reads `1.0*100 + (-1.0) = 99`. That is why the STFT gauge sits at "99%" even when STFT is disabled / applying no correction.

## Fix

The intent is to display percent deviation from neutral — `(raw-1.0)*100` — so `1.0` maps to `0%`, `1.05` to `+5%`, etc. In the `raw*scale + offset` form that requires `offset = -100`, not `-1.0`: `1.0*100 + (-100) = 0`. The channel min/max is also changed from `50,150` to `-50,50` to match the deviation semantics and the existing `-30..30` gauge range in `secondary_panels.ini`.

## Good side effect

`egoCorrectionForVeAnalyze = { 100 + stftCorrection1 }`, used by VE Analyze and WUE Analyze, read `199` at neutral and now reads the correct `100`, removing a large bias from VE autotune.

## Scope / not affected

- Internal C++ value is unchanged (still a `1.0`-neutral multiplier).
- CAN verbose (`100*(x-1)`) and OBD2 (`128*x`) already used the raw multiplier correctly — unaffected.
- The SD-card binary log is unaffected: `stftCorrection` is a plain float logged with scale=1, so it already records the raw multiplier, not the display value. This PR only changes the TunerStudio display scaling.

