### PR TITLE
less fragile engine module disable (LTFT case)

### DIFF
--- a/.junie/guidelines.md
+++ b/.junie/guidelines.md
@@ -4,6 +4,10 @@
 
 See also: `CLAUDE.md`, `docs/adding-new-trigger.md`, `.junie/ts-help-topic.md`, `.junie/ts-readme.md`, `README-mcp.md`, `java_console/mcp_lua/README.md`, `firmware/controllers/lua/examples/`, [Lua-Scripting.md](https://github.com/rusefi/rusefi_documentation/blob/master/Lua-Scripting.md).
 
+## Firmware: engine modules
+
+When creating a new engine module (or disabling an existing one), first search the codebase for the `[tag:disable_engine_module]` comment tag and read every hit for context — the main how-to lives in `firmware/controllers/core/engine_module.h`, with the module registry in `firmware/controllers/algo/engine.h` and `long_term_fuel_trim.h`/`.cpp` as the worked example of an optional module that owns a TunerStudio page. See also the "Engine modules" bullet under Key Concepts in `CLAUDE.md`.
+
 ## Frontend (Java console)
 
 `CLAUDE.md` focuses on the C++ firmware / unit tests / simulator. This section covers the Java side, which `CLAUDE.md` does not describe.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,6 +109,7 @@ For detailed technical documentation intended for AI assistants, see:
 - **Configuration-driven**: Board and engine parameters externalized; firmware adapts via configuration
 - **Calibration Compatibility**: Maintaining [compatibility with older tunes](docs/calibration-compatibility.md) when adding new parameters.
 - **ChibiOS RTOS**: Real-time operating system foundation
+- **Engine modules**: Engine-asynchronous control logic derives from `EngineModule` and registers in the `type_list` in `firmware/controllers/algo/engine.h`. Before creating a module or making one compile-time optional, search the codebase for `[tag:disable_engine_module]` and read those comments — they document the module lifecycle and the TS-page guard-flag rules (a module that owns a TunerStudio page must have its `EFI_*` flag declared in the board `prepend.txt`, never in `board.mk` or `efifeatures.h`).
 
 #### Generated configuration layout
 

--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -208,6 +208,16 @@ endif
 endif
 DDEFS += -DSHORT_BOARD_NAME=$(SHORT_BOARD_NAME)
 
+# TS-page guard flags (see [tag:ts_page_table]) are declared once in the board's
+# prepend.txt - the only input the .ini generator can see. Lift them into DDEFS here
+# so the firmware compiles with the same value and the .ini page table can never
+# diverge from the pages the firmware actually serves (a divergence makes the firmware
+# answer reads of a page the .ini still lists with out_of_range, and TunerStudio
+# retries that page until it drops the connection).
+# Keep the list in sync with the guardFlag column of TS_PAGES in TSProjectConsumer.java.
+TS_PAGE_GUARD_FLAGS = EFI_LTFT_CONTROL|EFI_LUA
+DDEFS += $(shell sed -nE 's/^#define[[:space:]]+($(TS_PAGE_GUARD_FLAGS))[[:space:]]+(TRUE|FALSE)[[:space:]]*$$/-D\1=\2/p' $(BOARD_DIR)/prepend.txt $(BOARD_DIR)/prepend_$(SHORT_BOARD_NAME).txt 2>/dev/null)
+
 # Include various ChibiOS mk files
 # Licensing files.
 include $(CHIBIOS)/os/license/license.mk

--- a/firmware/config/boards/f746-discovery/board.mk
+++ b/firmware/config/boards/f746-discovery/board.mk
@@ -16,8 +16,8 @@ BOARDINC = $(CHIBIOS)/os/hal/boards/ST_STM32F746G_DISCOVERY/
 # Default F7 linker script is not compatible
 LDSCRIPT = $(PROJECT_DIR)/hw_layer/ports/stm32/stm32f7/STM32F746xG.ld
 
-# Save some RAM until we enable SDRAM.
-DDEFS += -DEFI_LUA=FALSE
+# Save some RAM until we enable SDRAM: EFI_LUA=FALSE is declared in
+# prepend.txt and lifted into DDEFS by the Makefile - see [tag:ts_page_table]
 
 # USB OTG FS connector:
 DDEFS += -DEFI_USB_SERIAL_DM=Gpio::A11

--- a/firmware/config/boards/f746-discovery/prepend.txt
+++ b/firmware/config/boards/f746-discovery/prepend.txt
@@ -1,3 +1,4 @@
-; board.mk builds with -DEFI_LUA=FALSE; mirror it here so the generator drops the Lua
-; TS page (page 5) from this board's .ini - see [tag:ts_page_table] / issue #9699
+; Single declaration point for this TS-page guard flag: the .ini generator reads it
+; here to drop the Lua TS page (pageIdentifier 0x0400), and firmware/Makefile lifts it
+; into DDEFS for the firmware build - see [tag:ts_page_table] / issue #9699
 #define EFI_LUA FALSE

--- a/firmware/config/boards/s105/board.mk
+++ b/firmware/config/boards/s105/board.mk
@@ -18,8 +18,8 @@ DDEFS += -DLED_CRITICAL_ERROR_BRAIN_PIN=Gpio::Unassigned
 # and no LCD
 DDEFS += -DEFI_HD44780_LCD=FALSE
 
-# No Lua support as we are limited in RAM and ROM
-DDEFS += -DEFI_LUA=FALSE
+# No Lua support as we are limited in RAM and ROM: EFI_LUA=FALSE is declared in
+# prepend.txt and lifted into DDEFS by the Makefile - see [tag:ts_page_table]
 
 #This board has no USB wired out
 DDEFS += -DSTM32_USB_USE_OTG1=FALSE

--- a/firmware/config/boards/s105/prepend.txt
+++ b/firmware/config/boards/s105/prepend.txt
@@ -8,8 +8,9 @@
 #define ts_show_software_knock true
 #define ts_show_hardware_simulator false
 
-; board.mk builds with -DEFI_LUA=FALSE; mirror it here so the generator drops the Lua
-; TS page (page 5) from this board's .ini - see [tag:ts_page_table] / issue #9699
+; Single declaration point for this TS-page guard flag: the .ini generator reads it
+; here to drop the Lua TS page (pageIdentifier 0x0400), and firmware/Makefile lifts it
+; into DDEFS for the firmware build - see [tag:ts_page_table] / issue #9699
 #define EFI_LUA FALSE
 
 

--- a/firmware/config/stm32f4ems/efifeatures.h
+++ b/firmware/config/stm32f4ems/efifeatures.h
@@ -43,6 +43,12 @@
 #endif
 
 /* Long Term Fuel Trims */
+/* [tag:disable_engine_module] CAVEAT: EFI_LTFT_CONTROL gates TS page TS_PAGE_LTFT_TRIMS
+ * so a board must NOT flip it here or via board.mk DDEFS - declare `#define EFI_LTFT_CONTROL FALSE` in the
+ * board's prepend.txt instead.
+ * <p>
+ * Note the simulator and unit_tests keep their own efifeatures.h copies that bypass all of this.
+*/
 #ifndef EFI_LTFT_CONTROL
 #define EFI_LTFT_CONTROL TRUE
 #endif

--- a/firmware/console/binary/tunerstudio.cpp
+++ b/firmware/console/binary/tunerstudio.cpp
@@ -224,6 +224,16 @@ static uint8_t* getWorkingPageAddr(TsChannelBase* tsChannel, size_t page, size_t
 	return nullptr;
 }
 
+#if EFI_PROD_CODE
+// [tag:ts_page_table] The .ini generator only reads the board's prepend.txt, so that file is
+// the single place a TS page guard flag is declared; the Makefile lifts it into DDEFS from
+// there. If the compile flag diverges anyway (e.g. via EXTRA_PARAMS or a board.mk override),
+// the firmware would answer reads of a page the .ini still lists with out_of_range and
+// TunerStudio would retry that page until it drops the connection - fail the build instead.
+static_assert(EFI_LTFT_CONTROL == LTFT_PAGE_ENABLED,
+		"EFI_LTFT_CONTROL must match generated LTFT_PAGE_ENABLED - declare the flag in the board prepend.txt only");
+#endif // EFI_PROD_CODE
+
 static constexpr size_t getTunerStudioPageSize(size_t page) {
 	// [tag:ts_page_table] per-page sizes here must match the sizes the generator emits into the .ini
 	switch (page) {

--- a/firmware/controllers/algo/engine.h
+++ b/firmware/controllers/algo/engine.h
@@ -147,6 +147,10 @@ public:
     FuelComputer fuelComputer{};
 #endif // EFI_ENGINE_CONTROL
 
+    // [tag:disable_engine_module] Entries wrapped in #if EFI_<NAME> are compile-time optional
+    // modules. Before adding or disabling one, read the how-to in engine_module.h - especially
+    // the TS-page rules: a module that owns a TunerStudio page (like LongTermFuelTrim below)
+    // must have its flag declared in the board prepend.txt, not in board.mk or efifeatures.h.
     type_list<
         Mockable<InjectorModelPrimary>,
         Mockable<InjectorModelSecondary>,

--- a/firmware/controllers/core/engine_module.h
+++ b/firmware/controllers/core/engine_module.h
@@ -1,5 +1,37 @@
 /**
  * @file engine_module.h
+ *
+ * Engine modules are the building blocks of engine-asynchronous control logic. A module
+ * derives from EngineModule, overrides the lifecycle hooks it needs, and is registered in
+ * the type_list<...> engineModules in engine.h; the framework then invokes each hook on
+ * every registered module (see [tag:disable_engine_module] in engine.h for the list itself).
+ *
+ * [tag:disable_engine_module] Making a module compile-time optional:
+ *
+ * 1. Pick an EFI_<NAME> feature flag and give it an #ifndef-guarded default in
+ *    firmware/config/stm32f4ems/efifeatures.h (the master feature list - other ports and
+ *    the simulator/unit_tests keep their own copies, see the caveat there).
+ * 2. Wrap the module's entry in the engine.h type_list and the body of its .cpp in
+ *    #if EFI_<NAME>. Keep the .h compilable either way so callers can be guarded locally.
+ * 3. Guard call sites (status_loop, live_data, bench_test, storage, ...) with the same flag.
+ *
+ * EXTRA RULES when the module owns a TunerStudio page or any other .ini surface
+ * (tooltips, table editors, gauges) - see [tag:ts_page_table]:
+ *
+ * - The feature flag becomes a "TS page guard flag". It must be declared in the board's
+ *   prepend.txt (NOT in board.mk, NOT by editing efifeatures.h): prepend.txt is the only
+ *   input the .ini generator can see, and firmware/Makefile lifts the flag from there into
+ *   DDEFS so firmware and .ini always agree. Add the flag to TS_PAGE_GUARD_FLAGS in
+ *   firmware/Makefile and a guardFlag row in TS_PAGES (TSProjectConsumer.java).
+ * - Add a static_assert(EFI_<NAME> == <NAME>_PAGE_ENABLED, ...) next to the page table in
+ *   tunerstudio.cpp, like LTFT does. If firmware and .ini ever disagree, the firmware
+ *   answers reads of a page the .ini still lists with out_of_range (0x84) and TunerStudio
+ *   retries that page until it drops the connection - the assert turns that into a build error.
+ *
+ * LongTermFuelTrim (long_term_fuel_trim.cpp, EFI_LTFT_CONTROL, TS page identifier 0x0200 aka
+ * TS_PAGE_LTFT_TRIMS) is the worked example of an optional module that owns a TS page. Always
+ * refer to pages by their wire pageIdentifier (TS_PAGE_* in tunerstudio.h), never by their
+ * 1-based ordinal - ordinals are renumbered when a guarded page is dropped from the .ini.
  */
 
 #pragma once

--- a/firmware/controllers/long_term_fuel_trim.cpp
+++ b/firmware/controllers/long_term_fuel_trim.cpp
@@ -1,5 +1,12 @@
 #include "pch.h"
 
+// [tag:disable_engine_module] LTFT is a example of a compile-time optional engine
+// module that owns a TunerStudio page (pageIdentifier 0x0200, TS_PAGE_LTFT_TRIMS). Because of
+// that page, boards
+// must disable it via `#define EFI_LTFT_CONTROL FALSE` in their prepend.txt (never board.mk
+// or efifeatures.h): the .ini generator drops the page from that same declaration and
+// firmware/Makefile lifts it into DDEFS, so firmware and .ini cannot disagree. See the
+// how-to in engine_module.h and the static_assert next to the page table in tunerstudio.cpp.
 #if EFI_LTFT_CONTROL
 
 #include "storage.h"

--- a/firmware/controllers/long_term_fuel_trim.h
+++ b/firmware/controllers/long_term_fuel_trim.h
@@ -1,4 +1,9 @@
 // file long_term_fuel_trim.h
+//
+// [tag:disable_engine_module] Optional engine module gated by EFI_LTFT_CONTROL; it owns
+// TS page 0x0200 (TS_PAGE_LTFT_TRIMS), so the flag is a TS-page guard flag declared in the
+// board prepend.txt only.
+// See engine_module.h for the full how-to before copying this pattern.
 
 #pragma once
 

--- a/java_tools/configuration_definition/src/main/java/com/rusefi/output/TSProjectConsumer.java
+++ b/java_tools/configuration_definition/src/main/java/com/rusefi/output/TSProjectConsumer.java
@@ -109,15 +109,20 @@ public class TSProjectConsumer implements ConfigurationConsumer {
     // command list, the page=N field blocks and the triggeredPageRefresh ordinals are then all
     // rebuilt from the surviving pages so they stay consistent. See issue #9699.
     // A guarded page is dropped from the .ini when its guardFlag is FALSE in the registry (read
-    // from a board prepend). The guardFlag must mirror the board's compile flag. IMPORTANT: a page
+    // from a board prepend). The board's prepend.txt is the single declaration point for a guard
+    // flag: firmware/Makefile lifts flags listed in TS_PAGE_GUARD_FLAGS from prepend.txt into
+    // DDEFS (keep that list in sync with this column), and tunerstudio.cpp static_asserts that
+    // the compile flag matches the generated *_PAGE_ENABLED value. IMPORTANT: a page
     // that has a reference surface (tooltips, [TableEditor], menus, triggeredPageRefresh that name
     // its fields) also needs an enabledFlag and those references wrapped in @@if_block <enabledFlag>,
     // exactly as LTFT does - otherwise the drop leaves dangling references. LTFT has such a surface
     // (enabledFlag = LTFT_PAGE_ENABLED); Lua does not - its only page-5 entity is the luaScript
     // field, which is dropped with the field block, so it needs no enabledFlag. The size==0 rule is
     // generic but only safe for a genuinely empty page (no fields, hence nothing to reference).
-    // NOTE: EFI_LUA gates the .ini only; the firmware still serves page 5 (it is not gated on
-    // EFI_LUA), which is the safe direction - TS simply never requests the dropped page.
+    // NOTE: EFI_LUA gates the .ini only; the firmware still serves the Lua page (identifier
+    // \x00\x04 - it is not gated on EFI_LUA), which is the safe direction - TS simply never
+    // requests the dropped page. Refer to pages by wire identifier, not 1-based ordinal:
+    // ordinals shift when a guarded page is dropped.
     private static final TsPage[] TS_PAGES = {
         new TsPage("\\x00\\x00", "persistent_config_s_size", null,            true,  "triggerPageRefreshFlag", null,               null),
         new TsPage("\\x00\\x01", "PAGE_SIZE_2",              "PAGE_CONTENT_2", false, null,                     null,               null),

--- a/simulator/simulator/efifeatures.h
+++ b/simulator/simulator/efifeatures.h
@@ -17,7 +17,14 @@
 
 #define EFI_ENABLE_ASSERTS TRUE
 #define EFI_LAUNCH_CONTROL TRUE
-#define EFI_LTFT_CONTROL TRUE
+/* Long Term Fuel Trims */
+/* [tag:disable_engine_module] CAVEAT: EFI_LTFT_CONTROL gates TS page TS_PAGE_LTFT_TRIMS
+ * so a board must NOT flip it here or via board.mk DDEFS - declare `#define EFI_LTFT_CONTROL FALSE` in the
+ * board's prepend.txt instead.
+ * <p>
+ * Note the simulator and unit_tests keep their own efifeatures.h copies that bypass all of this.
+*/
+#define EFI_LTFT_CONTROL FALSE
 #define EFI_AUX_VALVES FALSE
 
 #define EFI_TS_TUNNEL_CAN TRUE


### PR DESCRIPTION
now EngineModules wich uses their own TS pages needs to be enabled/disabled only from the prepend.txt file, updated the docs