### PR TITLE
cranking & priming: flex-fuel 2D coolant x ethanol tables (single flexCranking toggle)

### DIFF
--- a/docs/AI/fueling_system.md
+++ b/docs/AI/fueling_system.md
@@ -36,7 +36,7 @@ crankingFuel = baseCrankingFuel * coolantTemperatureCoefficient * tpsCoefficient
   1. **`flexCranking` off (or no flex sensor)** — a single coolant curve, `crankingFuelCoef`.
   2. **`flexCranking` on, flex sensor present** — `crankingFuelFlexTable`, a coolant (X, shared `crankingFuelBins`) by ethanol-% (Y, `crankingFuelFlexBins`, 4 rows to keep RAM small) `interpolate3d` lookup. The dedicated ethanol axis lets the whole E0..E100 range be calibrated directly.
 
-The legacy 1D `crankingFuelCoefE100` curve (and its E0→E100 blend) is gone from the firmware path; the field is retained for tune compatibility but is no longer used or shown in TunerStudio.
+The legacy 1D `crankingFuelCoefE100` curve (and its E0→E100 blend) is gone from the firmware path. The field is **retired** (renamed with the `unused` prefix so its byte slot stays reserved and the migration framework ignores it); old tunes that calibrated it are carried over to `crankingFuelFlexTable` by `CrankingFlexTableMigrator` (see below).
 
 ## Priming Pulse
 
@@ -48,7 +48,13 @@ The priming pulse (`PrimeController::getPrimeDuration()`) mirrors the cranking d
 
 Be careful: in running-math mode the `baseCrankingFuel` already reflects the **flex-adjusted stoichiometric ratio** (ethanol shifts stoich from ~14.7 toward ~9.0). The cranking flex multiplier therefore acts as **additional** cold-start enrichment on top of that, not as the full ethanol fuel correction — calibrate it accordingly to avoid double-counting ethanol.
 
-The 2D table fields are appended config so existing tunes remain valid; `defaultsOrFixOnBurn()` seeds each 2D table from the existing 1D curve for tunes that predate it. See `docs/calibration-compatibility.md`.
+### Legacy tune migration
+
+The 2D table fields are appended config so existing tunes stay valid. Two mechanisms keep old tunes working:
+- `defaultsOrFixOnBurn()` seeds each 2D table from its corresponding 1D curve (E0 / `primeValues`) for any tune whose ethanol axis is still all-zero, so turning flex on is neutral until calibrated.
+- `CrankingFlexTableMigrator` (`java_console`, part of the `ComposedTuneMigrator` pipeline) reconstructs `crankingFuelFlexTable` from a user's old `crankingFuelCoef` (E0) and retired `crankingFuelCoefE100` (E100) curves, reproducing the legacy 85%-anchored blend at each ethanol node — so people who had tuned the old flex cranking curves keep their behaviour.
+
+See `docs/calibration-compatibility.md` and `TuneMigrator.java`.
 
 ## Key Files
 - `firmware/controllers/algo/fuel_math.cpp`: Core mass calculations.

--- a/docs/AI/fueling_system.md
+++ b/docs/AI/fueling_system.md
@@ -22,6 +22,34 @@ The rusEFI fueling system is a mass-based model that translates configuration an
 16. **Output Logic**: Pulse width is clamped and synchronized with the engine phase.
 17. **Hardware Driver**: MOSFETs/GDI drivers fire the physical injectors.
 
+## Cranking Fuel
+
+While the engine is below `cranking.rpm` the pipeline above is bypassed and `getCrankingFuel3()` (in `fuel_math.cpp`) computes the per-cylinder injected mass as:
+
+```
+crankingFuel = baseCrankingFuel * coolantTemperatureCoefficient * tpsCoefficient
+```
+
+- **`baseCrankingFuel`** comes either from the 3D `crankingCycleBaseFuel` table (coolant x engine-revolutions, `useRunningMathForCranking = false`) or directly from the running math (`useRunningMathForCranking = true`).
+- **`tpsCoefficient`** is the `crankingTpsCoef` curve (flood-clear / throttle compensation).
+- **`coolantTemperatureCoefficient`** is the coolant enrichment, resolved in one of two ways, selected by a single `flexCranking` toggle:
+  1. **`flexCranking` off (or no flex sensor)** — a single coolant curve, `crankingFuelCoef`.
+  2. **`flexCranking` on, flex sensor present** — `crankingFuelFlexTable`, a coolant (X, shared `crankingFuelBins`) by ethanol-% (Y, `crankingFuelFlexBins`, 4 rows to keep RAM small) `interpolate3d` lookup. The dedicated ethanol axis lets the whole E0..E100 range be calibrated directly.
+
+The legacy 1D `crankingFuelCoefE100` curve (and its E0→E100 blend) is gone from the firmware path; the field is retained for tune compatibility but is no longer used or shown in TunerStudio.
+
+## Priming Pulse
+
+The priming pulse (`PrimeController::getPrimeDuration()`) mirrors the cranking design and is driven by the **same** `flexCranking` toggle:
+- **off / no flex sensor** — 1D `primeValues` curve vs coolant (`primeBins`).
+- **on, flex sensor present** — `primeFlexTable`, a coolant by ethanol-% `interpolate3d` lookup (shares `primeBins` for the coolant axis; 4-row ethanol axis `primeFlexBins`).
+
+### Flex-fuel interaction with `useRunningMathForCranking`
+
+Be careful: in running-math mode the `baseCrankingFuel` already reflects the **flex-adjusted stoichiometric ratio** (ethanol shifts stoich from ~14.7 toward ~9.0). The cranking flex multiplier therefore acts as **additional** cold-start enrichment on top of that, not as the full ethanol fuel correction — calibrate it accordingly to avoid double-counting ethanol.
+
+The 2D table fields are appended config so existing tunes remain valid; `defaultsOrFixOnBurn()` seeds each 2D table from the existing 1D curve for tunes that predate it. See `docs/calibration-compatibility.md`.
+
 ## Key Files
 - `firmware/controllers/algo/fuel_math.cpp`: Core mass calculations.
 - `firmware/controllers/algo/wall_fuel.cpp`: Transient fueling logic.

--- a/firmware/controllers/algo/defaults/default_base_engine.cpp
+++ b/firmware/controllers/algo/defaults/default_base_engine.cpp
@@ -139,6 +139,49 @@ void defaultsOrFixOnBurn() {
     engineConfiguration->mainRelayDisableTime = 1;
   }
 
