### PR TITLE
One console for all boards from main repo

### DIFF
--- a/java_console/autoupdate/src/main/java/com/rusefi/autoupdate/Autoupdate.java
+++ b/java_console/autoupdate/src/main/java/com/rusefi/autoupdate/Autoupdate.java
@@ -6,6 +6,7 @@ import com.rusefi.AutoupdateProperty;
 import com.rusefi.core.FindFileHelper;
 import com.rusefi.core.io.BundleInfo;
 import com.rusefi.core.io.BundleInfoStrategy;
+import com.rusefi.core.io.ConnectedEcuTarget;
 import com.rusefi.core.io.BundleUtil;
 import com.rusefi.core.net.ConnectionAndMeta;
 import com.rusefi.core.FileUtil;
@@ -134,7 +135,33 @@ public class Autoupdate {
         // ATTENTION! To avoid `ClassNotFoundException` we need to load all necessary classes before unzipping
         // autoupdate archive
         unzipAutoUpdate(downloadedAutoupdateFile);
+        prefetchLastConnectedBoardFirmware();
         startConsoleAsANewProcess(consoleExeFileName, args);
+    }
+
+    /**
+     * #9714 At startup, fetch (or refresh to the latest) the
+     * firmware of the most recently connected board so a later "Update Firmware" is instant.
+     * <p>
+     * No-op when: autoupdate is disabled, no board has ever connected, or this is a single-board
+     * bundle whose own firmware is the last-connected board (already refreshed by the bundle update
+     * above). Only downloads when the server has a newer build than the local cache.
+     */
+    private static void prefetchLastConnectedBoardFirmware() {
+        try {
+            if (!isAutoUpdateEnabled()) {
+                return;
+            }
+            String lastBoard = ConnectedEcuTarget.readPersisted();
+            if (lastBoard == null) {
+                log.info("[universal_bundle] prefetch: no previously connected board recorded");
+                return;
+            }
+            log.info("[universal_bundle] prefetch: ensuring latest firmware for last connected board " + lastBoard);
+            ensureFirmwareForTarget(lastBoard, percent -> {}, log::info);
+        } catch (Throwable e) {
+            log.error("[universal_bundle] prefetch error: " + e);
+        }
     }
 
     /**
@@ -460,6 +487,97 @@ public class Autoupdate {
         String branchUrl = BundleInfoStrategy.getDownloadUrl(bundleInfo, PropertiesHolder.getBaseUrl(), BundleInfoStrategy::selectBranchName);
         return downloadAutoupdateZipFile(bundleInfo, branchUrl, FindFileHelper.isObfuscated());
     }
+
+    /**
+     * when a universal bundle is connected to an ECU whose board
+     * differs from the one this bundle shipped with, fetch that board's firmware on demand by downloading
+     * its autoupdate zip from the build server and unpacking the firmware artifacts
+     * (rusefi.bin / *_update.srec / openblt.bin) next to the console, where the existing DFU/OpenBLT
+     * flashers look for them. Because the target is derived from the connected ECU's signature, the
+     * staged firmware always matches the ECU.
+     *
+     * @param ecuTarget bundle target reported by the connected ECU (its signature's bundle target)
+     * @return true if firmware for {@code ecuTarget} is present locally afterwards
+     */
+    public static boolean ensureFirmwareForTarget(String ecuTarget,
+                                                  ConnectionAndMeta.DownloadProgressListener progressListener,
+                                                  Consumer<String> logger) {
+        if (ecuTarget == null || ecuTarget.trim().isEmpty()) {
+            log.error("[universal_bundle] ensureFirmwareForTarget: no ECU target");
+            return false;
+        }
+        BundleInfo local = BundleUtil.readBundleFullNameNotNull();
+        String localTarget = local.getTarget();
+        if (localTarget != null && localTarget.equalsIgnoreCase(ecuTarget)) {
+            // the connected ECU is this bundle's own board - firmware already shipped locally
+            return true;
+        }
+        String branchName = BundleInfo.isUndefined(local) ? "master" : local.getBranchName();
+        BundleInfo wanted = new BundleInfo(branchName, null, ecuTarget);
+        String baseUrl = BundleInfoStrategy.getDownloadUrl(wanted, PropertiesHolder.getBaseUrl(), BundleInfo::getBranchName);
+        String zip = downloadZipForTarget(wanted, baseUrl, progressListener, logger);
+        if (zip == null) {
+            return false;
+        }
+        try {
+            findSrecFile(false); // move firmware of the previously-selected board into older-fw
+            log.info("[universal_bundle] ensureFirmwareForTarget: unpacking firmware for " + ecuTarget + " from " + zip);
+            FileUtil.unzip(zip, new File(".."), isFirmwareArtifact);
+            return true;
+        } catch (IOException e) {
+            log.error("[universal_bundle] ensureFirmwareForTarget: unzip failed: " + e);
+            return false;
+        }
+    }
+
+    /**
+     * Like the firmware half of {@link #downloadAutoupdateZipFile} but returns the local zip path even
+     * when the cached copy is already up to date (we still need to unpack it for the selected board).
+     *
+     * @return local zip path, or null on error
+     */
+    private static String downloadZipForTarget(BundleInfo info, String baseUrl,
+                                               ConnectionAndMeta.DownloadProgressListener progressListener,
+                                               Consumer<String> logger) {
+        try {
+            String folderName = info.getTarget() + "_" + info.getBranchName();
+            String localFolder = userHomeSubDirectory + folderName + File.separator;
+            new File(localFolder).mkdirs();
+            String fileName = ConnectionAndMeta.getWhiteLabel(ConnectionAndMeta.getProperties())
+                + "_bundle_" + info.getTarget() + "_autoupdate.zip";
+            String localZipFileName = localFolder + fileName;
+            ConnectionAndMeta connectionAndMeta = new ConnectionAndMeta(fileName).invoke(baseUrl);
+            long lastModified = connectionAndMeta.getLastModified();
+            if (AutoupdateUtil.hasExistingFile(localZipFileName, connectionAndMeta.getCompleteFileSize(), lastModified)) {
+                log.info("[universal_bundle] downloadZipForTarget: reusing cached " + localZipFileName);
+                logger.accept("Using cached firmware download for " + info.getTarget());
+            } else {
+                logger.accept("[universal_bundle] Downloading firmware for " + info.getTarget()
+                    + " (" + (connectionAndMeta.getCompleteFileSize() / 1024) + " KB)...");
+                // Route progress through the caller's callbacks (the reflash progress bar) instead of
+                // popping up a separate download dialog - #9714 makes it an inline step.
+                ConnectionAndMeta.downloadFile(localZipFileName, connectionAndMeta, progressListener);
+                new File(localZipFileName).setLastModified(lastModified);
+                logger.accept("[universal_bundle] Firmware download complete");
+            }
+            return localZipFileName;
+        } catch (IOException e) {
+            log.error("[universal_bundle] downloadZipForTarget error: " + e);
+            return null;
+        }
+    }
+
+    /**
+     * Firmware binaries that live at the root of an autoupdate zip. Deliberately excludes the console
+     * jar, release.txt, shared_io.properties and the .ini
+     */
+    private static final Predicate<ZipEntry> isFirmwareArtifact = entry -> {
+        if (entry.isDirectory())
+            return false;
+        String lower = entry.getName().toLowerCase();
+        return lower.endsWith(".srec") || lower.endsWith(".hex")
+            || lower.endsWith("rusefi.bin") || lower.endsWith("openblt.bin");
+    };
 
     /**
      * rusefi_updater.exe/invokes rusefi_console.jar - entry point is Launcher#main

--- a/java_console/io/src/main/java/com/rusefi/binaryprotocol/BinaryProtocol.java
+++ b/java_console/io/src/main/java/com/rusefi/binaryprotocol/BinaryProtocol.java
@@ -17,6 +17,7 @@ import com.rusefi.core.Pair;
 import com.rusefi.core.RusEfiSignature;
 import com.rusefi.core.SensorCentral;
 import com.rusefi.core.SignatureHelper;
+import com.rusefi.core.io.BoardCompatibility;
 import com.rusefi.core.io.BundleInfo;
 import com.rusefi.core.io.BundleUtil;
 import com.rusefi.core.net.ConnectionAndMeta;
@@ -212,10 +213,14 @@ public class BinaryProtocol {
         // Check for bundle/ECU mismatch before attempting to read configuration
         // Skip check if bundle target is unknown (e.g., simulator, local development)
         RusEfiSignature ecuSignature = SignatureHelper.parse(signature);
+        if (ecuSignature != null) {
+            // remember the connected board so universal bundles can pick the right firmware / hardware kind
+            com.rusefi.core.io.ConnectedEcuTarget.set(ecuSignature.getBundleTarget());
+        }
         String bundleTarget = BundleUtil.getBundleTarget();
         if (ecuSignature != null && bundleTarget != null && !"unknown".equalsIgnoreCase(bundleTarget)) {
-            // [tag:QC_firmware]
-            if (!bundleTarget.equalsIgnoreCase(ecuSignature.getBundleTarget()) && !bundleTarget.contains("_QC_")) {
+            // exact target, _QC_ hack and board_compatibility (* / allowlist) all handled here [tag:QC_firmware]
+            if (!com.rusefi.core.io.BoardCompatibility.isEcuCompatible(bundleTarget, ecuSignature.getBundleTarget())) {
                 String errorMsg = String.format(
                     "Bundle/ECU mismatch detected!\n\n" +
                     "Connected ECU: %s\n" +

--- a/java_console/shared_io/src/main/java/com/rusefi/core/io/BoardCompatibility.java
+++ b/java_console/shared_io/src/main/java/com/rusefi/core/io/BoardCompatibility.java
@@ -1,0 +1,76 @@
+package com.rusefi.core.io;
+
+import com.rusefi.core.net.PropertiesHolder;
+
+/**
+ * A console bundle declares which ECUs it is allowed to serve via the
+ * {@code board_compatibility} property in {@code shared_io.properties}:
+ * <ul>
+ *     <li>absent/blank - legacy behavior: only the exact bundle target (plus the {@code _QC_} hack)</li>
+ *     <li>{@code *} - universal bundle, compatible with any ECU target</li>
+ *     <li>comma list (e.g. {@code uaefi,uaefi_pro,super-uaefi}) - case-insensitive allowlist</li>
+ * </ul>
+ */
+public class BoardCompatibility {
+    public static final String BOARD_COMPATIBILITY_KEY = "board_compatibility";
+    public static final String WILDCARD = "*";
+
+    /**
+     * @return trimmed {@code board_compatibility} value, or null when absent/blank
+     */
+    public static String getBoardCompatibility() {
+        String value = PropertiesHolder.getProperty(BOARD_COMPATIBILITY_KEY);
+        if (value == null)
+            return null;
+        value = value.trim();
+        return value.isEmpty() ? null : value;
+    }
+
+    /**
+     * Whether this bundle may talk to / flash an ECU reporting {@code ecuTarget}.
+     *
+     * @param bundleTarget local bundle target (from release.txt), may be null
+     * @param ecuTarget    connected ECU's bundle target (from its signature)
+     */
+    public static boolean isEcuCompatible(String bundleTarget, String ecuTarget) {
+        return isEcuCompatible(bundleTarget, ecuTarget, getBoardCompatibility());
+    }
+
+    /**
+     * Pure variant taking the compatibility value explicitly (testable, no property lookup).
+     */
+    public static boolean isEcuCompatible(String bundleTarget, String ecuTarget, String compat) {
+        if (ecuTarget == null) {
+            // nothing to compare against - stay tolerant, matching prior callers
+            return true;
+        }
+        if (bundleTarget != null && bundleTarget.equalsIgnoreCase(ecuTarget)) {
+            return true;
+        }
+        // hack: QC firmware self-identifies as "normal" firmware [tag:QC_firmware]
+        if (bundleTarget != null && bundleTarget.contains("_QC_")) {
+            return true;
+        }
+        return matchesCompatibility(ecuTarget, compat);
+    }
+
+    /**
+     * Does the {@code board_compatibility} property alone allow this ECU target?
+     * {@code *} matches anything; otherwise a case-insensitive comma list.
+     */
+    public static boolean matchesCompatibility(String ecuTarget) {
+        return matchesCompatibility(ecuTarget, getBoardCompatibility());
+    }
+
+    public static boolean matchesCompatibility(String ecuTarget, String compat) {
+        if (compat == null)
+            return false;
+        if (WILDCARD.equals(compat))
+            return true;
+        for (String token : compat.split(",")) {
+            if (token.trim().equalsIgnoreCase(ecuTarget))
+                return true;
+        }
+        return false;
+    }
+}

