### PR TITLE
chore: update clang-format only:none

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -62,3 +62,5 @@ AlignTrailingComments: true
 # Packing
 BinPackArguments: false
 BinPackParameters: false
+
+InsertBraces: true


### PR DESCRIPTION
> InsertBraces (Boolean) clang-format 15 [¶](https://clang.llvm.org/docs/ClangFormatStyleOptions.html#insertbraces)
> Insert braces after control statements (if, else, for, do, and while) in C++ unless the control statements are inside macro definitions or the braces would enclose preprocessor directives.

no more `if (stuff) evil_call();`