### PR TITLE
Misleading axis labels in fuel and spark tables

### DIFF
--- a/firmware/integration/config_page_4.txt
+++ b/firmware/integration/config_page_4.txt
@@ -6,7 +6,7 @@ custom gppwm_channel_e 1 bits, U08, @OFFSET@, [0:5], $gppwm_channel_e_enum
 struct_no_prefix page4_s
   ! note this is pretty similar to a blend table!
   uint16_t[VE_LOAD_COUNT x VE_RPM_COUNT] autoscale secondVeTable;;"%", 0.1, 0, 0, 999, 1
-  uint16_t[VE_LOAD_COUNT] secondVeLoadBins;;{bitStringValue(veLoadUnitLabels, veLoadUnitIdxPcv)}, {!(veOverrideMode == 1 || (veOverrideMode == 0 && fuelAlgorithm == 0)) || useMetricOnInterface ? 1 : @@UNITS_KPA_TO_PSI@@}, 0, 0, {veOverrideMode == 1 || (veOverrideMode == 0 && fuelAlgorithm == 0) ? (useMetricOnInterface ? @@MAP_UPPER_LIMIT@@ : @@MAP_UPPER_LIMIT@@ * @@UNITS_KPA_TO_PSI@@) : @@MAP_UPPER_LIMIT@@}, 0
+  uint16_t[VE_LOAD_COUNT] secondVeLoadBins;;{bitStringValue(veLoadUnitLabels, veLoadUnitIdx)}, {!(veOverrideMode == 1 || (veOverrideMode == 0 && fuelAlgorithm == 0)) || useMetricOnInterface ? 1 : @@UNITS_KPA_TO_PSI@@}, 0, 0, {veOverrideMode == 1 || (veOverrideMode == 0 && fuelAlgorithm == 0) ? (useMetricOnInterface ? @@MAP_UPPER_LIMIT@@ : @@MAP_UPPER_LIMIT@@ * @@UNITS_KPA_TO_PSI@@) : @@MAP_UPPER_LIMIT@@}, 0
   uint16_t[VE_RPM_COUNT] secondVeRpmBins;;"RPM",	   1, 0, 0, 18000, 0
 
   switch_input_pin_e secondVeTableInput;Pin that activates the second VE table (hard switch, overrides blend)
@@ -19,7 +19,7 @@ struct_no_prefix page4_s
 
   ! note this is pretty similar to a blend table!
   int16_t[IGN_LOAD_COUNT x IGN_RPM_COUNT] autoscale secondIgnitionTable;;"deg", 0.1, 0, -20, 90, 1
-  uint16_t[IGN_LOAD_COUNT] secondIgnitionLoadBins;;{bitStringValue(ignLoadUnitLabels, ignLoadUnitIdxPcv)}, {!(ignOverrideMode == 1 || (ignOverrideMode == 0 && fuelAlgorithm == 0)) || useMetricOnInterface ? 1 : @@UNITS_KPA_TO_PSI@@}, 0, 0, {ignOverrideMode == 1 || (ignOverrideMode == 0 && fuelAlgorithm == 0) ? (useMetricOnInterface ? @@MAP_UPPER_LIMIT@@ : @@MAP_UPPER_LIMIT@@ * @@UNITS_KPA_TO_PSI@@) : @@MAP_UPPER_LIMIT@@}, 0
+  uint16_t[IGN_LOAD_COUNT] secondIgnitionLoadBins;;{bitStringValue(ignLoadUnitLabels, ignLoadUnitIdx)}, {!(ignOverrideMode == 1 || (ignOverrideMode == 0 && fuelAlgorithm == 0)) || useMetricOnInterface ? 1 : @@UNITS_KPA_TO_PSI@@}, 0, 0, {ignOverrideMode == 1 || (ignOverrideMode == 0 && fuelAlgorithm == 0) ? (useMetricOnInterface ? @@MAP_UPPER_LIMIT@@ : @@MAP_UPPER_LIMIT@@ * @@UNITS_KPA_TO_PSI@@) : @@MAP_UPPER_LIMIT@@}, 0
   uint16_t[IGN_RPM_COUNT] secondIgnitionRpmBins;;"RPM",	   1, 0, 0, 18000, 0
 
   switch_input_pin_e secondIgnitionTableInput;Pin that activates the second ignition table (hard switch, overrides blend)

