### PR TITLE
feat: improve OpenBLT bootloader handling and UI feedback

### DIFF
--- a/java_console/ui/src/main/java/com/rusefi/StartupFrame.java
+++ b/java_console/ui/src/main/java/com/rusefi/StartupFrame.java
@@ -103,6 +103,7 @@ public class StartupFrame {
      * closing the application.
      */
     private boolean isProceeding;
+    // TODO: we should rename this!; now we are showing more than the "no ports connected" message
     private final JLabel noPortsMessage = new JLabel();
     private final JLabel dfuErrorMessage = new JLabel(
         "Failed to check for DFU devices. Try 'Run as Administrator'");
@@ -523,15 +524,28 @@ public class StartupFrame {
 
 
         boolean hasEcuOrBootloader = applyPortSelectionToUIcontrol(portsComboBox.getComboPorts(), ports);
+        PortResult openBltPort = ports.stream()
+            .filter(p -> p.type == OpenBlt)
+            .findFirst()
+            .orElse(null);
+        boolean hasOpenBlt = openBltPort != null;
         if (ports.isEmpty()) {
+            noPortsMessage.setForeground(Color.red);
             noPortsMessage.setText(NO_PORTS_FOUND);
+        } else if (hasOpenBlt) {
+            // A board sitting in the OpenBLT bootloader has no running firmware to auto-connect to —
+            // mirror the auto-connect status line and point the user at the firmware-update flow.
+            noPortsMessage.setForeground(Color.darkGray);
+            noPortsMessage.setText("Board in OpenBLT bootloader on " + openBltPort.port
+                + " — use the Update Firmware tab");
         } else {
+            noPortsMessage.setForeground(Color.red);
             noPortsMessage.setText("Make sure you are disconnected from TunerStudio");
         }
 
         updateConnectButtonState();
 
-        noPortsMessage.setVisible(ports.isEmpty() || !hasEcuOrBootloader);
+        noPortsMessage.setVisible(ports.isEmpty() || !hasEcuOrBootloader || hasOpenBlt);
 
         AutoupdateUtil.trueLayoutAndRepaint(connectPanel);
 

--- a/java_console/ui/src/main/java/com/rusefi/maintenance/ProgramSelector.java
+++ b/java_console/ui/src/main/java/com/rusefi/maintenance/ProgramSelector.java
@@ -25,6 +25,7 @@ import javax.swing.*;
 import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.awt.event.ItemEvent;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -62,7 +63,35 @@ public class ProgramSelector {
         updateModeAndButton.setVisible(false);
         updateModeAndButton.add(splitButton);
 
-        splitButton.addActionListener(e -> executeJob(splitButton, OPENBLT_AUTO, (PortResult) comboPorts.getSelectedItem()));
+        splitButton.addActionListener(e -> {
+            final PortResult selectedPort = (PortResult) comboPorts.getSelectedItem();
+            executeJob(splitButton, mainButtonModeFor(selectedPort), selectedPort);
+        });
+
+        // Keep the main button label in sync with whatever port is currently selected. The combo is
+        // shared with the Connect tab and is repopulated/re-selected after apply() runs, so drive the
+        // text off selection changes (same source the action reads) rather than off apply()'s snapshot.
+        comboPorts.addItemListener(e -> {
+            if (e.getStateChange() == ItemEvent.SELECTED) {
+                refreshMainButtonText();
+            }
+        });
+        refreshMainButtonText();
+    }
+
+    /**
+     * A board already sitting in the OpenBLT bootloader has no running firmware: it never auto-connects,
+     * so {@link #linkManager} is never set for it and {@link UpdateMode#OPENBLT_AUTO} (which reboots a
+     * live ECU into the bootloader) cannot work. Flash it directly via {@link UpdateMode#OPENBLT_MANUAL}.
+     */
+    private static UpdateMode mainButtonModeFor(@Nullable PortResult selectedPort) {
+        return (selectedPort != null && selectedPort.type == OpenBlt) ? OPENBLT_MANUAL : OPENBLT_AUTO;
+    }
+
+    private void refreshMainButtonText() {
+        final PortResult selectedPort = (PortResult) comboPorts.getSelectedItem();
+        final boolean isOpenBltBoard = mainButtonModeFor(selectedPort) == OPENBLT_MANUAL;
+        splitButton.setText(isOpenBltBoard ? OPENBLT_MANUAL.displayText : "Update Firmware");
     }
 
     private void executeJob(JComponent parent, UpdateMode selectedMode, PortResult selectedPort) {

--- a/java_console/ui/src/main/java/com/rusefi/ui/widgets/JSplitButton.java
+++ b/java_console/ui/src/main/java/com/rusefi/ui/widgets/JSplitButton.java
@@ -45,6 +45,10 @@ public class JSplitButton extends JPanel {
         mainButton.setIcon(icon);
     }
 
+    public void setText(String text) {
+        mainButton.setText(text);
+    }
+
     public void setPopupMenu(JPopupMenu popupMenu) {
         this.popupMenu = popupMenu;
     }


### PR DESCRIPTION
resolves #9562

now we pre-select the correct button:

<img width="677" height="269" alt="image" src="https://github.com/user-attachments/assets/dfcf988d-8d91-44cd-ab7f-c41e2ffa4101" />

also we tell the user that we are already connected:

<img width="676" height="337" alt="image" src="https://github.com/user-attachments/assets/3fe016b2-23f6-4ca2-a130-838fc8448cf0" />

(this also happens if the user clicks using the manual blt switch, as i do for making this screenshots)
