### PR TITLE
TS: simplify MAP sensor dialog layout

### DIFF
--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -908,7 +908,7 @@ spi_device_e digitalPotentiometerSpiDevice;Digital Potentiometer is used by stoc
 	bit verboseTLE8888,"yes","no"
 	bit enableVerboseCanTx,"yes","no";CAN broadcast using custom rusEFI protocol
 	bit externalRusEfiGdiModule,"yes","no"
-	bit measureMapOnlyInOneCylinder,"yes","no";Useful for individual intakes
+	bit measureMapOnlyInOneCylinder,"yes","no";Sample MAP during only one cylinder's intake per engine cycle instead of every cylinder.\nEnable for individual throttle bodies, where the MAP sensor reads a single runner with its own pressure pulses. Leave disabled for a shared plenum or single throttle so every intake event is averaged together for a smoother reading.
 
 	! bit 13
 	bit stepperForceParkingEveryRestart,"yes","no"

--- a/firmware/tunerstudio/tunerstudio.template.ini
+++ b/firmware/tunerstudio/tunerstudio.template.ini
@@ -3282,29 +3282,38 @@ dialog = allPinsOutputs_1_and_2, "", xAxis
 		field = "SENT Input #1",						sentInputPins1
 
 ;			Sensors->MAP sensor
+	; Custom 2-point calibration - only shown when "Custom" sensor model is selected
+	dialog = mapCustomCal, "Custom calibration", yAxis
+		field = "Low point voltage",			mapLowValueVoltage
+		field = "Low point pressure",			map_sensor_lowValue
+		field = "High point voltage",			mapHighValueVoltage
+		field = "High point pressure",			map_sensor_highValue
+
+	; The essentials: input pin + sensor model (+ custom cal when applicable)
 	dialog = mapSensorAnalog, "MAP sensor", yAxis
-		field = "MAP input",						    map_sensor_hwChannel
-		field = "MAP type",								map_sensor_type, { map_sensor_hwChannel != @@ADC_CHANNEL_NONE@@ }
-		field = "MAP value low point",				map_sensor_lowValue, { map_sensor_hwChannel != @@ADC_CHANNEL_NONE@@ && map_sensor_type == 0 }
-		field = "MAP voltage low point",				mapLowValueVoltage,  { map_sensor_hwChannel != @@ADC_CHANNEL_NONE@@ && map_sensor_type == 0 }
-		field = "MAP value high point",						map_sensor_highValue, { map_sensor_hwChannel != @@ADC_CHANNEL_NONE@@ && map_sensor_type == 0 }
-		field = "MAP voltage high value",					mapHighValueVoltage, { map_sensor_hwChannel != @@ADC_CHANNEL_NONE@@ && map_sensor_type == 0 }
+		field = "Input pin",					map_sensor_hwChannel
+		field = "Sensor model",					map_sensor_type, { map_sensor_hwChannel != @@ADC_CHANNEL_NONE@@ }
+		panel = mapCustomCal, { map_sensor_hwChannel != @@ADC_CHANNEL_NONE@@ && map_sensor_type == 0 }
 
 	indicatorPanel = mapValidIndicators, 1
 		indicator = {isMapValid}, "BAD Map Input", "Good MAP Input", red, black, green, black
 
-	dialog = mapCommon, "MAP common settings"
-		field = "Low value threshold",					mapErrorDetectionTooLow
-		field = "High value threshold",					mapErrorDetectionTooHigh
+	; Plausibility / fault detection
+	dialog = mapCommon, "Fault detection", yAxis
+		field = "Fault if reading below",		mapErrorDetectionTooLow
+		field = "Fault if reading above",		mapErrorDetectionTooHigh
 		panel = mapValidIndicators
-		field = ""
-		field = "Measure Map Only In One Cylinder",		measureMapOnlyInOneCylinder@@if_ts_show_measureMapOnlyInOneCylinder
-		field = "Cylinder count to sample MAP",					mapMinBufferLength@@if_ts_show_mapMinBufferLength
-    field = "MAP sensor ExpAverage dampening", mapExpAverageAlpha
+
+	; Advanced: individual throttle bodies + input filtering
+	dialog = mapAdvanced, "Advanced", yAxis
+		field = "Individual throttle bodies",	measureMapOnlyInOneCylinder@@if_ts_show_measureMapOnlyInOneCylinder
+		field = "Samples per cycle",			mapMinBufferLength@@if_ts_show_mapMinBufferLength
+		field = "Input smoothing (EMA alpha)",	mapExpAverageAlpha
 
 	dialog = mapSettingsLeft, "", yAxis
-		panel = mapCommon
 		panel = mapSensorAnalog
+		panel = mapCommon
+		panel = mapAdvanced, { 1 }, { uiMode == @@UiMode_FULL@@ || uiMode == @@UiMode_INSTALLATION@@ }
 
 	dialog = mapGauges
 		gauge = MAPGauge

--- a/firmware/tunerstudio/tunerstudio.template.ini
+++ b/firmware/tunerstudio/tunerstudio.template.ini
@@ -3306,7 +3306,7 @@ dialog = allPinsOutputs_1_and_2, "", xAxis
 
 	; Advanced: individual throttle bodies + input filtering
 	dialog = mapAdvanced, "Advanced", yAxis
-		field = "Individual throttle bodies",	measureMapOnlyInOneCylinder@@if_ts_show_measureMapOnlyInOneCylinder
+		field = "Measure Map Only In One Cylinder",	measureMapOnlyInOneCylinder@@if_ts_show_measureMapOnlyInOneCylinder
 		field = "Samples per cycle",			mapMinBufferLength@@if_ts_show_mapMinBufferLength
 		field = "Input smoothing (EMA alpha)",	mapExpAverageAlpha
 


### PR DESCRIPTION
Simplifies the MAP sensor dialog so the essentials come first, without losing any functionality. Labels/layout only — no config struct or memory-layout change, so tune compatibility is untouched.

- Essentials first: "Input pin" + "Sensor model", then fault detection, then advanced.
- Custom 2-point calibration moved to its own panel, shown only when the "Custom" sensor model is selected (instead of always-greyed). Consistent field names: Low/High point voltage/pressure.
- "Low/High value threshold" → "Fault if reading below/above" under a "Fault detection" group, clarifying these are plausibility limits.
- "Measure Map Only In One Cylinder" kept, with a clearer tooltip explaining per-cylinder vs every-cylinder MAP sampling.
- Input filtering grouped under "Advanced", hidden outside Full/Installation UI modes to declutter Tuning mode.

Closes #9723

🤖 Generated with [Claude Code](https://claude.com/claude-code)