--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -2164,11 +2164,11 @@ uint16_t[VVT_TABLE_SIZE] vvtTable2LoadBins;;"L", 1, 0, 0,  @@MAP_UPPER_LIMIT@@, 
 uint16_t[VVT_TABLE_RPM_SIZE] vvtTable2RpmBins;;"RPM", 1, 0, 0, 18000, 0
 
 int16_t[IGN_LOAD_COUNT x IGN_RPM_COUNT] autoscale ignitionTable;;"deg", 0.1, 0, -20, 90, 1
-uint16_t[IGN_LOAD_COUNT] ignitionLoadBins;;{bitStringValue(ignLoadUnitLabels, ignLoadUnitIdxPcv)}, {!(ignOverrideMode == 1 || (ignOverrideMode == 0 && fuelAlgorithm == 0)) || useMetricOnInterface ? 1 : @@UNITS_KPA_TO_PSI@@}, 0, 0, {ignOverrideMode == 1 || (ignOverrideMode == 0 && fuelAlgorithm == 0) ? (useMetricOnInterface ? @@MAP_UPPER_LIMIT@@ : @@MAP_UPPER_LIMIT@@ * @@UNITS_KPA_TO_PSI@@) : @@MAP_UPPER_LIMIT@@}, 0
+uint16_t[IGN_LOAD_COUNT] ignitionLoadBins;;{bitStringValue(ignLoadUnitLabels, ignLoadUnitIdx)}, {!(ignOverrideMode == 1 || (ignOverrideMode == 0 && fuelAlgorithm == 0)) || useMetricOnInterface ? 1 : @@UNITS_KPA_TO_PSI@@}, 0, 0, {ignOverrideMode == 1 || (ignOverrideMode == 0 && fuelAlgorithm == 0) ? (useMetricOnInterface ? @@MAP_UPPER_LIMIT@@ : @@MAP_UPPER_LIMIT@@ * @@UNITS_KPA_TO_PSI@@) : @@MAP_UPPER_LIMIT@@}, 0
 uint16_t[IGN_RPM_COUNT] ignitionRpmBins;;"RPM",	   1, 0, 0, 18000, 0
 
 uint16_t[VE_LOAD_COUNT x VE_RPM_COUNT] autoscale veTable;;"%", 0.1, 0, 0, 999, 1
-uint16_t[VE_LOAD_COUNT] veLoadBins;;{bitStringValue(veLoadUnitLabels, veLoadUnitIdxPcv)}, {!(veOverrideMode == 1 || (veOverrideMode == 0 && fuelAlgorithm == 0)) || useMetricOnInterface ? 1 : @@UNITS_KPA_TO_PSI@@}, 0, 0, {veOverrideMode == 1 || (veOverrideMode == 0 && fuelAlgorithm == 0) ? (useMetricOnInterface ? @@MAP_UPPER_LIMIT@@ : @@MAP_UPPER_LIMIT@@ * @@UNITS_KPA_TO_PSI@@) : @@MAP_UPPER_LIMIT@@}, 0
+uint16_t[VE_LOAD_COUNT] veLoadBins;;{bitStringValue(veLoadUnitLabels, veLoadUnitIdx)}, {!(veOverrideMode == 1 || (veOverrideMode == 0 && fuelAlgorithm == 0)) || useMetricOnInterface ? 1 : @@UNITS_KPA_TO_PSI@@}, 0, 0, {veOverrideMode == 1 || (veOverrideMode == 0 && fuelAlgorithm == 0) ? (useMetricOnInterface ? @@MAP_UPPER_LIMIT@@ : @@MAP_UPPER_LIMIT@@ * @@UNITS_KPA_TO_PSI@@) : @@MAP_UPPER_LIMIT@@}, 0
 uint16_t[VE_RPM_COUNT] veRpmBins;;"RPM",	   1, 0, 0, 18000, 0
 
 ! TODO at some point we need to flip this table to use AFR on the affected tests, since otherwise we get some no-to-nice fields as consequence
