### PR TITLE
Fix/wbo status labels noheat

### DIFF
--- a/firmware/tunerstudio/tunerstudio.template.ini
+++ b/firmware/tunerstudio/tunerstudio.template.ini
@@ -292,7 +292,8 @@ include_file @@TUNING_SECTION_FILE@@
 	egoCorrectionForVeAnalyze = { 100 + stftCorrection1 }
 
 
-	wb1hasFault = { enableAemXSeries && ((wb1stateCode >= 3 && wb1stateCode <= 5) || !wb1isValid) }
+	wb1hasFault = { enableAemXSeries && ((wb1stateCode >= 4 && wb1stateCode <= 6) || !wb1isValid) }
+	wb2hasFault = { enableAemXSeries && ((wb2stateCode >= 4 && wb2stateCode <= 6) || !wb2isValid) }
 
 ; calculated values by metric/imperial units
 ; "useMetricOnInterface" controls whether metric or imperial units are displayed
@@ -401,7 +402,7 @@ include_file @@TUNING_SECTION_FILE@@
 	debugFieldI4List = bits,	U08,	[0:7], "Alt: Period",				"",						"",			"Idle: State",						"Idle di4",				"Cycle Cnt 1",					"",			"",								"",						"",							"",						"",		"",			"",			"",				"",			"",						"ETB di4",					"executor",			"",			"di4",			"di4",			"22di4",			"",		"24:di4",		"",				"",			"",				"",		"",	"",	"Init Count",	"",							"",	"",		"",		"",""					"",			"",					"",				"",			"",				"",										"",			"",					"",						"Solenoid 4 State",  "",					"",							"",							""
 	debugFieldI5List = bits,	U08,	[0:7], "",								"",						"",			"",										"Idle di5",				"Cycle Cnt 2",					"",			"",								"",						"",							"",						"",		"",			"",			"",				"di5",		"di5",					"ETB di5",					"max executor",		"di5",		"di5",			"di5",			"22di5",			"di5",	"di5",		"di5",				"di5",		"di5",			"",		"di5",  "di5",  "di5",				"",							"di5", "di5",	"di5",	"",""					"",			"",					"",				"",			"",				"",										"",			"",					"",						"Solenoid 5 State",  "",					"",							"",							""
 
-	wboStateList = bits, U08, [0:3], "preheat", "warmup", "closed loop", "failed to heat", "overheat", "underheat", "not allowed", "CAN silent"
+	wboStateList = bits, U08, [0:3], "noheat", "preheat", "warmup", "closed loop", "failed to heat", "overheat", "underheat", "not allowed", "CAN silent"
 
 	injModeList = bits, U08, [0:3], "Simultaneous", "Sequential", "Batch", "Single Point"
 	ignModeList = bits, U08, [0:3], "Single Coil", "Sequential", "Wasted", "Two Coils"
@@ -3436,26 +3437,30 @@ dialog = allPinsOutputs_1_and_2, "", xAxis
 		indicator = { wb2canSilent == 1 }, "Communication ok", "Timeout reading", green, black, red, black
 
 	indicatorPanel = uegoCan0IndicatorsExt, 1, { enableAemXSeries == 1 && canWbo1_type == @@can_wbo_type_e_RUSEFI@@ }
+		indicator = { wb1hasFault }, { WBO1 state: bitStringValue(wboStateList, wb1stateCode) }, { WBO1 state: bitStringValue(wboStateList, wb1stateCode) }, white, black, red, black
 		indicator = { !wb1allowed }, "WBO allowed", "WBO stopped", green, black, yellow, black
