### PR TITLE
Launch rpm threshold for clutch down switch

### DIFF
--- a/firmware/controllers/algo/launch_control.cpp
+++ b/firmware/controllers/algo/launch_control.cpp
@@ -96,13 +96,25 @@ LaunchCondition LaunchControlBase::calculateRPMLaunchCondition(const float rpm) 
 
 LaunchCondition LaunchControlBase::calculateLaunchCondition(const float rpm) {
 	const LaunchCondition currentRpmLaunchCondition = calculateRPMLaunchCondition(rpm);
-	activateSwitchCondition = isInsideSwitchCondition();
+
+	const bool rawSwitchCondition = isInsideSwitchCondition();
+	if (engineConfiguration->launchRpmThreshold > 0) {
+		if (!rawSwitchCondition) {
+			isLaunchLatched = false;
+		} else if (!activateSwitchCondition) {
+			isLaunchLatched = (rpm <= engineConfiguration->launchRpmThreshold);
+		}
+	} else {
+		isLaunchLatched = rawSwitchCondition;
+	}
+	activateSwitchCondition = rawSwitchCondition;
+
 	rpmLaunchCondition = (currentRpmLaunchCondition == LaunchCondition::Launch);
 	rpmPreLaunchCondition = (currentRpmLaunchCondition == LaunchCondition::PreLaunch);
 	speedCondition = isInsideSpeedCondition();
 	tpsCondition = isInsideTpsCondition();
 
-	if(speedCondition && activateSwitchCondition && tpsCondition) {
+	if(speedCondition && isLaunchLatched && tpsCondition) {
 		return currentRpmLaunchCondition;
 	} else {
 		return LaunchCondition::NotMet;

--- a/firmware/controllers/algo/launch_control.cpp
+++ b/firmware/controllers/algo/launch_control.cpp
@@ -121,6 +121,19 @@ LaunchCondition LaunchControlBase::calculateLaunchCondition(const float rpm) {
 	}
 }
 
+bool LaunchControlBase::ownsSharedTrigger() const {
+	// SWITCH_INPUT_LAUNCH + LAUNCH_BUTTON already has its own RPM-based guard in
+	// calculateRPMLaunchCondition() that doesn't touch the latch, so it's excluded here.
+	const bool sameTrigger =
+		engineConfiguration->launchActivationMode == CLUTCH_INPUT_LAUNCH
+		&& engineConfiguration->torqueReductionActivationMode == TORQUE_REDUCTION_CLUTCH_DOWN_SWITCH;
+
+	return sameTrigger
+		&& engineConfiguration->launchControlEnabled
+		&& engineConfiguration->launchRpmThreshold > 0
+		&& isLaunchLatched;
+}
+
 LaunchControlBase::LaunchControlBase() {
 	launchActivatePinState = false;
 	isPreLaunchCondition = false;

--- a/firmware/controllers/algo/launch_control.h
+++ b/firmware/controllers/algo/launch_control.h
@@ -32,6 +32,7 @@ public:
 
 	bool isLaunchSparkRpmRetardCondition() const;
 	bool isLaunchFuelRpmRetardCondition() const;
+	bool ownsSharedTrigger() const;
 
 	float getSparkSkipRatio() const { return sparkSkipRatio; }
 

--- a/firmware/controllers/algo/launch_control_state.txt
+++ b/firmware/controllers/algo/launch_control_state.txt
@@ -15,5 +15,6 @@ bit     rpmPreLaunchCondition;
 	bit speedCondition;Launch: speedCondition
 	bit tpsCondition;Launch: tpsCondition
 	bit luaLaunchState
+	bit isLaunchLatched;Launch: isLaunchLatched
 
 end_struct

--- a/firmware/controllers/algo/shift_torque_reduction_controller.cpp
+++ b/firmware/controllers/algo/shift_torque_reduction_controller.cpp
@@ -22,7 +22,7 @@ void ShiftTorqueReductionController::update() {
         updateAppConditionSatisfied();
 
         isFlatShiftConditionSatisfied = torqueReductionTriggerPinState && isTimeConditionSatisfied
-            && isRpmConditionSatisfied && isAppConditionSatisfied;
+            && isRpmConditionSatisfied && isAppConditionSatisfied && !engine->launchController.ownsSharedTrigger();
     }
 }
 

--- a/firmware/docs_enums.mk
+++ b/firmware/docs_enums.mk
@@ -14,6 +14,7 @@ DOCS_ENUMS_INPUTS = \
   $(PROJECT_DIR)/controllers/trigger/trigger_state.txt \
   $(PROJECT_DIR)/controllers/trigger/trigger_state_primary.txt \
   $(PROJECT_DIR)/controllers/algo/shift_torque_reduction_state.txt \
+  $(PROJECT_DIR)/controllers/algo/launch_control_state.txt \
   $(PROJECT_DIR)/controllers/engine_cycle/high_pressure_fuel_pump.txt \
   $(PROJECT_DIR)/controllers/actuators/idle_state.txt \
   $(PROJECT_DIR)/controllers/actuators/electronic_throttle.txt \

--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -1991,6 +1991,8 @@ end_struct
 
 ! historically 'unusedOftenChangesDuringFirmwareUpdate' was here - now that's just an anchor reminding where to insert new fields
 
+	uint16_t launchRpmThreshold;Launch RPM Threshold: when above 0, launch only engages if the activation switch (button/clutch) is pressed at or below this RPM, and stays latched while held - even past this RPM. This lets a standing launch (switch pressed low, revved up) coexist with flat shift / torque reduction (switch blipped high during an upshift). 0 disables the gate (legacy behavior).;"rpm", 1, 0, 0, 20000, 0
+
 	! --- Misfire Detection ---
 	bit misfireDetectionEnabled,"enabled","disabled";Misfire Detection: master enable. Active at idle only. Latches check-engine light (P0300) once the count threshold is reached.
 	uint8_t misfireConsecutiveCount;Misfire Detection: minimum flagged firings within the recent-firings window before a misfire is counted.;"events", 1, 0, 1, 20, 0

--- a/firmware/tunerstudio/tunerstudio.template.ini
+++ b/firmware/tunerstudio/tunerstudio.template.ini
@@ -4940,7 +4940,7 @@ dialog = tcuControls, "Transmission Settings"
 		field = "Clutch Down mode",						clutchDownPinMode,     {launchControlEnabled == 1 && launchActivationMode == @@launchActivationMode_e_CLUTCH_INPUT_LAUNCH@@}@@if_ts_show_clutch_down_pin
 		field = ""
 
-; dead code		field = "Rpm Threshold",								launchRpmThreshold,  {launchControlEnabled == 1}
+		field = "Launch RPM Threshold (0=off)",			launchRpmThreshold,  {launchControlEnabled == 1}
 		field = "Speed Threshold",							launchSpeedThreshold,  {launchControlEnabled == 1}
 		field = ""
 		field = "Launch RPM",								launchRpm,  {launchControlEnabled == 1}

--- a/unit_tests/tests/launch/test_launch_rpm_threshold.cpp
+++ b/unit_tests/tests/launch/test_launch_rpm_threshold.cpp
@@ -1,0 +1,54 @@
+#include "pch.h"
+
+namespace {
+    constexpr int TEST_LAUNCH_RPM = 4000;
+    constexpr int TEST_THRESHOLD_RPM = 2000;
+
+    void setUpThresholdTest(const int threshold) {
+        engineConfiguration->launchControlEnabled = true;
+        engineConfiguration->launchActivationMode = LUA_LAUNCH;
+        engineConfiguration->launchRpm = TEST_LAUNCH_RPM;
+        engineConfiguration->launchRpmWindow = 0;
+        engineConfiguration->launchSpeedThreshold = 0;
+        engineConfiguration->launchTpsThreshold = 0;
+        engineConfiguration->launchRpmThreshold = threshold;
+        Sensor::setMockValue(SensorType::DriverThrottleIntent, 5);
+    }
+
+    void update(const int rpm, const bool switchPressed) {
+        Sensor::setMockValue(SensorType::Rpm, rpm);
+        engine->launchController.luaLaunchState = switchPressed;
+        engine->launchController.update();
+    }
+
+    TEST(launchRpmThreshold, standingLaunchLatches) {
+        EngineTestHelper eth(engine_type_e::TEST_ENGINE);
+        setUpThresholdTest(TEST_THRESHOLD_RPM);
+
+        update(1500, true);
+        EXPECT_TRUE(engine->launchController.isLaunchLatched);
+
+        update(TEST_LAUNCH_RPM, true);
+        EXPECT_TRUE(engine->launchController.isLaunchLatched);
+        EXPECT_TRUE(engine->launchController.isLaunchCondition);
+    }
+
+    TEST(launchRpmThreshold, highRpmBlipDoesNotArm) {
+        EngineTestHelper eth(engine_type_e::TEST_ENGINE);
+        setUpThresholdTest(TEST_THRESHOLD_RPM);
+
+        update(6000, false);
+        update(6000, true);
+        EXPECT_FALSE(engine->launchController.isLaunchLatched);
+        EXPECT_FALSE(engine->launchController.isLaunchCondition);
+    }
+
+    TEST(launchRpmThreshold, zeroThresholdIsLegacy) {
+        EngineTestHelper eth(engine_type_e::TEST_ENGINE);
+        setUpThresholdTest(0);
+
+        update(6000, true);
+        EXPECT_TRUE(engine->launchController.isLaunchLatched);
+        EXPECT_TRUE(engine->launchController.isLaunchCondition);
+    }
+}

--- a/unit_tests/tests/launch/test_launch_rpm_threshold.cpp
+++ b/unit_tests/tests/launch/test_launch_rpm_threshold.cpp
@@ -51,4 +51,53 @@ namespace {
         EXPECT_TRUE(engine->launchController.isLaunchLatched);
         EXPECT_TRUE(engine->launchController.isLaunchCondition);
     }
+
+    constexpr int TEST_ARMING_RPM = 3800;
+
+    void setUpSharedClutchTest() {
+        engineConfiguration->launchControlEnabled = true;
+        engineConfiguration->launchActivationMode = CLUTCH_INPUT_LAUNCH;
+        engineConfiguration->launchRpm = TEST_LAUNCH_RPM;
+        engineConfiguration->launchRpmWindow = 0;
+        engineConfiguration->launchSpeedThreshold = 0;
+        engineConfiguration->launchTpsThreshold = 0;
+        engineConfiguration->launchRpmThreshold = TEST_THRESHOLD_RPM;
+
+        engineConfiguration->torqueReductionEnabled = true;
+        engineConfiguration->torqueReductionActivationMode = TORQUE_REDUCTION_CLUTCH_DOWN_SWITCH;
+        engineConfiguration->torqueReductionArmingRpm = TEST_ARMING_RPM;
+        engineConfiguration->torqueReductionArmingApp = 0;
+        engineConfiguration->limitTorqueReductionTime = false;
+
+        Sensor::setMockValue(SensorType::DriverThrottleIntent, 5);
+    }
+
+    void updateShared(const int rpm, const bool clutchDown) {
+        Sensor::setMockValue(SensorType::Rpm, rpm);
+        engine->engineState.lua.clutchDownState = clutchDown;
+        engine->launchController.update();
+        engine->shiftTorqueReductionController.update();
+    }
+
+    TEST(launchRpmThreshold, latchedLaunchSuppressesFlatShift) {
+        EngineTestHelper eth(engine_type_e::TEST_ENGINE);
+        setUpSharedClutchTest();
+
+        updateShared(1500, true);
+        EXPECT_TRUE(engine->launchController.isLaunchLatched);
+
+        updateShared(TEST_LAUNCH_RPM, true);
+        EXPECT_TRUE(engine->launchController.isLaunchCondition);
+        EXPECT_FALSE(engine->shiftTorqueReductionController.isFlatShiftConditionSatisfied);
+    }
+
+    TEST(launchRpmThreshold, blipAboveThresholdAllowsFlatShift) {
+        EngineTestHelper eth(engine_type_e::TEST_ENGINE);
+        setUpSharedClutchTest();
+
+        updateShared(6000, false);
+        updateShared(6000, true);
+        EXPECT_FALSE(engine->launchController.isLaunchLatched);
+        EXPECT_TRUE(engine->shiftTorqueReductionController.isFlatShiftConditionSatisfied);
+    }
 }

--- a/unit_tests/tests/tests.mk
+++ b/unit_tests/tests/tests.mk
@@ -79,6 +79,7 @@ TESTS_SRC_CPP = \
 	tests/launch/test_retard_threshold_rpm.cpp \
 	tests/launch/test_ignition_angle_advance.cpp \
 	tests/launch/test_spark_skip_ratio.cpp \
+	tests/launch/test_launch_rpm_threshold.cpp \
 	tests/shift_torque_reduction/flat_shift_condition_test_base.cpp \
 	tests/shift_torque_reduction/shift_torque_reduction_switch_params.cpp \
 	tests/shift_torque_reduction/shift_torque_reduction_switch_test_base.cpp \


### PR DESCRIPTION
Adds `launchRpmThreshold`: launch only arms if the switch (button or clutch) is pressed at or below this RPM. Once armed, it stays armed even if RPM goes higher. This lets launch and flat shift share the same clutch switch without conflict — right now launch just wins above the arming RPM and flat shift never works.

Also makes flat shift back off when launch is using the same switch, so they don't both cut spark at the same time.

Extra fix: `launch_control_state.txt` was missing from the build config list, so changing it alone didn't rebuild its generated file.

Added tests for the new behavior.