@@ -2176,7 +2176,7 @@ uint16_t[VE_RPM_COUNT] veRpmBins;;"RPM",	   1, 0, 0, 18000, 0
 ! [tag:lambdaTable]
 uint8_t[FUEL_LOAD_COUNT x FUEL_RPM_COUNT] autoscale lambdaTable;;{useLambdaOnInterface ? "lambda" : "afr"}, { useLambdaOnInterface ? 1/@@PACK_MULT_LAMBDA_CFG@@ : 1/@@PACK_MULT_AFR_CFG@@ }, 0, {useLambdaOnInterface ? 0.6 : 0}, {useLambdaOnInterface ? 1.5 : 25}, {useLambdaOnInterface ? 2 : 1}
 
-uint16_t[FUEL_LOAD_COUNT] lambdaLoadBins;;{bitStringValue(afrLoadUnitLabels, afrLoadUnitIdxPcv)}, {!(afrOverrideMode == 1 || (afrOverrideMode == 0 && fuelAlgorithm == 0)) || useMetricOnInterface ? 1 : @@UNITS_KPA_TO_PSI@@}, 0, 0, {afrOverrideMode == 1 || (afrOverrideMode == 0 && fuelAlgorithm == 0) ? (useMetricOnInterface ? @@MAP_UPPER_LIMIT@@ : @@MAP_UPPER_LIMIT@@ * @@UNITS_KPA_TO_PSI@@) : @@MAP_UPPER_LIMIT@@}, 0
+uint16_t[FUEL_LOAD_COUNT] lambdaLoadBins;;{bitStringValue(afrLoadUnitLabels, afrLoadUnitIdx)}, {!(afrOverrideMode == 1 || (afrOverrideMode == 0 && fuelAlgorithm == 0)) || useMetricOnInterface ? 1 : @@UNITS_KPA_TO_PSI@@}, 0, 0, {afrOverrideMode == 1 || (afrOverrideMode == 0 && fuelAlgorithm == 0) ? (useMetricOnInterface ? @@MAP_UPPER_LIMIT@@ : @@MAP_UPPER_LIMIT@@ * @@UNITS_KPA_TO_PSI@@) : @@MAP_UPPER_LIMIT@@}, 0
 uint16_t[FUEL_RPM_COUNT] lambdaRpmBins;;"RPM",	  1, 0, 0, 18000, 0
 
 float[TPS_TPS_ACCEL_TABLE x TPS_TPS_ACCEL_TABLE] tpsTpsAccelTable;;"value", 1, 0, 0, 30000, 2
@@ -2211,12 +2211,12 @@ struct fuel_cyl_trim_s
 end_struct
 
 ! All ign trim tables share axes
-uint16_t[IGN_TRIM_SIZE] ignTrimLoadBins;;{bitStringValue(ignLoadUnitLabels, ignLoadUnitIdxPcv)}, {!(ignOverrideMode == 1 || (ignOverrideMode == 0 && fuelAlgorithm == 0)) || useMetricOnInterface ? 1 : @@UNITS_KPA_TO_PSI@@}, 0, 0, {ignOverrideMode == 1 || (ignOverrideMode == 0 && fuelAlgorithm == 0) ? (useMetricOnInterface ? @@MAP_UPPER_LIMIT@@ : @@MAP_UPPER_LIMIT@@ * @@UNITS_KPA_TO_PSI@@) : @@MAP_UPPER_LIMIT@@}, 0
+uint16_t[IGN_TRIM_SIZE] ignTrimLoadBins;;{bitStringValue(ignLoadUnitLabels, ignLoadUnitIdx)}, {!(ignOverrideMode == 1 || (ignOverrideMode == 0 && fuelAlgorithm == 0)) || useMetricOnInterface ? 1 : @@UNITS_KPA_TO_PSI@@}, 0, 0, {ignOverrideMode == 1 || (ignOverrideMode == 0 && fuelAlgorithm == 0) ? (useMetricOnInterface ? @@MAP_UPPER_LIMIT@@ : @@MAP_UPPER_LIMIT@@ * @@UNITS_KPA_TO_PSI@@) : @@MAP_UPPER_LIMIT@@}, 0
 uint16_t[IGN_TRIM_SIZE] ignTrimRpmBins;;"rpm", 1, 0, 0, 20000, 0
 ign_cyl_trim_s[MAX_CYLINDER_COUNT iterate] ignTrims
 
 ! All fuel trim tables share axes