--- a/java_console/shared_io/src/main/java/com/rusefi/core/io/ConnectedEcuTarget.java
+++ b/java_console/shared_io/src/main/java/com/rusefi/core/io/ConnectedEcuTarget.java
@@ -1,0 +1,80 @@
+package com.rusefi.core.io;
+
+import com.devexperts.logging.Logging;
+import com.rusefi.core.FileUtil;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+
+import static com.devexperts.logging.Logging.getLogging;
+
+/**
+ * the bundle target of the most recently connected ECU, captured from its signature at connect time.
+ * <p>
+ * A universal bundle's own {@code release.txt} target is not specific to the attached board, so
+ * hardware-kind decisions (DFU H7 vs F4/F7 driver query, ST-Link OpenOCD config) consult this
+ * instead. For a single-board bundle this equals the bundle target, so reading it is harmless.
+ * <p>
+ * The target is also persisted to disk (#9714) so the separate autoupdate process can pre-fetch the
+ * latest firmware for the board you actually use, making a later "Update Firmware" instant.
+ */
+public class ConnectedEcuTarget {
+    private static final Logging log = getLogging(ConnectedEcuTarget.class);
+    private static final String LAST_BOARD_FILE = FileUtil.RUSEFI_SETTINGS_FOLDER + "last_connected_board.txt";
+
+    private static volatile String connectedTarget;
+
+    public static void set(String ecuTarget) {
+        connectedTarget = ecuTarget;
+        persist(ecuTarget);
+    }
+
+    /**
+     * @return connected ECU target if known, otherwise the local bundle target.
+     */
+    public static String effectiveTarget() {
+        String t = connectedTarget;
+        return t != null ? t : BundleUtil.getBundleTarget();
+    }
+
+    private static void persist(String ecuTarget) {
+        if (ecuTarget == null || ecuTarget.trim().isEmpty()) {
+            return;
+        }
+        try {
+            File f = new File(LAST_BOARD_FILE);
+            File parent = f.getParentFile();
+            if (parent != null) {
+                parent.mkdirs();
+            }
+            Files.write(f.toPath(), ecuTarget.trim().getBytes());
+        } catch (IOException e) {
+            log.warn("[universal_bundle] Could not persist last connected board: " + e);
+        }
+    }
+
+    /**
+     * @return the target of the most recently connected ECU across sessions, or null if none recorded.
+     */
+    public static String readPersisted() {
+        try {
+            Path p = Paths.get(LAST_BOARD_FILE);
+            if (!Files.exists(p)) {
+                return null;
+            }
+            List<String> lines = Files.readAllLines(p);
+            if (lines.isEmpty()) {
+                return null;
+            }
+            String s = lines.get(0).trim();
+            return s.isEmpty() ? null : s;
+        } catch (IOException e) {
+            log.warn("[universal_bundle] Could not read last connected board: " + e);
+            return null;
+        }
+    }
+}