+  // Seed the 2D cranking flex table for tunes that predate it (all-zero ethanol axis). Mirror the existing
+  // E0 coolant curve at every ethanol level so turning on flexCranking stays neutral with respect to ethanol
+  // until the user calibrates it.
+  {
+    bool flexBinsEmpty = true;
+    for (size_t i = 0; i < efi::size(config->crankingFuelFlexBins); i++) {
+      if (config->crankingFuelFlexBins[i] != 0) {
+        flexBinsEmpty = false;
+        break;
+      }
+    }
+    if (flexBinsEmpty) {
+      static const uint8_t crankingFlexEthanolBins[] = { 0, 35, 65, 100 };
+      copyArray(config->crankingFuelFlexBins, crankingFlexEthanolBins);
+      for (size_t ethanolIdx = 0; ethanolIdx < efi::size(config->crankingFuelFlexTable); ethanolIdx++) {
+        for (size_t cltIdx = 0; cltIdx < CRANKING_CURVE_SIZE; cltIdx++) {
+          config->crankingFuelFlexTable[ethanolIdx][cltIdx] = config->crankingFuelCoef[cltIdx];
+        }
+      }
+    }
+  }
+
+  // Same migration for the 2D priming flex table: seed it from the existing 1D priming curve (primeValues)
+  // so turning on flexCranking does not change priming behaviour until the user calibrates the ethanol axis.
+  {
+    bool primeFlexBinsEmpty = true;
+    for (size_t i = 0; i < efi::size(engineConfiguration->primeFlexBins); i++) {
+      if (engineConfiguration->primeFlexBins[i] != 0) {
+        primeFlexBinsEmpty = false;
+        break;
+      }
+    }
+    if (primeFlexBinsEmpty) {
+      static const uint8_t primeFlexEthanolBins[] = { 0, 35, 65, 100 };
+      copyArray(engineConfiguration->primeFlexBins, primeFlexEthanolBins);
+      for (size_t ethanolIdx = 0; ethanolIdx < efi::size(engineConfiguration->primeFlexTable); ethanolIdx++) {
+        for (size_t cltIdx = 0; cltIdx < PRIME_CURVE_COUNT; cltIdx++) {
+          engineConfiguration->primeFlexTable[ethanolIdx][cltIdx] = engineConfiguration->primeValues[cltIdx];
+        }
+      }
+    }
+  }
+
 #if HW_PROTEUS && defined(STM32F4XX)
   // should have been proteus per-board validation
   engineConfiguration->is_enabled_spi_5 = false;

--- a/firmware/controllers/algo/defaults/default_cranking.cpp
+++ b/firmware/controllers/algo/defaults/default_cranking.cpp
@@ -62,6 +62,17 @@ void setDefaultCranking() {
 		90
 	};
 	copyArray(config->crankingFuelBins, crankingBins);
+
+	// Opt-in 2D cranking flex table: seed every ethanol row with the same coolant curve so it starts
+	// neutral with respect to ethanol (identical to the non-flex behaviour) until the user calibrates it.
+	static const uint8_t crankingFlexEthanolBins[] = { 0, 35, 65, 100 };
+	copyArray(config->crankingFuelFlexBins, crankingFlexEthanolBins);
+
+	for (size_t ethanolIdx = 0; ethanolIdx < efi::size(config->crankingFuelFlexTable); ethanolIdx++) {
+		for (size_t cltIdx = 0; cltIdx < CRANKING_CURVE_SIZE; cltIdx++) {
+			config->crankingFuelFlexTable[ethanolIdx][cltIdx] = crankingCoef[cltIdx];
+		}
+	}
 #endif
 	// Cranking cycle compensation
 

--- a/firmware/controllers/algo/defaults/default_cranking.cpp
+++ b/firmware/controllers/algo/defaults/default_cranking.cpp
@@ -47,8 +47,7 @@ void setDefaultCranking() {
 		1.0,
 		1.0
 	};