-uint16_t[FUEL_TRIM_SIZE] fuelTrimLoadBins;;{bitStringValue(veLoadUnitLabels, veLoadUnitIdxPcv)}, {!(veOverrideMode == 1 || (veOverrideMode == 0 && fuelAlgorithm == 0)) || useMetricOnInterface ? 1 : @@UNITS_KPA_TO_PSI@@}, 0, 0, {veOverrideMode == 1 || (veOverrideMode == 0 && fuelAlgorithm == 0) ? (useMetricOnInterface ? @@MAP_UPPER_LIMIT@@ : @@MAP_UPPER_LIMIT@@ * @@UNITS_KPA_TO_PSI@@) : @@MAP_UPPER_LIMIT@@}, 0
+uint16_t[FUEL_TRIM_SIZE] fuelTrimLoadBins;;{bitStringValue(veLoadUnitLabels, veLoadUnitIdx)}, {!(veOverrideMode == 1 || (veOverrideMode == 0 && fuelAlgorithm == 0)) || useMetricOnInterface ? 1 : @@UNITS_KPA_TO_PSI@@}, 0, 0, {veOverrideMode == 1 || (veOverrideMode == 0 && fuelAlgorithm == 0) ? (useMetricOnInterface ? @@MAP_UPPER_LIMIT@@ : @@MAP_UPPER_LIMIT@@ * @@UNITS_KPA_TO_PSI@@) : @@MAP_UPPER_LIMIT@@}, 0
 uint16_t[FUEL_TRIM_SIZE] fuelTrimRpmBins;;"rpm", 1, 0, 0, 20000, 0
 fuel_cyl_trim_s[MAX_CYLINDER_COUNT iterate] fuelTrims
 
@@ -2342,14 +2342,14 @@ float[RANGE_INPUT_COUNT] tcu_rangeLow;;"level", 1, 0, 0, 200000, 0
 #define LAM_RPM_SIZE 4
 
 uint8_t[LAM_SIZE x LAM_RPM_SIZE] autoscale lambdaMaxDeviationTable;;"lambda", 0.01, 0, 0, 1, 2
-uint16_t[LAM_SIZE] lambdaMaxDeviationLoadBins;;{bitStringValue(afrLoadUnitLabels, afrLoadUnitIdxPcv)}, {!(afrOverrideMode == 1 || (afrOverrideMode == 0 && fuelAlgorithm == 0)) || useMetricOnInterface ? 1 : @@UNITS_KPA_TO_PSI@@}, 0, 0, {afrOverrideMode == 1 || (afrOverrideMode == 0 && fuelAlgorithm == 0) ? (useMetricOnInterface ? @@MAP_UPPER_LIMIT@@ : @@MAP_UPPER_LIMIT@@ * @@UNITS_KPA_TO_PSI@@) : @@MAP_UPPER_LIMIT@@}, 0
+uint16_t[LAM_SIZE] lambdaMaxDeviationLoadBins;;{bitStringValue(afrLoadUnitLabels, afrLoadUnitIdx)}, {!(afrOverrideMode == 1 || (afrOverrideMode == 0 && fuelAlgorithm == 0)) || useMetricOnInterface ? 1 : @@UNITS_KPA_TO_PSI@@}, 0, 0, {afrOverrideMode == 1 || (afrOverrideMode == 0 && fuelAlgorithm == 0) ? (useMetricOnInterface ? @@MAP_UPPER_LIMIT@@ : @@MAP_UPPER_LIMIT@@ * @@UNITS_KPA_TO_PSI@@) : @@MAP_UPPER_LIMIT@@}, 0
 uint16_t[LAM_RPM_SIZE] lambdaMaxDeviationRpmBins;;"RPM",  1, 0, 0, 18000, 0
 
 #define INJ_STAGING_COUNT 6
 #define INJ_STAGING_RPM_SIZE 6
 
 uint8_t[INJ_STAGING_COUNT x INJ_STAGING_RPM_SIZE] injectorStagingTable;;"%", 1, 0, 0, 90, 0