--- a/java_console/shared_io/src/main/resources/shared_io.properties
+++ b/java_console/shared_io/src/main/resources/shared_io.properties
@@ -1,4 +1,6 @@
-board_compatibility=*
+# #9714: boards a bundle may connect/tune/reflash beyond its own target (case-insensitive).
+# Use '*' for any board.
+board_compatibility=uaefi,uaefi_pro,mre_f4,mre_f7,mre-legacy_f4,nano-tcu-gateway
 auto_update_root_url=https://rusefi.com/build_server
 pinout_base_url=https://rusefi.com/docs/
 pinout_meta_name=boards_meta.yaml

--- a/java_console/shared_io/src/test/java/com/rusefi/core/io/BoardCompatibilityTest.java
+++ b/java_console/shared_io/src/test/java/com/rusefi/core/io/BoardCompatibilityTest.java
@@ -1,0 +1,48 @@
+package com.rusefi.core.io;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class BoardCompatibilityTest {
+
+    @Test
+    public void exactMatchAlwaysCompatible() {
+        // even with no board_compatibility, exact target matches (legacy behavior)
+        assertTrue(BoardCompatibility.isEcuCompatible("uaefi", "uaefi", null));
+        assertTrue(BoardCompatibility.isEcuCompatible("UAEFI", "uaefi", null));
+    }
+
+    @Test
+    public void mismatchWithoutCompatibilityIsRejected() {
+        assertFalse(BoardCompatibility.isEcuCompatible("uaefi", "uaefi_pro", null));
+        assertFalse(BoardCompatibility.isEcuCompatible("uaefi", "uaefi_pro", ""));
+    }
+
+    @Test
+    public void qcFirmwareBypass() {
+        // QC firmware self-identifies as normal firmware [tag:QC_firmware]
+        assertTrue(BoardCompatibility.isEcuCompatible("uaefi_QC_special", "uaefi_pro", null));
+    }
+
+    @Test
+    public void wildcardMatchesAnything() {
+        assertTrue(BoardCompatibility.isEcuCompatible("universal", "uaefi", "*"));
+        assertTrue(BoardCompatibility.isEcuCompatible("universal", "super-uaefi", "*"));
+        assertTrue(BoardCompatibility.isEcuCompatible(null, "anything", "*"));
+    }
+
+    @Test
+    public void allowlistMatching() {
+        String list = "uaefi, uaefi_pro , super-uaefi";
+        assertTrue(BoardCompatibility.isEcuCompatible("universal", "uaefi_pro", list));
+        assertTrue(BoardCompatibility.isEcuCompatible("universal", "SUPER-UAEFI", list));
+        assertFalse(BoardCompatibility.isEcuCompatible("universal", "hellen121nissan", list));
+    }
+
+    @Test
+    public void nullEcuTargetIsTolerant() {
+        assertTrue(BoardCompatibility.isEcuCompatible("uaefi", null, null));
+    }
+}

