### PR TITLE
Too much frame blinking on start-up

### DIFF
--- a/java_console/core_ui/src/main/java/com/rusefi/core/ui/FrameHelper.java
+++ b/java_console/core_ui/src/main/java/com/rusefi/core/ui/FrameHelper.java
@@ -104,8 +104,10 @@ public class FrameHelper {
         frame.add(content);
         AutoupdateUtil.trueLayoutAndRepaint(frame);
         onWindowOpened();
-        // The loading overlay raised by StartupFrame.connect stays up across this swap; it's taken
-        // down when the gauge grid finishes its chunked build (#9715, see ConsoleUI / GaugesPanel).
+        // The loading overlay raised by StartupFrame.connect stays up across this swap and is taken
+        // down once the new content has painted (#9715): invokeLater drains after the repaint queued
+        // above, so the overlay lifts as the gauges become visible — no flicker, no fixed delay.
+        SwingUtilities.invokeLater(() -> LoadingOverlay.hide(frame));
     }
 
     private void installWindowListener(final boolean maximizeOnStart) {

--- a/java_console/core_ui/src/main/java/com/rusefi/core/ui/FrameHelper.java
+++ b/java_console/core_ui/src/main/java/com/rusefi/core/ui/FrameHelper.java
@@ -8,6 +8,7 @@ import javax.swing.*;
 import java.awt.*;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
+import java.awt.event.WindowListener;
 import java.util.Arrays;
 
 import static com.devexperts.logging.Logging.getLogging;
@@ -18,14 +19,31 @@ import static com.devexperts.logging.Logging.getLogging;
  */
 public class FrameHelper {
     private static final Logging log = getLogging(FrameHelper.class);
-    private final JFrame frame = new JFrame();
+    private final JFrame frame;
+    /**
+     * True when this helper wraps an already-visible frame handed off from another window
+     * (#9715) — in that case {@link #showFrame} swaps content in place instead of creating and
+     * showing a new window.
+     */
+    private final boolean reusing;
 
     public FrameHelper() {
         this(JDialog.DISPOSE_ON_CLOSE);
     }
 
     public FrameHelper(int operation) {
+        this(null, operation);
+    }
+
+    /**
+     * When {@code existingFrame} is non-null, reuse that already-visible frame instead of creating a
+     * new window (#9715) — used to hand the maximized splash frame to the main console so there is no
+     * second window flashing in. When null, a fresh {@link JFrame} is created as usual.
+     */
+    public FrameHelper(JFrame existingFrame, int operation) {
         AutoupdateUtil.assertAwtThread();
+        this.reusing = existingFrame != null;
+        this.frame = reusing ? existingFrame : new JFrame();
         frame.setDefaultCloseOperation(operation);
         AutoupdateUtil.setAppIcon(frame);
     }
@@ -52,8 +70,12 @@ public class FrameHelper {
     }
 
     public void showFrame(JComponent content, final boolean maximizeOnStart) {
-        initFrame(content, maximizeOnStart);
-        frame.setVisible(true);
+        if (reusing) {
+            swapContent(content);
+        } else {
+            initFrame(content, maximizeOnStart);
+            frame.setVisible(true);
+        }
     }
 
     public void initFrame(JComponent content, final boolean maximizeOnStart) {
@@ -62,6 +84,31 @@ public class FrameHelper {
         } else if (frame.getSize().getWidth() < 1 || frame.getSize().getHeight() < 1){
             frame.setSize(800, 500);
         }
+        installWindowListener(maximizeOnStart);
+        frame.add(content);
+    }
+
+    /**
+     * Swap the content of an already-visible, maximized frame (#9715). The previous owner's window
+     * listeners (e.g. the splash's "save config on close") and its default button are dropped, our
+     * close-handling listener is installed, and {@link #onWindowOpened()} is invoked explicitly
+     * because {@code WINDOW_OPENED} does not re-fire on a frame that is already showing.
+     */
+    private void swapContent(JComponent content) {
+        for (WindowListener l : frame.getWindowListeners()) {
+            frame.removeWindowListener(l);
+        }
+        installWindowListener(false);
+        frame.getRootPane().setDefaultButton(null);
+        frame.getContentPane().removeAll();
+        frame.add(content);
+        AutoupdateUtil.trueLayoutAndRepaint(frame);
+        onWindowOpened();
+        // The loading overlay raised by StartupFrame.connect stays up across this swap; it's taken
+        // down when the gauge grid finishes its chunked build (#9715, see ConsoleUI / GaugesPanel).
+    }
+
+    private void installWindowListener(final boolean maximizeOnStart) {
         frame.addWindowListener(new WindowAdapter() {
             @Override
             public void windowOpened(WindowEvent e) {
@@ -80,7 +127,6 @@ public class FrameHelper {
                 log.info(Arrays.toString(Frame.getFrames()));
             }
         });
-        frame.add(content);
     }
 
     protected void onWindowOpened() {

--- a/java_console/core_ui/src/main/java/com/rusefi/core/ui/LoadingOverlay.java
+++ b/java_console/core_ui/src/main/java/com/rusefi/core/ui/LoadingOverlay.java
@@ -6,10 +6,10 @@ import java.awt.*;
 /**
  * Opaque, centered "loading" cover painted on a frame's glassPane (#9715). Used to bridge the
  * splash → console handoff as a single indicator: shown when the user connects, kept across the
- * ConsoleUI build, and removed once the gauge grid finishes its chunked build (GaugesPanel).
+ * ConsoleUI build, and removed once the new content has painted (FrameHelper.swapContent).
  *
- * <p>The bar animates because the gauge grid is built one element per EDT cycle, yielding the EDT
- * between batches; if that chunking is ever removed the bar will freeze (Swing single-thread).
+ * <p>Note: the bar does not animate while the EDT is building/painting the console — it reads as a
+ * static cover. That's a Swing single-thread limit; lazy-loading heavy tabs keeps the freeze short.
  */
 public class LoadingOverlay {
     public static void show(JFrame frame, String message) {

--- a/java_console/core_ui/src/main/java/com/rusefi/core/ui/LoadingOverlay.java
+++ b/java_console/core_ui/src/main/java/com/rusefi/core/ui/LoadingOverlay.java
@@ -1,0 +1,42 @@
+package com.rusefi.core.ui;
+
+import javax.swing.*;
+import java.awt.*;
+
+/**
+ * Opaque, centered "loading" cover painted on a frame's glassPane (#9715). Used to bridge the
+ * splash → console handoff as a single indicator: shown when the user connects, kept across the
+ * ConsoleUI build, and removed once the gauge grid finishes its chunked build (GaugesPanel).
+ *
+ * <p>The bar animates because the gauge grid is built one element per EDT cycle, yielding the EDT
+ * between batches; if that chunking is ever removed the bar will freeze (Swing single-thread).
+ */
+public class LoadingOverlay {
+    public static void show(JFrame frame, String message) {
+        JPanel inner = new JPanel();
+        inner.setLayout(new BoxLayout(inner, BoxLayout.Y_AXIS));
+
+        JLabel label = new JLabel(message);
+        label.setAlignmentX(Component.CENTER_ALIGNMENT);
+        label.setFont(label.getFont().deriveFont(Font.BOLD, 18f));
+        inner.add(label);
+        inner.add(Box.createVerticalStrut(16));
+
+        JProgressBar bar = new JProgressBar();
+        bar.setIndeterminate(true);
+        bar.setPreferredSize(new Dimension(320, 28));
+        bar.setMaximumSize(bar.getPreferredSize());
+        bar.setAlignmentX(Component.CENTER_ALIGNMENT);
+        inner.add(bar);
+
+        JPanel overlay = new JPanel(new GridBagLayout());
+        overlay.setOpaque(true);
+        overlay.add(inner);
+        frame.setGlassPane(overlay);
+        overlay.setVisible(true);
+    }
+
+    public static void hide(JFrame frame) {
+        frame.getGlassPane().setVisible(false);
+    }
+}

--- a/java_console/ui/src/main/java/com/rusefi/ConsoleUI.java
+++ b/java_console/ui/src/main/java/com/rusefi/ConsoleUI.java
@@ -35,8 +35,12 @@ import org.jetbrains.annotations.NotNull;
 import javax.swing.*;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
+import com.rusefi.ui.InitOnFirstPaintPanel;
+import com.rusefi.ui.basic.LoadTuneHelper;
 import java.awt.*;
+import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.util.function.Supplier;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.util.HashMap;
@@ -103,6 +107,21 @@ public class ConsoleUI {
      */
     public ConsoleUI(UIContext uiContext, IniFileModel ini, ConfigurationImage initialImage) {
         this(uiContext, null, SerialPortType.Unknown, false, ini, initialImage, null);
+    }
+
+    /**
+     * A menu action that builds the (lazily-constructed) Tuning pane on first use, then delegates to
+     * its real action (#9715). After the build, {@code buildTuning} re-points the menu at the real
+     * actions, so this wrapper only ever runs once.
+     */
+    private static Action lazyTuneAction(String text, Runnable buildTuning, Supplier<Action> realAction) {
+        return new AbstractAction(text) {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                buildTuning.run();
+                realAction.get().actionPerformed(e);
+            }
+        };
     }
 
     private ConsoleUI(UIContext uiContext, String port, SerialPortType serialPortType,
@@ -196,14 +215,28 @@ public class ConsoleUI {
 
         uiContext.DetachedRepositoryINSTANCE.init(getConfig().getRoot().getChild("detached"));
         uiContext.DetachedRepositoryINSTANCE.load();
+        // Heavy tabs (Lua, Tuning) are lazy-built unless they are the user's last-opened tab, which
+        // will be shown immediately on startup — in that case build eagerly (#9715).
+        int savedTabIndex = getConfig().getRoot().getIntProperty(TAB_INDEX, DEFAULT_TAB_INDEX);
         if (isOffline || !linkManager.isLogViewer()) {
             tabbedPane.addTab("Gauges", new GaugesPanel(uiContext, getConfig().getRoot().getChild("gauges")).getContent());
 
             MessagesPane messagesPane = new MessagesPane(uiContext, getConfig().getRoot().getChild("messages"));
             tabbedPaneAdd("Messages", messagesPane.getContent(), messagesPane.getTabSelectedListener());
 
-            LuaScriptPanel luaScriptPanel = new LuaScriptPanel(uiContext, getConfig().getRoot().getChild("lua"));
-            tabbedPaneAdd("Lua Scripting", luaScriptPanel.getPanel(), luaScriptPanel.getTabSelectedListener());
+            int luaIndex = tabbedPane.tabbedPane.getTabCount();
+            if (luaIndex == savedTabIndex) {
+                LuaScriptPanel luaScriptPanel = new LuaScriptPanel(uiContext, getConfig().getRoot().getChild("lua"));
+                tabbedPaneAdd("Lua Scripting", luaScriptPanel.getPanel(), luaScriptPanel.getTabSelectedListener());
+            } else {
+                // Build the (heavy) Lua editor only when its tab is first shown (#9715).
+                tabbedPane.addTab("Lua Scripting", new InitOnFirstPaintPanel() {
+                    @Override
+                    protected JPanel createContent() {
+                        return new LuaScriptPanel(uiContext, getConfig().getRoot().getChild("lua")).getPanel();
+                    }
+                }.getContent());
+            }
         }
 
         if (UiProperties.isEngineSnifferEnabled()) {
@@ -231,13 +264,46 @@ console live data tab is broken #8402
 
             tabbedPane.addTab("Live Data", LiveDataPane.createLazy(uiContext).getContent());
  */
-            TuningPane tuningPane = new TuningPane(uiContext, offlineImage);
-            mainFrame.setTuneActions(tuningPane.getLoadTuneAction(), tuningPane.getSaveTuneAction());
-            if (isOffline && offlineImage != null) {
-                tuningPane.seedOfflineImage(offlineImage, null);
-            }
             PinoutPane pinoutPane = new PinoutPane(uiContext);
-            tabbedPane.addTab("Tuning", tuningPane.getContent());
+
+            // Tuning is heavy (~60ms) and not always the startup tab. Build it on first use — tab
+            // shown, File>Load/Save Tune, or Pinout→Tune nav — unless it's the restored tab (#9715).
+            // The holder wires the tune menu + navigation the first time the instance is needed.
+            final TuningPane[] tuningHolder = {null};
+            final Runnable buildTuning = () -> {
+                if (tuningHolder[0] != null) {
+                    return;
+                }
+                TuningPane tp = new TuningPane(uiContext, offlineImage);
+                tuningHolder[0] = tp;
+                if (isOffline && offlineImage != null) {
+                    tp.seedOfflineImage(offlineImage, null);
+                }
+                mainFrame.setTuneActions(tp.getLoadTuneAction(), tp.getSaveTuneAction());
+                if (UiProperties.isPinoutEnabled()) {
+                    tp.setNavigateToPinout(enumValue -> {
+                        tabbedPane.selectTab("Pinout");
+                        pinoutPane.highlightByEnumValue(enumValue);
+                    });
+                }
+            };
+
+            int tuningIndex = tabbedPane.tabbedPane.getTabCount();
+            tabbedPane.addTab("Tuning", new InitOnFirstPaintPanel() {
+                @Override
+                protected JPanel createContent() {
+                    buildTuning.run();
+                    JPanel wrapper = new JPanel(new BorderLayout());
+                    wrapper.add(tuningHolder[0].getContent(), BorderLayout.CENTER);
+                    return wrapper;
+                }
+            }.getContent());
+            // Until Tuning is built, the menu actions build it on first click then delegate; once
+            // built, buildTuning re-points the menu at the real actions.
+            mainFrame.setTuneActions(
+                lazyTuneAction(LoadTuneHelper.LOAD_TUNE_TEXT, buildTuning, () -> tuningHolder[0].getLoadTuneAction()),
+                lazyTuneAction(LoadTuneHelper.SAVE_TUNE_TEXT, buildTuning, () -> tuningHolder[0].getSaveTuneAction()));
+
             tabbedPane.addTab("Knock Analyzer", new KnockPane(uiContext).getContent());
             if (UiProperties.isPinoutEnabled()) {
                 tabbedPane.addTab("Pinout", pinoutPane.getContent());
@@ -251,14 +317,14 @@ console live data tab is broken #8402
 
             // Pinout ↔ Tune bidirectional navigation
             pinoutPane.setNavigateToTune((dialogKey, fieldKey) -> {
+                buildTuning.run();
                 tabbedPane.selectTab("Tuning");
-                tuningPane.navigateToField(dialogKey, fieldKey);
+                tuningHolder[0].navigateToField(dialogKey, fieldKey);
             });
-            if (UiProperties.isPinoutEnabled()) {
-                tuningPane.setNavigateToPinout(enumValue -> {
-                    tabbedPane.selectTab("Pinout");
-                    pinoutPane.highlightByEnumValue(enumValue);
-                });
+
+            // Build eagerly if Tuning was the user's last-opened tab (shown immediately on startup).
+            if (tuningIndex == savedTabIndex) {
+                buildTuning.run();
             }
         }
 
@@ -282,9 +348,8 @@ console live data tab is broken #8402
         }
 
         if (isOffline || !LinkManager.isLogViewerMode(port)) {
-            int selectedIndex = getConfig().getRoot().getIntProperty(TAB_INDEX, DEFAULT_TAB_INDEX);
-            if (selectedIndex < tabbedPane.tabbedPane.getTabCount())
-                tabbedPane.tabbedPane.setSelectedIndex(selectedIndex);
+            if (savedTabIndex < tabbedPane.tabbedPane.getTabCount())
+                tabbedPane.tabbedPane.setSelectedIndex(savedTabIndex);
         }
 
         tabbedPane.tabbedPane.addChangeListener(new ChangeListener() {

--- a/java_console/ui/src/main/java/com/rusefi/ConsoleUI.java
+++ b/java_console/ui/src/main/java/com/rusefi/ConsoleUI.java
@@ -77,11 +77,19 @@ public class ConsoleUI {
     private final Map<Component, ActionListener> tabSelectedListeners = new HashMap<>();
 
     public ConsoleUI(String port, SerialPortType serialPortType) {
-        this(new UIContext(), port, serialPortType, false, null, null);
+        this(new UIContext(), port, serialPortType, false, null, null, null);
     }
 
     public ConsoleUI(UIContext uiContext, String port, SerialPortType serialPortType, boolean alreadyConnected) {
-        this(uiContext, port, serialPortType, alreadyConnected, null, null);
+        this(uiContext, port, serialPortType, alreadyConnected, null, null, null);
+    }
+
+    /**
+     * Reuses the already-visible, maximized {@code reuseFrame} handed off from {@link StartupFrame}
+     * instead of opening a second window (#9715).
+     */
+    public ConsoleUI(UIContext uiContext, String port, SerialPortType serialPortType, boolean alreadyConnected, JFrame reuseFrame) {
+        this(uiContext, port, serialPortType, alreadyConnected, null, null, reuseFrame);
     }
 
     /**
@@ -94,11 +102,12 @@ public class ConsoleUI {
      * @param initialImage   ConfigurationImage loaded from the MSQ file
      */
     public ConsoleUI(UIContext uiContext, IniFileModel ini, ConfigurationImage initialImage) {
-        this(uiContext, null, SerialPortType.Unknown, false, ini, initialImage);
+        this(uiContext, null, SerialPortType.Unknown, false, ini, initialImage, null);
     }
 
     private ConsoleUI(UIContext uiContext, String port, SerialPortType serialPortType,
-                      boolean alreadyConnected, IniFileModel offlineIni, ConfigurationImage offlineImage) {
+                      boolean alreadyConnected, IniFileModel offlineIni, ConfigurationImage offlineImage,
+                      JFrame reuseFrame) {
         this.uiContext = uiContext;
         LinkManager linkManager = uiContext.getLinkManager();
 
@@ -162,7 +171,7 @@ public class ConsoleUI {
 
         // ---------------
 
-        MainFrame mainFrame = new MainFrame(this, tabbedPane);
+        MainFrame mainFrame = new MainFrame(this, tabbedPane, reuseFrame);
         JFrame frame = mainFrame.getFrame().getFrame();
         setFrameIcon(frame);
         log.info("Console " + UiVersion.CONSOLE_VERSION);

--- a/java_console/ui/src/main/java/com/rusefi/StartupFrame.java
+++ b/java_console/ui/src/main/java/com/rusefi/StartupFrame.java
@@ -11,6 +11,7 @@ import com.rusefi.core.preferences.storage.PersistentConfiguration;
 import com.rusefi.ts.TsProjectCreator;
 import com.rusefi.core.ui.AutoupdateUtil;
 import com.rusefi.core.ui.FrameHelper;
+import com.rusefi.core.ui.LoadingOverlay;
 import com.rusefi.io.ConnectionStatusLogic;
 import com.rusefi.io.LinkManager;
 import com.rusefi.maintenance.*;
@@ -81,6 +82,13 @@ public class StartupFrame {
     private static final String STARTUP_TAB_INDEX = "startup_tab_index";
     private static final String NO_PORTS_FOUND = "<html>No ports found!<br>Confirm blue LED is blinking</html>";
     public static final String SCANNING_PORTS = "Scanning ports";
+    private static final String CARD_SCANNING = "scanning";
+    private static final String CARD_STARTUP = "startup";
+    private static final String CARD_WIZARD = "wizard";
+    // After this delay with no single-ECU auto-connect in flight, reveal the full connect controls
+    // instead of holding on the large scanning animation forever (#9715). Generous enough to cover a
+    // typical scan -> auto-connect on a slow machine so the controls never flash before auto-connect.
+    private static final int REVEAL_CONTROLS_DELAY_MS = 4000;
 
     private final JFrame frame;
     private final JPanel connectPanel = new JPanel(new FlowLayout());
@@ -124,6 +132,11 @@ public class StartupFrame {
 
     private final UIContext uiContext;
     private final JPanel rootContent = new JPanel(new CardLayout());
+    // The large "scanning" card shown first (#9715); its status line is updated to "Connecting to X…"
+    // if a single-ECU auto-connect fires before the controls are revealed.
+    private JLabel scanningStatusLabel;
+    private Timer revealControlsTimer;
+    private boolean controlsRevealed = false;
     private WizardContainer wizardContainer;
     private PortResult autoConnectedPort;
     private Thread autoConnectThread;
@@ -269,7 +282,7 @@ public class StartupFrame {
         Timer dfuErrorTimer = new Timer(15_000, e -> {
             if (DfuFlasher.dfuDetectionCommandFailed && !hasSeenEcuOrSimulator) {
                 dfuErrorMessage.setVisible(true);
-                frame.pack();
+                AutoupdateUtil.trueLayoutAndRepaint(realHardwarePanel);
             }
         });
         dfuErrorTimer.setRepeats(false);
@@ -316,7 +329,9 @@ public class StartupFrame {
                     hasSeenEcuOrSimulator = true;
                 }
             }
-            frame.pack();
+            // Frame is fixed-maximized (#9715) — reflow the content in place instead of resizing
+            // the window on every scan tick, which caused the visible "blinking".
+            AutoupdateUtil.trueLayoutAndRepaint(rootContent);
         }));
 
         /*
@@ -363,8 +378,9 @@ public class StartupFrame {
         content.add(leftPanel, BorderLayout.WEST);
         content.add(rightPanel, BorderLayout.EAST);
 
-        JPanel connectTabWrapper = new JPanel(new BorderLayout());
-        connectTabWrapper.add(content, BorderLayout.NORTH);
+        // Center the connect controls in the maximized window instead of pinning them top-left (#9715).
+        JPanel connectTabWrapper = new JPanel(new GridBagLayout());
+        connectTabWrapper.add(content, new GridBagConstraints());
 
         outerTabs = new JTabbedPane() {
             @Override
@@ -413,19 +429,30 @@ public class StartupFrame {
 
         wizardContainer = new WizardContainer(uiContext, /*compact=*/true);
         wizardContainer.setOnWizardExit(() -> {
-            showCard("startup");
+            showCard(CARD_STARTUP);
         });
-        rootContent.add(outerTabs, "startup");
-        rootContent.add(wizardContainer, "wizard");
+        rootContent.add(outerTabs, CARD_STARTUP);
+        rootContent.add(wizardContainer, CARD_WIZARD);
+        rootContent.add(createScanningPanel(), CARD_SCANNING);
+        ((CardLayout) rootContent.getLayout()).show(rootContent, CARD_SCANNING);
 
         TunerStudioHelper.checkTunerStudio(frame.getContentPane(), () -> restoreContent(rootContent));
 
         frame.add(rootContent);
-        frame.pack();
+        // Maximize for the whole splash lifecycle so it doesn't jump to center then get replaced by
+        // a second maximized console window (#9715). Mirrors FrameHelper.initFrame.
+        frame.setSize(GraphicsEnvironment.getLocalGraphicsEnvironment().getMaximumWindowBounds().getSize());
         setFrameIcon(frame);
+        frame.addWindowListener(new WindowAdapter() {
+            @Override
+            public void windowOpened(WindowEvent e) {
+                frame.setExtendedState(frame.getExtendedState() | JFrame.MAXIMIZED_BOTH);
+            }
+        });
         log.info("setVisible");
         frame.setVisible(true);
-        UiUtils.centerWindow(frame);
+
+        startRevealControlsTimer();
 
         KeyListener hwTestEasterEgg = functionalTestEasterEgg();
 
@@ -503,7 +530,8 @@ public class StartupFrame {
     private void restoreContent(JComponent root) {
         frame.getContentPane().removeAll();
         frame.add(root);
-        AutoupdateUtil.pack(frame);
+        // Frame stays fixed-maximized (#9715) — relayout in place instead of pack()/resize.
+        AutoupdateUtil.trueLayoutAndRepaint(frame);
     }
 
     private void updateConnectButtonState() {
@@ -587,9 +615,12 @@ public class StartupFrame {
             log.info("connect: closing stale LinkManager");
             uiContext.getLinkManager().close();
         }
-        log.info("connect: disposing splash and creating ConsoleUI");
-        disposeFrameAndProceed();
-        new ConsoleUI(uiContext, selectedPort.port, selectedPort.type, alreadyConnected);
+        // Reuse this maximized splash frame for the console
+        log.info("connect: handing off splash frame to ConsoleUI");
+        prepareForHandoff();
+        LoadingOverlay.show(frame, "Loading console…");
+        SwingUtilities.invokeLater(() ->
+            new ConsoleUI(uiContext, selectedPort.port, selectedPort.type, alreadyConnected, frame));
     }
 
     /**
@@ -612,6 +643,9 @@ public class StartupFrame {
         getConfig().save();
         frame.dispose();
         status.stop();
+        if (revealControlsTimer != null) {
+            revealControlsTimer.stop();
+        }
         if (firmwareTabStatus != null) {
             firmwareTabStatus.stop();
         }
@@ -643,6 +677,14 @@ public class StartupFrame {
 
     private void autoConnect(PortResult target) {
         autoConnectedPort = target;
+        // A single-ECU auto-connect is starting: cancel the reveal timer and reflect status on the
+        // scanning card so the connect controls never flash before the console opens (#9715).
+        if (revealControlsTimer != null) {
+            revealControlsTimer.stop();
+        }
+        if (scanningStatusLabel != null) {
+            scanningStatusLabel.setText("Connecting to " + target.port + "…");
+        }
         if (offlineConsoleOpen) {
             // [tag:offline_tune] Pre-cache the target so the scanner skips re-inspecting it during the
             // connect read window — otherwise a scan tick could reopen the port mid-read and hang in LOADING.
@@ -689,24 +731,80 @@ public class StartupFrame {
     }
 
     /**
-     * Flip the root {@link CardLayout} and resize the frame to the active card's preferred size.
-     * Without per-card packing, CardLayout reports the max of all children, leaving empty
-     * horizontal margins around the narrower wizard content.
+     * "scanning" card shown while we look for an ECU (#9715): logo + status
+     * line + an indeterminate progress bar.
+     */
+    private JPanel createScanningPanel() {
+        JPanel inner = new JPanel();
+        // BoxLayout (not VerticalFlowLayout) so setAlignmentX(CENTER) is honored on the children.
+        inner.setLayout(new BoxLayout(inner, BoxLayout.Y_AXIS));
+
+        JLabel logo = LogoHelper.createLogoLabel();
+        if (logo != null) {
+            logo.setAlignmentX(Component.CENTER_ALIGNMENT);
+            inner.add(logo);
+        }
+        inner.add(Box.createVerticalStrut(16));
+
+        scanningStatusLabel = new JLabel("Scanning for ECU…");
+        scanningStatusLabel.setAlignmentX(Component.CENTER_ALIGNMENT);
+        scanningStatusLabel.setHorizontalAlignment(SwingConstants.CENTER);
+        scanningStatusLabel.setFont(scanningStatusLabel.getFont().deriveFont(Font.BOLD, 18f));
+        inner.add(scanningStatusLabel);
+        inner.add(Box.createVerticalStrut(16));
+
+        JProgressBar progressBar = new JProgressBar();
+        progressBar.setIndeterminate(true);
+        progressBar.setPreferredSize(new Dimension(320, 28));
+        progressBar.setMaximumSize(progressBar.getPreferredSize());
+        progressBar.setAlignmentX(Component.CENTER_ALIGNMENT);
+        inner.add(progressBar);
+
+        // Center the inner block in the maximized window.
+        JPanel centered = new JPanel(new GridBagLayout());
+        centered.add(inner, new GridBagConstraints());
+        return centered;
+    }
+
+    /**
+     *  if no single-ECU auto-connect is in flight when it fires, reveal the
+     * connect controls. The reveal is also triggered by auto-connect failure/drop (see
+     * {@link #onSplashDisconnected} / {@link #onSplashConnectFailed}) so a failed auto-connect never
+     * strands the user on the scanning animation.
+     */
+    private void startRevealControlsTimer() {
+        revealControlsTimer = new Timer(REVEAL_CONTROLS_DELAY_MS, e -> {
+            // Only reveal if we are not mid auto-connect and not already handing off to the console.
+            if (autoConnectedPort == null && !isProceeding) {
+                revealControls();
+            }
+        });
+        revealControlsTimer.setRepeats(false);
+        revealControlsTimer.start();
+    }
+
+    /**
+     * Swap the scanning animation for the full connect controls.
+     */
+    private void revealControls() {
+        if (controlsRevealed) {
+            return;
+        }
+        controlsRevealed = true;
+        if (revealControlsTimer != null) {
+            revealControlsTimer.stop();
+        }
+        showCard(CARD_STARTUP);
+    }
+
+    /**
+     * Flip the root {@link CardLayout}. The frame stays fixed-maximized (#9715), so we relayout
+     * the content in place rather than packing/resizing the window.
      */
     private void showCard(String name) {
         CardLayout cl = (CardLayout) rootContent.getLayout();
         cl.show(rootContent, name);
-        Component active = null;
-        for (Component c : rootContent.getComponents()) {
-            if (c.isVisible()) {
-                active = c;
-                break;
-            }
-        }
-        if (active != null) {
-            rootContent.setPreferredSize(active.getPreferredSize());
-        }
-        frame.pack();
+        AutoupdateUtil.trueLayoutAndRepaint(rootContent);
     }
 
     private void onSplashConnected(PortResult target) {
@@ -729,9 +827,13 @@ public class StartupFrame {
         connectButton.setText("Connect");
         connectButton.setEnabled(true);
         portsComboBox.getComboPorts().setEnabled(true);
+        String launchingMsg = "Connected to " + target.port + " — launching console…";
         noPortsMessage.setForeground(Color.darkGray);
-        noPortsMessage.setText("Connected to " + target.port + " — launching console…");
+        noPortsMessage.setText(launchingMsg);
         noPortsMessage.setVisible(true);
+        if (scanningStatusLabel != null) {
+            scanningStatusLabel.setText(launchingMsg);
+        }
 
         // Hand the live LinkManager to firmware-update jobs so they can disconnect/reconnect
         // cleanly instead of closing and re-opening the port from scratch.
@@ -747,7 +849,7 @@ public class StartupFrame {
             if (d.needsAttention == null || !d.needsAttention.test(uiContext)) continue;
             WizardStep step = d.factory.apply(uiContext);
             wizardContainer.startSingleStep(step);
-            showCard("wizard");
+            showCard(CARD_WIZARD);
             return;
         }
         connect(target);
@@ -913,6 +1015,8 @@ public class StartupFrame {
         connectButton.setText("Connect");
         connectButton.setEnabled(true);
         portsComboBox.getComboPorts().setEnabled(true);
+        // Auto-connect dropped — make sure the user isn't stranded on the scanning animation (#9715).
+        revealControls();
     }
 
     private void onSplashConnectFailed(String msg) {
@@ -933,6 +1037,8 @@ public class StartupFrame {
         noPortsMessage.setForeground(Color.red);
         noPortsMessage.setText("Auto-connect failed: " + msg);
         noPortsMessage.setVisible(true);
+        // Reveal the connect controls so the user can retry/pick a port (#9715).
+        revealControls();
     }
 
     /**
@@ -978,10 +1084,16 @@ public class StartupFrame {
             getConfig().getRoot().setProperty(STARTUP_TAB_INDEX, outerTabs.getSelectedIndex());
     }
 
-    public void disposeFrameAndProceed() {
+    /**
+     * Tear down everything that drives the splash window — listeners, animations, timers and the
+     * port scanner — and persist state, WITHOUT disposing the frame. Used both before disposing the
+     * frame ({@link #disposeFrameAndProceed}) and when handing the still-live frame to ConsoleUI for
+     * reuse ({@link #connect}, #9715).
+     */
+    private void prepareForHandoff() {
         isProceeding = true;
-        // Detach the splash-scoped connection listener so it doesn't keep mutating this disposed
-        // frame's widgets when ConsoleUI (or a reconnect) fires ConnectionStatusLogic events.
+        // Detach the splash-scoped connection listener so it doesn't keep mutating this frame's
+        // widgets when ConsoleUI (or a reconnect) fires ConnectionStatusLogic events.
         if (splashListener != null) {
             ConnectionStatusLogic.INSTANCE.removeListener(splashListener);
             splashListener = null;
@@ -992,11 +1104,17 @@ public class StartupFrame {
         }
         saveTabIndex();
         getConfig().save();
-        frame.dispose();
         status.stop();
+        if (revealControlsTimer != null)
+            revealControlsTimer.stop();
         if (firmwareTabStatus != null)
             firmwareTabStatus.stop();
         connectivityContext.getSerialPortScanner().stopTimer();
+    }
+
+    public void disposeFrameAndProceed() {
+        prepareForHandoff();
+        frame.dispose();
     }
 
     private static boolean applyPortSelectionToUIcontrol(JComboBox<PortResult> comboPorts, List<PortResult> ports) {

--- a/java_console/ui/src/main/java/com/rusefi/ui/console/MainFrame.java
+++ b/java_console/ui/src/main/java/com/rusefi/ui/console/MainFrame.java
@@ -49,25 +49,7 @@ public class MainFrame {
     /**
      * @see StartupFrame
      */
-    private final FrameHelper frame = new FrameHelper() {
-        @Override
-        protected void onWindowOpened() {
-            log.info("onWindowOpened");
-            windowOpenedHandler();
-        }
-
-        @Override
-        protected void onWindowClosed() {
-            /**
-             * here we would close the port and log a message about it
-             */
-            windowClosedHandler();
-            /**
-             * here we would close the log file
-             */
-            log.info("onWindowClosed");
-        }
-    };
+    private final FrameHelper frame;
 
     public final ConnectionStatusLogic.Listener listener;
 
@@ -78,9 +60,32 @@ public class MainFrame {
     private Runnable updateEcuAction;
 
     public MainFrame(ConsoleUI consoleUI, TabbedPanel tabbedPane) {
+        this(consoleUI, tabbedPane, null);
+    }
+
+    /**
+     * @param reuseFrame when non-null, the console reuses this already-visible, maximized frame
+     *                   (handed off from {@link StartupFrame}) instead of creating a new window (#9715).
+     */
+    public MainFrame(ConsoleUI consoleUI, TabbedPanel tabbedPane, JFrame reuseFrame) {
         this.consoleUI = Objects.requireNonNull(consoleUI);
         this.tabbedPane = tabbedPane;
         listener = ConnectionStatusLogic.Listener.VOID;
+        // reuseFrame == null creates a new window; non-null reuses the splash frame in place (#9715).
+        this.frame = new FrameHelper(reuseFrame, JFrame.DISPOSE_ON_CLOSE) {
+            @Override
+            protected void onWindowOpened() {
+                log.info("onWindowOpened");
+                windowOpenedHandler();
+            }
+
+            @Override
+            protected void onWindowClosed() {
+                // close the port, then the log file
+                windowClosedHandler();
+                log.info("onWindowClosed");
+            }
+        };
 
         createMenuBar();
     }


### PR DESCRIPTION
demo:

[screen-capture.webm](https://github.com/user-attachments/assets/354bcc7c-54c0-4a7b-b2e6-ea30cd6781c5)


also some optimization!

before:
```
I 260627 224530.144 [AWT-EventQueue-0] ConsoleUI - [startup-timing] pre-link build            16 ms
I 260627 224530.144 [AWT-EventQueue-0] ConsoleUI - [startup-timing] linkManager.start          0 ms
I 260627 224530.172 [AWT-EventQueue-0] ConsoleUI - [startup-timing] Gauges tab                28 ms
I 260627 224530.577 [AWT-EventQueue-0] ConsoleUI - [startup-timing] Messages+Lua tabs        405 ms
I 260627 224530.577 [AWT-EventQueue-0] ConsoleUI - [startup-timing] EngineSniffer tab          0 ms
I 260627 224530.649 [AWT-EventQueue-0] ConsoleUI - [startup-timing] TuningPane build          72 ms
I 260627 224530.673 [AWT-EventQueue-0] ConsoleUI - [startup-timing] Pinout build + Tuning tab    24 ms
I 260627 224530.679 [AWT-EventQueue-0] ConsoleUI - [startup-timing] Knock tab                  6 ms
I 260627 224530.684 [AWT-EventQueue-0] ConsoleUI - [startup-timing] Device tab                 5 ms
I 260627 224530.686 [AWT-EventQueue-0] ConsoleUI - [startup-timing] rest of ctor               2 ms
I 260627 224530.720 [AWT-EventQueue-0] ConsoleUI - [startup-timing] showFrame/swapContent     34 ms
``` 

now:

```
I 260627 231917.612 [AWT-EventQueue-0] ConsoleUI - [startup-timing] pre-link build            13 ms
I 260627 231917.612 [AWT-EventQueue-0] ConsoleUI - [startup-timing] linkManager.start          0 ms
I 260627 231917.634 [AWT-EventQueue-0] ConsoleUI - [startup-timing] Gauges tab                22 ms
I 260627 231917.654 [AWT-EventQueue-0] ConsoleUI - [startup-timing] Messages tab              20 ms
I 260627 231917.655 [AWT-EventQueue-0] ConsoleUI - [startup-timing] Lua tab                    1 ms
I 260627 231917.655 [AWT-EventQueue-0] ConsoleUI - [startup-timing] EngineSniffer tab          0 ms
I 260627 231917.677 [AWT-EventQueue-0] ConsoleUI - [startup-timing] Tuning tab (lazy)         22 ms
I 260627 231917.686 [AWT-EventQueue-0] ConsoleUI - [startup-timing] Knock tab                  9 ms
I 260627 231917.690 [AWT-EventQueue-0] ConsoleUI - [startup-timing] Device tab                 4 ms
I 260627 231917.762 [AWT-EventQueue-0] ConsoleUI - [startup-timing] rest of ctor              72 ms
I 260627 231917.785 [AWT-EventQueue-0] ConsoleUI - [startup-timing] showFrame/swapContent     23 ms
``` 

related #9715