### PR TITLE
flex: add Flex sensor status indicator (Flex OK / Flex error)

### DIFF
--- a/firmware/console/binary/output_channels.txt
+++ b/firmware/console/binary/output_channels.txt
@@ -381,6 +381,8 @@ bit vvtChannel3;bank 2 intake cam input
 ! bit 29
 bit vvtChannel4;bank 2 exhaust cam input
 bit isMapPredictionActive;AE: Map Prediction Active
+! bit 31 - last one!
+bit isFlexError;Error: Flex
 
 uint32_t outputRequestPeriod
 float mapFast

--- a/firmware/console/status_loop.cpp
+++ b/firmware/console/status_loop.cpp
@@ -422,7 +422,10 @@ static void updateFuelSensors() {
 	// High pressure is in bar, aka 100 kpa
 	engine->outputChannels.highFuelPressure = KPA2BAR(Sensor::getOrZero(SensorType::FuelPressureHigh));
 
-	engine->outputChannels.flexPercent = Sensor::getOrZero(SensorType::FuelEthanolPercent);
+	SensorResult flex = Sensor::get(SensorType::FuelEthanolPercent);
+	engine->outputChannels.flexPercent = flex.value_or(0);
+	// Only report fail if a flex sensor is actually configured (many engines don't have one)
+	engine->outputChannels.isFlexError = Sensor::hasSensor(SensorType::FuelEthanolPercent) ? !flex.Valid : false;
 
 	engine->outputChannels.fuelTankLevel = Sensor::getOrZero(SensorType::FuelLevel);
 }

--- a/firmware/tunerstudio/tunerstudio.template.ini
+++ b/firmware/tunerstudio/tunerstudio.template.ini
@@ -1896,6 +1896,7 @@ include_file @@MAIN_PAGE_GAUGES_FILE@@
 	indicator =					{ isPedalError },				@@PPS_OK_INDICATOR@@,		@@PPS_FAIL_INDICATOR@@,  white,  black,	red,  black@@if_ts_show_etb
 	indicator =					{ isCltError },				"CLT OK",			"CLT error",  white,  black,	red,  black
 	indicator =					{ isIatError },				"IAT OK",			"IAT error",  white,  black,	red,  black@@if_ts_show_iat
+	indicator =					{ isFlexError },				"Flex OK",			"Flex error",  white,  black,	red,  black
 	; not implemented
 	; indicator = { ind_map_error}, "map",	"map error",	white, black, red,	black
 	indicator =					{ sd_present },			"No SD card",	"SD card present",  white,  black,  green,  black


### PR DESCRIPTION
Add isFlexError output channel (new 32-bit word, existing bit positions untouched), populated in updateFuelSensors() with a hasSensor() guard so it only flags a fault when a flex sensor is actually configured. Add the matching "Flex OK / Flex error" indicator in the TS template, mirroring the existing CLT/IAT/Trigger indicators. Output-channel/display only - no change to persisted configuration, so old tunes stay compatible.