--- a/java_console/ui/src/main/java/com/rusefi/io/BootloaderHelper.java
+++ b/java_console/ui/src/main/java/com/rusefi/io/BootloaderHelper.java
@@ -2,8 +2,10 @@ package com.rusefi.io;
 
 import com.devexperts.logging.Logging;
 import com.rusefi.UiProperties;
+import com.rusefi.autoupdate.Autoupdate;
 import com.rusefi.core.RusEfiSignature;
 import com.rusefi.core.SignatureHelper;
+import com.rusefi.core.io.BoardCompatibility;
 import com.rusefi.core.io.BundleUtil;
 
 import javax.swing.*;
@@ -22,27 +24,37 @@ public class BootloaderHelper {
         RusEfiSignature controllerSignature = SignatureHelper.parse(signature);
         String fileSystemBundleTarget = BundleUtil.getBundleTarget();
         if (fileSystemBundleTarget != null && controllerSignature != null) {
-            // hack: QC firmware self-identifies as "normal" not QC firmware :(
-            // [tag:QC_firmware]
-            if (!UiProperties.skipEcuTypeDetection() &&
-                !fileSystemBundleTarget.equalsIgnoreCase(controllerSignature.getBundleTarget()) && !fileSystemBundleTarget.contains("_QC_")) {
-                String message = String.format("You have \"%s\" controller does not look right to program it with \"%s\"", controllerSignature.getBundleTarget(), fileSystemBundleTarget);
-                log.info(message);
+            String ecuTarget = controllerSignature.getBundleTarget();
+            // hack: QC firmware self-identifies as "normal" not QC firmware :( [tag:QC_firmware]
+            boolean ownBoard = fileSystemBundleTarget.equalsIgnoreCase(ecuTarget) || fileSystemBundleTarget.contains("_QC_");
+            if (!ownBoard && !UiProperties.skipEcuTypeDetection()) {
+                if (BoardCompatibility.matchesCompatibility(ecuTarget)) {
+                    // #9714:  fetch the matching firmware on demand before rebooting to bootloader.
+                    callbacks.logLine("[universal_bundle]: downloading firmware for \"" + ecuTarget + "\"...");
+                    if (!Autoupdate.ensureFirmwareForTarget(ecuTarget, callbacks::updateProgress, callbacks::logLine)) {
+                        SwingUtilities.invokeLater(() -> JOptionPane.showMessageDialog(parent, String.format(
+                            "Universal bundle could not download firmware for \"%s\".\nPlease check your internet connection and retry.", ecuTarget)));
+                        return false;
+                    }
+                } else {
+                    String message = String.format("You have \"%s\" controller does not look right to program it with \"%s\"", ecuTarget, fileSystemBundleTarget);
+                    log.info(message);
 
-                SwingUtilities.invokeLater(() -> {
-                    JOptionPane.showMessageDialog(parent, message);
-                    // in case of mismatched bundle type we are supposed do close connection
-                    // and properly handle the case of user hitting "Update Firmware" again
-                    // closing connection is a mess on Windows so it's simpler to just exit
-                    new Thread(() -> {
-                        // let's have a delay and separate thread to address
-                        // "wrong bundle" warning text sometimes not visible #3267
-                        sleep(5 * SECOND);
-                        System.exit(-5);
-                    }).start();
-                });
+                    SwingUtilities.invokeLater(() -> {
+                        JOptionPane.showMessageDialog(parent, message);
+                        // in case of mismatched bundle type we are supposed do close connection
+                        // and properly handle the case of user hitting "Update Firmware" again
+                        // closing connection is a mess on Windows so it's simpler to just exit
+                        new Thread(() -> {
+                            // let's have a delay and separate thread to address
+                            // "wrong bundle" warning text sometimes not visible #3267
+                            sleep(5 * SECOND);
+                            System.exit(-5);
+                        }).start();
+                    });
 
-                return false;
+                    return false;
+                }
             }
         }
 

--- a/java_console/ui/src/main/java/com/rusefi/maintenance/DfuFlasher.java
+++ b/java_console/ui/src/main/java/com/rusefi/maintenance/DfuFlasher.java
@@ -235,7 +235,11 @@ public class DfuFlasher {
     }
 
     public static boolean detectSTM32BootloaderDriverState(UpdateOperationCallbacks callbacks) {
-        String command = ConnectionAndMeta.getBoolean("is_h7") ? WMIC_DFU_QUERY_H7_COMMAND : WMIC_DFU_QUERY_COMMAND;
+        // #9714: a universal bundle's is_h7 property can't cover every board, so trust the connected
+        // ECU's target first (e.g. "uaefi_pro_h7"), falling back to the bundled is_h7 property.
+        String effectiveTarget = com.rusefi.core.io.ConnectedEcuTarget.effectiveTarget();
+        boolean isH7 = (effectiveTarget != null && effectiveTarget.contains("h7")) || ConnectionAndMeta.getBoolean("is_h7");
+        String command = isH7 ? WMIC_DFU_QUERY_H7_COMMAND : WMIC_DFU_QUERY_COMMAND;
         try {
             return MaintenanceUtil.detectDevice(callbacks, command, "ConfigManagerErrorCode=0");
         } catch (ErrorExecutingCommand e) {

--- a/java_console/ui/src/main/java/com/rusefi/maintenance/StLinkFlasher.java
+++ b/java_console/ui/src/main/java/com/rusefi/maintenance/StLinkFlasher.java
@@ -83,7 +83,8 @@ public class StLinkFlasher {
 
     @NotNull
     public static HwPlatform getHardwareKind() {
-        String bundle = BundleUtil.readBundleFullNameNotNull().getTarget();
+        // #9714: prefer the connected ECU's target so a universal bundle picks the right MCU platform
+        String bundle = com.rusefi.core.io.ConnectedEcuTarget.effectiveTarget();
         if (bundle.contains("h7"))
             return HwPlatform.H7;
         if (bundle.contains("f7"))


### PR DESCRIPTION
- Implemented `ConnectedEcuTarget` to manage the latest connected ECU target and improve board-specific functionality detection (#9714).
- Integrated firmware prefetching for last connected boards for "Update Firmware".
- Updated logic in DFU and ST-Link flashers to trust connected ECU target over bundled properties.
-  Autoupdate to download firmware on demand for mismatched universal bundles. 
- Added unit tests for board compatibility validation.

related #9714