### PR TITLE
9713 renix trigger ratios

### DIFF
--- a/firmware/controllers/trigger/decoders/trigger_renix.cpp
+++ b/firmware/controllers/trigger/decoders/trigger_renix.cpp
@@ -41,7 +41,12 @@ static void commonRenix(TriggerWaveform *s) {
 	// Sync on the tooth at slot 1: it follows the missing slot 0 (a 2x gap),
 	// while the preceding tooth (slot 21 of the previous cycle) was a regular
 	// tooth - so this/last = 2.0 and last/prev = 1.0.
-	s->setTriggerSynchronizationGap3(/*gapIndex*/0, 1.5, 2.5);
+  // Ideal gap ratios for the 44-2-2 pattern are:
+  // 1.0 - 2.0 - 1.0 - 0.5 
+  // But due to timing artifacts first gap may be significantly shorter than 2x
+  // throwing everything off.
+  // So we use a more relaxed range for the first gap ratio.
+	s->setTriggerSynchronizationGap3(/*gapIndex*/0, 1.25, 2.5);
 	s->setTriggerSynchronizationGap3(/*gapIndex*/1, 0.75, 1.25);
 }
 

--- a/unit_tests/tests/trigger/test_real_renix_44_2_2.cpp
+++ b/unit_tests/tests/trigger/test_real_renix_44_2_2.cpp
@@ -90,5 +90,5 @@ TEST(triggerRenix44, renix44RealCrankingFromFileAnotherOne) {
 	ASSERT_TRUE(engine->triggerCentral.triggerState.getShaftSynchronized()) << "renix44 shaft sync";
 	ASSERT_NEAR(219, Sensor::getOrZero(SensorType::Rpm), 5) << "renix44 RPM";
 
-	ASSERT_EQ(531, tooManyTeethCounter);
+	ASSERT_EQ(3, tooManyTeethCounter);
 }

--- a/unit_tests/tests/trigger/test_real_renix_44_2_2.cpp
+++ b/unit_tests/tests/trigger/test_real_renix_44_2_2.cpp
@@ -9,7 +9,11 @@
 #include "logicdata_csv_reader.h"
 #include "unit_test_logger.h"
 
+extern int tooManyTeethCounter;
+
 TEST(triggerRenix44, renix44RealCrankingFromFile) {
+	tooManyTeethCounter = 0;
+
 	ScopedLogFileSizeLimit sz(32 * 1024 * 1024);
 	// It's a long trace, let's not waste time and disk space on logs
 	ScopedUnitTestCreateLogs sz2(false);
@@ -49,9 +53,12 @@ TEST(triggerRenix44, renix44RealCrankingFromFile) {
 	// zero error/warning count here.
 	ASSERT_TRUE(engine->triggerCentral.triggerState.getShaftSynchronized()) << "renix44 shaft sync";
 	ASSERT_NEAR(1389, Sensor::getOrZero(SensorType::Rpm), 5) << "renix44 RPM";
+	ASSERT_EQ(84, tooManyTeethCounter);
 }
 
 TEST(triggerRenix44, renix44RealCrankingFromFileAnotherOne) {
+	tooManyTeethCounter = 0;
+
 	ScopedLogFileSizeLimit sz(32 * 1024 * 1024);
 	// It's a long trace, let's not waste time and disk space on logs
 	ScopedUnitTestCreateLogs sz2(false);
@@ -82,4 +89,6 @@ TEST(triggerRenix44, renix44RealCrankingFromFileAnotherOne) {
 	ASSERT_NEAR(556.71, firstSyncRpm, 0.5) << "renix44 first sync RPM";
 	ASSERT_TRUE(engine->triggerCentral.triggerState.getShaftSynchronized()) << "renix44 shaft sync";
 	ASSERT_NEAR(219, Sensor::getOrZero(SensorType::Rpm), 5) << "renix44 RPM";
+
+	ASSERT_EQ(531, tooManyTeethCounter);
 }


### PR DESCRIPTION
#9713

<img width="1887" height="715" alt="image" src="https://github.com/user-attachments/assets/ade95ed7-595e-44ed-8ee2-e72f059d2092" />

Due to timing artifacts first gap may be as low as 1.3
So instead of 1.0-2.0-1.0-0.5 (as in the left part of the image)
it becomes 1.0-1.5-1.7-0.4

Here we widen the first ratio a bit to accommodate the artifacts.