### PR TITLE
fix: gcc_map_reader location

### DIFF
--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -459,7 +459,13 @@ CLEAN_PCH_HOOK:
 CLEAN_BUNDLE_HOOK:
 
 POST_MAKE_ALL_RULE_HOOK: $(BUILDDIR)/$(PROJECT).elf
-	@java -jar ../java_tools/gcc_map_reader.jar $(BUILDDIR)/$(PROJECT).map | grep Total || echo Unable to run gcc_map_reader
+	@JAR=../java_tools/gcc_map_reader.jar; \
+	  [ -f "$$JAR" ] || JAR=../java_tools/gcc_map_reader/build/libs/gcc_map_reader.jar; \
+	  if [ -f "$$JAR" ]; then \
+	    java -jar "$$JAR" $(BUILDDIR)/$(PROJECT).map | grep Total || echo "gcc_map_reader ran but produced no output"; \
+	  else \
+	    echo "gcc_map_reader.jar not found, skipping memory report"; \
+	  fi
 	@$(TRGT)objdump -h $(BUILDDIR)/$(PROJECT).elf | grep -w ram4
 
 VPATH     = $(patsubst ./%,%,$(SRCPATHS))

--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -458,14 +458,8 @@ CLEAN_PCH_HOOK:
 
 CLEAN_BUNDLE_HOOK:
 
-POST_MAKE_ALL_RULE_HOOK: $(BUILDDIR)/$(PROJECT).elf
-	@JAR=../java_tools/gcc_map_reader.jar; \
-	  [ -f "$$JAR" ] || JAR=../java_tools/gcc_map_reader/build/libs/gcc_map_reader.jar; \
-	  if [ -f "$$JAR" ]; then \
-	    java -jar "$$JAR" $(BUILDDIR)/$(PROJECT).map | grep Total || echo "gcc_map_reader ran but produced no output"; \
-	  else \
-	    echo "gcc_map_reader.jar not found, skipping memory report"; \
-	  fi
+POST_MAKE_ALL_RULE_HOOK: $(BUILDDIR)/$(PROJECT).elf $(GCC_MAP_READER_JAR)
+	@java -jar $(GCC_MAP_READER_JAR) $(BUILDDIR)/$(PROJECT).map | grep Total || echo Unable to run gcc_map_reader
 	@$(TRGT)objdump -h $(BUILDDIR)/$(PROJECT).elf | grep -w ram4
 
 VPATH     = $(patsubst ./%,%,$(SRCPATHS))

--- a/firmware/config/boards/kinetis/!generate_memory_usage_report.bat
+++ b/firmware/config/boards/kinetis/!generate_memory_usage_report.bat
@@ -1,3 +1,3 @@
 
 rem Generate human-readable version of the .map memory usage report
-java -jar ../../../../java_tools/gcc_map_reader.jar ../../../build_kinetis/rusefi.map > kinetis_ram_report.txt
+java -jar ../../../../java_tools/gcc_map_reader/build/libs/gcc_map_reader-all.jar ../../../build_kinetis/rusefi.map > kinetis_ram_report.txt

--- a/firmware/generate_memory_usage_report.bat
+++ b/firmware/generate_memory_usage_report.bat
@@ -1,3 +1,3 @@
 
 rem Generate human-readable version of the .map memory usage report
-java -jar ../java_tools/gcc_map_reader.jar build/rusefi.map > rusefi_ram_report.txt
+java -jar ../java_tools/gcc_map_reader/build/libs/gcc_map_reader-all.jar build/rusefi.map > rusefi_ram_report.txt

--- a/firmware/generate_memory_usage_report.sh
+++ b/firmware/generate_memory_usage_report.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 # Generate human-readable version of the .map memory usage report
-java -jar ../java_tools/gcc_map_reader.jar build/rusefi.map > rusefi_ram_report.txt
+java -jar ../java_tools/gcc_map_reader/build/libs/gcc_map_reader-all.jar build/rusefi.map > rusefi_ram_report.txt

--- a/java_tools/gcc_map_reader/build.gradle
+++ b/java_tools/gcc_map_reader/build.gradle
@@ -1,16 +1,6 @@
-plugins {
-    id 'java'
-    id 'application'
-}
-
 defaultTasks 'shadowJar'
 
-jar {
-    application {
-        mainClass = 'rusefi.GccMapReader'
-    }
-
-    destinationDirectory = file( '$rootDir/../..' )
+shadowJar {
     manifest {
         attributes(
             'Main-Class': 'rusefi.GccMapReader'

--- a/java_tools/java_tools.mk
+++ b/java_tools/java_tools.mk
@@ -16,6 +16,7 @@ ENUM_TO_STRING_JAR = $(JAVA_TOOLS)/enum_to_string/build/libs/enum_to_string-all.
 # TUNE_TOOLS_JAR = $(JAVA_TOOLS)/tune-tools/build/libs/tune-tools-all.jar
 TS_PLUGIN_LAUNCHER_JAR = $(JAVA_TOOLS)/ts_plugin_launcher/build/jar/rusefi_ts_plugin_launcher.jar
 CONSOLE_JAR = $(PROJECT_DIR)/../console/rusefi_console.jar
+GCC_MAP_READER_JAR = $(JAVA_TOOLS)/gcc_map_reader/build/libs/gcc_map_reader-all.jar
 
 # We use .FORCE to always rebuild these tools. Gradle won't actually touch the jars if it doesn't need to,
 # so we don't have to worry about triggering rebuilds of things that have these tools as a prerequisite.
@@ -37,6 +38,9 @@ $(TS_PLUGIN_LAUNCHER_JAR): .FORCE
 
 $(CONSOLE_JAR): .docsenums-sentinel .config-sentinel .FORCE
 	cd $(GRADLE_ROOT) && $(FLOCK) ./gradlew :ui:shadowJar
+
+$(GCC_MAP_READER_JAR): .FORCE
+	cd $(GRADLE_ROOT) && $(FLOCK) ./gradlew :gcc_map_reader:shadowJar
 
 .FORCE:
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -29,6 +29,7 @@ project(':trigger-ui').projectDir = new File(rootRelativePath + 'java_console/tr
 include ':logging-api'
 project(':logging-api').projectDir = new File(rootRelativePath + 'java_console/logging-api')
 include ':gcc_map_reader'
+project(':gcc_map_reader').projectDir = new File(rootRelativePath + 'java_tools/gcc_map_reader')
 
 include ':enum_to_string'
 project(':enum_to_string').projectDir = new File(rootRelativePath + 'java_tools/enum_to_string')


### PR DESCRIPTION
I don't know why but gcc_map_reader is not present at ../java_tools/ but at ../java_tools/gcc_map_reader/build/libs/, the patch is "retro active" testing the original path before fallbacking to ../java_tools/gcc_map_reader/build/libs/