-uint16_t[INJ_STAGING_COUNT] injectorStagingLoadBins;;{bitStringValue(afrLoadUnitLabels, afrLoadUnitIdxPcv)}, {!(afrOverrideMode == 1 || (afrOverrideMode == 0 && fuelAlgorithm == 0)) || useMetricOnInterface ? 1 : @@UNITS_KPA_TO_PSI@@}, 0, 0, {afrOverrideMode == 1 || (afrOverrideMode == 0 && fuelAlgorithm == 0) ? (useMetricOnInterface ? @@MAP_UPPER_LIMIT@@ : @@MAP_UPPER_LIMIT@@ * @@UNITS_KPA_TO_PSI@@) : @@MAP_UPPER_LIMIT@@}, 0
+uint16_t[INJ_STAGING_COUNT] injectorStagingLoadBins;;{bitStringValue(afrLoadUnitLabels, afrLoadUnitIdx)}, {!(afrOverrideMode == 1 || (afrOverrideMode == 0 && fuelAlgorithm == 0)) || useMetricOnInterface ? 1 : @@UNITS_KPA_TO_PSI@@}, 0, 0, {afrOverrideMode == 1 || (afrOverrideMode == 0 && fuelAlgorithm == 0) ? (useMetricOnInterface ? @@MAP_UPPER_LIMIT@@ : @@MAP_UPPER_LIMIT@@ * @@UNITS_KPA_TO_PSI@@) : @@MAP_UPPER_LIMIT@@}, 0
 uint16_t[INJ_STAGING_RPM_SIZE] injectorStagingRpmBins;;"RPM",  1, 0, 0, 18000, 0
 
 #define WWAE_TABLE_SIZE 8

--- a/firmware/tunerstudio/tunerstudio.template.ini
+++ b/firmware/tunerstudio/tunerstudio.template.ini
@@ -353,31 +353,24 @@ include_file @@TUNING_SECTION_FILE@@
 	; Closed Loop Fuel Correction / Short Term Fuel Trims
 	isSTFT = { fuelClosedLoopCorrectionEnabled == 1 }
 
-	; effective load source: 0=MAP 1=TPS 2=Air mass(MAF) 3=Lua (+ign: 4=Acc Pedal 5=Cyl Filling)
-	; when override is None the source follows fuelAlgorithm (0=SD/MAP, 1=MAF, 2=Alpha-N/TPS, 3=Lua)
-	veLoadSrc  = { veOverrideMode == 1 ? 0 : veOverrideMode == 2 ? 1 : (fuelAlgorithm == 0 ? 0 : fuelAlgorithm == 2 ? 1 : fuelAlgorithm == 1 ? 2 : 3) }
-	ignLoadSrc = { ignOverrideMode == 1 ? 0 : ignOverrideMode == 2 ? 1 : ignOverrideMode == 3 ? 4 : ignOverrideMode == 4 ? 5 : (fuelAlgorithm == 0 ? 0 : fuelAlgorithm == 2 ? 1 : fuelAlgorithm == 1 ? 2 : 3) }
-	afrLoadSrc = { afrOverrideMode == 1 ? 0 : afrOverrideMode == 2 ? 1 : afrOverrideMode == 3 ? 4 : afrOverrideMode == 4 ? 5 : (fuelAlgorithm == 0 ? 0 : fuelAlgorithm == 2 ? 1 : fuelAlgorithm == 1 ? 2 : 3) }
-	; unit label index: 0=psi, 1=kPa, 2=%, 3=Lua  (MAP->psi/kPa by metric, Lua->Lua, else %)
-	ignLoadUnitIdx = { ignLoadSrc == 0 ? useMetricOnInterface : (ignLoadSrc == 3 ? 3 : 2) }
-	veLoadUnitIdx = { veLoadSrc == 0 ? useMetricOnInterface : (veLoadSrc == 3 ? 3 : 2) }
-	afrLoadUnitIdx = { afrLoadSrc == 0 ? useMetricOnInterface : (afrLoadSrc == 3 ? 3 : 2) }
-
 [PcVariables]
 	fuelUnits = bits, U08, [0:2], @@UNITS_KPA@@, "MAF", "%TPS", "Lua"
 	pwmAxisLabels = bits, U08, [0:5], "Zero", "TPS %", "MAP kPa", "CLT C", "IAT C", "Fuel Load", "Ignition Load", "Aux Temp 1 C", "Aux Temp 2 C", "Accel Pedal %", "Battery Voltage Volts", "VVT 1 I Deg", "VVT 1 E Deg", "VVT 2 I Deg", "VVT 2 E Deg", "Ethanol (Flex) %", "Aux Linear 1 *", "Aux Linear 2 *", "GPPWM Output 1 %", "GPPWM Output 2 %", "GPPWM Output 3 %", "GPPWM Output 4 %", "Lua Gauge 1", "Lua Gauge 2", "RPM", "Gear (detected)", "Baro pressure kPa", "EGT 1 C", "EGT 2 C", "Aux Linear 3", "Aux Linear 4", "Vehicle Speed KPH", "Oil pressure kPa", "Oil temp C", "Fuel Pressure", "Throttle Pressure Ratio"
