### PR TITLE
microsecond-timer: stop when core is stopped by debuger

### DIFF
--- a/firmware/hw_layer/ports/stm32/microsecond_timer_stm32.cpp
+++ b/firmware/hw_layer/ports/stm32/microsecond_timer_stm32.cpp
@@ -68,7 +68,9 @@ void portInitMicrosecondTimer() {
 	#if defined(STM32F4XX) || defined (STM32F7XX)
 		DBGMCU->APB1FZ |= DBGMCU_APB1_FZ_DBG_TIM5_STOP;
 	#endif
-		/* TODO: stm32h7? */
+	#if defined(STM32H7XX)
+		DBGMCU->APB1LFZ1 |= DBGMCU_APB1LFZ1_DBG_TIM5;
+	#endif
 	}
 }
 


### PR DESCRIPTION
This allows debuging without getting "gap in time" error

only:uaefi_pro_h7