### PR TITLE
MRE: EFI_STORAGE_MFS_EXTERNAL is outdated and dead

### DIFF
--- a/firmware/config/boards/microrusefi/board.mk
+++ b/firmware/config/boards/microrusefi/board.mk
@@ -66,7 +66,6 @@ ifeq ($(BOARD_HAS_EXT_FLASH),yes)
     include $(PROJECT_DIR)/hw_layer/ports/stm32/use_higher_level_flash_api.mk
     include $(PROJECT_DIR)/hw_layer/drivers/flash/w25q/w25q_single_spi.mk
     DDEFS += -DEFI_STORAGE_SD=FALSE
-    DDEFS += -DEFI_STORAGE_MFS_EXTERNAL=TRUE
     # Use same method to workaround DMA access to CCM memory where persistentState can be located
     DDEFS += -DSNOR_SPI_WORKAROUND_CACHE=TRUE
     # This board has SPI flash instead of SD connector


### PR DESCRIPTION
Replaced with EFI_STORAGE_MFS and use_higher_level_flash_api.mk

only:microrusefi