### PR TITLE
tunerstudio: wrap sdLoggingState readout in a readoutPanel

### DIFF
--- a/firmware/tunerstudio/tunerstudio.template.ini
+++ b/firmware/tunerstudio/tunerstudio.template.ini
@@ -4097,6 +4097,8 @@ include_file @@SECONDARY_PANELS_FILE@@
 		field = "Toggle button pin (overrides RPM)",	sdLogTriggerPin, { isSdCardEnabled && sdCardConditionalLogging }
 		field = "Toggle button mode",					sdLogTriggerPinMode, { isSdCardEnabled && sdCardConditionalLogging && sdLogTriggerPin != 0 }
 		field = "#State codes: 3=uncond 4=active 5=stop delay 6=wait RPM 7=wait cond 8=button off"
+
+	readoutPanel = sdLoggingStatePanel
 		readout = sdLoggingState, "Logging state", "", 0, 8, 0, 0, 1, 1, 0, 0
 
 	dialog = sdCardCommands, "SD commands"
@@ -4129,6 +4131,7 @@ include_file @@SECONDARY_PANELS_FILE@@
 		panel = sdCardActivityIndicators
 		panel = sdCardLogging
 		panel = sdConditionalLogging
+		panel = sdLoggingStatePanel
 		panel = sdCardStateIndicators
 		panel = sdCardErrorPanel
 		panel = sdCardCommands


### PR DESCRIPTION
The `readout = sdLoggingState` added in #9646 was placed directly inside the `sdConditionalLogging` dialog. TunerStudio only honors `readout` directives inside a `readoutPanel`, so it emitted:

  Warning: readout defined in UserDefined with no readoutPanel defined, ignoring.

Move the readout into a dedicated `readoutPanel = sdLoggingStatePanel` and reference it from the `sdCard` dialog, matching the existing `sdCardErrorPanel` pattern.

Fixes #9697