### PR TITLE
starter: add clutch-down cranking condition option

### DIFF
--- a/firmware/controllers/algo/rusefi_enums.h
+++ b/firmware/controllers/algo/rusefi_enums.h
@@ -528,6 +528,7 @@ typedef enum __attribute__ ((__packed__)) {
 	CCNONE = 0,
 	CC_BRAKE = 1,
 	CC_CLUTCH = 2,
+	CC_CLUTCH_DOWN = 3,
 } cranking_condition_e;
 
 /**

--- a/firmware/controllers/start_stop.cpp
+++ b/firmware/controllers/start_stop.cpp
@@ -80,6 +80,9 @@ void slowStartStopButtonCallback() {
     if (engineConfiguration->crankingCondition == CC_CLUTCH && !engine->clutchUpSwitchedState) {
       return;
     }
+    if (engineConfiguration->crankingCondition == CC_CLUTCH_DOWN && !engine->engineState.clutchDownState) {
+      return;
+    }
 
     if (isCrankingSuppressed()) {
       return;

--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -1088,7 +1088,7 @@ bit verboseCan2,"Print all","Do not print";Print incoming and outgoing second bu
     custom antiLagActivationMode_e  1 bits, S08, @OFFSET@, [0:1], @@antiLagActivationMode_e_enum@@
     antiLagActivationMode_e antiLagActivationMode;
 
-#define cranking_condition_e_enum "None", "Brake", "Clutch"
+#define cranking_condition_e_enum "None", "Brake", "Clutch Up", "Clutch Down"
 custom cranking_condition_e 1 bits, S08, @OFFSET@, [0:1], @@cranking_condition_e_enum@@
 cranking_condition_e crankingCondition;
 


### PR DESCRIPTION
Adds CC_CLUTCH_DOWN alongside the existing CC_CLUTCH (clutch up) cranking condition, gating start on engine->engineState.clutchDownState. Renames the existing TunerStudio option to "Clutch Up" for clarity.

Original only checked for clutch up, which is not always the case. User should tell us which clutch sensor is being used to gate starter, because there can be more than one