### PR TITLE
ignition: add dwell duty cycle mode for Ford TFI modules (and others)

### DIFF
--- a/firmware/controllers/algo/defaults/default_ignition.cpp
+++ b/firmware/controllers/algo/defaults/default_ignition.cpp
@@ -114,6 +114,10 @@ void setDefaultIgnition() {
 	setLinearCurve(config->dwellVoltageCorrVoltBins, 8, 15, 0.1);
 	setLinearCurve(config->dwellVoltageCorrValues, 1, 1, 1);
 
+	// Dwell Duty Mode - disabled by default; 50% is the standard TFI module target.
+	engineConfiguration->dwellDutyModeEnabled = false;
+	engineConfiguration->dwellDutyPercent = 50;
+
 	// Multispark
 	setDefaultMultisparkParameters();
 

--- a/firmware/controllers/algo/ignition/ignition_state.cpp
+++ b/firmware/controllers/algo/ignition/ignition_state.cpp
@@ -23,6 +23,8 @@
 #include "idle_thread.h"
 #include "launch_control.h"
 #include "gppwm_channel.h"
+#include "spark_logic.h"
+#include "engine_math.h"
 
 #if EFI_ENGINE_CONTROL
 
@@ -346,6 +348,15 @@ floatms_t IgnitionState::getSparkDwell(float rpm, bool isCranking) {
 	float dwellMs;
 	if (isCranking) {
 		dwellMs = engineConfiguration->ignitionDwellForCrankingMs;
+	} else if (engineConfiguration->dwellDutyModeEnabled) {
+		efiAssert(ObdCode::CUSTOM_ERR_ASSERT, !std::isnan(rpm), "invalid rpm", NAN);
+		// Duty mode: dwell = duty% × (engine cycle duration / sparks per cycle).
+		// Exact inverse of getCoilDutyCycle() — gives the dwell that produces the
+		// requested duty on the coil output pin (e.g. 50% for Ford TFI modules).
+		float intervalMs = getEngineCycleDuration(rpm) / getNumberOfSparks(getCurrentIgnitionMode());
+		baseDwell = engineConfiguration->dwellDutyPercent / 100.0f * intervalMs;
+		dwellVoltageCorrection = 1.0f;
+		dwellMs = baseDwell;
 	} else {
 		efiAssert(ObdCode::CUSTOM_ERR_ASSERT, !std::isnan(rpm), "invalid rpm", NAN);
 

--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -93,7 +93,7 @@
 ! This is the version of the data stored in flash configuration
 ! Any time an incompatible change is made to the configuration format stored in flash,
 ! update this string to the current date!
-#define FLASH_DATA_VERSION 260529
+#define FLASH_DATA_VERSION 260622
 
 ! Remove next line when Java toolset gets adjusted to load those from json config into VariablesRegistry
 ! Also remove file integration/generated/rusefi_config_generated_enums.txt
@@ -1970,6 +1970,15 @@ end_struct
 	float misfireWobbleAlphaRise;Misfire Detection: wobble EMA alpha when spread is increasing.;"", 1, 0, 0.001, 1, 3
 	float misfireWobbleAlphaFall;Misfire Detection: wobble EMA alpha when spread is decreasing.;"", 1, 0, 0.001, 1, 3
 	uint16_t misfireSettleCycles;Misfire Detection: firings to wait after entering idle before flagging starts. 0 = immediate.;"cycles", 1, 0, 0, 5000, 0
+
+	! --- Dwell Duty Mode ---
+	! Instead of the RPM/voltage dwell tables, compute dwell as a fixed percentage of the
+	! time between consecutive ignition pulses on the same output. This matches what Ford
+	! TFI (Thick Film Ignition) modules expect: a 50% duty cycle square wave where the ECU
+	! controls timing by advancing or retarding the pulse edge, not the absolute dwell time.
+	! Cranking always uses ignitionDwellForCrankingMs regardless of this setting.
+	bit dwellDutyModeEnabled,"enabled","disabled";Dwell Duty Mode: when enabled, ignores the RPM/voltage dwell tables and computes dwell as a fixed percentage of the time between consecutive ignition pulses. Required for Ford TFI modules that expect a 50% duty cycle square wave.
+	uint8_t dwellDutyPercent;Dwell Duty Mode: percentage of the inter-spark interval used as coil dwell time. 50 = half the interval between pulses (standard TFI target).;"%", 1, 0, 1, 90, 0
 
 ! end of engine_configuration_s
 end_struct

--- a/firmware/tunerstudio/tunerstudio.template.ini
+++ b/firmware/tunerstudio/tunerstudio.template.ini
@@ -2809,8 +2809,10 @@ cmd_set_engine_type_default					= "@@TS_IO_TEST_COMMAND_char@@@@ts_command_e_TS_
 		panel = targetAfrBlend2Bias, { targetAfrBlends2_blendParameter }
 
 	dialog = dwellSettings, "", yAxis
-		panel = dwellCorrection
-		panel = dwellVoltageCorrection
+		field = "Dwell Duty Mode",  dwellDutyModeEnabled
+		field = "Duty %",           dwellDutyPercent,       {dwellDutyModeEnabled}
+		panel = dwellCorrection,        {!dwellDutyModeEnabled}
+		panel = dwellVoltageCorrection, {!dwellDutyModeEnabled}
 
 	dialog = auxTempSensor1_thermistor,	"aux1 Thermistor Settings"
 		field = "Input channel",			auxTempSensor1_adcChannel

--- a/unit_tests/tests/ignition_injection/test_ignition_state.cpp
+++ b/unit_tests/tests/ignition_injection/test_ignition_state.cpp
@@ -322,4 +322,20 @@ TEST(ignition_state, getSparkDwellTableAndVoltageCorrection) {
   setArrayValues(config->dwellVoltageCorrValues, 0);
   engine->ignitionState.updateDwell(3000, false);
   EXPECT_NEAR(5, engine->ignitionState.getDwell(), EPS2D);
+
+  // Duty mode (for Ford TFI modules) bypasses the table/voltage-correction
+  // calculation above entirely, computing dwell as a fixed percentage of the
+  // inter-spark interval instead.
+  engineConfiguration->ignitionMode = IM_WASTED_SPARK;
+  engineConfiguration->dwellDutyModeEnabled = true;
+  engineConfiguration->dwellDutyPercent = 50;
+
+  // engine cycle @3000rpm = 40ms, 2 sparks per cycle (wasted spark) -> 20ms interval, 50% = 10ms
+  engine->ignitionState.updateDwell(3000, false);
+  EXPECT_NEAR(10, engine->ignitionState.getDwell(), EPS2D);
+
+  // duty mode ignores battery voltage correction entirely
+  Sensor::setMockValue(SensorType::BatteryVoltage, 8);
+  engine->ignitionState.updateDwell(3000, false);
+  EXPECT_NEAR(10, engine->ignitionState.getDwell(), EPS2D);
 }


### PR DESCRIPTION
Adds a switch that replaces the RPM/voltage dwell tables with a fixed percentage of the inter-spark interval. Ford TFI (Thick Film Ignition) modules used on Windsor engines expect a 50% duty cycle square wave rather than an absolute dwell time.

When enabled, dwell = (dutyPercent/100) * engineCycleDuration / numSparks, which is the exact inverse of the existing getCoilDutyCycle() function. Cranking still uses ignitionDwellForCrankingMs regardless of this setting.

Tested on a 95 Ford Mustang 5.0 with TFI, auto-calculates correct dwell duty to the setting.
<img width="500" height="615" alt="image" src="https://github.com/user-attachments/assets/b89e564b-7828-4fce-96c8-ff8d6e3c6964" />
