### PR TITLE
feat(ui): better UI for TuneManagementTab

### DIFF
--- a/java_console/core_ui/src/main/java/com/rusefi/core/ui/LoadingOverlay.java
+++ b/java_console/core_ui/src/main/java/com/rusefi/core/ui/LoadingOverlay.java
@@ -13,8 +13,23 @@ import java.awt.*;
  */
 public class LoadingOverlay {
     public static void show(JFrame frame, String message) {
+        show(frame, message, null);
+    }
+
+    /**
+     * @param logo optional logo shown above the message so it stays put across the splash → console
+     *             handoff instead of vanishing mid-load (#9715). Passed in because core_ui can't see
+     *             the ui-module LogoHelper.
+     */
+    public static void show(JFrame frame, String message, JComponent logo) {
         JPanel inner = new JPanel();
         inner.setLayout(new BoxLayout(inner, BoxLayout.Y_AXIS));
+
+        if (logo != null) {
+            logo.setAlignmentX(Component.CENTER_ALIGNMENT);
+            inner.add(logo);
+            inner.add(Box.createVerticalStrut(24));
+        }
 
         JLabel label = new JLabel(message);
         label.setAlignmentX(Component.CENTER_ALIGNMENT);

--- a/java_console/ui/src/main/java/com/rusefi/StartupFrame.java
+++ b/java_console/ui/src/main/java/com/rusefi/StartupFrame.java
@@ -618,7 +618,7 @@ public class StartupFrame {
         // Reuse this maximized splash frame for the console
         log.info("connect: handing off splash frame to ConsoleUI");
         prepareForHandoff();
-        LoadingOverlay.show(frame, "Loading console…");
+        LoadingOverlay.show(frame, "Loading console…", LogoHelper.createLogoLabel());
         SwingUtilities.invokeLater(() ->
             new ConsoleUI(uiContext, selectedPort.port, selectedPort.type, alreadyConnected, frame));
     }

--- a/java_console/ui/src/main/java/com/rusefi/ui/basic/TuneManagementTab.java
+++ b/java_console/ui/src/main/java/com/rusefi/ui/basic/TuneManagementTab.java
@@ -80,8 +80,6 @@ public class TuneManagementTab {
             centerPanel.add(tableScroll, BorderLayout.CENTER);
             centerPanel.add(uploadProgress, BorderLayout.SOUTH);
 
-            totalContent.add(centerPanel, BorderLayout.CENTER);
-
             singleAsyncJobExecutor.addOnJobInProgressFinishedListener(() -> {
                 if (!awaitingCompletion.compareAndSet(true, false))
                     return;
@@ -157,10 +155,45 @@ public class TuneManagementTab {
 
         JButton loadTuneFileButton = new JButton("Load Tune File");
         loadTuneFileButton.addActionListener(e -> loadTuneFileOffline());
-        JPanel bottomPanel = new JPanel(new BorderLayout());
-        bottomPanel.add(importTuneButton, BorderLayout.NORTH);
-        bottomPanel.add(loadTuneFileButton, BorderLayout.SOUTH);
-        totalContent.add(bottomPanel, BorderLayout.SOUTH);
+        // A bit bigger so it reads as the primary offline action (#9715).
+        loadTuneFileButton.setFont(loadTuneFileButton.getFont().deriveFont(Font.BOLD, 16f));
+        loadTuneFileButton.setMargin(new Insets(12, 28, 12, 28));
+
+        JPanel buttonPanel = new JPanel();
+        buttonPanel.setLayout(new BoxLayout(buttonPanel, BoxLayout.Y_AXIS));
+        buttonPanel.add(centerHorizontally(importTuneButton));
+        buttonPanel.add(Box.createVerticalStrut(28));
+        buttonPanel.add(centerHorizontally(loadTuneFileButton));
+
+        if (tunesManifestUrl != null) {
+            // Keep the tune list but cap it at ~80% of the height, with the buttons in the lower 20%,
+            // so they aren't pinned to the very bottom edge of the now-maximized splash (#9715).
+            JPanel body = new JPanel(new GridBagLayout());
+            GridBagConstraints c = new GridBagConstraints();
+            c.gridx = 0;
+            c.gridy = 0;
+            c.weightx = 1;
+            c.weighty = 0.8;
+            c.fill = GridBagConstraints.BOTH;
+            body.add(centerPanel, c);
+            c.gridy = 1;
+            c.weighty = 0.2;
+            c.fill = GridBagConstraints.NONE;
+            c.anchor = GridBagConstraints.CENTER;
+            body.add(buttonPanel, c);
+            totalContent.add(body, BorderLayout.CENTER);
+        } else {
+            // No tune list available — just center the buttons in the tab (#9715).
+            JPanel centered = new JPanel(new GridBagLayout());
+            centered.add(buttonPanel, new GridBagConstraints());
+            totalContent.add(centered, BorderLayout.CENTER);
+        }
+    }
+
+    private static JPanel centerHorizontally(Component c) {
+        JPanel row = new JPanel(new FlowLayout(FlowLayout.CENTER, 0, 0));
+        row.add(c);
+        return row;
     }
 
     private void showErrorLogPopup(String logText) {


### PR DESCRIPTION
resolves #9715 

no tune-list buttons:

<img width="1919" height="1049" alt="image" src="https://github.com/user-attachments/assets/420c9fca-34ce-4de8-a736-d0bdc11641ee" />