-	veAxisLabels = bits, U08, [0:1], "MAP", "TPS", "Air mass", "Lua"
-	targetAfrAxisLabels = bits, U08, [0:2], "MAP", "TPS", "Air mass", "Lua", "Acc Pedal", "Cyl Filling"
-	ignAxisLabels = bits, U08, [0:2], "MAP", "TPS", "Air mass", "Lua", "Acc Pedal", "Cyl Filling"
+	veAxisLabels = bits, U08, [0:1], "MAP", "TPS", "Air Charge", "Lua"
+	targetAfrAxisLabels = bits, U08, [0:2], "MAP", "TPS", "Air Charge", "Lua", "Acc Pedal", "Cyl Filling"
+	ignAxisLabels = bits, U08, [0:2], "MAP", "TPS", "Air Charge", "Lua", "Acc Pedal", "Cyl Filling"
 	ignLoadUnitLabels = bits, U08, [0:1], @@UNITS_PSI@@, @@UNITS_KPA@@, "%", "Lua"
 	veLoadUnitLabels = bits, U08, [0:1], @@UNITS_PSI@@, @@UNITS_KPA@@, "%", "Lua"
 	afrLoadUnitLabels = bits, U08, [0:1], @@UNITS_PSI@@, @@UNITS_KPA@@, "%", "Lua"
-	ignLoadUnitIdxPcv = continuousChannelValue, ignLoadUnitIdx
-	veLoadUnitIdxPcv = continuousChannelValue, veLoadUnitIdx
-	veAxisDescIdxPcv = continuousChannelValue, veLoadSrc
-	ignAxisDescIdxPcv = continuousChannelValue, ignLoadSrc
-	afrLoadUnitIdxPcv = continuousChannelValue, afrLoadUnitIdx
-	afrAxisDescIdxPcv = continuousChannelValue, afrLoadSrc
+
+	; effective load source: 0=MAP 1=TPS 2=Air Charge(MAF) 3=Lua (+ign/afr: 4=Acc Pedal 5=Cyl Filling)
+	veLoadSrc       = scalar, U08, "", 1, 0, 0, 5, 0, noMsqSave
+	ignLoadSrc      = scalar, U08, "", 1, 0, 0, 5, 0, noMsqSave
+	afrLoadSrc      = scalar, U08, "", 1, 0, 0, 5, 0, noMsqSave
+	; unit label index: 0=psi, 1=kPa, 2=%, 3=Lua
+	veLoadUnitIdx   = scalar, U08, "", 1, 0, 0, 3, 0, noMsqSave
+	ignLoadUnitIdx  = scalar, U08, "", 1, 0, 0, 3, 0, noMsqSave
+	afrLoadUnitIdx  = scalar, U08, "", 1, 0, 0, 3, 0, noMsqSave
 
 	tuneCrcPcVariable = continuousChannelValue, tuneCrc16
 
@@ -445,6 +438,20 @@ include_file @@TUNING_SECTION_FILE@@
 	; constant is used as a variable in the ini.
 	; defaultValue = constantName, value;
 	defaultValue = wueAfrTargetOffset, -1.5 -1.4 -1.15 -0.95 -0.775 -0.65 -0.5625 -0.5 -0.4375 -0.375 -0.3125 -0.25 -0.1875 -0.125 -0.0625 0