-		indicator = { wb1stateCode == 0 }, "No preheat", "Preheat", white, black, green, black
-		indicator = { wb1stateCode == 1 }, "No warmup", "Warmup", white, black, green, black
-		indicator = { wb1stateCode == 2 }, "No closed loop", "Closed loop", white, black, green, black
-		indicator = { wb1stateCode == 3 }, "No heating failure", "Heating failed", green, black, red, black
-		indicator = { wb1stateCode == 4 }, "No overheat", "Overheat", green, black, red, black
-		indicator = { wb1stateCode == 5 }, "No underheat", "Underheat", green, black, red, black
-		indicator = { wb1stateCode == 6 }, "Heater allowed", "Heater not allowed", green, black, yellow, black
+		indicator = { wb1stateCode == 0 }, "No noheat", "No heat (waiting allowed)", white, black, green, black
+		indicator = { wb1stateCode == 1 }, "No preheat", "Preheat", white, black, green, black
+		indicator = { wb1stateCode == 2 }, "No warmup", "Warmup", white, black, green, black
+		indicator = { wb1stateCode == 3 }, "No closed loop", "Closed loop", white, black, green, black
+		indicator = { wb1stateCode == 4 }, "No heating failure", "Heating failed", green, black, red, black
+		indicator = { wb1stateCode == 5 }, "No overheat", "Overheat", green, black, red, black
+		indicator = { wb1stateCode == 6 }, "No underheat", "Underheat", green, black, red, black
+		indicator = { wb1stateCode == 7 }, "Heater allowed", "Heater not allowed", green, black, yellow, black
 ;		hide, this confuses users
 ;		indicator = { wb1fwOutdated }, "FW: compatible", "FW: need update", green, black, yellow, black
 
 	indicatorPanel = uegoCan1IndicatorsExt, 1, { enableAemXSeries == 1 && canWbo2_type == @@can_wbo_type_e_RUSEFI@@ }
+		indicator = { wb2hasFault }, { WBO2 state: bitStringValue(wboStateList, wb2stateCode) }, { WBO2 state: bitStringValue(wboStateList, wb2stateCode) }, white, black, red, black
 		indicator = { !wb2allowed }, "WBO allowed", "WBO stopped", green, black, yellow, black
-		indicator = { wb2stateCode == 0 }, "No preheat", "Preheat", white, black, green, black
-		indicator = { wb2stateCode == 1 }, "No warmup", "Warmup", white, black, green, black
-		indicator = { wb2stateCode == 2 }, "No closed loop", "Closed loop", white, black, green, black
-		indicator = { wb2stateCode == 3 }, "No heating failure", "Heating failed", green, black, red, black
-		indicator = { wb2stateCode == 4 }, "No overheat", "Overheat", green, black, red, black
-		indicator = { wb2stateCode == 5 }, "No underheat", "Underheat", green, black, red, black
-		indicator = { wb2stateCode == 6 }, "Heater allowed", "Heater not allowed", green, black, yellow, black
+		indicator = { wb2stateCode == 0 }, "No noheat", "No heat (waiting allowed)", white, black, green, black
+		indicator = { wb2stateCode == 1 }, "No preheat", "Preheat", white, black, green, black
+		indicator = { wb2stateCode == 2 }, "No warmup", "Warmup", white, black, green, black
+		indicator = { wb2stateCode == 3 }, "No closed loop", "Closed loop", white, black, green, black
+		indicator = { wb2stateCode == 4 }, "No heating failure", "Heating failed", green, black, red, black
+		indicator = { wb2stateCode == 5 }, "No overheat", "Overheat", green, black, red, black
+		indicator = { wb2stateCode == 6 }, "No underheat", "Underheat", green, black, red, black
+		indicator = { wb2stateCode == 7 }, "Heater allowed", "Heater not allowed", green, black, yellow, black
 ;		hide, this confuses users
 ;		indicator = { wb2fwOutdated }, "FW: compatible", "FW: need update", green, black, yellow, black
 

--- a/unit_tests/tests/controllers/can/test_can_wideband.cpp
+++ b/unit_tests/tests/controllers/can/test_can_wideband.cpp
@@ -293,7 +293,7 @@ TEST(CanWideband, DecodeRusefiStandard)
 	EXPECT_FLOAT_EQ(-1, Sensor::get(SensorType::Lambda1).value_or(-1));
 
 	// ...but no error until egine is runnig
-	EXPECT_EQ((uint8_t)wbo::Status::Preheat, dut.stateCode);
+	EXPECT_EQ((uint8_t)wbo::Status::NoHeat, dut.stateCode);
 	EXPECT_EQ(false, dut.allowed);
 
 	// Now driver should handle valid bit and error states from wbo


### PR DESCRIPTION
Depends on [wideband#84](https://github.com/rusefi/wideband/pull/84)

With the add of no heat state in the wbo controller, some labels are to be updated in the main firmware