### PR TITLE
fix: dead-code compile errors under EFI_DETAILED_LOGGING

### DIFF
--- a/firmware/controllers/algo/engine_configuration.cpp
+++ b/firmware/controllers/algo/engine_configuration.cpp
@@ -136,7 +136,7 @@ void incrementGlobalConfigurationVersion(const char * msg) {
     }
 	engine->globalConfigurationVersion++;
 #if EFI_DETAILED_LOGGING
-	efiPrintf("set globalConfigurationVersion=%d", globalConfigurationVersion);
+	efiPrintf("set globalConfigurationVersion=%d", engine->globalConfigurationVersion);
 #endif /* EFI_DETAILED_LOGGING */
 
 	applyNewHardwareSettings();

--- a/firmware/controllers/engine_cycle/main_trigger_callback.cpp
+++ b/firmware/controllers/engine_cycle/main_trigger_callback.cpp
@@ -218,12 +218,12 @@ void InjectionEvent::onTriggerTooth(efitick_t nowNt, float currentPhase, float n
 	printf("scheduling injection angle=%.2f/delay=%d injectionDuration=%d %d\r\n", angleFromNow, (int)NT2US(startTime - nowNt), (int)durationUsStage1, (int)durationUsStage2);
 #endif
 #if EFI_DETAILED_LOGGING
-	efiPrintf("handleFuel pin=%s eventIndex %d duration=%.2fms %d", outputs[0]->name,
-			injEventIndex,
+	efiPrintf("handleFuel pin=%s eventIndex %d duration=%.2fms %u", outputs[0]->getName(),
+			cylinderNumber,
 			injectionDurationStage1,
-			getRevolutionCounter());
-	efiPrintf("handleFuel pin=%s delay=%.2f %d", outputs[0]->name, NT2US(startTime - nowNt),
-			getRevolutionCounter());
+			(unsigned)getRevolutionCounter());
+	efiPrintf("handleFuel pin=%s delay=%.2f %u", outputs[0]->getName(), NT2USF(startTime - nowNt),
+			(unsigned)getRevolutionCounter());
 #endif /* EFI_DETAILED_LOGGING */
 }
 

--- a/firmware/controllers/trigger/trigger_central.cpp
+++ b/firmware/controllers/trigger/trigger_central.cpp
@@ -1094,7 +1094,7 @@ void onConfigurationChangeTriggerCallback() {
 	#endif
 	}
 #if EFI_DETAILED_LOGGING
-	efiPrintf("isTriggerConfigChanged=%d", triggerConfigChanged);
+	efiPrintf("isTriggerConfigChanged=%d", changed);
 #endif /* EFI_DETAILED_LOGGING */
 
 	// we do not want to miss two updates in a row


### PR DESCRIPTION
With EFI_DETAILED_LOGGING TRUE firmware won't build with errors