+
+	; source: 0=MAP 1=TPS 2=Air Charge 3=Lua 4=Acc Pedal 5=Cyl Filling ; unit: 0=psi 1=kPa 2=% 3=Lua
+	defaultValue = veLoadSrc, 0
+	defaultValue = ignLoadSrc, 0
+	defaultValue = afrLoadSrc, 0
+	defaultValue = veLoadUnitIdx, 1
+	defaultValue = ignLoadUnitIdx, 1
+	defaultValue = afrLoadUnitIdx, 1
+	maintainConstantValue = veLoadSrc,  { veOverrideMode == 1 ? 0 : veOverrideMode == 2 ? 1 : (fuelAlgorithm == 0 ? 0 : fuelAlgorithm == 2 ? 1 : fuelAlgorithm == 1 ? 2 : 3) }
+	maintainConstantValue = ignLoadSrc, { ignOverrideMode == 1 ? 0 : ignOverrideMode == 2 ? 1 : ignOverrideMode == 3 ? 4 : ignOverrideMode == 4 ? 5 : (fuelAlgorithm == 0 ? 0 : fuelAlgorithm == 2 ? 1 : fuelAlgorithm == 1 ? 2 : 3) }
+	maintainConstantValue = afrLoadSrc, { afrOverrideMode == 1 ? 0 : afrOverrideMode == 2 ? 1 : afrOverrideMode == 3 ? 4 : afrOverrideMode == 4 ? 5 : (fuelAlgorithm == 0 ? 0 : fuelAlgorithm == 2 ? 1 : fuelAlgorithm == 1 ? 2 : 3) }
+	maintainConstantValue = veLoadUnitIdx,  { (veOverrideMode == 1 || (veOverrideMode == 0 && fuelAlgorithm == 0)) ? useMetricOnInterface : ((veOverrideMode == 0 && fuelAlgorithm == 3) ? 3 : 2) }
+	maintainConstantValue = ignLoadUnitIdx, { (ignOverrideMode == 1 || (ignOverrideMode == 0 && fuelAlgorithm == 0)) ? useMetricOnInterface : ((ignOverrideMode == 0 && fuelAlgorithm == 3) ? 3 : 2) }
+	maintainConstantValue = afrLoadUnitIdx, { (afrOverrideMode == 1 || (afrOverrideMode == 0 && fuelAlgorithm == 0)) ? useMetricOnInterface : ((afrOverrideMode == 0 && fuelAlgorithm == 3) ? 3 : 2) }
 
 	; this magic is best described in output_channels.txt search for 'maintainConstantValue'
 	; TPS 1 Primary
@@ -1277,7 +1284,7 @@ curve = rangeMatrix, "Range Switch Input Matrix"
 		upDownLabel = "(RICHER)", "(LEANER)"
 
 	table = ignitionTableTbl,  ignitionTableMap,  @@IGNITION_ADVANCE_TABLE_NAME@@,	1
-		xyLabels = "RPM", {bitStringValue(ignAxisLabels, ignAxisDescIdxPcv)}
+		xyLabels = "RPM", {bitStringValue(ignAxisLabels, ignLoadSrc)}
 		xBins		= ignitionRpmBins,  rpmForIgnitionTableDot
 		yBins		= ignitionLoadBins,  loadForIgnitionTableDot
 		zBins		= ignitionTable
@@ -1285,7 +1292,7 @@ curve = rangeMatrix, "Range Switch Input Matrix"
 		upDownLabel = "(RICHER)", "(LEANER)"
 
 	table = secondIgnitionTableTbl, secondIgnitionTableMap, @@SECOND_IGNITION_TABLE@@, 1
-		xyLabels	= "RPM", {bitStringValue(ignAxisLabels, ignAxisDescIdxPcv)}
+		xyLabels	= "RPM", {bitStringValue(ignAxisLabels, ignLoadSrc)}
 		xBins		= secondIgnitionRpmBins,  RPMValue
 		yBins		= secondIgnitionLoadBins, loadForIgnitionTableDot
 		zBins		= secondIgnitionTable
@@ -1427,7 +1434,7 @@ curve = rangeMatrix, "Range Switch Input Matrix"
 		zBins		= tmfTable
 
 	table = veTableTbl,  veTableMap,  @@VE_TABLE_NAME@@,	1
