### PR TITLE
Console tuner: allow offline tune edits

### DIFF
--- a/java_console/ui/src/main/java/com/rusefi/ConsoleUI.java
+++ b/java_console/ui/src/main/java/com/rusefi/ConsoleUI.java
@@ -2,6 +2,8 @@ package com.rusefi;
 
 import com.devexperts.logging.FileLogger;
 import com.devexperts.logging.Logging;
+import com.opensr5.ConfigurationImage;
+import com.opensr5.ini.IniFileModel;
 import com.rusefi.autodetect.PortDetector;
 import com.rusefi.binaryprotocol.BinaryProtocolLogger;
 import com.rusefi.binaryprotocol.ShortcutsHelper;
@@ -75,12 +77,36 @@ public class ConsoleUI {
     private final Map<Component, ActionListener> tabSelectedListeners = new HashMap<>();
 
     public ConsoleUI(String port, SerialPortType serialPortType) {
-        this(new UIContext(), port, serialPortType, false);
+        this(new UIContext(), port, serialPortType, false, null, null);
     }
 
     public ConsoleUI(UIContext uiContext, String port, SerialPortType serialPortType, boolean alreadyConnected) {
+        this(uiContext, port, serialPortType, alreadyConnected, null, null);
+    }
+
+    /**
+     * [tag:offline_tune]
+     * Constructor for offline mode: opens the console with a pre-loaded tune and INI,
+     * without requiring a live ECU connection.
+     *
+     * @param uiContext      shared UI context
+     * @param ini            INI file model resolved from the MSQ signature
+     * @param initialImage   ConfigurationImage loaded from the MSQ file
+     */
+    public ConsoleUI(UIContext uiContext, IniFileModel ini, ConfigurationImage initialImage) {
+        this(uiContext, null, SerialPortType.Unknown, false, ini, initialImage);
+    }
+
+    private ConsoleUI(UIContext uiContext, String port, SerialPortType serialPortType,
+                      boolean alreadyConnected, IniFileModel offlineIni, ConfigurationImage offlineImage) {
         this.uiContext = uiContext;
         LinkManager linkManager = uiContext.getLinkManager();
+
+        boolean isOffline = (offlineIni != null && offlineImage != null);
+        if (isOffline) {
+            uiContext.setOfflineMode(true);
+            uiContext.setIniFileModelForOffline(offlineIni);
+        }
 
         CommandQueue.ERROR_HANDLER = e -> {
             log.error("Connectivity error", e);
@@ -146,13 +172,13 @@ public class ConsoleUI {
         getConfig().getRoot().setProperty(PORT_KEY, port);
         getConfig().getRoot().setProperty(SPEED_KEY, BaudRateHolder.INSTANCE.baudRate);
 
-        if (!alreadyConnected) {
+        if (!alreadyConnected && !isOffline) {
             // todo: this blocking IO operation should NOT be happening on the UI thread
             linkManager.start(port, mainFrame.listener);
         }
 
         engineSnifferPanel = new EngineSnifferPanel(uiContext, getConfig().getRoot().getChild("digital_sniffer"));
-        if (!LinkManager.isLogViewerMode(port))
+        if (isOffline || !LinkManager.isLogViewerMode(port))
             engineSnifferPanel.setOutpinListener(uiContext.getLinkManager().getEngineState());
 
         // what is LogViewer? is this all dead?
@@ -161,7 +187,7 @@ public class ConsoleUI {
 
         uiContext.DetachedRepositoryINSTANCE.init(getConfig().getRoot().getChild("detached"));
         uiContext.DetachedRepositoryINSTANCE.load();
-        if (!linkManager.isLogViewer()) {
+        if (isOffline || !linkManager.isLogViewer()) {
             tabbedPane.addTab("Gauges", new GaugesPanel(uiContext, getConfig().getRoot().getChild("gauges")).getContent());
 
             MessagesPane messagesPane = new MessagesPane(uiContext, getConfig().getRoot().getChild("messages"));
@@ -190,14 +216,17 @@ public class ConsoleUI {
 
 //        if (!linkManager.isLogViewer())
 //            tabbedPane.addTab("Settings", tabbedPane.settingsTab.createPane());
-        if (!linkManager.isLogViewer()) {
+        if (isOffline || !linkManager.isLogViewer()) {
 /*
 console live data tab is broken #8402
 
             tabbedPane.addTab("Live Data", LiveDataPane.createLazy(uiContext).getContent());
  */
-            TuningPane tuningPane = new TuningPane(uiContext);
+            TuningPane tuningPane = new TuningPane(uiContext, offlineImage);
             mainFrame.setTuneActions(tuningPane.getLoadTuneAction(), tuningPane.getSaveTuneAction());
+            if (isOffline && offlineImage != null) {
+                tuningPane.seedOfflineImage(offlineImage, null);
+            }
             PinoutPane pinoutPane = new PinoutPane(uiContext);
             tabbedPane.addTab("Tuning", tuningPane.getContent());
             tabbedPane.addTab("Knock Analyzer", new KnockPane(uiContext).getContent());
@@ -224,8 +253,10 @@ console live data tab is broken #8402
             }
         }
 
-        if (!linkManager.isLogViewer() && false) // todo: fix it & better name?
+        if ((isOffline || !linkManager.isLogViewer()) && false) {
+            // todo: fix it & better name?
             tabbedPane.addTab("Logs Manager", tabbedPane.logsManager.getContent());
+        }
 
 
         MessagesCentral.getInstance().postMessage(ConsoleUI.class, "COMPOSITE_OFF_RPM=" + BinaryProtocolLogger.COMPOSITE_OFF_RPM);
@@ -241,7 +272,7 @@ console live data tab is broken #8402
             uiContext.sensorLogger.init();
         }
 
-        if (!LinkManager.isLogViewerMode(port)) {
+        if (isOffline || !LinkManager.isLogViewerMode(port)) {
             int selectedIndex = getConfig().getRoot().getIntProperty(TAB_INDEX, DEFAULT_TAB_INDEX);
             if (selectedIndex < tabbedPane.tabbedPane.getTabCount())
                 tabbedPane.tabbedPane.setSelectedIndex(selectedIndex);
@@ -263,7 +294,6 @@ console live data tab is broken #8402
 
         ShortcutsHelper.installConnectAndDisconnect(uiContext, tabbedPane.tabbedPane);
         AutoupdateUtil.setAppIcon(mainFrame.getFrame().getFrame());
-        log.info("showFrame");
 
         mainFrame.getFrame().showFrame(rootPanel);
     }

--- a/java_console/ui/src/main/java/com/rusefi/StartupFrame.java
+++ b/java_console/ui/src/main/java/com/rusefi/StartupFrame.java
@@ -1,6 +1,8 @@
 package com.rusefi;
 
 import com.devexperts.logging.Logging;
+import com.opensr5.ConfigurationImage;
+import com.opensr5.ini.IniFileModel;
 import com.opensr5.ini.PrimeTunerStudioCache;
 import com.rusefi.autoupdate.Autoupdate;
 import com.rusefi.core.net.ConnectionAndMeta;
@@ -124,6 +126,11 @@ public class StartupFrame {
     private WizardContainer wizardContainer;
     private PortResult autoConnectedPort;
     private Thread autoConnectThread;
+    // [tag:offline_tune] True once an offline-tune console has been opened on the shared uiContext. The
+    // splash window is gone but the port scanner stays alive so a plugged-in ECU still auto-connects —
+    // and the splash must NOT open a second console when that happens (the offline console transitions
+    // itself online).
+    private boolean offlineConsoleOpen = false;
     private ConnectionStatusLogic.Listener splashListener;
     // Registered in releaseSplashConnection() for firmware jobs; fires once on post-flash reconnect.
     private ConnectionStatusLogic.Listener postFlashReconnectListener;
@@ -282,7 +289,23 @@ public class StartupFrame {
         realHardwarePanel.add(openTunerStudio, "right, wrap");
 
         connectivityContext.getSerialPortScanner().addListener(currentHardware -> SwingUtilities.invokeLater(() -> {
+            if (offlineConsoleOpen) {
+                // [tag:offline_tune] Splash UI is disposed; keep only the auto-connect path alive so
+                // plugging in an ECU transitions the already-open offline console online (see onSplashConnected).
+                applyKnownPorts(currentHardware);
+                return;
+            }
             status.stop();
+            // Hide the scanning indicator after the initial scan completes —
+            // the scanner runs continuously in the background but the UI shouldn't
+            // show "Scanning ports..." on every cycle. Only clear if the current
+            // text is the scanning animation, preserving other messages like
+            // "Connected to X" or auto-connect failures.
+            String currentText = noPortsMessage.getText();
+            if (currentText != null && currentText.startsWith(SCANNING_PORTS)) {
+                noPortsMessage.setText("");
+                noPortsMessage.setVisible(false);
+            }
             selector.apply(currentHardware);
             applyKnownPorts(currentHardware);
             if (!hasSeenEcuOrSimulator) {
@@ -369,7 +392,8 @@ public class StartupFrame {
             uiContext,
             firmwareUpdateTab.getBasicUpdaterPanel().getImportTuneButton().getContent(),
             asyncJobExecutor,
-            tuneStatusPanel
+            tuneStatusPanel,
+            this::openOfflineConsole
         ).getContent());
         outerTabs.addTab("Connect", connectTabWrapper);
 
@@ -539,15 +563,47 @@ public class StartupFrame {
     }
 
     private void connect(PortResult selectedPort) {
+        log.info("connect: port=" + selectedPort.port);
         boolean alreadyConnected = isAutoConnected(selectedPort);
+        log.info("connect: alreadyConnected=" + alreadyConnected);
         // Splash started LinkManager but the live connection dropped (ECU reboot, cable yank)
         // before the user clicked Connect. Reset it so ConsoleUI's start() can set a fresh connector
         // without tripping the "Already started" guard.
         if (!alreadyConnected && autoConnectedPort != null) {
+            log.info("connect: closing stale LinkManager");
             uiContext.getLinkManager().close();
         }
+        log.info("connect: disposing splash and creating ConsoleUI");
         disposeFrameAndProceed();
         new ConsoleUI(uiContext, selectedPort.port, selectedPort.type, alreadyConnected);
+    }
+
+    /**
+     * [tag:offline_tune]
+     * Opens the full console in offline mode with a pre-loaded tune, reusing the shared {@link UIContext}.
+     * Disposes the splash window but keeps the serial-port scanner running so that plugging in an ECU
+     * later auto-connects and the offline console transitions itself online — without spawning a second
+     * console (see the {@link #offlineConsoleOpen} guards).
+     */
+    public void openOfflineConsole(IniFileModel ini, ConfigurationImage image) {
+        log.info("openOfflineConsole: launching offline console on shared uiContext");
+        offlineConsoleOpen = true;
+        isProceeding = true;
+        // Drop the splash-scoped connection listener so it can't mutate the disposed splash widgets.
+        if (splashListener != null) {
+            ConnectionStatusLogic.INSTANCE.removeListener(splashListener);
+            splashListener = null;
+        }
+        saveTabIndex();
+        getConfig().save();
+        frame.dispose();
+        status.stop();
+        if (firmwareTabStatus != null) {
+            firmwareTabStatus.stop();
+        }
+        // NOTE: intentionally do NOT call serialPortScanner.stopTimer() — the offline console relies on
+        // the scanner's auto-connect to go online.
+        new ConsoleUI(uiContext, ini, image);
     }
 
     /**
@@ -573,6 +629,11 @@ public class StartupFrame {
 
     private void autoConnect(PortResult target) {
         autoConnectedPort = target;
+        if (offlineConsoleOpen) {
+            // [tag:offline_tune] Pre-cache the target so the scanner skips re-inspecting it during the
+            // connect read window — otherwise a scan tick could reopen the port mid-read and hang in LOADING.
+            connectivityContext.getSerialPortScanner().cachePort(new PortResult(target.port, target.type));
+        }
         connectButton.setEnabled(false);
         connectButton.setText("Connecting...");
         portsComboBox.getComboPorts().setEnabled(false);
@@ -588,9 +649,15 @@ public class StartupFrame {
                     return;
                 }
                 SwingUtilities.invokeLater(() -> {
-                    if (!ConnectionStatusLogic.INSTANCE.isConnected()) return;
-                    if (uiContext.getBinaryProtocol() == null) return;
-                    if (uiContext.getBinaryProtocol().getControllerConfiguration() == null) return;
+                    if (!ConnectionStatusLogic.INSTANCE.isConnected()) {
+                        return;
+                    }
+                    if (uiContext.getBinaryProtocol() == null) {
+                        return;
+                    }
+                    if (uiContext.getBinaryProtocol().getControllerConfiguration() == null) {
+                        return;
+                    }
                     onSplashConnected(target);
                 });
             }
@@ -631,6 +698,18 @@ public class StartupFrame {
     private void onSplashConnected(PortResult target) {
         if (autoConnectedPort == null || !autoConnectedPort.port.equals(target.port)) {
             // User cancelled or moved on — ignore the late event.
+            return;
+        }
+        if (offlineConsoleOpen) {
+            // [tag:offline_tune] The offline console (already open on the shared uiContext) is now connected
+            // via autoConnect.
+            // Cache the connected port so the still-running scanner does NOT re-probe it — re-opening the
+            // connected port mid-read races the live read and hangs the UI in LOADING. The scanner stays
+            // alive (and the splash listener stays registered) so a later disconnect/replug — possibly
+            // under a different port name — auto-reconnects (handled via onSplashDisconnected re-arming).
+            // Do NOT open a second console.
+            log.info("onSplashConnected: offline console online on " + target.port + " — caching port, scanner kept alive");
+            connectivityContext.getSerialPortScanner().cachePort(new PortResult(target.port, target.type));
             return;
         }
         connectButton.setText("Connect");
@@ -808,6 +887,13 @@ public class StartupFrame {
         firmwareUpdateTab.getBasicUpdaterPanel().setSplashLinkManager(null);
         // Sets isStarted=false so the next connect() can create a new LinkManager connector.
         uiContext.getLinkManager().close();
+        if (offlineConsoleOpen && autoConnectedPort != null) {
+            // [tag:offline_tune] The offline console is still up. Re-arm scanner-driven auto-connect and
+            // let the scanner re-inspect the (now stale) port so the console reconnects when the board
+            // comes back — possibly under a different port name (USB re-enumeration).
+            connectivityContext.getSerialPortScanner().invalidatePort(autoConnectedPort.port);
+            firstTimeAutoConnect = true;
+        }
         autoConnectedPort = null;
         autoConnectThread = null;
         connectButton.setText("Connect");

--- a/java_console/ui/src/main/java/com/rusefi/maintenance/OfflineEditMigration.java
+++ b/java_console/ui/src/main/java/com/rusefi/maintenance/OfflineEditMigration.java
@@ -1,0 +1,104 @@
+package com.rusefi.maintenance;
+
+import com.devexperts.logging.Logging;
+import com.opensr5.ConfigurationImage;
+import com.opensr5.ini.IniFileModel;
+import com.opensr5.ini.field.IniField;
+import com.rusefi.tune.ConfigurationImageGetterSetter2;
+import com.rusefi.tune.xml.Constant;
+import com.rusefi.tune.xml.MsqFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+import static com.devexperts.logging.Logging.getLogging;
+
+/**
+ * [tag:offline_tune]
+ * Migrates the user's offline edits onto an ECU that has a different .ini signature.
+ *
+ * <p>"Edits" are the fields whose value differs between the loaded baseline and the current
+ * (edited) image, both interpreted with the .ini the tune was loaded with. A field can be
+ * migrated only if it also exists in the target ECU's .ini — otherwise it is reported as
+ * incompatible so the user can decide whether to proceed.
+ */
+public final class OfflineEditMigration {
+    private static final Logging log = getLogging(OfflineEditMigration.class);
+
+    private OfflineEditMigration() {
+    }
+
+    public static final class Plan {
+        /** Edited fields that exist in the target .ini and will be written. */
+        public final List<Constant> migratable;
+        /** Names of edited fields absent from the target .ini (cannot be migrated). */
+        public final List<String> incompatible;
+
+        Plan(List<Constant> migratable, List<String> incompatible) {
+            this.migratable = migratable;
+            this.incompatible = incompatible;
+        }
+
+        public boolean isEmpty() {
+            return migratable.isEmpty() && incompatible.isEmpty();
+        }
+    }
+
+    /**
+     * Computes which edited fields can be carried over to a different-signature ECU.
+     *
+     * @param baseline  image as originally loaded (no edits)
+     * @param edited    current image with the user's edits
+     * @param sourceIni .ini the offline tune was loaded/edited with
+     * @param targetIni .ini of the connected ECU
+     */
+    public static Plan computePlan(ConfigurationImage baseline, ConfigurationImage edited,
+                                   IniFileModel sourceIni, IniFileModel targetIni) {
+        Map<String, Constant> baseMap = MsqFactory.valueOf(baseline, sourceIni).getConstantsAsMap();
+        Map<String, Constant> editMap = MsqFactory.valueOf(edited, sourceIni).getConstantsAsMap();
+
+        List<Constant> migratable = new ArrayList<>();
+        List<String> incompatible = new ArrayList<>();
+
+        for (Map.Entry<String, Constant> e : editMap.entrySet()) {
+            String name = e.getKey();
+            Constant editedConst = e.getValue();
+            Constant baseConst = baseMap.get(name);
+            // Unchanged fields are not edits — skip them.
+            if (baseConst != null && Objects.equals(baseConst.getValue(), editedConst.getValue())) {
+                continue;
+            }
+            if (targetIni.findIniField(name).isPresent()) {
+                migratable.add(editedConst);
+            } else {
+                incompatible.add(name);
+            }
+        }
+        return new Plan(migratable, incompatible);
+    }
+
+    /**
+     * Applies the migratable edits onto a clone of the target ECU image.
+     * Fields that fail to set (type/scale mismatch) are skipped and logged.
+     *
+     * @return a new image with the edits applied
+     */
+    public static ConfigurationImage apply(ConfigurationImage targetImage, IniFileModel targetIni, List<Constant> migratable) {
+        ConfigurationImage merged = targetImage.clone();
+        for (Constant c : migratable) {
+            Optional<IniField> field = targetIni.findIniField(c.getName());
+            if (!field.isPresent()) {
+                continue;
+            }
+            try {
+                ConfigurationImageGetterSetter2.setValue(field.get(), merged, c);
+            } catch (Throwable t) {
+                log.warn("Skipping field `" + c.getName() + "` during offline-edit migration: " + t.getMessage());
+            }
+        }
+        return merged;
+    }
+}

--- a/java_console/ui/src/main/java/com/rusefi/maintenance/OfflineTuneLoader.java
+++ b/java_console/ui/src/main/java/com/rusefi/maintenance/OfflineTuneLoader.java
@@ -1,0 +1,141 @@
+package com.rusefi.maintenance;
+
+import com.devexperts.logging.Logging;
+import com.opensr5.ConfigurationImage;
+import com.opensr5.ini.IniFileModel;
+import com.rusefi.binaryprotocol.IniNotFoundException;
+import com.rusefi.binaryprotocol.RealIniFileProvider;
+import com.rusefi.ini.reader.IniFileReaderUtil;
+import com.rusefi.ini.reader.IniParsingException;
+import com.rusefi.tune.xml.Msq;
+
+import javax.swing.*;
+import javax.swing.filechooser.FileNameExtensionFilter;
+import java.awt.Component;
+import java.io.File;
+import java.io.FileNotFoundException;
+
+import static com.devexperts.logging.Logging.getLogging;
+
+/**
+ * Loads a tune from an MSQ file without requiring a live ECU connection.
+ * Extracts the signature from the MSQ, fetches the matching INI (with manual
+ * fallback), and produces a ConfigurationImage ready for offline editing.
+ */
+public class OfflineTuneLoader {
+    private static final Logging log = getLogging(OfflineTuneLoader.class);
+
+    private OfflineTuneLoader() {}
+
+    public static class Result {
+        public final Msq msq;
+        public final IniFileModel ini;
+        public final ConfigurationImage image;
+        public final String signature;
+
+        public Result(Msq msq, IniFileModel ini, ConfigurationImage image, String signature) {
+            this.msq = msq;
+            this.ini = ini;
+            this.image = image;
+            this.signature = signature;
+        }
+    }
+
+    /**
+     * Loads an MSQ file, resolves the matching INI, and returns a Result with
+     * the parsed MSQ, INI model, ConfigurationImage, and signature.
+     *
+     * @param msqPath absolute path to the .msq file
+     * @param parent  parent component for file chooser / error dialogs (may be null)
+     * @return Result containing msq, ini, image, and signature; or null if user cancels
+     */
+    public static Result loadTuneFromFile(String msqPath, Component parent) {
+        Msq msq;
+        try {
+            msq = Msq.readTune(msqPath);
+        } catch (Exception e) {
+            log.error("Failed to read MSQ: " + msqPath, e);
+            showErrorDialog(parent, "Failed to read tune file:\n" + e.getMessage());
+            return null;
+        }
+
+        String signature = msq.getVersionInfo() != null ? msq.getVersionInfo().getSignature() : null;
+        if (signature == null || signature.isEmpty()) {
+            showErrorDialog(parent, "MSQ file does not contain a signature.\nCannot determine which INI file to use.");
+            return null;
+        }
+
+        IniFileModel ini = tryLoadIni(signature, parent);
+        if (ini == null) {
+            return null;
+        }
+
+        ConfigurationImage image = msq.asImage(ini);
+        return new Result(msq, ini, image, signature);
+    }
+
+    private static IniFileModel tryLoadIni(String signature, Component parent) {
+        // Attempt automatic resolution via RealIniFileProvider (download + local fallback)
+        try {
+            RealIniFileProvider provider = new RealIniFileProvider();
+            IniFileModel ini = provider.provide(signature);
+            if (ini != null) {
+                log.info("Resolved INI for signature: " + signature);
+                return ini;
+            }
+        } catch (IniNotFoundException e) {
+            log.info("Automatic INI resolution failed for " + signature + ": " + e.getMessage());
+        } catch (Exception e) {
+            log.info("Automatic INI resolution failed for " + signature + ": " + e.getMessage());
+        }
+
+        // Manual fallback: let user pick an INI file
+        log.info("Attempting manual INI selection for signature: " + signature);
+        return promptForIniFile(parent, signature);
+    }
+
+    private static IniFileModel promptForIniFile(Component parent, String signature) {
+        int choice = JOptionPane.showConfirmDialog(
+            parent,
+            "Could not automatically find an INI file for signature:\n" + signature + "\n\nWould you like to select an INI file manually?",
+            "INI File Not Found",
+            JOptionPane.YES_NO_OPTION,
+            JOptionPane.WARNING_MESSAGE
+        );
+        if (choice != JOptionPane.YES_OPTION) {
+            return null;
+        }
+
+        JFileChooser chooser = new JFileChooser();
+        chooser.setFileSelectionMode(JFileChooser.FILES_ONLY);
+        chooser.setFileFilter(new FileNameExtensionFilter("INI files", "ini"));
+        if (chooser.showOpenDialog(parent) != JFileChooser.APPROVE_OPTION) {
+            return null;
+        }
+
+        File iniFile = chooser.getSelectedFile();
+        try {
+            IniFileModel ini = IniFileReaderUtil.readIniFileChecked(iniFile.getAbsolutePath());
+            log.info("Manually loaded INI: " + iniFile.getAbsolutePath());
+            return ini;
+        } catch (FileNotFoundException e) {
+            showErrorDialog(parent, "INI file not found:\n" + iniFile.getAbsolutePath());
+            return null;
+        } catch (IniParsingException e) {
+            showErrorDialog(parent, "Failed to parse INI file:\n" + e.getMessage());
+            return null;
+        } catch (Exception e) {
+            showErrorDialog(parent, "Failed to read INI file:\n" + e.getMessage());
+            return null;
+        }
+    }
+
+    private static void showErrorDialog(Component parent, String message) {
+        JOptionPane.showMessageDialog(
+            parent,
+            message,
+            "Error",
+            JOptionPane.ERROR_MESSAGE
+        );
+    }
+}

--- a/java_console/ui/src/main/java/com/rusefi/ui/TuningPane.java
+++ b/java_console/ui/src/main/java/com/rusefi/ui/TuningPane.java
@@ -10,6 +10,7 @@ import com.opensr5.ini.IndicatorModel;
 import com.opensr5.ini.IniFileModel;
 import com.rusefi.binaryprotocol.BinaryProtocol;
 import com.rusefi.core.SensorCentral;
+import com.rusefi.maintenance.OfflineEditMigration;
 import com.rusefi.io.ConnectionStatusLogic;
 import com.rusefi.ui.widgets.tune.CalibrationDialogWidget;
 import com.rusefi.ui.widgets.tune.IndicatorPanel;
@@ -34,30 +35,44 @@ public class TuningPane {
     private static final Logging log = Logging.getLogging(TuningPane.class);
 
     private final JPanel content = new JPanel(new BorderLayout());
+    private final UIContext uiContext;
     private final MainMenuTreeWidget left;
     private final TuningToolbarWidget toolbar;
+    /** Accumulated tune edits across all dialogs for this session. Field so offline seeding can set it. */
+    private final AtomicReference<ConfigurationImage> sessionImage = new AtomicReference<>();
+    /** Single-element holder for the currently displayed menu key. Field so the connect handler can access it. */
+    private final AtomicReference<String> currentKey = new AtomicReference<>();
+    /** [tag:offline_tune] The .ini the offline tune was loaded with — used to migrate edits if a different-signature ECU connects. */
+    private IniFileModel offlineIni;
     /** Fired when the user picks "Show in Pinout" on a pin-enum field. Wired from ConsoleUI after construction. */
     private Consumer<String> navigateToPinout;
 
     public TuningPane(UIContext uiContext) {
+        this(uiContext, null);
+    }
+
+    /**
+     * @param uiContext       live context (BinaryProtocol, LinkManager)
+     * @param initialBaseline optional baseline image for discard (used in offline mode when a tune is pre-loaded)
+     */
+    public TuningPane(UIContext uiContext, ConfigurationImage initialBaseline) {
+        this.uiContext = uiContext;
         left = new MainMenuTreeWidget(uiContext);
 
         CalibrationDialogWidget right = new CalibrationDialogWidget(uiContext);
         JScrollPane rightScrollPane = new JScrollPane(right.getContentPane());
 
-        final AtomicReference<String> currentKey = new AtomicReference<>();
-
-        // Accumulated tune edits across all dialogs for this session.
-        final AtomicReference<ConfigurationImage> sessionImage = new AtomicReference<>();
-
-        toolbar = new TuningToolbarWidget(uiContext, right, currentKey, sessionImage);
+        toolbar = new TuningToolbarWidget(uiContext, right, currentKey, sessionImage, initialBaseline);
 
         JSplitPane splitPane = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT, left.getContentPane(), rightScrollPane);
         splitPane.setResizeWeight(0.3);
 
         left.setOnSelect(subMenu -> {
             BinaryProtocol bp = uiContext.getBinaryProtocol();
-            if (bp == null || bp.getControllerConfiguration() == null) {
+            ConfigurationImage ecuImage = (bp != null) ? bp.getControllerConfiguration() : null;
+            // [tag:offline_tune] Offline mode has no ECU image; fall back to the session image seeded
+            // from the loaded tune. Bail only if we have neither source — else the right pane stays blank.
+            if (ecuImage == null && sessionImage.get() == null) {
                 return;
             }
 
@@ -71,7 +86,7 @@ public class TuningPane {
             if (pending != null) {
                 sessionImage.set(pending);
             } else if (sessionImage.get() == null) {
-                sessionImage.set(bp.getControllerConfiguration().clone());
+                sessionImage.set(ecuImage.clone());
             }
 
             currentKey.set(subMenu.getKey());
@@ -152,28 +167,46 @@ public class TuningPane {
         };
         SensorCentral.getInstance().addListener(eventTriggerListener);
 
-        // When the ECU disconnects (e.g. after a firmware flash or board swap), drop all stale
-        // session state so the next connection re-reads calibrations fresh from the new board.
-        // Without this, sessionImage/workingImage from the old board (possibly a different config
-        // page size) would be used as the diff baseline in uploadChangesWithoutBurn.
-        // currentKey is preserved so that reconnection can automatically re-render the last section.
+        // When the ECU disconnects (e.g. after a firmware flash or board swap), drop stale
+        // undo/redo state so the next connection starts fresh, but preserve sessionImage
+        // and baselineImage so the user can continue editing offline.
+        // Without clearing sessionImage, the old board's image would be used as the diff
+        // baseline in uploadChangesWithoutBurn — but that's fine because on reconnect
+        // we re-seed from the ECU below.
         ConnectionStatusLogic.INSTANCE.addListener(isConnected -> {
             if (!isConnected) {
                 SwingUtilities.invokeLater(() -> {
                     toolbar.onDisconnect();
                     right.reset();
-                    sessionImage.set(null);
+                    // Preserve sessionImage for offline editing — do NOT set to null
                     triggerPrevValues.clear();
                 });
             } else {
                 SwingUtilities.invokeLater(() -> {
                     triggerPrevValues.clear();
-                    String key = currentKey.get();
-                    if (key == null) return;
                     BinaryProtocol bp = uiContext.getBinaryProtocol();
-                    if (bp == null || bp.getControllerConfiguration() == null) return;
+                    if (bp == null || bp.getControllerConfiguration() == null) {
+                        return;
+                    }
+
+                    // [tag:offline_tune] If we were editing offline and have pending changes, ask the
+                    // user what to do before the freshly-read ECU image overwrites their edits. If the
+                    // user chose to write/migrate, the helper takes over and we keep their edits.
+                    ConfigurationImage offlineEdits = sessionImage.get();
+                    if (uiContext.isOfflineMode() && toolbar.hasUnsavedChanges(offlineEdits)
+                            && reconcileOfflineEditsOnConnect(bp, right, offlineEdits)) {
+                        return;
+                    }
+
+                    // Default: adopt the ECU's current tune.
+                    uiContext.setOfflineMode(false);
+                    toolbar.onEcuConnected();
                     sessionImage.set(bp.getControllerConfiguration().clone());
-                    right.update(key, uiContext.iniFileState.getIniFileModel(), sessionImage.get());
+                    toolbar.setBaselineImage(sessionImage.get().clone());
+                    String key = currentKey.get();
+                    if (key != null) {
+                        right.update(key, uiContext.iniFileState.getIniFileModel(), sessionImage.get());
+                    }
                 });
             }
         });
@@ -231,5 +264,120 @@ public class TuningPane {
 
     public Action getSaveTuneAction() {
         return toolbar.getSaveTuneAction();
+    }
+
+    /**
+     * [tag:offline_tune]
+     * Seeds the session image and baseline for offline editing (no ECU connection).
+     * Called from ConsoleUI when opening with a pre-loaded tune.
+     */
+    public void seedOfflineImage(ConfigurationImage image, String dialogKey) {
+        if (image == null) return;
+        // Seed the session image so the onSelect handler has a base image to render against
+        // (offline mode has no BinaryProtocol/ECU image to fall back to).
+        sessionImage.set(image.clone());
+        toolbar.setBaselineImage(image.clone());
+        // Remember which .ini these edits belong to so a different-signature ECU can migrate them.
+        offlineIni = uiContext.iniFileState.getIniFileModel();
+        // Select the first dialog if none is selected yet
+        if (dialogKey != null) {
+            left.selectSubMenu(dialogKey);
+        }
+    }
+
+    /**
+     * [tag:offline_tune]
+     * Called on the EDT when an ECU connects while there are unsaved offline edits.
+     * Prompts the user to write/migrate their edits or discard them.
+     *
+     * @return true if the user chose to write/migrate (edits handled, caller must NOT reseed);
+     *         false if the user chose discard (caller should adopt the ECU tune).
+     */
+    private boolean reconcileOfflineEditsOnConnect(BinaryProtocol bp, CalibrationDialogWidget right,
+                                                   ConfigurationImage offlineEdits) {
+        IniFileModel ecuIni = uiContext.iniFileState.getIniFileModel();
+        String ecuSig = (ecuIni != null) ? ecuIni.getSignature() : bp.signature;
+        String offlineSig = (offlineIni != null) ? offlineIni.getSignature() : null;
+        boolean sameSignature = offlineSig != null && offlineSig.equals(ecuSig);
+
+        // Same firmware (or we cannot compare layouts): the edited image is byte-compatible — write it raw.
+        if (sameSignature || offlineIni == null || ecuIni == null) {
+            int choice = JOptionPane.showOptionDialog(content,
+                    "You have unsaved offline tune edits.\n" +
+                            "Write them to the connected ECU, or discard them and load the ECU's current tune?",
+                    "ECU Connected", JOptionPane.YES_NO_OPTION, JOptionPane.QUESTION_MESSAGE,
+                    null, new Object[]{"Write to ECU", "Discard edits"}, "Write to ECU");
+            if (choice != JOptionPane.YES_OPTION) {
+                return false;
+            }
+            final ConfigurationImage toWrite = offlineEdits.clone();
+            uiContext.getLinkManager().submit(() -> {
+                bp.uploadChanges(toWrite); // uploads + burns + caches the image
+                SwingUtilities.invokeLater(() -> {
+                    uiContext.setOfflineMode(false);
+                    toolbar.onEcuConnected();
+                    toolbar.setBaselineImage(toWrite.clone());
+                });
+            });
+            return true;
+        }
+
+        // Different firmware signature: migrate only the edited fields that also exist on the ECU.
+        // ponytail: name-based field migration on the EDT; fine for a one-shot connect dialog.
+        ConfigurationImage baseline = toolbar.getBaselineImage();
+        if (baseline == null) {
+            baseline = offlineEdits; // no baseline => nothing detectable as an edit
+        }
+        OfflineEditMigration.Plan plan = OfflineEditMigration.computePlan(baseline, offlineEdits, offlineIni, ecuIni);
+
+        StringBuilder msg = new StringBuilder();
+        msg.append("The connected ECU uses a different firmware than your offline tune.\n\n")
+                .append("Offline tune signature:\n    ").append(offlineSig).append("\n")
+                .append("Connected ECU signature:\n    ").append(ecuSig).append("\n\n")
+                .append(plan.migratable.size()).append(" of your edited field(s) can be migrated to this ECU.\n");
+        if (!plan.incompatible.isEmpty()) {
+            msg.append(plan.incompatible.size())
+                    .append(" edited field(s) do not exist on this ECU and will be skipped:\n")
+                    .append(formatFieldList(plan.incompatible)).append("\n");
+        }
+        msg.append("\nMigrate your edits to the connected ECU, or discard them?");
+
+        int choice = JOptionPane.showOptionDialog(content, msg.toString(),
+                "ECU Signature Mismatch", JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE,
+                null, new Object[]{"Migrate to ECU", "Discard edits"}, "Migrate to ECU");
+        if (choice != JOptionPane.YES_OPTION || plan.migratable.isEmpty()) {
+            // Nothing to migrate, or user discarded — adopt the ECU tune.
+            return false;
+        }
+
+        final ConfigurationImage merged = OfflineEditMigration.apply(bp.getControllerConfiguration(), ecuIni, plan.migratable);
+        final IniFileModel targetIni = ecuIni;
+        uiContext.getLinkManager().submit(() -> {
+            bp.uploadChanges(merged); // uploads + burns + caches the image
+            SwingUtilities.invokeLater(() -> {
+                uiContext.setOfflineMode(false);
+                toolbar.onEcuConnected();
+                sessionImage.set(merged.clone());
+                toolbar.setBaselineImage(merged.clone());
+                String key = currentKey.get();
+                if (key != null) {
+                    right.update(key, targetIni, sessionImage.get());
+                }
+            });
+        });
+        return true;
+    }
+
+    /** Formats a field-name list for a dialog, truncating long lists. */
+    private static String formatFieldList(List<String> fields) {
+        final int max = 15;
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < Math.min(fields.size(), max); i++) {
+            sb.append("    • ").append(fields.get(i)).append("\n");
+        }
+        if (fields.size() > max) {
+            sb.append("    … and ").append(fields.size() - max).append(" more\n");
+        }
+        return sb.toString();
     }
 }

--- a/java_console/ui/src/main/java/com/rusefi/ui/UIContext.java
+++ b/java_console/ui/src/main/java/com/rusefi/ui/UIContext.java
@@ -1,6 +1,7 @@
 package com.rusefi.ui;
 
 import com.opensr5.ConfigurationImage;
+import com.opensr5.ini.IniFileModel;
 import com.rusefi.binaryprotocol.BinaryProtocol;
 import com.rusefi.ini.IniFileState;
 import com.rusefi.io.CommandQueue;
@@ -23,6 +24,8 @@ public class UIContext {
     public IniFileState iniFileState = new IniFileState(this);
     public GaugesPanel.DetachedRepository DetachedRepositoryINSTANCE = new GaugesPanel.DetachedRepository(this);
 
+    /** [tag:offline_tune] True when the console was opened in offline mode (no ECU connection, tune loaded from file). */
+    private boolean offlineMode;
 
     @NotNull
     public LinkManager getLinkManager() {
@@ -36,6 +39,21 @@ public class UIContext {
 
     public CommandQueue getCommandQueue() {
         return linkManager.getCommandQueue();
+    }
+
+    public boolean isOfflineMode() {
+        return offlineMode;
+    }
+
+    public void setOfflineMode(boolean offlineMode) {
+        this.offlineMode = offlineMode;
+    }
+
+    /**
+     * [tag:offline_tune] Sets the INI model directly for offline editing (no ECU connection).
+     */
+    public void setIniFileModelForOffline(IniFileModel ini) {
+        iniFileState.setIniFileModelForTest(ini);
     }
 
     // ---- Config-image change notifications ----

--- a/java_console/ui/src/main/java/com/rusefi/ui/basic/TuneManagementTab.java
+++ b/java_console/ui/src/main/java/com/rusefi/ui/basic/TuneManagementTab.java
@@ -1,12 +1,15 @@
 package com.rusefi.ui.basic;
 
 import com.devexperts.logging.Logging;
+import com.opensr5.ConfigurationImage;
+import com.opensr5.ini.IniFileModel;
 import com.rusefi.ConnectivityContext;
 import com.rusefi.binaryprotocol.BinaryProtocol;
 import com.rusefi.core.net.PropertiesHolder;
 import com.rusefi.core.ui.AutoupdateUtil;
 import com.rusefi.core.ui.ErrorMessageHelper;
 import com.rusefi.io.LinkManager;
+import com.rusefi.maintenance.OfflineTuneLoader;
 import com.rusefi.maintenance.jobs.ImportTuneJob;
 import com.rusefi.ui.UIContext;
 import com.rusefi.tune_manifest.ManifestParseException;
@@ -18,6 +21,7 @@ import com.rusefi.ui.widgets.StatusPanel;
 import org.json.simple.parser.ParseException;
 
 import javax.swing.*;
+import javax.swing.filechooser.FileNameExtensionFilter;
 import javax.swing.table.AbstractTableModel;
 import javax.swing.table.TableColumn;
 import java.awt.*;
@@ -47,11 +51,16 @@ public class TuneManagementTab {
     private final AtomicBoolean awaitingCompletion = new AtomicBoolean(false);
     private List<TuneModel> tunes = new ArrayList<>();
 
+    /** [tag:offline_tune] Hands an offline-loaded tune back to the splash so it can open the console on the shared uiContext. */
+    private final java.util.function.BiConsumer<IniFileModel, ConfigurationImage> offlineConsoleLauncher;
+
     public TuneManagementTab(ConnectivityContext connectivityContext,
                              UIContext uiContext,
                              Component importTuneButton,
                              SingleAsyncJobExecutor singleAsyncJobExecutor,
-                             StatusPanel statusPanelTuneTab) {
+                             StatusPanel statusPanelTuneTab,
+                             java.util.function.BiConsumer<IniFileModel, ConfigurationImage> offlineConsoleLauncher) {
+        this.offlineConsoleLauncher = offlineConsoleLauncher;
         uploadProgress.setIndeterminate(true);
         uploadProgress.setStringPainted(true);
         uploadProgress.setString("Loading tune...");
@@ -146,7 +155,12 @@ public class TuneManagementTab {
             }
         }));
 
-        totalContent.add(importTuneButton, BorderLayout.SOUTH);
+        JButton loadTuneFileButton = new JButton("Load Tune File");
+        loadTuneFileButton.addActionListener(e -> loadTuneFileOffline());
+        JPanel bottomPanel = new JPanel(new BorderLayout());
+        bottomPanel.add(importTuneButton, BorderLayout.NORTH);
+        bottomPanel.add(loadTuneFileButton, BorderLayout.SOUTH);
+        totalContent.add(bottomPanel, BorderLayout.SOUTH);
     }
 
     private void showErrorLogPopup(String logText) {
@@ -206,6 +220,26 @@ public class TuneManagementTab {
 
     public static String getTunesManifestUrl() {
         return PropertiesHolder.getProperty("tunes_manifest");
+    }
+
+    /** [tag:offline_tune] Lets the user pick an .msq and open the console offline (no ECU connection). */
+    private void loadTuneFileOffline() {
+        JFileChooser chooser = new JFileChooser();
+        chooser.setFileSelectionMode(JFileChooser.FILES_ONLY);
+        chooser.setFileFilter(new FileNameExtensionFilter("Tune files (.msq)", "msq"));
+        if (chooser.showOpenDialog(totalContent) != JFileChooser.APPROVE_OPTION) {
+            return;
+        }
+
+        String path = chooser.getSelectedFile().getAbsolutePath();
+        OfflineTuneLoader.Result result = OfflineTuneLoader.loadTuneFromFile(path, totalContent);
+        if (result == null) {
+            return;
+        }
+
+        // Hand off to the splash, which disposes itself and opens the console on the shared uiContext
+        // (keeping the scanner alive so a later ECU connect transitions this console online — no 2nd window).
+        SwingUtilities.invokeLater(() -> offlineConsoleLauncher.accept(result.ini, result.image));
     }
 
     class MyTableModel extends AbstractTableModel {

--- a/java_console/ui/src/main/java/com/rusefi/ui/console/MainFrame.java
+++ b/java_console/ui/src/main/java/com/rusefi/ui/console/MainFrame.java
@@ -1,6 +1,7 @@
 package com.rusefi.ui.console;
 
 import com.devexperts.logging.Logging;
+import com.opensr5.ini.IniFileModel;
 import com.rusefi.*;
 import com.rusefi.autoupdate.Autoupdate;
 import com.rusefi.binaryprotocol.BinaryProtocol;
@@ -307,6 +308,11 @@ public class MainFrame {
             BinaryProtocol bp = consoleUI.uiContext.getBinaryProtocol();
             String signature = bp == null ? "not loaded" : bp.signature;
             frameTitle = consoleVersion + "; firmware=" + Launcher.firmwareVersion.get() + "@" + consoleUI.getPort() + " " + signature;
+        } else if (consoleUI.uiContext.isOfflineMode()) {
+            // [tag:offline_tune] no ECU — title reflects the loaded tune's signature
+            IniFileModel ini = consoleUI.uiContext.iniFileState.getIniFileModel();
+            String signature = ini != null ? ini.getSignature() : "no INI";
+            frameTitle = "OFFLINE " + consoleVersion + " " + signature;
         } else {
             frameTitle = "DISCONNECTED " + consoleVersion;
         }

--- a/java_console/ui/src/main/java/com/rusefi/ui/console/TabbedPanel.java
+++ b/java_console/ui/src/main/java/com/rusefi/ui/console/TabbedPanel.java
@@ -45,17 +45,15 @@ public class TabbedPanel {
                 text = "Updating";
                 textColor = Color.orange;
             } else {
-                switch (ConnectionStatusLogic.INSTANCE.getValue()) {
-                    case NOT_CONNECTED:
-                        text = "Not connected";
-                        textColor = Color.white;
-                        break;
-                    case LOADING:
-                        text = "Loading";
-                        textColor = Color.white;
-                        break;
-                    default:
-                        return;
+                ConnectionStatusValue status = ConnectionStatusLogic.INSTANCE.getValue();
+                if (status == ConnectionStatusValue.LOADING) {
+                    text = "Loading";
+                    textColor = Color.white;
+                } else {
+                    // Don't show "Not connected" overlay — the status is visible in the
+                    // title bar and corner icon. Blocking the entire UI with a black overlay
+                    // is too aggressive, especially for offline editing.
+                    return;
                 }
             }
             FontMetrics fm = g.getFontMetrics();
@@ -85,7 +83,7 @@ public class TabbedPanel {
     private boolean hasOverlay() {
         return criticalError != null
             || Boolean.TRUE.equals(tabbedPane.getClientProperty("isUpdating"))
-            || ConnectionStatusLogic.INSTANCE.getValue() != ConnectionStatusValue.CONNECTED;
+            || ConnectionStatusLogic.INSTANCE.getValue() == ConnectionStatusValue.LOADING;
     }
 
     private void refreshOverlay() {

--- a/java_console/ui/src/main/java/com/rusefi/ui/widgets/tune/TuningToolbarWidget.java
+++ b/java_console/ui/src/main/java/com/rusefi/ui/widgets/tune/TuningToolbarWidget.java
@@ -4,6 +4,7 @@ import com.opensr5.ConfigurationImage;
 import com.opensr5.ini.IniFileModel;
 import com.rusefi.binaryprotocol.BinaryProtocol;
 import com.rusefi.io.UpdateOperationCallbacks;
+import com.rusefi.maintenance.OfflineTuneLoader;
 import com.rusefi.maintenance.jobs.AsyncJob;
 import com.rusefi.maintenance.jobs.AsyncJobExecutor;
 import com.rusefi.maintenance.jobs.JobHelper;
@@ -39,6 +40,9 @@ public class TuningToolbarWidget {
     private final ArrayDeque<ConfigurationImage> redoStack = new ArrayDeque<>();
     private final AtomicReference<ConfigurationImage> undoBaseline = new AtomicReference<>();
 
+    /** [tag:offline_tune] Baseline image for discard — set when a tune is loaded (from ECU or MSQ file). */
+    private ConfigurationImage baselineImage;
+
     private final JButton undoButton = new JButton("Undo");
     private final JButton redoButton = new JButton("Redo");
 
@@ -49,15 +53,18 @@ public class TuningToolbarWidget {
     private final Timer uploadTimer;
 
     /**
-     * @param uiContext    live context (BinaryProtocol, LinkManager)
-     * @param right        the dialog widget — needed for get/update working image
-     * @param currentKey   single-element array holding the currently displayed menu key
-     * @param sessionImage single-element array holding the accumulated session image
+     * @param uiContext      live context (BinaryProtocol, LinkManager)
+     * @param right          the dialog widget — needed for get/update working image
+     * @param currentKey     single-element array holding the currently displayed menu key
+     * @param sessionImage   single-element array holding the accumulated session image
+     * @param baselineImage  baseline image for discard (from ECU or loaded MSQ); may be null initially
      */
     public TuningToolbarWidget(UIContext uiContext,
                                 CalibrationDialogWidget right,
                                 AtomicReference<String> currentKey,
-                                AtomicReference<ConfigurationImage> sessionImage) {
+                                AtomicReference<ConfigurationImage> sessionImage,
+                                ConfigurationImage baselineImage) {
+        this.baselineImage = baselineImage;
         undoButton.setEnabled(false);
         redoButton.setEnabled(false);
 
@@ -93,8 +100,10 @@ public class TuningToolbarWidget {
         uploadTimer.setRepeats(false);
 
         JButton burnButton = getBurnToEcuButton(uiContext, right, sessionImage);
+        burnButton.setEnabled(uiContext.getBinaryProtocol() != null);
 
         JButton discardButton = getDiscardButton(uiContext, right, sessionImage, currentKey, updateButtons);
+        discardButton.setEnabled(baselineImage != null);
 
         buildLoadTuneAction(uiContext, right, currentKey, sessionImage);
         buildSaveTuneAction(uiContext, right, sessionImage);
@@ -165,6 +174,17 @@ public class TuningToolbarWidget {
         return burnButton;
     }
 
+    /** Call when ECU connects to enable the burn button. */
+    public void onEcuConnected() {
+        Component[] components = panel.getComponents();
+        for (Component c : components) {
+            if (c instanceof JButton && "Burn to ECU".equals(((JButton) c).getText())) {
+                ((JButton) c).setEnabled(true);
+                break;
+            }
+        }
+    }
+
     private @NotNull JButton getDiscardButton(UIContext uiContext,
                                               CalibrationDialogWidget right,
                                               AtomicReference<ConfigurationImage> sessionImage,
@@ -173,15 +193,10 @@ public class TuningToolbarWidget {
         JButton discardButton = new JButton("Discard changes");
 
         discardButton.addActionListener(e -> {
-            BinaryProtocol bp = uiContext.getBinaryProtocol();
-            if (bp == null) {
+            if (baselineImage == null) {
                 return;
             }
-            ConfigurationImage baseline = bp.getCachedImage();
-            if (baseline == null) {
-                baseline = bp.getControllerConfiguration();
-            }
-            sessionImage.set(baseline.clone());
+            sessionImage.set(baselineImage.clone());
             String key = currentKey.get();
             if (key != null) {
                 right.update(key, uiContext.iniFileState.getIniFileModel(), sessionImage.get());
@@ -207,18 +222,9 @@ public class TuningToolbarWidget {
                 if (chooser.showOpenDialog(null) != JFileChooser.APPROVE_OPTION) {
                     return;
                 }
-                IniFileModel ini = uiContext.iniFileState.getIniFileModel();
-                if (ini == null) {
-                    JOptionPane.showMessageDialog(null, "No INI file loaded", "Error", JOptionPane.ERROR_MESSAGE);
-                    return;
-                }
                 final String path = chooser.getSelectedFile().getAbsolutePath();
                 final String fileName = chooser.getSelectedFile().getName();
-                ConfigurationImage sessionImg = sessionImage.get();
-                final ConfigurationImage base = sessionImg != null
-                        ? sessionImg
-                        : new ConfigurationImage(ini.getMetaInfo().getPageSize(0));
-                final AtomicReference<ConfigurationImage> result = new AtomicReference<>();
+
                 final StatusWindow statusWindow = new StatusWindow();
                 statusWindow.showFrame("Load Tune");
                 final UpdateOperationCallbacks callbacks = statusWindow.getContent();
@@ -229,13 +235,23 @@ public class TuningToolbarWidget {
                         public void doJob(UpdateOperationCallbacks cb, Runnable onJobFinished) {
                             JobHelper.doJob(() -> {
                                 try {
-                                    callbacks.logLine("Reading " + fileName + "...");
-                                    Msq msq = Msq.readTune(path);
-                                    callbacks.logLine("Applying tune fields...");
-                                    ConfigurationImage newImage = msq.applyOnto(base, ini);
+                                    cb.logLine("Loading " + fileName + "...");
+                                    OfflineTuneLoader.Result result = OfflineTuneLoader.loadTuneFromFile(path, null);
+                                    if (result == null) {
+                                        cb.logLine("Load cancelled or failed.");
+                                        cb.error();
+                                        return;
+                                    }
+                                    cb.logLine("Applying tune fields...");
+                                    ConfigurationImage sessionImg = sessionImage.get();
+                                    ConfigurationImage base = sessionImg != null
+                                            ? sessionImg.clone()
+                                            : new ConfigurationImage(result.ini.getMetaInfo().getPageSize(0));
+                                    ConfigurationImage newImage = result.msq.applyOnto(base, result.ini);
+
                                     BinaryProtocol bp = uiContext.getBinaryProtocol();
                                     if (bp != null) {
-                                        callbacks.logLine("Uploading and burning to ECU...");
+                                        cb.logLine("Uploading and burning to ECU...");
                                         CountDownLatch latch = new CountDownLatch(1);
                                         uiContext.getLinkManager().submit(() -> {
                                             try {
@@ -246,28 +262,34 @@ public class TuningToolbarWidget {
                                         });
                                         latch.await();
                                     }
-                                    result.set(newImage);
-                                    callbacks.done();
+
+                                    SwingUtilities.invokeLater(() -> {
+                                        sessionImage.set(newImage);
+                                        baselineImage = newImage.clone();
+                                        String key = currentKey.get();
+                                        if (key != null) {
+                                            right.update(key, result.ini, newImage);
+                                        }
+                                        // Enable discard now that we have a baseline
+                                        Component[] components = panel.getComponents();
+                                        for (Component c : components) {
+                                            if (c instanceof JButton && "Discard changes".equals(((JButton) c).getText())) {
+                                                ((JButton) c).setEnabled(true);
+                                                break;
+                                            }
+                                        }
+                                        uiContext.fireConfigImageChanged(newImage);
+                                        cb.done();
+                                    });
                                 } catch (Exception ex) {
-                                    callbacks.logLine("Error: " + ex.getMessage());
-                                    callbacks.error();
+                                    cb.logLine("Error: " + ex.getMessage());
+                                    cb.error();
                                 }
                             }, onJobFinished);
                         }
                     },
                     callbacks,
-                    () -> SwingUtilities.invokeLater(() -> {
-                        ConfigurationImage res = result.get();
-                        if (res != null) {
-                            statusWindow.getFrame().dispose();
-                            sessionImage.set(res);
-                            String key = currentKey.get();
-                            if (key != null) {
-                                right.update(key, ini, res);
-                            }
-                            uiContext.fireConfigImageChanged(res);
-                        }
-                    })
+                    () -> SwingUtilities.invokeLater(() -> statusWindow.getFrame().dispose())
                 );
             }
         };
@@ -283,12 +305,6 @@ public class TuningToolbarWidget {
                 IniFileModel ini = uiContext.iniFileState.getIniFileModel();
                 ConfigurationImage image = right.getWorkingImage();
                 if (image == null) image = sessionImage.get();
-                if (image == null) {
-                    BinaryProtocol bp = uiContext.getBinaryProtocol();
-                    if (bp != null) {
-                        image = bp.getControllerConfiguration();
-                    }
-                }
                 if (ini == null || image == null) {
                     JOptionPane.showMessageDialog(null, "No configuration loaded", "Error", JOptionPane.ERROR_MESSAGE);
                     return;
@@ -321,6 +337,37 @@ public class TuningToolbarWidget {
 
     public AbstractAction getSaveTuneAction() {
         return saveTuneAction;
+    }
+
+    /**
+     * @return true if {@code current} differs from the loaded baseline (i.e. there are pending edits).
+     * If there is no baseline yet, any non-null image counts as a change.
+     */
+    public boolean hasUnsavedChanges(ConfigurationImage current) {
+        if (current == null) {
+            return false;
+        }
+        if (baselineImage == null) {
+            return true;
+        }
+        return !java.util.Arrays.equals(current.getContent(), baselineImage.getContent());
+    }
+
+    /** @return the loaded baseline image (pre-edit), or null if none loaded. */
+    public ConfigurationImage getBaselineImage() {
+        return baselineImage;
+    }
+
+    /** Sets the baseline image for discard and enables the discard button. */
+    public void setBaselineImage(ConfigurationImage image) {
+        this.baselineImage = image;
+        Component[] components = panel.getComponents();
+        for (Component c : components) {
+            if (c instanceof JButton && "Discard changes".equals(((JButton) c).getText())) {
+                ((JButton) c).setEnabled(image != null);
+                break;
+            }
+        }
     }
 
     private static @NotNull JFileChooser createMsqFileChooser() {
@@ -373,6 +420,7 @@ public class TuningToolbarWidget {
 
     /**
      * Must be called when the ECU disconnects so stale state is dropped.
+     * [tag:offline_tune] Preserves baselineImage so discard still works in offline mode.
      */
     public void onDisconnect() {
         undoCommitTimer.stop();
@@ -382,5 +430,13 @@ public class TuningToolbarWidget {
         undoBaseline.set(null);
         undoButton.setEnabled(false);
         redoButton.setEnabled(false);
+        // Disable burn button when ECU disconnects
+        Component[] components = panel.getComponents();
+        for (Component c : components) {
+            if (c instanceof JButton && "Burn to ECU".equals(((JButton) c).getText())) {
+                ((JButton) c).setEnabled(false);
+                break;
+            }
+        }
     }
 }

--- a/java_console/ui/src/test/java/com/rusefi/maintenance/OfflineEditMigrationTest.java
+++ b/java_console/ui/src/test/java/com/rusefi/maintenance/OfflineEditMigrationTest.java
@@ -1,0 +1,56 @@
+package com.rusefi.maintenance;
+
+import com.opensr5.ConfigurationImage;
+import com.opensr5.ini.IniFileModel;
+import com.opensr5.ini.field.IniField;
+import com.rusefi.tune.ConfigurationImageGetterSetter2;
+import com.rusefi.tune.xml.Constant;
+import com.rusefi.tune.xml.MsqFactory;
+import jakarta.xml.bind.JAXBException;
+import org.junit.jupiter.api.Test;
+
+import static com.rusefi.maintenance.migration.default_migration.DefaultTestTuneMigrationContext.load;
+import static com.rusefi.maintenance.migration.migrators.CltIdleCorrMigrator.MAN_IDLE_POSITION_FIELD_NAME;
+import static org.junit.jupiter.api.Assertions.*;
+
+class OfflineEditMigrationTest {
+
+    @Test
+    void noEditsYieldsEmptyPlan() throws JAXBException {
+        TestTuneMigrationContext ctx = load();
+        IniFileModel ini = ctx.getPrevIniFile();
+        ConfigurationImage baseline = ctx.getPrevTune().asImage(ini);
+
+        OfflineEditMigration.Plan plan = OfflineEditMigration.computePlan(baseline, baseline.clone(), ini, ini);
+
+        assertTrue(plan.isEmpty(), "unchanged image must produce no edits");
+    }
+
+    @Test
+    void editedFieldPresentInTargetIsMigratable() throws JAXBException {
+        TestTuneMigrationContext ctx = load();
+        IniFileModel sourceIni = ctx.getPrevIniFile();
+        IniFileModel targetIni = ctx.getUpdatedIniFile();
+
+        ConfigurationImage baseline = ctx.getPrevTune().asImage(sourceIni);
+        ConfigurationImage edited = baseline.clone();
+
+        // Change a single scalar field that exists in both signatures.
+        IniField field = sourceIni.findIniField(MAN_IDLE_POSITION_FIELD_NAME).orElseThrow();
+        Constant original = MsqFactory.valueOf(baseline, sourceIni).getConstantsAsMap().get(MAN_IDLE_POSITION_FIELD_NAME);
+        ConfigurationImageGetterSetter2.setValue(field, edited, original.cloneWithValue("42.0"));
+
+        OfflineEditMigration.Plan plan = OfflineEditMigration.computePlan(baseline, edited, sourceIni, targetIni);
+
+        assertEquals(1, plan.migratable.size(), "exactly one edited field expected");
+        assertEquals(MAN_IDLE_POSITION_FIELD_NAME, plan.migratable.get(0).getName());
+        assertTrue(plan.incompatible.isEmpty(), "field exists on target, so nothing incompatible");
+
+        // And applying it actually writes the edited value onto a target-layout image
+        // (compare numerically — target .ini may render with different digits, e.g. "42" vs "42.0").
+        ConfigurationImage targetImage = ctx.getUpdatedTune().asImage(targetIni);
+        ConfigurationImage merged = OfflineEditMigration.apply(targetImage, targetIni, plan.migratable);
+        String mergedValue = MsqFactory.valueOf(merged, targetIni).getConstantsAsMap().get(MAN_IDLE_POSITION_FIELD_NAME).getValue();
+        assertEquals(42.0, Double.parseDouble(mergedValue), 1e-6);
+    }
+}


### PR DESCRIPTION
resolves #9634

new button on splash screen if we dont have any ecu connected:

<img width="604" height="405" alt="image" src="https://github.com/user-attachments/assets/2dcfcdcb-9f03-46d0-86f4-e6f9ee820529" />

opens console with correct .ini extracted from the msq file:

<img width="1286" height="783" alt="image" src="https://github.com/user-attachments/assets/9670cf84-ae41-4ad9-9053-b6c0e1510e80" />


at connection with real ecu we ask the user if they want to upload the changes to the board:

<img width="607" height="271" alt="image" src="https://github.com/user-attachments/assets/7bd76582-087b-4f62-9c7b-a689ad0f809c" />

also we can disconected the ecu while online, console will be on offline mode, we can edit/save the tune and upload to the ecu when we reconnected it