### PR TITLE
fix: address curve widget layout collapse on narrow windows and resolve units expression rendering

### DIFF
--- a/java_console/ui/src/main/java/com/rusefi/ui/widgets/tune/CurveWidget.java
+++ b/java_console/ui/src/main/java/com/rusefi/ui/widgets/tune/CurveWidget.java
@@ -5,6 +5,7 @@ import com.opensr5.ConfigurationImageGetterSetter;
 import com.opensr5.ini.AxisModel;
 import com.opensr5.ini.CurveModel;
 import com.opensr5.ini.IniFileModel;
+import com.opensr5.ini.TsStringFunction;
 import com.opensr5.ini.field.ArrayIniField;
 import com.opensr5.ini.field.IniField;
 import com.rusefi.config.StringFormatter;
@@ -15,6 +16,7 @@ import javax.swing.table.DefaultTableCellRenderer;
 import java.awt.*;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -51,9 +53,14 @@ public class CurveWidget {
     public CurveWidget(CurveModel curveModel, IniFileModel iniFileModel, ConfigurationImage ci) {
         table.getTableHeader().setReorderingAllowed(false);
         table.setDefaultRenderer(Object.class, new GradientRenderer());
+        // JTable defaults to a 450x400 preferredScrollableViewportSize; left unchanged the table would
+        // claim ~450px of fixed preferred width and starve the canvas (which only receives the GridBag
+        // remainder) on narrow windows. Size the table to its actual content so the 0.8/0.2 weights hold.
+        table.setPreferredScrollableViewportSize(new Dimension(180, 300));
 
         JPanel rightPanel = new JPanel(new BorderLayout());
-        rightPanel.add(table.getTableHeader(), BorderLayout.NORTH);
+        // The table header is reparented into the JScrollPane's column header by configureEnclosingScrollPane(),
+        // so it does not need (and must not get) a separate NORTH slot here.
         rightPanel.add(new JScrollPane(table), BorderLayout.CENTER);
 
         content.setLayout(new GridBagLayout());
@@ -77,7 +84,7 @@ public class CurveWidget {
         this.imageTarget = ci;
 
         IniField xField = iniFile.findIniField(curveModel.getxBins()).get();
-        this.xUnits = xField.getUnits();
+        this.xUnits = resolveUnits(xField.getUnits(), iniFile, ci);
         this.xDigits = parseDigits(xField.getDigits());
         this.xBinsField = xField instanceof ArrayIniField ? (ArrayIniField) xField : null;
 
@@ -102,6 +109,28 @@ public class CurveWidget {
         if (imageTarget == null) return;
         if (xBinsField != null) ConfigurationImageGetterSetter.setArrayValues(xBinsField, imageTarget, xValues);
         if (yBinsField != null) ConfigurationImageGetterSetter.setArrayValues(yBinsField, imageTarget, yValues);
+    }
+
+    /**
+     * The units token may be a TunerStudio expression such as {@code {bitStringValue(unitsLabels,
+     * useMetricOnInterface)}}, which picks a °C/°F label depending on a config setting. Resolve it so the
+     * canvas shows the actual unit instead of the raw expression (issue #9635). {@code useMetricOnInterface}
+     * lives in the configuration image, so {@code ci} is passed as the config source (not output channels).
+     */
+    public static String resolveUnits(String raw, IniFileModel ini, ConfigurationImage ci) {
+        if (raw == null) {
+            return null;
+        }
+        if (TsStringFunction.containsStringFunction(raw)) {
+            String resolved = TsStringFunction.resolve(raw, ini, ci, null);
+            // On failure (e.g. no config image) show nothing rather than the raw expression text.
+            return resolved != null ? resolved : "";
+        }
+        String t = raw.trim();
+        if (t.startsWith("{")) {
+            t = t.replaceAll("^\\{\\s*", "").replaceAll("\\s*}$", "").trim();
+        }
+        return t;
     }
 
     private int parseDigits(String digits) {
@@ -158,6 +187,12 @@ public class CurveWidget {
 
         public CurveCanvas() {
             setBackground(Color.BLACK);
+            // An empty JPanel reports a near-zero preferred width, so GridBagLayout has no canvas baseline
+            // to defend while shrinking and the plot collapses to a sliver on small windows (issue #9635).
+            // A real preferred size lets the 0.8 weight keep the canvas usefully wide as the window resizes.
+            // (No minimumSize on purpose: with the no-horizontal-scroll container a minimum could push the
+            // table off the right edge on a very narrow window; the preferred size already carries the fix.)
+            setPreferredSize(new Dimension(400, 300));
             MouseAdapter mouseAdapter = new MouseAdapter() {
                 @Override
                 public void mousePressed(MouseEvent e) {
@@ -248,6 +283,9 @@ public class CurveWidget {
             FontMetrics fm = g2.getFontMetrics();
 
             // Draw vertical grid lines
+            // Track the right edge of the last drawn x-axis label so that, on narrow canvases, we skip
+            // labels that would overlap their neighbour (the grid lines themselves are always drawn).
+            int lastXLabelRight = Integer.MIN_VALUE;
             for (int i = 0; i < xAxis.getStep(); i++) {
                 double val = xAxis.getMin() + (xAxis.getMax() - xAxis.getMin()) * i / (xAxis.getStep() - 1);
                 Point p1 = worldToCanvas(val, yAxis.getMin());
@@ -256,10 +294,15 @@ public class CurveWidget {
                 g2.setColor(gridColor);
                 g2.drawLine(p1.x, p1.y, p2.x, p2.y);
 
-                g2.setColor(Color.RED);
-                String label = String.format("%." + xDigits + "f", val);
+                // Locale.ROOT so the decimal separator is always a dot (e.g. "0.00", not "0,00" on es_* systems).
+                String label = String.format(Locale.ROOT, "%." + xDigits + "f", val);
                 int labelWidth = fm.stringWidth(label);
-                g2.drawString(label, p1.x - labelWidth / 2, p1.y + fm.getAscent() + 2);
+                int labelLeft = p1.x - labelWidth / 2;
+                if (labelLeft > lastXLabelRight) {
+                    g2.setColor(Color.RED);
+                    g2.drawString(label, labelLeft, p1.y + fm.getAscent() + 2);
+                    lastXLabelRight = labelLeft + labelWidth + 4; // 4px minimum gap between labels
+                }
             }
 
             // Draw horizontal grid lines
@@ -272,7 +315,7 @@ public class CurveWidget {
                 g2.drawLine(p1.x, p1.y, p2.x, p2.y);
 
                 g2.setColor(Color.RED);
-                String label = String.format("%." + yDigits + "f", val);
+                String label = String.format(Locale.ROOT, "%." + yDigits + "f", val);
                 int labelWidth = fm.stringWidth(label);
                 g2.drawString(label, p1.x - labelWidth - 5, p1.y + fm.getAscent() / 2);
             }

--- a/java_console/ui/src/test/java/com/rusefi/ui/widgets/MainMenuTreeWidgetTest.java
+++ b/java_console/ui/src/test/java/com/rusefi/ui/widgets/MainMenuTreeWidgetTest.java
@@ -1,5 +1,6 @@
 package com.rusefi.ui.widgets;
 
+import com.opensr5.ConfigurationImage;
 import com.opensr5.ini.AxisModel;
 import com.opensr5.ini.CurveModel;
 import com.opensr5.ini.DialogModel;
@@ -613,5 +614,106 @@ todo: spllit into smaller tests?
             }
         }
         return null;
+    }
+
+    private Component findCanvas(Container container) {
+        for (Component c : container.getComponents()) {
+            if (c.getClass().getName().endsWith("CurveCanvas")) return c;
+            if (c instanceof Container) {
+                Component found = findCanvas((Container) c);
+                if (found != null) return found;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Regression test for issue #9635: on small windows the curve plot collapsed to a sliver while the
+     * JTable held a large fixed width. Root cause: a JTable reports its preferredScrollableViewportSize
+     * (default 450x400) as the enclosing JScrollPane's preferred width, so GridBagLayout reserved ~450px
+     * for the table and gave the canvas (which started with a near-zero preferred size) only the weighted
+     * remainder. The fix shrinks the table's preferred footprint and gives the canvas a real preferred
+     * size so the 0.8/0.2 weights actually keep the plot wide.
+     *
+     * This asserts the layout *mechanism* (preferred sizes) rather than rendered widths: in this test
+     * environment GridBag was observed to distribute width by weight alone (the canvas never collapsed at
+     * any width), so a pixel-width assertion would not exercise the crush seen in the real app. The bug is
+     * documented by the issue screenshots, where the table holds its large preferred width while the canvas
+     * absorbs all the shrinkage.
+     */
+    @Test
+    public void testCurveWidgetCanvasKeepsWidthWhenNarrow() {
+        String string = "[Constants]\n" +
+            "page = 1\n" +
+            "scriptCurve1Bins = array, F32, 0, [16], \"x\", 1, 0, 0, 100, 3\n" +
+            "scriptCurve1 = array, F32, 64, [16], \"y\", 1, 0, 0, 100, 3\n " +
+            "[CurveEditor]\n" +
+            "\tcurve = scriptCurve1, \"Script Curve #1\"\n" +
+            "\t\txAxis\t\t=  0, 100, 10\n" +
+            "\t\tyAxis\t\t=  0, 200, 20\n" +
+            "\t\txBins\t\t= scriptCurve1Bins\n" +
+            "\t\tyBins\t\t= scriptCurve1\n";
+
+        RawIniFile lines = IniFileReaderUtil.read(new ByteArrayInputStream(string.getBytes()));
+        IniFileModel model = readLines(lines);
+
+        CurveModel curve = model.getCurves().get("scriptCurve1");
+        assertNotNull(curve, "curve scriptCurve1 should exist");
+
+        com.rusefi.ui.widgets.tune.CurveWidget widget =
+            new com.rusefi.ui.widgets.tune.CurveWidget(curve, model, null);
+        JPanel curvePanel = widget.getContentPane();
+
+        Component canvas = findCanvas(curvePanel);
+        assertNotNull(canvas, "curve canvas should be present");
+        JTable table = findTable(curvePanel);
+        assertNotNull(table, "curve table should be present");
+
+        // The table must no longer claim the JTable default of 450px (which starved the canvas). It keeps
+        // a modest preferred footprint and grows only via its 0.2 GridBag weight on wide windows.
+        assertTrue(table.getPreferredScrollableViewportSize().width <= 220,
+            "table preferred viewport width should be shrunk well below the 450px JTable default, was "
+                + table.getPreferredScrollableViewportSize().width);
+
+        // The canvas must advertise a real preferred width so the 0.8 weight has a baseline to defend as
+        // the window shrinks (an empty JPanel would report a near-zero preferred width).
+        assertTrue(canvas.getPreferredSize().width >= 300,
+            "canvas should advertise a usable preferred width, was " + canvas.getPreferredSize().width);
+    }
+
+    /**
+     * Regression test for issue #9635: a curve whose axis units are a TunerStudio expression such as
+     * {@code {bitStringValue(unitsLabels, useMetricOnInterface)}} used to render the raw expression text
+     * under the plot. CurveWidget.resolveUnits must evaluate it against the config image (where
+     * useMetricOnInterface lives) and yield the actual °C / °F label.
+     */
+    @Test
+    public void testCurveWidgetResolvesUnitsExpression() {
+        String iniContent = "[Constants]\n" +
+            "page = 1\n" +
+            "useMetricOnInterface = bits, U32, 772, [29:29], \"Imperial\", \"Metric\"\n" +
+            "[PcVariables]\n" +
+            "unitsLabels = bits, U08, [0:2], \"F\", \"C\"\n";
+
+        RawIniFile lines = IniFileReaderUtil.read(new ByteArrayInputStream(iniContent.getBytes()));
+        IniFileModel model = readLines(lines);
+
+        String unitsExpr = "{bitStringValue(unitsLabels, useMetricOnInterface)}";
+
+        // Metric: bit 29 of the U32 at offset 772 set (LE byte 775 = 0x20) -> "C"
+        byte[] metric = new byte[800];
+        metric[775] = 0x20;
+        assertEquals("C", com.rusefi.ui.widgets.tune.CurveWidget.resolveUnits(
+            unitsExpr, model, new ConfigurationImage(metric)),
+            "metric config should resolve units to C");
+
+        // Imperial: bit 29 clear -> "F"
+        assertEquals("F", com.rusefi.ui.widgets.tune.CurveWidget.resolveUnits(
+            unitsExpr, model, new ConfigurationImage(new byte[800])),
+            "imperial config should resolve units to F");
+
+        // Plain (non-expression) units pass through, with surrounding braces stripped.
+        assertEquals("RPM", com.rusefi.ui.widgets.tune.CurveWidget.resolveUnits("RPM", model, null));
+        assertEquals("deg", com.rusefi.ui.widgets.tune.CurveWidget.resolveUnits("{ deg }", model, null));
     }
 }


### PR DESCRIPTION
- adjust preferred sizes for curve components to maintain layout proportions.
- Ensure units expressions are resolved against configuration image.

resolves #9635 

extreme case:

<img width="1030" height="831" alt="image" src="https://github.com/user-attachments/assets/c7461a48-cc08-492e-8d3c-38e7cb4328b7" />

a more normal:
<img width="1317" height="833" alt="image" src="https://github.com/user-attachments/assets/6ba77560-c05f-4ccd-af37-d7e51906ccfc" />

another one (splited 1920x1080 screen):

<img width="1919" height="1046" alt="image" src="https://github.com/user-attachments/assets/7f798444-6b6c-4013-b66c-edb1d2a0e4e4" />