-		xyLabels	= "RPM", {bitStringValue(veAxisLabels, veAxisDescIdxPcv)}
+		xyLabels	= "RPM", {bitStringValue(veAxisLabels, veLoadSrc)}
 		xBins		= veRpmBins,  RPMValue
 		yBins		= veLoadBins, veTableYAxis
 		zBins		= veTable
@@ -1444,7 +1451,7 @@ curve = rangeMatrix, "Range Switch Input Matrix"
 		upDownLabel = "(RICHER)", "(LEANER)"
 
 	table = secondVeTableTbl, secondVeTableMap, "Second VE Table", 1
-		xyLabels	= "RPM", {bitStringValue(veAxisLabels, veAxisDescIdxPcv)}
+		xyLabels	= "RPM", {bitStringValue(veAxisLabels, veLoadSrc)}
 		xBins		= secondVeRpmBins,  RPMValue
 		yBins		= secondVeLoadBins, veTableYAxis
 		zBins		= secondVeTable
@@ -1678,7 +1685,7 @@ curve = rangeMatrix, "Range Switch Input Matrix"
 		zBins = knockGains12_table
 
 	table = afrTableTbl,  afrTableMap,  "Target AFR Table",	1, { !useLambdaOnInterface }
-		xyLabels	= "RPM", {bitStringValue(targetAfrAxisLabels, afrAxisDescIdxPcv)}
+		xyLabels	= "RPM", {bitStringValue(targetAfrAxisLabels, afrLoadSrc)}
 		xBins		= lambdaRpmBins,  RPMValue
 		yBins		= lambdaLoadBins, afrTableYAxis
 		zBins		= lambdaTable
@@ -1687,7 +1694,7 @@ curve = rangeMatrix, "Range Switch Input Matrix"
 		upDownLabel = "(RICHER)", "(LEANER)"
 
 	table = lambdaTableTbl,  lambdaTableMap,  "Target Lambda Table",	1, { useLambdaOnInterface }
-		xyLabels	= "RPM", {bitStringValue(targetAfrAxisLabels, afrAxisDescIdxPcv)}
+		xyLabels	= "RPM", {bitStringValue(targetAfrAxisLabels, afrLoadSrc)}
 		xBins		= lambdaRpmBins,  RPMValue
 		yBins		= lambdaLoadBins, afrTableYAxis
 		zBins		= lambdaTable
@@ -1834,7 +1841,7 @@ curve = rangeMatrix, "Range Switch Input Matrix"
 
 @@if_block LTFT_PAGE_ENABLED@@
 	table = ltftBank1Tbl, ltftBank1Map, @@GAUGE_NAME_FUEL_LTFT_1@@
-		xyLabels	= "RPM", {bitStringValue(veAxisLabels, veAxisDescIdxPcv)}
+		xyLabels	= "RPM", {bitStringValue(veAxisLabels, veLoadSrc)}
 		xBins		= veRpmBins,  RPMValue, readOnly
 		yBins		= veLoadBins, veTableYAxis, readOnly
 		zBins       = ltft_table_bank1
@@ -1842,7 +1849,7 @@ curve = rangeMatrix, "Range Switch Input Matrix"
 		gridOrient  = 250,   0, 340 ; Space 123 rotation of grid in degrees.
 
 	table = ltftBank2Tbl, ltftBank2Map, @@GAUGE_NAME_FUEL_LTFT_2@@
-		xyLabels	= "RPM", {bitStringValue(veAxisLabels, veAxisDescIdxPcv)}
+		xyLabels	= "RPM", {bitStringValue(veAxisLabels, veLoadSrc)}
 		xBins		= veRpmBins,  RPMValue, readOnly
 		yBins		= veLoadBins, veTableYAxis, readOnly
 		zBins       = ltft_table_bank2


### PR DESCRIPTION
- Unified usage of `xLoadSrc` and `xLoadUnitIdx` across VE, ignition, AFR tables.
- Simplified logic for axis labels and bin units.
- Resolved misleading axis labels ("Air mass" -> "Air Charge").
- fix labels while offline tuning using maintainConstantValue

related #9654