-	copyArray(config->crankingFuelCoef,     crankingCoef);
-	copyArray(config->crankingFuelCoefE100, crankingCoef);
+	copyArray(config->crankingFuelCoef, crankingCoef);
 
 	// Deg C
 	static const float crankingBins[] = {

--- a/firmware/controllers/algo/defaults/default_fuel.cpp
+++ b/firmware/controllers/algo/defaults/default_fuel.cpp
@@ -320,6 +320,17 @@ static void setDefaultPriming() {
 
 	copyArray(engineConfiguration->primeBins, primeBins);
 	copyArray(engineConfiguration->primeValues, primeValues);
+
+	// Opt-in 2D priming flex table: seed every ethanol row with the same coolant curve so it starts
+	// neutral with respect to ethanol (identical to the non-flex curve) until the user calibrates it.
+	static constexpr uint8_t primeFlexEthanolBins[] = { 0, 35, 65, 100 };
+	copyArray(engineConfiguration->primeFlexBins, primeFlexEthanolBins);
+
+	for (size_t ethanolIdx = 0; ethanolIdx < efi::size(engineConfiguration->primeFlexTable); ethanolIdx++) {
+		for (size_t cltIdx = 0; cltIdx < PRIME_CURVE_COUNT; cltIdx++) {
+			engineConfiguration->primeFlexTable[ethanolIdx][cltIdx] = primeValues[cltIdx];
+		}
+	}
 }
 
 void setDefaultFuel() {

--- a/firmware/controllers/algo/fuel_math.cpp
+++ b/firmware/controllers/algo/fuel_math.cpp
@@ -60,34 +60,39 @@ float getCrankingFuel3(float baseFuel, uint32_t revolutionCounterSinceStart) {
 	 * If the sensor is failed, use 20 deg C
 	 */
 	auto clt = Sensor::get(SensorType::Clt).value_or(20);
-	auto e0Mult = interpolate2d(clt, config->crankingFuelBins, config->crankingFuelCoef);
 
 	bool alreadyWarned = false;
-	if (e0Mult <= 0.1f) {
-		warning(ObdCode::CUSTOM_ERR_ZERO_E0_MULT, "zero e0 multiplier");
+
+	/**
+	 * Resolve the cranking coolant-temperature multiplier:
+	 *   - Flex fuel ON (flexCranking) with a present flex sensor -> 2D table over (coolant, ethanol%),
+	 *     so the whole E0..E100 range is calibrated directly (4-row ethanol axis).
+	 *   - Otherwise -> the single coolant curve crankingFuelCoef.
+	 *
+	 * Note on the base mass this multiplies: with useRunningMathForCranking the base already reflects the
+	 * flex-adjusted stoich ratio, so this multiplier is ADDITIONAL ethanol enrichment, not the full correction.
+	 */
+	float coolantMult;
+
+	if (engineConfiguration->flexCranking && Sensor::hasSensor(SensorType::FuelEthanolPercent)) {
+		// If the flex sensor has failed, default to 50% ethanol.
+		auto flex = Sensor::get(SensorType::FuelEthanolPercent).value_or(50);
+
+		coolantMult = interpolate3d(
+			config->crankingFuelFlexTable,
+			config->crankingFuelFlexBins, flex,
+			config->crankingFuelBins, clt
+		);
+	} else {
+		coolantMult = interpolate2d(clt, config->crankingFuelBins, config->crankingFuelCoef);
+	}
+
+	if (coolantMult <= 0.1f) {
+		warning(ObdCode::CUSTOM_ERR_ZERO_E0_MULT, "zero cranking coolant multiplier");
 		alreadyWarned = true;
 	}
 
-	if (engineConfiguration->flexCranking && Sensor::hasSensor(SensorType::FuelEthanolPercent)) {
-		auto e85Mult = interpolate2d(clt, config->crankingFuelBins, config->crankingFuelCoefE100);
-
-		if (e85Mult <= 0.1f) {
-			warning(ObdCode::CUSTOM_ERR_ZERO_E85_MULT, "zero e85 multiplier");
-			alreadyWarned = true;
-		}
-
-		// If failed flex sensor, default to 50% E
-		auto flex = Sensor::get(SensorType::FuelEthanolPercent).value_or(50);
-
-		engine->engineState.crankingFuel.coolantTemperatureCoefficient =
-			interpolateClamped(
-				0, e0Mult,
-				85, e85Mult,
-				flex
-			);
-	} else {
-		engine->engineState.crankingFuel.coolantTemperatureCoefficient = e0Mult;
-	}
+	engine->engineState.crankingFuel.coolantTemperatureCoefficient = coolantMult;
 
 	auto tps = Sensor::get(SensorType::DriverThrottleIntent);
 	engine->engineState.crankingFuel.tpsCoefficient =

--- a/firmware/controllers/engine_cycle/prime_injection.cpp
+++ b/firmware/controllers/engine_cycle/prime_injection.cpp
@@ -19,9 +19,22 @@ floatms_t PrimeController::getPrimeDuration() const {
 		return 0;
 	}
 
-	auto primeMass =
-		0.001f *	// convert milligram to gram
-		interpolate2d(clt.Value, engineConfiguration->primeBins, engineConfiguration->primeValues);
+	// Flex fuel ON (flexCranking) with a present flex sensor selects a 2D table over (coolant, ethanol%) -
+	// the same single toggle that switches the cranking multiplier to its 2D table. Otherwise the 1D curve.
+	float primeMassMg;
+	if (engineConfiguration->flexCranking && Sensor::hasSensor(SensorType::FuelEthanolPercent)) {
+		// If the flex sensor has failed, default to 50% ethanol.
+		auto flex = Sensor::get(SensorType::FuelEthanolPercent).value_or(50);
+		primeMassMg = interpolate3d(
+			engineConfiguration->primeFlexTable,
+			engineConfiguration->primeFlexBins, flex,
+			engineConfiguration->primeBins, clt.Value
+		);
+	} else {
+		primeMassMg = interpolate2d(clt.Value, engineConfiguration->primeBins, engineConfiguration->primeValues);
+	}
+
+	auto primeMass = 0.001f * primeMassMg;	// convert milligram to gram
 
 	efiPrintf("Priming pulse mass: %.4f g", primeMass);
 

--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -161,6 +161,9 @@ struct_no_prefix engine_configuration_s
 #define CLT_CRANKING_CURVE_SIZE 8
 #define CLT_CRANKING_TAPER_CURVE_SIZE 6
 #define CRANKING_CYCLE_CLT_SIZE 4
+! Ethanol axis size for the opt-in 2D cranking flex-fuel enrichment table (crankingFuelFlexTable).
+! Deliberately small (4 rows) to keep RAM usage low - cranking enrichment does not need fine ethanol resolution.
+#define CRANKING_FLEX_SIZE 4
 #define IDLE_ADVANCE_CURVE_SIZE 8
 #define CRANKING_ADVANCE_CURVE_SIZE 4
 #define TRAILING_SPARK_SIZE 4
@@ -584,7 +587,7 @@ bit kickStartCranking,"yes","no"
 bit useSeparateIdleTablesForCrankingTaper,"enabled","disabled";This uses separate ignition timing and VE tables not only for idle conditions, also during the postcranking-to-idle taper transition (See also afterCrankingIACtaperDuration).
 bit launchControlEnabled,"enabled","disabled"
 bit antiLagEnabled,"enabled","disabled"
-bit useRunningMathForCranking,"Fuel Map","Fixed";For cranking either use the specified fixed base fuel mass, or use the normal running math (VE table).
+bit useRunningMathForCranking,"Fuel Map","Fixed";For cranking either use the specified fixed base fuel mass, or use the normal running math (VE table). Note: in 'Fuel Map' (running math) mode the base mass already reflects the flex-adjusted stoich ratio, so the cranking flex multipliers act as ADDITIONAL enrichment on top of that - do not re-apply the full ethanol correction there.
 bit displayLogicLevelsInEngineSniffer,"yes","no";Shall we display real life signal or just the part consumed by trigger decoder.\nApplies to both trigger and cam/vvt input.
 bit useTLE8888_stepper,"yes","no"
 bit usescriptTableForCanSniffingFiltering,"yes","no"
@@ -1197,7 +1200,7 @@ custom idle_mode_e 1 bits, U08, @OFFSET@, [0:0], "Open Loop + Closed Loop", "Ope
 bit useFixedBaroCorrFromMap,"yes","no";Read MAP sensor on ECU start-up to use as baro value.
 bit useSeparateAdvanceForCranking,"Table","Fixed (auto taper)";In Constant mode, timing is automatically tapered to running as RPM increases.\nIn Table mode, the "Cranking ignition advance" table is used directly.
 bit useAdvanceCorrectionsForCranking,"yes","no";This enables the various ignition corrections during cranking (IAT, CLT and PID idle).\nYou probably don't need this.
-bit flexCranking,"enabled","disabled";Enable a second cranking table to use for E100 flex fuel, interpolating between the two based on flex fuel sensor.
+bit flexCranking,"enabled","disabled";Enable flex-fuel compensation for engine start. When on (and a flex fuel sensor is present) the cranking coolant multiplier and the priming pulse mass each come from a 2D table over coolant and ethanol % (crankingFuelFlexTable / primeFlexTable, 4-row ethanol axis) instead of their 1D coolant curves. When off, the 1D curves (crankingFuelCoef / primeValues) are used.
 bit flexFuelTransientComp,"enabled","disabled";Enable flex-fuel transient fueling compensation (acceleration enrichment and wall wetting tau/beta) based on ethanol content and coolant temperature.
 bit useIacPidMultTable,"yes","no";This flag allows to use a special 'PID Multiplier' table (0.0-1.0) to compensate for nonlinear nature of IAC-RPM controller
 bit isBoostControlEnabled,"enabled","disabled"
@@ -1478,6 +1481,8 @@ custom stepper_num_micro_steps_e 1 bits, U08,	@OFFSET@,	[0:3], @@stepper_num_mic
 	pid_s[CAMS_PER_BANK iterate] auxPid;VVT output PID\nTODO: rename to vvtPid
 	float[8 iterate] injectorCorrectionPolynomial;;"", 1, 0, -1000, 1000, 4
 #define PRIME_CURVE_COUNT 8
+! Ethanol axis size for the opt-in 2D priming-pulse flex table (primeFlexTable). 4 rows keeps RAM low.
+#define PRIME_FLEX_SIZE 4
 	int16_t[PRIME_CURVE_COUNT] autoscale primeBins;;{bitStringValue(unitsLabels, useMetricOnInterface)}, {useMetricOnInterface ? 1 : 1.8}, {useMetricOnInterface ? 0 : 17.77777}, {useMetricOnInterface ? -40 : -40}, {useMetricOnInterface ? @@CLT_UPPER_LIMIT@@ : @@CLT_UPPER_LIMIT@@ * 1.8 + 32}, 0
 
 	linear_sensor_s oilPressure;
@@ -1551,6 +1556,11 @@ float tChargeAirDecrLimit;Maximum allowed rate of decrease allowed for the estim
 	uint8_t[MAX_CYLINDER_COUNT iterate] cylinderBankSelect;Select which fuel correction bank this cylinder belongs to. Group cylinders that share the same O2 sensor;"", 1, 1, 1, 2, 0
 
 	uint8_t[PRIME_CURVE_COUNT] autoscale primeValues;;"mg", 5, 0, 0, 1250, 0
+
+	! 2D priming pulse fuel mass vs ethanol %, used when flexCranking is enabled (same single toggle as the
+	! cranking 2D table). Shares the coolant axis with primeBins; uint8 (5 mg resolution) keeps RAM tiny.
+	uint8_t[PRIME_FLEX_SIZE] primeFlexBins;Ethanol % axis (Y) for primeFlexTable.;"%", 1, 0, 0, 100, 0
+	uint8_t[PRIME_FLEX_SIZE x PRIME_CURVE_COUNT] autoscale primeFlexTable;Priming pulse fuel mass as a function of coolant (X axis, shared primeBins) and ethanol % (Y axis, primeFlexBins). Used instead of primeValues when flexCranking is enabled and a flex sensor is present.;"mg", 5, 0, 0, 1250, 0
 
 	uint8_t autoscale triggerCompCenterVolt;Trigger comparator center point voltage;"V", @@VOLTAGE_1_BYTE_PACKING_DIV@@, 0, 0, 5.1, 2
 	uint8_t autoscale triggerCompHystMin;Trigger comparator hysteresis voltage (Min);"V", @@VOLTAGE_1_BYTE_PACKING_DIV@@, 0, 0, 5.1, 2
@@ -2167,7 +2177,16 @@ uint16_t[FUEL_TRIM_SIZE] fuelTrimLoadBins;;{bitStringValue(veLoadUnitLabels, veL
 uint16_t[FUEL_TRIM_SIZE] fuelTrimRpmBins;;"rpm", 1, 0, 0, 20000, 0
 fuel_cyl_trim_s[MAX_CYLINDER_COUNT iterate] fuelTrims
 
-uint16_t[CRANKING_CURVE_SIZE] autoscale crankingFuelCoefE100;;"ratio", 0.01, 0, 0, 50, 2
+! Legacy 1D cranking coolant multiplier at E100. Retained for tune compatibility (keeps the config layout and
+! lets older tunes preserve the value), but no longer used by firmware - flex cranking now uses crankingFuelFlexTable.
+! Intentionally NOT referenced by any TunerStudio dialog/curve/menu, so it is hidden from the tuner.
+uint16_t[CRANKING_CURVE_SIZE] autoscale crankingFuelCoefE100;Legacy E100 cranking coolant multiplier - retained for compatibility, unused and hidden.;"ratio", 0.01, 0, 0, 50, 2
+
+! 2D cranking coolant multiplier vs ethanol %, used when flexCranking is enabled.
+! A real ethanol axis (default 0/35/65/100) lets the whole E0..E100 range be calibrated directly.
+! uint8 (0.02 resolution) keeps RAM tiny.
+uint8_t[CRANKING_FLEX_SIZE] crankingFuelFlexBins;Ethanol % axis (Y) for crankingFuelFlexTable.;"%", 1, 0, 0, 100, 0
+uint8_t[CRANKING_FLEX_SIZE x CRANKING_CURVE_SIZE] autoscale crankingFuelFlexTable;Cranking coolant multiplier as a function of coolant (X axis, shared crankingFuelBins) and ethanol % (Y axis, crankingFuelFlexBins). Used instead of crankingFuelCoef when flexCranking is enabled and a flex sensor is present.;"mult", 0.02, 0, 0, 5, 2
 
 #define TCU_TABLE_WIDTH 8
 

--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -2177,10 +2177,10 @@ uint16_t[FUEL_TRIM_SIZE] fuelTrimLoadBins;;{bitStringValue(veLoadUnitLabels, veL
 uint16_t[FUEL_TRIM_SIZE] fuelTrimRpmBins;;"rpm", 1, 0, 0, 20000, 0
 fuel_cyl_trim_s[MAX_CYLINDER_COUNT iterate] fuelTrims
 
-! Legacy 1D cranking coolant multiplier at E100. Retained for tune compatibility (keeps the config layout and
-! lets older tunes preserve the value), but no longer used by firmware - flex cranking now uses crankingFuelFlexTable.
-! Intentionally NOT referenced by any TunerStudio dialog/curve/menu, so it is hidden from the tuner.
-uint16_t[CRANKING_CURVE_SIZE] autoscale crankingFuelCoefE100;Legacy E100 cranking coolant multiplier - retained for compatibility, unused and hidden.;"ratio", 0.01, 0, 0, 50, 2
+! Retired field: the old 1D E100 cranking multiplier. Cranking flex now uses crankingFuelFlexTable, and old
+! tunes are migrated into it by CrankingFlexTableMigrator (java_console). Renamed with the 'unused' prefix so the
+! byte slot stays reserved (stable offsets, reusable later) and the tune-migration framework ignores it.
+uint16_t[CRANKING_CURVE_SIZE] autoscale unusedCrankingFuelCoefE100;;"ratio", 0.01, 0, 0, 50, 2
 
 ! 2D cranking coolant multiplier vs ethanol %, used when flexCranking is enabled.
 ! A real ethanol axis (default 0/35/65/100) lets the whole E0..E100 range be calibrated directly.

--- a/firmware/tunerstudio/top_level_menu.ini
+++ b/firmware/tunerstudio/top_level_menu.ini
@@ -152,8 +152,8 @@
 		subMenu = std_separator
 
 		subMenu = crankingCycleFuelMultTbl,	"Cranking Base Fuel  (Engine Cycle vs CLT)"
-		subMenu = crankingCltCurve,			"Cranking Fuel multiplier"
-		subMenu = crankingCltCurveE100,		"Fuel Engine Temp (Flex Fuel E85)", { flexSensorPin != @@ADC_CHANNEL_NONE@@ && flexCranking }, { uiMode == @@UiMode_FULL@@ || uiMode == @@UiMode_INSTALLATION@@ }
+		subMenu = crankingCltCurve,			"Cranking Fuel multiplier", { flexSensorPin == @@ADC_CHANNEL_NONE@@ || flexCranking == 0 }
+		subMenu = crankingFuelFlexTbl,		"Cranking Fuel multiplier (Coolant vs Ethanol)", { flexSensorPin != @@ADC_CHANNEL_NONE@@ && flexCranking }, { uiMode == @@UiMode_FULL@@ || uiMode == @@UiMode_INSTALLATION@@ }
 		subMenu = crankingTpsCurve,			"Cranking Fuel TPS multiplier"@@if_ts_show_crankingTpsCurve
 		subMenu = std_separator
 

--- a/firmware/tunerstudio/tunerstudio.template.ini
+++ b/firmware/tunerstudio/tunerstudio.template.ini
@@ -736,14 +736,6 @@ include_file controllers/actuators/boost_control.curves.ini
 		yBins		= crankingFuelCoef
 		gauge		= CLTGauge
 
-	curve = crankingCltCurveE100, "Cranking Coolant Temperature Multiplier (Flex Fuel E85)"
-		columnLabel = "Coolant", "Multiplier"
-		xAxis		=  -40, { cltHighXaxis }, 9
-		yAxis		=  0,  3, 10
-		xBins		= crankingFuelBins, coolantTemperature
-		yBins		= crankingFuelCoefE100
-		gauge		= CLTGauge
-
 	curve = cltRevLimitCurve, ""
 		columnLabel = "Coolant", "RPM Limit"
 		xAxis		= -40, { cltHighXaxis }, 9
@@ -1779,6 +1771,18 @@ curve = rangeMatrix, "Range Switch Input Matrix"
 		xBins		= crankingCycleBins, revolutionCounterSinceStart
 		yBins		= crankingCycleFuelCltBins, coolantTemperature
 		zBins		= crankingCycleBaseFuel
+
+	table = crankingFuelFlexTbl, crankingFuelFlexMap, "Cranking Fuel Multiplier (Coolant vs Ethanol)", 1
+		xyLabels	= "Coolant Temp", "Ethanol %"
+		xBins		= crankingFuelBins, coolantTemperature
+		yBins		= crankingFuelFlexBins, flexPercent
+		zBins		= crankingFuelFlexTable
+
+	table = primeFlexTbl, primeFlexMap, "Priming Pulse Mass (Coolant vs Ethanol)", 1
+		xyLabels	= "Coolant Temp", "Ethanol %"
+		xBins		= primeBins, coolantTemperature
+		yBins		= primeFlexBins, flexPercent
+		zBins		= primeFlexTable
 
 	table = alternatorVoltageTargetTableTbl,  alternatorVoltageTargetTableMap,  "Alternator Voltage Target Table",	1
 		xBins		= alternatorVoltageTargetRpmBins,  RPMValue
@@ -4199,13 +4203,14 @@ include_file @@SECONDARY_PANELS_FILE@@
 	dialog = primingFuelPulsePanel, "Priming fuel pulse"
 @@BOARD_PRIMING_PULSE_PANEL_FROM_FILE@@
 		field = "Priming delay",	primingDelay
-		panel = primingPulse
+		panel = primingPulse, { flexSensorPin == @@ADC_CHANNEL_NONE@@ || flexCranking == 0 }
+		panel = primeFlexTbl, { flexSensorPin != @@ADC_CHANNEL_NONE@@ && flexCranking }
 
 	dialog = crankingAdv, "Advanced"
 		field = "Flood clear",				isCylinderCleanupEnabled@@if_ts_show_flood_clear
 		field = "Faster engine spin-up",			isFasterEngineSpinUpEnabled@@if_ts_show_faster_spin_up
 		field = "Use Advance Corrections for cranking",	useAdvanceCorrectionsForCranking@@if_ts_show_AdvanceCorrectionsForCranking
-		field = "Separate Flex Fuel cranking table",			flexCranking, { flexSensorPin != @@ADC_CHANNEL_NONE@@ }
+		field = "Flex Fuel compensation (cranking + priming)",	flexCranking, { flexSensorPin != @@ADC_CHANNEL_NONE@@ }
 
 ;			Cranking->Cranking Settings
 	dialog = crankingDialog, "Cranking Settings"

--- a/java_console/io/src/main/java/com/rusefi/maintenance/migration/migrators/ComposedTuneMigrator.java
+++ b/java_console/io/src/main/java/com/rusefi/maintenance/migration/migrators/ComposedTuneMigrator.java
@@ -29,6 +29,7 @@ public enum ComposedTuneMigrator implements TuneMigrator {
         STFTFieldMigrator.INSTANCE,
         IdleCurveMigrator.INSTANCE,
         MultiplierToTableMigrator.INSTANCE,
+        CrankingFlexTableMigrator.INSTANCE,
         ScalarToArrayMigrator.INSTANCE,
         MapSamplingValuesMigrator.INSTANCE,
         ImperialUnitsMigrator.INSTANCE,

--- a/java_console/io/src/main/java/com/rusefi/maintenance/migration/migrators/CrankingFlexTableMigrator.java
+++ b/java_console/io/src/main/java/com/rusefi/maintenance/migration/migrators/CrankingFlexTableMigrator.java
@@ -1,0 +1,129 @@
+package com.rusefi.maintenance.migration.migrators;
+
+import static com.rusefi.maintenance.migration.IniFieldMigrationUtils.generateConstant;
+
+import com.opensr5.ini.field.ArrayIniField;
+import com.opensr5.ini.field.IniField;
+import com.rusefi.maintenance.migration.TuneMigrationContext;
+import com.rusefi.tune.xml.Constant;
+
+import java.util.Optional;
+
+/**
+ * Migrates legacy cranking flex-fuel tunes onto the new 2D coolant-vs-ethanol table.
+ *
+ * Old firmware blended two 1D coolant curves - {@code crankingFuelCoef} (E0) and {@code crankingFuelCoefE100}
+ * (E100) - by the flex sensor reading, using {@code interpolateClamped(0, E0, 85, E100, ethanol%)}.
+ * The new firmware drops that blend and instead reads {@code crankingFuelFlexTable}, a 2D table over
+ * (coolant, ethanol%). {@code crankingFuelCoefE100} has been retired (renamed to {@code unused...}).
+ *
+ * This migrator reconstructs the new table from the user's old E0/E100 curves so their cranking flex behaviour
+ * is preserved: each ethanol row reproduces the legacy 85%-anchored blend of the two curves at that ethanol level.
+ */
+public enum CrankingFlexTableMigrator implements TuneMigrator {
+    INSTANCE;
+
+    private static final String E0_CURVE_FIELD = "crankingFuelCoef";          // exists before and after
+    private static final String E100_CURVE_FIELD = "crankingFuelCoefE100";    // retired by this change
+    private static final String FLEX_TABLE_FIELD = "crankingFuelFlexTable";   // new 2D table (coolant x ethanol%)
+    private static final String FLEX_ETHANOL_BINS_FIELD = "crankingFuelFlexBins"; // new ethanol % axis
+
+    // Legacy firmware anchored the E0->E100 blend at this ethanol %, clamping above it.
+    private static final double LEGACY_ETHANOL_ANCHOR = 85.0;
+
+    @Override
+    public void migrateTune(final TuneMigrationContext context) {
+        // Only migrate when the E100 curve existed before but is gone now, and the new table exists - i.e. this is
+        // exactly the upgrade introducing the 2D table. Mirrors the guard used by MultiplierToTableMigrator.
+        final boolean appliesToThisUpgrade =
+            context.getPrevIniFile().findIniField(E100_CURVE_FIELD).isPresent()
+                && !context.getUpdatedIniFile().findIniField(E100_CURVE_FIELD).isPresent()
+                && context.getUpdatedIniFile().findIniField(FLEX_TABLE_FIELD).isPresent();
+        if (appliesToThisUpgrade) {
+            migrate(context);
+        }
+    }
+
+    private static void migrate(final TuneMigrationContext context) {
+        final Optional<ArrayIniField> e0Field = arrayField(context.getPrevIniFile().findIniField(E0_CURVE_FIELD));
+        final Optional<ArrayIniField> e100Field = arrayField(context.getPrevIniFile().findIniField(E100_CURVE_FIELD));
+        final Optional<ArrayIniField> tableField = arrayField(context.getUpdatedIniFile().findIniField(FLEX_TABLE_FIELD));
+        final Optional<ArrayIniField> ethanolBinsField =
+            arrayField(context.getUpdatedIniFile().findIniField(FLEX_ETHANOL_BINS_FIELD));
+        if (!e0Field.isPresent() || !e100Field.isPresent() || !tableField.isPresent() || !ethanolBinsField.isPresent()) {
+            return;
+        }
+
+        final Constant e0Const = context.getPrevTune().getConstantsAsMap().get(E0_CURVE_FIELD);
+        final Constant e100Const = context.getPrevTune().getConstantsAsMap().get(E100_CURVE_FIELD);
+        final Constant ethanolBinsConst = context.getUpdatedTune().getConstantsAsMap().get(FLEX_ETHANOL_BINS_FIELD);
+        if (e0Const == null || e100Const == null || ethanolBinsConst == null) {
+            return;
+        }
+
+        final double[] e0 = readArray(e0Field.get(), e0Const.getValue());
+        final double[] e100 = readArray(e100Field.get(), e100Const.getValue());
+        final double[] ethanol = readArray(ethanolBinsField.get(), ethanolBinsConst.getValue());
+
+        if (e0.length != e100.length) {
+            context.logWarn(String.format(
+                "Cranking flex migration skipped: %s has %d values but %s has %d",
+                E0_CURVE_FIELD, e0.length, E100_CURVE_FIELD, e100.length));
+            return;
+        }
+
+        final ArrayIniField table = tableField.get();
+        final int rows = table.getRows();
+        final int cols = table.getCols();
+        // One axis is coolant (length == e0.length), the other is ethanol (length == ethanol.length). Disambiguate
+        // by size so the migrator is robust to the table's row/column orientation.
+        final boolean colsAreCoolant = (cols == e0.length) && (rows == ethanol.length);
+        final boolean rowsAreCoolant = (rows == e0.length) && (cols == ethanol.length);
+        if (!colsAreCoolant && !rowsAreCoolant) {
+            context.logWarn(String.format(
+                "Cranking flex migration skipped: unexpected %s shape %dx%d for coolant(%d) x ethanol(%d)",
+                FLEX_TABLE_FIELD, rows, cols, e0.length, ethanol.length));
+            return;
+        }
+
+        final String[][] values = new String[rows][cols];
+        for (int row = 0; row < rows; row++) {
+            for (int col = 0; col < cols; col++) {
+                final int coolantIdx = colsAreCoolant ? col : row;
+                final int ethanolIdx = colsAreCoolant ? row : col;
+                final double fraction = legacyBlendFraction(ethanol[ethanolIdx]);
+                final double value = e0[coolantIdx] + fraction * (e100[coolantIdx] - e0[coolantIdx]);
+                values[row][col] = IdleCurveMigrator.formatArrayValue(value, table.getDigits());
+            }
+        }
+
+        context.addMigration(FLEX_TABLE_FIELD, generateConstant(table, table.formatValue(values)));
+    }
+
+    /**
+     * Reproduces the legacy {@code interpolateClamped(0, E0, 85, E100, ethanol%)} blend fraction at a given ethanol %.
+     */
+    private static double legacyBlendFraction(final double ethanolPercent) {
+        final double clamped = Math.max(0.0, Math.min(ethanolPercent, LEGACY_ETHANOL_ANCHOR));
+        return clamped / LEGACY_ETHANOL_ANCHOR;
+    }
+
+    private static Optional<ArrayIniField> arrayField(final Optional<IniField> field) {
+        if (field.isPresent() && (field.get() instanceof ArrayIniField)) {
+            return Optional.of((ArrayIniField) field.get());
+        }
+        return Optional.empty();
+    }
+
+    private static double[] readArray(final ArrayIniField field, final String value) {
+        final String[][] matrix = field.getValues(value);
+        final double[] result = new double[field.getRows() * field.getCols()];
+        int i = 0;
+        for (final String[] matrixRow : matrix) {
+            for (final String element : matrixRow) {
+                result[i++] = Double.parseDouble(element);
+            }
+        }
+        return result;
+    }
+}

--- a/java_console/ui/src/test/java/com/rusefi/maintenance/migration/cranking_flex_table_migration/CrankingFlexTableMigratorTest.java
+++ b/java_console/ui/src/test/java/com/rusefi/maintenance/migration/cranking_flex_table_migration/CrankingFlexTableMigratorTest.java
@@ -1,0 +1,120 @@
+package com.rusefi.maintenance.migration.cranking_flex_table_migration;
+
+import com.opensr5.ini.IniFileModel;
+import com.opensr5.ini.field.ArrayIniField;
+import com.rusefi.config.FieldType;
+import com.rusefi.maintenance.TestCallbacks;
+import com.rusefi.maintenance.TestTuneMigrationContext;
+import com.rusefi.maintenance.migration.migrators.CrankingFlexTableMigrator;
+import com.rusefi.tune.xml.Constant;
+import com.rusefi.tune.xml.Msq;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class CrankingFlexTableMigratorTest {
+
+    // 1D curve: ArrayIniField.parse of "[size]" yields cols=1, rows=size
+    private static ArrayIniField curve(final String name, final int size) {
+        return new ArrayIniField(name, 0, FieldType.FLOAT, 1, size, "ratio", 1.0, "0", "50", "2");
+    }
+
+    // C [ethanol][coolant] is emitted as .ini "[coolant x ethanol]" -> cols=coolant, rows=ethanol
+    private static ArrayIniField flexTable(final String name, final int coolantCols, final int ethanolRows) {
+        return new ArrayIniField(name, 0, FieldType.UINT8, coolantCols, ethanolRows, "mult", 1.0, "0", "5", "2");
+    }
+
+    private static ArrayIniField bins(final String name, final int size) {
+        return new ArrayIniField(name, 0, FieldType.UINT8, 1, size, "%", 1.0, "0", "100", "0");
+    }
+
+    private static Constant constant(final ArrayIniField field, final String value) {
+        return new Constant(field.getName(), field.getUnits(), value, field.getDigits(),
+            String.valueOf(field.getRows()), String.valueOf(field.getCols()));
+    }
+
+    @Test
+    void migratesLegacyE0E100CurvesIntoFlexTable() {
+        final int coolantSize = 8;
+        final int ethanolSize = 4;
+
+        final ArrayIniField e0Field = curve("crankingFuelCoef", coolantSize);
+        final ArrayIniField e100Field = curve("crankingFuelCoefE100", coolantSize);
+        final ArrayIniField tableField = flexTable("crankingFuelFlexTable", coolantSize, ethanolSize);
+        final ArrayIniField binsField = bins("crankingFuelFlexBins", ethanolSize);
+
+        // E0 = 1.0 at every coolant point, E100 = 3.0 at every coolant point
+        final Constant e0Const = constant(e0Field, "1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0");
+        final Constant e100Const = constant(e100Field, "3.0 3.0 3.0 3.0 3.0 3.0 3.0 3.0");
+        final Constant binsConst = constant(binsField, "0 35 65 100");
+
+        // Previous tune still has the two 1D curves
+        final IniFileModel prevIni = mock(IniFileModel.class);
+        when(prevIni.findIniField(any())).thenReturn(Optional.empty());
+        when(prevIni.findIniField("crankingFuelCoef")).thenReturn(Optional.of(e0Field));
+        when(prevIni.findIniField("crankingFuelCoefE100")).thenReturn(Optional.of(e100Field));
+        final Msq prevMsq = mock(Msq.class);
+        when(prevMsq.getConstantsAsMap()).thenReturn(Map.of(
+            "crankingFuelCoef", e0Const,
+            "crankingFuelCoefE100", e100Const));
+
+        // Updated tune: crankingFuelCoefE100 retired, new 2D table + ethanol axis present
+        final IniFileModel updatedIni = mock(IniFileModel.class);
+        when(updatedIni.findIniField(any())).thenReturn(Optional.empty());
+        when(updatedIni.findIniField("crankingFuelCoef")).thenReturn(Optional.of(e0Field));
+        when(updatedIni.findIniField("crankingFuelFlexTable")).thenReturn(Optional.of(tableField));
+        when(updatedIni.findIniField("crankingFuelFlexBins")).thenReturn(Optional.of(binsField));
+        final Msq updatedMsq = mock(Msq.class);
+        when(updatedMsq.getConstantsAsMap()).thenReturn(Map.of("crankingFuelFlexBins", binsConst));
+
+        final TestTuneMigrationContext context =
+            new TestTuneMigrationContext(prevMsq, prevIni, updatedMsq, updatedIni, new TestCallbacks());
+
+        CrankingFlexTableMigrator.INSTANCE.migrateTune(context);
+
+        final Constant migrated = context.getMigratedConstants().get("crankingFuelFlexTable");
+        assertNotNull(migrated, "crankingFuelFlexTable should have been migrated");
+
+        // Parse back into [ethanol rows][coolant cols]
+        final String[][] values = tableField.getValues(migrated.getValue());
+        assertEquals(ethanolSize, values.length);
+        assertEquals(coolantSize, values[0].length);
+
+        // 0% ethanol -> the E0 curve (1.0)
+        assertEquals(1.0, Double.parseDouble(values[0][0]), 1e-3);
+        // 100% ethanol -> clamped to the legacy 85% anchor -> the E100 curve (3.0)
+        assertEquals(3.0, Double.parseDouble(values[3][0]), 1e-3);
+        // 35% ethanol -> 1 + (35/85) * (3 - 1)
+        assertEquals(1.0 + (35.0 / 85.0) * 2.0, Double.parseDouble(values[1][0]), 1e-2);
+        // 65% ethanol -> 1 + (65/85) * (3 - 1)
+        assertEquals(1.0 + (65.0 / 85.0) * 2.0, Double.parseDouble(values[2][0]), 1e-2);
+    }
+
+    @Test
+    void doesNothingWhenLegacyE100FieldIsAbsent() {
+        // Not the upgrade this migrator handles (no retired crankingFuelCoefE100 in the previous .ini): do nothing.
+        final IniFileModel prevIni = mock(IniFileModel.class);
+        when(prevIni.findIniField(any())).thenReturn(Optional.empty());
+        final Msq prevMsq = mock(Msq.class);
+        when(prevMsq.getConstantsAsMap()).thenReturn(Map.of());
+        final IniFileModel updatedIni = mock(IniFileModel.class);
+        when(updatedIni.findIniField(any())).thenReturn(Optional.empty());
+        final Msq updatedMsq = mock(Msq.class);
+        when(updatedMsq.getConstantsAsMap()).thenReturn(Map.of());
+
+        final TestTuneMigrationContext context =
+            new TestTuneMigrationContext(prevMsq, prevIni, updatedMsq, updatedIni, new TestCallbacks());
+        CrankingFlexTableMigrator.INSTANCE.migrateTune(context);
+
+        assertNull(context.getMigratedConstants().get("crankingFuelFlexTable"));
+    }
+}

--- a/unit_tests/tests/ignition_injection/test_fuel_math.cpp
+++ b/unit_tests/tests/ignition_injection/test_fuel_math.cpp
@@ -462,6 +462,61 @@ TEST(FuelMath, postCrankingFactorAxis){
 	EXPECT_NEAR(engine->fuelComputer.running.postCrankingFuelCorrection, 5, EPS3D);
 }
 
+// flexCranking selects the cranking coolant-multiplier source: the 1D crankingFuelCoef curve when off
+// (or when no flex sensor is present), and the 2D crankingFuelFlexTable when on with a flex sensor.
+TEST(FuelMath, crankingFlexFallbackToCurve) {
+	EngineTestHelper eth(engine_type_e::TEST_ENGINE);
+
+	// Pass the base mass straight through so the return value equals the coolant multiplier.
+	engineConfiguration->useRunningMathForCranking = true;
+
+	setArrayValues(config->crankingFuelCoef, 2.0f);  // flat 1D curve
+	Sensor::setMockValue(SensorType::Clt, 20);
+
+	// flex off -> 1D curve, regardless of any ethanol reading.
+	engineConfiguration->flexCranking = false;
+	Sensor::setMockValue(SensorType::FuelEthanolPercent, 85);
+	EXPECT_NEAR(2.0f, getCrankingFuel3(1, 0), EPS4D);
+
+	// flex on but no flex sensor present -> still the 1D curve.
+	engineConfiguration->flexCranking = true;
+	Sensor::resetMockValue(SensorType::FuelEthanolPercent);
+	EXPECT_NEAR(2.0f, getCrankingFuel3(1, 0), EPS4D);
+}
+
+// flexCranking on + flex sensor present resolves the cranking coolant multiplier from the 2D ethanol table.
+TEST(FuelMath, crankingFlex2dTable) {
+	EngineTestHelper eth(engine_type_e::TEST_ENGINE);
+
+	engineConfiguration->useRunningMathForCranking = true;
+	engineConfiguration->flexCranking = true;
+
+	Sensor::setMockValue(SensorType::Clt, 20);
+
+	// Ethanol axis plus a table that is flat across coolant so only the ethanol axis matters.
+	const uint8_t ethanolBins[] = { 0, 35, 65, 100 };
+	copyArray(config->crankingFuelFlexBins, ethanolBins);
+
+	const float rowMult[] = { 2.0f, 2.5f, 3.5f, 5.0f };
+	for (size_t row = 0; row < efi::size(config->crankingFuelFlexTable); row++) {
+		for (size_t col = 0; col < CRANKING_CURVE_SIZE; col++) {
+			config->crankingFuelFlexTable[row][col] = rowMult[row];
+		}
+	}
+
+	// Exact ethanol bins hit their row.
+	Sensor::setMockValue(SensorType::FuelEthanolPercent, 0);
+	EXPECT_NEAR(2.0f, getCrankingFuel3(1, 0), EPS4D);
+	Sensor::setMockValue(SensorType::FuelEthanolPercent, 35);
+	EXPECT_NEAR(2.5f, getCrankingFuel3(1, 0), EPS4D);
+	Sensor::setMockValue(SensorType::FuelEthanolPercent, 100);
+	EXPECT_NEAR(5.0f, getCrankingFuel3(1, 0), EPS4D);
+
+	// Between bins -> linear interpolation on the ethanol axis (35 -> 65 at 50%).
+	Sensor::setMockValue(SensorType::FuelEthanolPercent, 50);
+	EXPECT_NEAR(3.0f, getCrankingFuel3(1, 0), EPS4D);
+}
+
 
 TEST(AirmassModes, PredictiveMapCalculation) {
 	StrictMock<MockVp3d> veTable;

--- a/unit_tests/tests/ignition_injection/test_startOfCrankingPrimingPulse.cpp
+++ b/unit_tests/tests/ignition_injection/test_startOfCrankingPrimingPulse.cpp
@@ -69,3 +69,40 @@ TEST(priming, duration) {
 	Sensor::resetMockValue(SensorType::Clt);
 	EXPECT_EQ(0, engine->module<PrimeController>()->getPrimeDuration());
 }
+
+// With flexCranking enabled and a flex sensor present, the priming mass comes from the 2D
+// coolant-vs-ethanol table (primeFlexTable) instead of the 1D primeValues curve.
+TEST(priming, flexTableDuration) {
+	EngineTestHelper eth(engine_type_e::TEST_ENGINE);
+
+	MockInjectorModel2 injectorModel;
+	engine->module<InjectorModelPrimary>().set(&injectorModel);
+
+	// Linear coolant axis; the table is flat across coolant so only the ethanol axis matters.
+	for (size_t i = 0; i < efi::size(engineConfiguration->primeBins); i++) {
+		engineConfiguration->primeBins[i] = i * 10;
+	}
+
+	const uint8_t ethanolBins[] = { 0, 35, 65, 100 };
+	copyArray(engineConfiguration->primeFlexBins, ethanolBins);
+
+	const uint16_t rowMassMg[] = { 100, 200, 300, 400 };	// mg per ethanol row (multiples of the 5 mg LSB)
+	for (size_t row = 0; row < efi::size(engineConfiguration->primeFlexTable); row++) {
+		for (size_t col = 0; col < PRIME_CURVE_COUNT; col++) {
+			engineConfiguration->primeFlexTable[row][col] = rowMassMg[row];
+		}
+	}
+
+	engineConfiguration->flexCranking = true;
+	Sensor::setMockValue(SensorType::Clt, 50);
+
+	// E35 -> row 1 -> 200 mg -> 0.2 g
+	EXPECT_CALL(injectorModel, getInjectionDuration(::testing::FloatNear(0.2f, 1e-4f))).WillOnce(Return(22.0f));
+	Sensor::setMockValue(SensorType::FuelEthanolPercent, 35);
+	EXPECT_EQ(22, engine->module<PrimeController>()->getPrimeDuration());
+
+	// E50 -> halfway between rows at 35 (200 mg) and 65 (300 mg) -> 250 mg -> 0.25 g
+	EXPECT_CALL(injectorModel, getInjectionDuration(::testing::FloatNear(0.25f, 1e-4f))).WillOnce(Return(28.0f));
+	Sensor::setMockValue(SensorType::FuelEthanolPercent, 50);
+	EXPECT_EQ(28, engine->module<PrimeController>()->getPrimeDuration());
+}


### PR DESCRIPTION
Supersedes #9643.

Consolidates flex-fuel start enrichment behind the single existing `flexCranking` toggle (plus a present flex fuel sensor):

- **Cranking coolant multiplier** — flex ON: 2D `crankingFuelFlexTable` (coolant x ethanol %, 4-row ethanol axis); flex OFF: the 1D `crankingFuelCoef` curve.
- **Priming pulse mass** — same toggle. flex ON: new 2D `primeFlexTable` (coolant x ethanol %, 4 rows); flex OFF: the 1D `primeValues` curve.

## Why this is needed — ethanol vs gasoline at cold start

Ethanol does not just need "a bit more fuel"; its cold-start behaviour differs from gasoline in a way that a single multiplier (or a two-endpoint E0/E100 blend) cannot represent well:

- **Stoichiometric ratio.** Gasoline is ~14.7:1, E100 is ~9.0:1 (E85 ~9.8:1). For the same air, ethanol needs roughly 30–60% more fuel mass at stoich — a large baseline shift that scales with ethanol content.
- **High heat of vaporization + low cold volatility.** Ethanol's latent heat of vaporization is ~2.5x gasoline's, and its vapor pressure at low temperature is very low. Cold, most of the injected ethanol stays **liquid** (wets the ports/cylinder) instead of forming combustible vapor. To get enough fuel *vapor* to light off, you must inject a large liquid excess.
- **The enrichment is non-linear in temperature, and the curve shape itself changes with ethanol content.** As coolant temperature drops, the required cranking/priming enrichment for high-ethanol blends rises far more steeply than for gasoline. So it is not enough to scale one coolant curve up and down — the *shape* vs coolant differs per ethanol level.

A single coolant curve scaled by ethanol (or a linear blend between only an E0 and an E100 curve) forces intermediate blends like E50 onto a straight line between two endpoints, which does not match the real, non-linear temperature behaviour. A **2D table over (coolant, ethanol %)** lets each ethanol level have its own coolant curve, so the whole E0..E100 range is calibrated directly.

The **priming pulse** wets cold ports before the first crank, so it is governed by the same physics and gets the same 2D treatment.

## Notable changes
- Removes the 1D E0->E100 blend from the firmware path (this is what #9643 implemented). `crankingFuelCoefE100` is **kept in the struct for tune compatibility** but is no longer used and is hidden from TunerStudio (no curve/menu references).
- Drops the interim `crankingUseFlexFuelTable` bit — `flexCranking` alone selects the table.
- 2D tables are `uint8` autoscale to keep RAM tiny (~36 bytes each).
- `defaultsOrFixOnBurn()` seeds each 2D table from its existing 1D curve for tunes that predate it, so enabling flex stays neutral until calibrated.

## Failure behaviour
A configured-but-failed flex sensor falls back to 50% ethanol (`value_or(50)`), matching prior behaviour; with no flex sensor configured the 1D curves are used.

## Tests
Adds/updates unit tests: cranking 2D table + fallback to the 1D curve, and the priming 2D table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)