### PR TITLE
launch console once, support all operations with same board

### DIFF
--- a/java_console/io/src/main/java/com/rusefi/io/ConnectionWatchdog.java
+++ b/java_console/io/src/main/java/com/rusefi/io/ConnectionWatchdog.java
@@ -17,6 +17,7 @@ public class ConnectionWatchdog {
 
     private final Timer reconnectTimer;
     private static boolean isCreated;
+    private static ConnectionWatchdog instance;
 
     private ConnectionWatchdog(int timeoutMs, Runnable restartAction) {
         reconnectTimer = new Timer(timeoutMs, e -> {
@@ -32,7 +33,7 @@ public class ConnectionWatchdog {
         if (isCreated)
             return; // only one instance is needed
         isCreated = true;
-        new ConnectionWatchdog(Timeouts.CONNECTION_RESTART_DELAY, () -> {
+        instance = new ConnectionWatchdog(Timeouts.CONNECTION_RESTART_DELAY, () -> {
             if (isRestartPending.compareAndSet(false, true)) {
                 linkManager.execute(() -> {
                     log.info("ConnectionWatchdog.reconnectTimer restarting: " + Timeouts.CONNECTION_RESTART_DELAY);
@@ -42,7 +43,29 @@ public class ConnectionWatchdog {
             } else {
                 log.info("restart already pending...");
             }
-        }).start();
+        });
+        instance.start();
+    }
+
+    /**
+     * Temporarily suppress the watchdog reconnect timer. Use this when a firmware flash
+     * or other operation owns the port exclusively so the watchdog does not race it. (#9771)
+     */
+    public synchronized static void pause() {
+        if (instance != null) {
+            instance.reconnectTimer.stop();
+            log.info("ConnectionWatchdog paused");
+        }
+    }
+
+    /**
+     * Resume the watchdog after {@link #pause()}. The timer restarts its full delay.
+     */
+    public synchronized static void resume() {
+        if (instance != null) {
+            instance.reconnectTimer.restart();
+            log.info("ConnectionWatchdog resumed");
+        }
     }
 
     void start() {

--- a/java_console/io/src/main/java/com/rusefi/io/ConnectionWatchdog.java
+++ b/java_console/io/src/main/java/com/rusefi/io/ConnectionWatchdog.java
@@ -49,7 +49,7 @@ public class ConnectionWatchdog {
 
     /**
      * Temporarily suppress the watchdog reconnect timer. Use this when a firmware flash
-     * or other operation owns the port exclusively so the watchdog does not race it. (#9771)
+     * or other operation owns the port exclusively so the watchdog does not race it. [tag:better_ux_for_flashing]
      */
     public synchronized static void pause() {
         if (instance != null) {

--- a/java_console/io/src/main/java/com/rusefi/io/LinkManager.java
+++ b/java_console/io/src/main/java/com/rusefi/io/LinkManager.java
@@ -35,6 +35,9 @@ public class LinkManager implements Closeable {
     private static final Logging log = getLogging(LinkManager.class);
     public static final String PCAN = "PCAN";
     public static final String SOCKET_CAN = "SocketCAN";
+    // Synthetic marker for a board in the STM32 built-in bootloader (DFU). Not a real serial port —
+    // never opened as a stream; used only to surface DFU in the ports list (#9771).
+    public static final String DFU = "DFU";
 
     @NotNull
     public static final LogLevel LOG_LEVEL = LogLevel.INFO;
@@ -208,6 +211,19 @@ public class LinkManager implements Closeable {
         restart();
     }
 
+    /**
+     * Reconnect to a specific port. #9771: the Device tab's Connect button targets the port selected in
+     * its combo (a board re-hooked on a different COM port than before) instead of blindly resuming the
+     * previous {@link #lastTriedPort}.
+     */
+    public void reconnect(String port) {
+        log.info("reconnect " + port);
+        Objects.requireNonNull(port, "port");
+        isDisconnectedByUser = false;
+        lastTriedPort = port;
+        restart();
+    }
+
     public enum LogLevel {
         INFO,
         DEBUG,
@@ -333,8 +349,13 @@ public class LinkManager implements Closeable {
         this.connector = connector;
     }
 
+    private static boolean isDfu(String port) {
+        return DFU.equals(port);
+    }
+
     public static boolean isSpecialNotSerial(String port) {
-        return isLogViewerMode(port) || isPcanPort(port) || isSocketCan(port) || TcpConnector.isTcpPort(port);
+        // DFU is a synthetic, non-serial marker (#9771) — never open it as a stream.
+        return isLogViewerMode(port) || isPcanPort(port) || isSocketCan(port) || TcpConnector.isTcpPort(port) || isDfu(port);
     }
 
     public static boolean isLogViewerMode(String port) {

--- a/java_console/io/src/main/java/com/rusefi/io/LinkManager.java
+++ b/java_console/io/src/main/java/com/rusefi/io/LinkManager.java
@@ -36,7 +36,7 @@ public class LinkManager implements Closeable {
     public static final String PCAN = "PCAN";
     public static final String SOCKET_CAN = "SocketCAN";
     // Synthetic marker for a board in the STM32 built-in bootloader (DFU). Not a real serial port —
-    // never opened as a stream; used only to surface DFU in the ports list (#9771).
+    // never opened as a stream; used only to surface DFU in the ports list [tag:better_ux_for_flashing].
     public static final String DFU = "DFU";
 
     @NotNull
@@ -214,7 +214,7 @@ public class LinkManager implements Closeable {
     /**
      * Reconnect to a specific port, updating {@link #lastTriedPort} so the watchdog follows it too. Used
      * after a firmware flash when the board re-enumerates onto a different port (Linux ttyACMx
-     * renumbering) than the one we were originally connected to. (#9771)
+     * renumbering) than the one we were originally connected to. [tag:better_ux_for_flashing]
      */
     public void reconnect(String port) {
         log.info("reconnect " + port);
@@ -354,7 +354,7 @@ public class LinkManager implements Closeable {
     }
 
     public static boolean isSpecialNotSerial(String port) {
-        // DFU is a synthetic, non-serial marker (#9771) — never open it as a stream.
+        // DFU is a synthetic, non-serial marker [tag:better_ux_for_flashing] — never open it as a stream.
         return isLogViewerMode(port) || isPcanPort(port) || isSocketCan(port) || TcpConnector.isTcpPort(port) || isDfu(port);
     }
 

--- a/java_console/io/src/main/java/com/rusefi/io/LinkManager.java
+++ b/java_console/io/src/main/java/com/rusefi/io/LinkManager.java
@@ -212,9 +212,9 @@ public class LinkManager implements Closeable {
     }
 
     /**
-     * Reconnect to a specific port. #9771: the Device tab's Connect button targets the port selected in
-     * its combo (a board re-hooked on a different COM port than before) instead of blindly resuming the
-     * previous {@link #lastTriedPort}.
+     * Reconnect to a specific port, updating {@link #lastTriedPort} so the watchdog follows it too. Used
+     * after a firmware flash when the board re-enumerates onto a different port (Linux ttyACMx
+     * renumbering) than the one we were originally connected to. (#9771)
      */
     public void reconnect(String port) {
         log.info("reconnect " + port);

--- a/java_console/io/src/main/java/com/rusefi/io/LinkManager.java
+++ b/java_console/io/src/main/java/com/rusefi/io/LinkManager.java
@@ -224,6 +224,16 @@ public class LinkManager implements Closeable {
         restart();
     }
 
+    /** Port name of the most recent connect attempt, or null before the first one. */
+    public String getLastTriedPort() {
+        return lastTriedPort;
+    }
+
+    /** True once {@link #disconnect()} was called and no reconnect has happened since. */
+    public boolean isDisconnectedByUser() {
+        return isDisconnectedByUser;
+    }
+
     public enum LogLevel {
         INFO,
         DEBUG,

--- a/java_console/shared_io/src/main/java/com/rusefi/core/FindFileHelper.java
+++ b/java_console/shared_io/src/main/java/com/rusefi/core/FindFileHelper.java
@@ -131,4 +131,103 @@ public class FindFileHelper {
         String srecFile = findSrecFile();
         return srecFile != null && srecFile.contains("obfuscated");
     }
+
+    /**
+     * Extract the board target from a firmware artifact file name, e.g.
+     * {@code rusefi_development_2026-07-06_uaefi_pro_2528425206_<sha>_update.srec} -> {@code uaefi_pro}.
+     * The target is the token(s) between the {@code yyyy-MM-dd} date and the numeric signature. Returns
+     * null for names that don't follow this pattern (e.g. a plain dev {@code rusefi.srec}). (#9771)
+     */
+    public static String extractTargetFromFirmwareName(String path) {
+        if (path == null) {
+            return null;
+        }
+        final String name = new File(path).getName();
+        final String[] parts = name.split("_");
+        int dateIdx = -1;
+        for (int i = 0; i < parts.length; i++) {
+            if (parts[i].matches("\\d{4}-\\d{2}-\\d{2}")) {
+                dateIdx = i;
+                break;
+            }
+        }
+        if (dateIdx < 0) {
+            return null;
+        }
+        final StringBuilder target = new StringBuilder();
+        boolean foundSignature = false;
+        for (int i = dateIdx + 1; i < parts.length; i++) {
+            if (parts[i].matches("\\d+")) {
+                foundSignature = true;
+                break; // reached the numeric signature — target tokens are done
+            }
+            if (target.length() > 0) {
+                target.append('_');
+            }
+            target.append(parts[i]);
+        }
+        // No numeric signature after the date (e.g. obfuscated builds, or an unrelated name) means there
+        // is no parseable target — return null so callers fall back / don't false-alarm.
+        if (!foundSignature || target.length() == 0) {
+            return null;
+        }
+        return target.toString();
+    }
+
+    /**
+     * Pick the {@code .srec} matching the currently-connected board, falling back to the generic
+     * single-file pick for dev builds / single-board bundles. This is the flash-time entry point that
+     * prevents grabbing another board's leftover image from a shared bundle dir. (#9771)
+     */
+    public static String findSrecFileForConnectedBoard() {
+        final String match = findSrecFileForTarget(com.rusefi.core.io.ConnectedEcuTarget.effectiveTarget());
+        return match != null ? match : findSrecFile();
+    }
+
+    /** @see #findSrecFileForConnectedBoard — same, for the {@code .bin} DFU image. */
+    public static String findFirmwareFileForConnectedBoard() {
+        final String match = findFirmwareFileForTarget(com.rusefi.core.io.ConnectedEcuTarget.effectiveTarget());
+        return match != null ? match : findFirmwareFile();
+    }
+
+    /**
+     * Newest {@code .srec} whose embedded target matches {@code target}, searching the bundle input dir
+     * first, then the {@code older-fw} archive (so a native image displaced there by a foreign download is
+     * recovered rather than lost). Null if none matches. (#9771)
+     */
+    public static String findSrecFileForTarget(String target) {
+        return findFirmwareForTarget(target, ".srec");
+    }
+
+    public static String findFirmwareFileForTarget(String target) {
+        return findFirmwareForTarget(target, ".bin");
+    }
+
+    private static String findFirmwareForTarget(String target, String suffix) {
+        if (target == null || target.trim().isEmpty()) {
+            return null;
+        }
+        for (String dir : new String[]{INPUT_FILES_PATH, RUSEFI_SETTINGS_FOLDER + "older-fw"}) {
+            final String match = newestMatchingTarget(dir, target, suffix);
+            if (match != null) {
+                return match;
+            }
+        }
+        return null;
+    }
+
+    private static String newestMatchingTarget(String dir, String target, String suffix) {
+        final File[] files = new File(dir).listFiles((d, name) -> name.startsWith("rusefi") && name.endsWith(suffix));
+        if (files == null) {
+            return null;
+        }
+        File best = null;
+        for (File f : files) {
+            final String t = extractTargetFromFirmwareName(f.getName());
+            if (t != null && t.equalsIgnoreCase(target) && (best == null || f.lastModified() > best.lastModified())) {
+                best = f;
+            }
+        }
+        return best == null ? null : best.getAbsolutePath();
+    }
 }

--- a/java_console/shared_io/src/main/java/com/rusefi/core/FindFileHelper.java
+++ b/java_console/shared_io/src/main/java/com/rusefi/core/FindFileHelper.java
@@ -136,7 +136,7 @@ public class FindFileHelper {
      * Extract the board target from a firmware artifact file name, e.g.
      * {@code rusefi_development_2026-07-06_uaefi_pro_2528425206_<sha>_update.srec} -> {@code uaefi_pro}.
      * The target is the token(s) between the {@code yyyy-MM-dd} date and the numeric signature. Returns
-     * null for names that don't follow this pattern (e.g. a plain dev {@code rusefi.srec}). (#9771)
+     * null for names that don't follow this pattern (e.g. a plain dev {@code rusefi.srec}). [tag:better_ux_for_flashing]
      */
     public static String extractTargetFromFirmwareName(String path) {
         if (path == null) {
@@ -177,7 +177,7 @@ public class FindFileHelper {
     /**
      * Pick the {@code .srec} matching the currently-connected board, falling back to the generic
      * single-file pick for dev builds / single-board bundles. This is the flash-time entry point that
-     * prevents grabbing another board's leftover image from a shared bundle dir. (#9771)
+     * prevents grabbing another board's leftover image from a shared bundle dir. [tag:better_ux_for_flashing]
      */
     public static String findSrecFileForConnectedBoard() {
         final String match = findSrecFileForTarget(com.rusefi.core.io.ConnectedEcuTarget.effectiveTarget());
@@ -193,7 +193,7 @@ public class FindFileHelper {
     /**
      * Newest {@code .srec} whose embedded target matches {@code target}, searching the bundle input dir
      * first, then the {@code older-fw} archive (so a native image displaced there by a foreign download is
-     * recovered rather than lost). Null if none matches. (#9771)
+     * recovered rather than lost). Null if none matches. [tag:better_ux_for_flashing]
      */
     public static String findSrecFileForTarget(String target) {
         return findFirmwareForTarget(target, ".srec");

--- a/java_console/shared_io/src/main/java/com/rusefi/core/io/ConnectedEcuTarget.java
+++ b/java_console/shared_io/src/main/java/com/rusefi/core/io/ConnectedEcuTarget.java
@@ -38,7 +38,25 @@ public class ConnectedEcuTarget {
      */
     public static String effectiveTarget() {
         String t = connectedTarget;
-        return t != null ? t : BundleUtil.getBundleTarget();
+        if (t != null) {
+            return t;
+        }
+        // No live connection this session (board sitting in a bootloader, or the console was just
+        // restarted): fall back to the last-connected board persisted across sessions before the generic
+        // bundle target, so hardware-kind decisions and the universal-bundle flash guard have the best
+        // available guess. This is only a guess — see isLiveTargetKnown(). (#9771)
+        String persisted = readPersisted();
+        return persisted != null ? persisted : BundleUtil.getBundleTarget();
+    }
+
+    /**
+     * @return true when {@link #effectiveTarget()} is backed by a live connection made this session (a
+     * verified ECU signature), rather than the persisted last-board guess or the bundle default. Callers
+     * that flash firmware must treat an unverified target as unconfirmed (a board in a bootloader cannot
+     * identify itself, and the user may have swapped hardware).
+     */
+    public static boolean isLiveTargetKnown() {
+        return connectedTarget != null;
     }
 
     private static void persist(String ecuTarget) {

--- a/java_console/shared_io/src/main/java/com/rusefi/core/io/ConnectedEcuTarget.java
+++ b/java_console/shared_io/src/main/java/com/rusefi/core/io/ConnectedEcuTarget.java
@@ -44,7 +44,7 @@ public class ConnectedEcuTarget {
         // No live connection this session (board sitting in a bootloader, or the console was just
         // restarted): fall back to the last-connected board persisted across sessions before the generic
         // bundle target, so hardware-kind decisions and the universal-bundle flash guard have the best
-        // available guess. This is only a guess — see isLiveTargetKnown(). (#9771)
+        // available guess. This is only a guess — see isLiveTargetKnown(). [tag:better_ux_for_flashing]
         String persisted = readPersisted();
         return persisted != null ? persisted : BundleUtil.getBundleTarget();
     }

--- a/java_console/shared_io/src/test/java/com/rusefi/core/FindFileHelperTest.java
+++ b/java_console/shared_io/src/test/java/com/rusefi/core/FindFileHelperTest.java
@@ -7,7 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class FindFileHelperTest {
     /**
-     * The target parsed here gates the firmware/board brick guard (#9771), so pin the real artifact
+     * The target parsed here gates the firmware/board brick guard [tag:better_ux_for_flashing], so pin the real artifact
      * shapes: a two-token target, a one-token target, obfuscated (no numeric signature) and dev builds.
      */
     @Test

--- a/java_console/shared_io/src/test/java/com/rusefi/core/FindFileHelperTest.java
+++ b/java_console/shared_io/src/test/java/com/rusefi/core/FindFileHelperTest.java
@@ -1,0 +1,25 @@
+package com.rusefi.core;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class FindFileHelperTest {
+    /**
+     * The target parsed here gates the firmware/board brick guard (#9771), so pin the real artifact
+     * shapes: a two-token target, a one-token target, obfuscated (no numeric signature) and dev builds.
+     */
+    @Test
+    public void extractsTargetFromArtifactName() {
+        assertEquals("uaefi_pro", FindFileHelper.extractTargetFromFirmwareName(
+            "/x/rusefi_development_2026-07-06_uaefi_pro_2528425206_7fb5500a13b00a3da2773de2d3749a4d8ecf03b6_update.srec"));
+        assertEquals("uaefi", FindFileHelper.extractTargetFromFirmwareName(
+            "rusefi_development_2026-07-01_uaefi_496885743_0d74c7f29351a14733ad1de1a72a35f99b1090c6_update.srec"));
+        // No parseable target: obfuscated (no numeric signature) and plain dev builds.
+        assertNull(FindFileHelper.extractTargetFromFirmwareName(
+            "rusefi-development_2026-04-20_ae5ed0955f20e64271039ea6347f8d7f5561cc5f_obfuscated.srec"));
+        assertNull(FindFileHelper.extractTargetFromFirmwareName("rusefi.srec"));
+        assertNull(FindFileHelper.extractTargetFromFirmwareName(null));
+    }
+}

--- a/java_console/shared_io/src/test/java/com/rusefi/core/io/ConnectedEcuTargetTest.java
+++ b/java_console/shared_io/src/test/java/com/rusefi/core/io/ConnectedEcuTargetTest.java
@@ -29,8 +29,12 @@ public class ConnectedEcuTargetTest {
         Field f = ConnectedEcuTarget.class.getDeclaredField("connectedTarget");
         f.setAccessible(true);
         f.set(null, null);
-        // Delete the persisted file so tests start from a clean slate
+        // Ensure the settings dir exists so the tests can write the persisted file (Files.write does
+        // not create parent dirs, and ~/.rusEFI may not exist yet in a clean test env).
         Path p = Paths.get(PERSISTED_FILE);
+        if (p.getParent() != null) {
+            Files.createDirectories(p.getParent());
+        }
         if (Files.exists(p)) {
             Files.delete(p);
         }

--- a/java_console/shared_io/src/test/java/com/rusefi/core/io/ConnectedEcuTargetTest.java
+++ b/java_console/shared_io/src/test/java/com/rusefi/core/io/ConnectedEcuTargetTest.java
@@ -1,0 +1,88 @@
+package com.rusefi.core.io;
+
+import com.rusefi.core.FileUtil;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for the effectiveTarget fallback chain and live-target tracking (#9771).
+ * The real persistence file lives in ~/.rusEFI/last_connected_board.txt, so tests
+ * clean it up between runs and use reflection to reset the in-memory state.
+ */
+public class ConnectedEcuTargetTest {
+
+    private static final String PERSISTED_FILE = FileUtil.RUSEFI_SETTINGS_FOLDER + "last_connected_board.txt";
+
+    @BeforeEach
+    @AfterEach
+    void resetState() throws Exception {
+        // Clear the in-memory live target
+        Field f = ConnectedEcuTarget.class.getDeclaredField("connectedTarget");
+        f.setAccessible(true);
+        f.set(null, null);
+        // Delete the persisted file so tests start from a clean slate
+        Path p = Paths.get(PERSISTED_FILE);
+        if (Files.exists(p)) {
+            Files.delete(p);
+        }
+    }
+
+    @Test
+    void isLiveTargetKnown_falseInitially() {
+        assertFalse(ConnectedEcuTarget.isLiveTargetKnown());
+    }
+
+    @Test
+    void isLiveTargetKnown_trueAfterSet() {
+        ConnectedEcuTarget.set("proteus_f7");
+        assertTrue(ConnectedEcuTarget.isLiveTargetKnown());
+    }
+
+    @Test
+    void effectiveTarget_returnsLiveTargetWhenSet() {
+        ConnectedEcuTarget.set("proteus_f7");
+        assertEquals("proteus_f7", ConnectedEcuTarget.effectiveTarget());
+    }
+
+    @Test
+    void effectiveTarget_fallsBackToBundleWhenNoLiveAndNoPersisted() {
+        // connectedTarget = null (reset), no persisted file
+        String bundleTarget = BundleUtil.getBundleTarget();
+        assertEquals(bundleTarget, ConnectedEcuTarget.effectiveTarget());
+    }
+
+    @Test
+    void effectiveTarget_usesPersistedWhenNoLive() throws Exception {
+        // Write a persisted value
+        Files.write(Paths.get(PERSISTED_FILE), "hellen154hyundai".getBytes());
+        // connectedTarget is still null
+        assertFalse(ConnectedEcuTarget.isLiveTargetKnown());
+        assertEquals("hellen154hyundai", ConnectedEcuTarget.effectiveTarget());
+    }
+
+    @Test
+    void effectiveTarget_liveOverridesPersisted() throws Exception {
+        // Write a persisted value
+        Files.write(Paths.get(PERSISTED_FILE), "hellen154hyundai".getBytes());
+        // Set a live target
+        ConnectedEcuTarget.set("proteus_f7");
+        assertEquals("proteus_f7", ConnectedEcuTarget.effectiveTarget());
+        assertTrue(ConnectedEcuTarget.isLiveTargetKnown());
+    }
+
+    @Test
+    void effectiveTarget_prefersPersistedOverBundle() throws Exception {
+        Files.write(Paths.get(PERSISTED_FILE), "hellen121nissan".getBytes());
+        String result = ConnectedEcuTarget.effectiveTarget();
+        assertEquals("hellen121nissan", result);
+    }
+}

--- a/java_console/shared_io/src/test/java/com/rusefi/core/io/ConnectedEcuTargetTest.java
+++ b/java_console/shared_io/src/test/java/com/rusefi/core/io/ConnectedEcuTargetTest.java
@@ -14,7 +14,7 @@ import java.nio.file.Paths;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * Tests for the effectiveTarget fallback chain and live-target tracking (#9771).
+ * Tests for the effectiveTarget fallback chain and live-target tracking [tag:better_ux_for_flashing].
  * The real persistence file lives in ~/.rusEFI/last_connected_board.txt, so tests
  * clean it up between runs and use reflection to reset the in-memory state.
  */

--- a/java_console/ui/src/main/java/com/rusefi/ConsoleUI.java
+++ b/java_console/ui/src/main/java/com/rusefi/ConsoleUI.java
@@ -308,7 +308,11 @@ console live data tab is broken #8402
             if (UiProperties.isPinoutEnabled()) {
                 tabbedPane.addTab("Pinout", pinoutPane.getContent());
             }
-            DevicePane devicePane = new DevicePane(uiContext, port, serialPortType, tabbedPane.tabbedPane);
+            // Single-session device manager (#9771): the scanner is kept alive for the whole console
+            // lifetime so this one instance can hook / remove / re-connect / DFU / OpenBLT the board.
+            PortResult initialPort = (port != null) ? new PortResult(port, serialPortType) : null;
+            DeviceSessionManager deviceSessionManager = new DeviceSessionManager(uiContext, ConnectivityContext.INSTANCE, initialPort);
+            DevicePane devicePane = new DevicePane(uiContext, deviceSessionManager, tabbedPane.tabbedPane);
             tabbedPane.addTab("Device", devicePane.getContent());
             mainFrame.setUpdateEcuAction(() -> {
                 tabbedPane.selectTab("Device");

--- a/java_console/ui/src/main/java/com/rusefi/ConsoleUI.java
+++ b/java_console/ui/src/main/java/com/rusefi/ConsoleUI.java
@@ -148,6 +148,39 @@ public class ConsoleUI {
         ConnectionStatusIcon connectionStatus = new ConnectionStatusIcon(linkManager, tabbedPane.tabbedPane);
         this.port = port;
 
+        // Follow a renumbered ECU across a bootloader round-trip. After a reboot to DFU/OpenBLT *without*
+        // flashing, the board can re-enumerate onto a different ttyACMx. ConnectionWatchdog.restart() only
+        // retries the original port name (isPortAvailableAgain=false forever), so the live session would
+        // never come back. When the scanner has classified exactly one ECU on a new port and we are not
+        // connected, repoint the LinkManager there. [tag:better_ux_for_flashing]
+        if (!isOffline) {
+            ConnectivityContext.INSTANCE.getSerialPortScanner().addListener(currentHardware -> {
+                if (linkManager.isDisconnectedByUser()) {
+                    return;
+                }
+                if (ConnectionStatusLogic.INSTANCE.isConnected()) {
+                    return;
+                }
+                final String currentPort = linkManager.getLastTriedPort();
+                // Only act once the original port has truly vanished — otherwise the watchdog's same-name
+                // restart() handles the reconnect and we must not fight it.
+                if (currentPort == null || LinkManager.getCommPorts().contains(currentPort)) {
+                    return;
+                }
+                final java.util.List<PortResult> ecuPorts = currentHardware.getKnownPorts(
+                    CompatibilitySet.of(SerialPortType.Ecu, SerialPortType.EcuWithOpenblt));
+                if (ecuPorts.size() != 1) {
+                    return;
+                }
+                final String newPort = ecuPorts.get(0).port;
+                if (newPort.equals(currentPort)) {
+                    return;
+                }
+                log.info("ECU reappeared on " + newPort + " (was " + currentPort + ") — following renumbered port");
+                linkManager.execute(() -> linkManager.reconnect(newPort));
+            });
+        }
+
         // Wizard container and CardLayout for switching between console and wizard modes
         JPanel rootPanel = new JPanel(new CardLayout());
         rootPanel.add(tabbedPane.getContent(), "console");

--- a/java_console/ui/src/main/java/com/rusefi/ConsoleUI.java
+++ b/java_console/ui/src/main/java/com/rusefi/ConsoleUI.java
@@ -144,7 +144,7 @@ public class ConsoleUI {
         tabbedPane = new TabbedPanel(uiContext);
 
         // Pass the tabbed pane so the icon can turn purple when a board is in a DFU/OpenBLT bootloader
-        // (DevicePane publishes the "bootloaderMode" client property on it). (#9771)
+        // (DevicePane publishes the "bootloaderMode" client property on it). [tag:better_ux_for_flashing]
         ConnectionStatusIcon connectionStatus = new ConnectionStatusIcon(linkManager, tabbedPane.tabbedPane);
         this.port = port;
 
@@ -310,7 +310,7 @@ console live data tab is broken #8402
             if (UiProperties.isPinoutEnabled()) {
                 tabbedPane.addTab("Pinout", pinoutPane.getContent());
             }
-            // Single-session device manager (#9771): the scanner is kept alive for the whole console
+            // Single-session device manager [tag:better_ux_for_flashing]: the scanner is kept alive for the whole console
             // lifetime so this one instance can hook / remove / re-connect / DFU / OpenBLT the board.
             PortResult initialPort = (port != null) ? new PortResult(port, serialPortType) : null;
             DeviceSessionManager deviceSessionManager = new DeviceSessionManager(ConnectivityContext.INSTANCE, initialPort);

--- a/java_console/ui/src/main/java/com/rusefi/ConsoleUI.java
+++ b/java_console/ui/src/main/java/com/rusefi/ConsoleUI.java
@@ -151,19 +151,19 @@ public class ConsoleUI {
         // Follow a renumbered ECU across a bootloader round-trip. After a reboot to DFU/OpenBLT *without*
         // flashing, the board can re-enumerate onto a different ttyACMx. ConnectionWatchdog.restart() only
         // retries the original port name (isPortAvailableAgain=false forever), so the live session would
-        // never come back. When the scanner has classified exactly one ECU on a new port and we are not
-        // connected, repoint the LinkManager there. [tag:better_ux_for_flashing]
+        // never come back. When the scanner has classified exactly one ECU on a new port and the port we
+        // were on has vanished, repoint the LinkManager there. [tag:better_ux_for_flashing]
         if (!isOffline) {
             ConnectivityContext.INSTANCE.getSerialPortScanner().addListener(currentHardware -> {
                 if (linkManager.isDisconnectedByUser()) {
                     return;
                 }
-                if (ConnectionStatusLogic.INSTANCE.isConnected()) {
-                    return;
-                }
+                // NB: intentionally NOT gated on ConnectionStatusLogic.isConnected(). After an OpenBLT
+                // switch the status can stay stale "connected", which would block recovery forever.
+                // if the port we were on is gone, the link is
+                // dead regardless of the status flag; while genuinely connected that port is still present
+                // so we skip and let the watchdog's same-name restart() own the reconnect.
                 final String currentPort = linkManager.getLastTriedPort();
-                // Only act once the original port has truly vanished — otherwise the watchdog's same-name
-                // restart() handles the reconnect and we must not fight it.
                 if (currentPort == null || LinkManager.getCommPorts().contains(currentPort)) {
                     return;
                 }

--- a/java_console/ui/src/main/java/com/rusefi/ConsoleUI.java
+++ b/java_console/ui/src/main/java/com/rusefi/ConsoleUI.java
@@ -141,9 +141,11 @@ public class ConsoleUI {
             linkManager.restart();
         };
 
-        ConnectionStatusIcon connectionStatus = new ConnectionStatusIcon(linkManager);
-
         tabbedPane = new TabbedPanel(uiContext);
+
+        // Pass the tabbed pane so the icon can turn purple when a board is in a DFU/OpenBLT bootloader
+        // (DevicePane publishes the "bootloaderMode" client property on it). (#9771)
+        ConnectionStatusIcon connectionStatus = new ConnectionStatusIcon(linkManager, tabbedPane.tabbedPane);
         this.port = port;
 
         // Wizard container and CardLayout for switching between console and wizard modes
@@ -311,7 +313,7 @@ console live data tab is broken #8402
             // Single-session device manager (#9771): the scanner is kept alive for the whole console
             // lifetime so this one instance can hook / remove / re-connect / DFU / OpenBLT the board.
             PortResult initialPort = (port != null) ? new PortResult(port, serialPortType) : null;
-            DeviceSessionManager deviceSessionManager = new DeviceSessionManager(uiContext, ConnectivityContext.INSTANCE, initialPort);
+            DeviceSessionManager deviceSessionManager = new DeviceSessionManager(ConnectivityContext.INSTANCE, initialPort);
             DevicePane devicePane = new DevicePane(uiContext, deviceSessionManager, tabbedPane.tabbedPane);
             tabbedPane.addTab("Device", devicePane.getContent());
             mainFrame.setUpdateEcuAction(() -> {

--- a/java_console/ui/src/main/java/com/rusefi/DevicePane.java
+++ b/java_console/ui/src/main/java/com/rusefi/DevicePane.java
@@ -132,6 +132,10 @@ public class DevicePane {
             selectDeviceTab();
             statusPanel.clear();
             statusPanel.log(bootloaderGuidance(state), true, false);
+        } else if (state == SessionState.CONNECTED && lastRenderedState != SessionState.CONNECTED) {
+            // Board is a live ECU again (e.g. it rebooted to firmware after a flash) — clear any stale
+            // "Board is in the … bootloader" hint left in the status log. [tag:better_ux_for_flashing]
+            statusPanel.clear();
         }
     }
 

--- a/java_console/ui/src/main/java/com/rusefi/DevicePane.java
+++ b/java_console/ui/src/main/java/com/rusefi/DevicePane.java
@@ -13,7 +13,7 @@ import java.util.Collections;
 import java.util.List;
 
 /**
- * The live console's "Device" tab — a single-session device manager (#9771).
+ * The live console's "Device" tab — a single-session device manager [tag:better_ux_for_flashing].
  * <p>
  * Instead of being frozen with the port/type it was opened with, this tab subscribes to
  * {@link DeviceSessionManager} and re-renders on every hardware/state change, so one running console
@@ -32,7 +32,7 @@ public class DevicePane {
     private final SingleAsyncJobExecutor jobExecutor;
     private final StatusPanelWithProgressBar statusPanel = new StatusPanelWithProgressBar();
     // Previous state rendered on the EDT — used to detect the *transition* into a bootloader state so we
-    // pull focus to the Device tab only once, not on every scan cycle (#9771).
+    // pull focus to the Device tab only once, not on every scan cycle [tag:better_ux_for_flashing].
     private SessionState lastRenderedState;
 
     public DevicePane(final UIContext uiContext, final DeviceSessionManager sessionManager, final JTabbedPane tabbedPane) {
@@ -53,7 +53,7 @@ public class DevicePane {
         // sits at the bottom of the pane (as elsewhere in the console). No connect/disconnect here — the
         // auto-connect watchdog owns the connection; this tab is just firmware updates. comboPorts is
         // kept only as a populated *model* feeding ProgramSelector's flash target (no visible picker
-        // needed for the single-board case). (#9771)
+        // needed for the single-board case). [tag:better_ux_for_flashing]
         content.setLayout(new BorderLayout());
         JPanel column = new JPanel();
         column.setLayout(new BoxLayout(column, BoxLayout.Y_AXIS));
@@ -103,7 +103,7 @@ public class DevicePane {
 
         // The board is a usable live ECU only in CONNECTED. While it is being flashed or sits in a
         // DFU/OpenBLT bootloader, the live tabs show frozen/stale data — lock them and (on entry) pull
-        // the user to the Device tab so the only offered action is a firmware update. (#9771)
+        // the user to the Device tab so the only offered action is a firmware update. [tag:better_ux_for_flashing]
         lockConsoleForState(state);
 
         lastRenderedState = state;
@@ -127,7 +127,7 @@ public class DevicePane {
         }
         // Only on the transition into a bootloader state: pull focus to Device once
         // and drop a one-line hint into the status log, which replaces the old
-        // status label. (#9771)
+        // status label. [tag:better_ux_for_flashing]
         if (bootloaderPresent && !isBootloaderState(lastRenderedState)) {
             selectDeviceTab();
             statusPanel.clear();
@@ -195,7 +195,7 @@ public class DevicePane {
 
     // Tabs usable without a live ECU: the Device tab (hosts the update controls), offline tune editing
     // ("Tuning") and the pinout reference. These stay enabled while the board is in a bootloader or being
-    // flashed; only the live-data tabs get locked. (#9771)
+    // flashed; only the live-data tabs get locked. [tag:better_ux_for_flashing]
     private static boolean isOfflineCapableTab(final String title) {
         return "Device".equals(title) || "Tuning".equals(title) || "Pinout".equals(title);
     }

--- a/java_console/ui/src/main/java/com/rusefi/DevicePane.java
+++ b/java_console/ui/src/main/java/com/rusefi/DevicePane.java
@@ -1,90 +1,207 @@
 package com.rusefi;
 
 import com.rusefi.core.preferences.storage.PersistentConfiguration;
-import com.rusefi.maintenance.jobs.AsyncJobExecutor;
-import com.rusefi.maintenance.jobs.OpenBltAutoJob;
-import com.rusefi.maintenance.jobs.OpenBltSwitchJob;
+import com.rusefi.maintenance.ProgramSelector;
 import com.rusefi.ui.UIContext;
 import com.rusefi.ui.basic.MigrateSettingsCheckboxState;
+import com.rusefi.ui.basic.SingleAsyncJobExecutor;
 import com.rusefi.ui.basic.StatusPanelWithProgressBar;
 
 import javax.swing.*;
 import java.awt.*;
+import java.util.Collections;
+import java.util.List;
 
+/**
+ * The live console's "Device" tab — a single-session device manager (#9771).
+ * <p>
+ * Instead of being frozen with the port/type it was opened with, this tab subscribes to
+ * {@link DeviceSessionManager} and re-renders on every hardware/state change, so one running console
+ * can hook / remove / re-connect an ECU and flash it via DFU or OpenBLT without a restart. Firmware
+ * operations reuse {@link ProgramSelector} (which already builds the DFU/OpenBLT menu from the detected
+ * {@link AvailableHardware}). The connection lifecycle itself is owned by the auto-connect watchdog —
+ * this tab only offers firmware updates and locks the live tabs while the board isn't a usable ECU.
+ */
 public class DevicePane {
     private final JPanel content = new JPanel();
-    private JButton autoUpdateButton;
+    private final DeviceSessionManager sessionManager;
+    private final JTabbedPane tabbedPane;
 
-    public DevicePane(UIContext uiContext, String port, SerialPortType serialPortType, JTabbedPane tabbedPane) {
-        content.setLayout(new BoxLayout(content, BoxLayout.Y_AXIS));
+    private final JComboBox<PortResult> comboPorts = new JComboBox<>();
+    private final ProgramSelector selector;
+    private final SingleAsyncJobExecutor jobExecutor;
+    private final StatusPanelWithProgressBar statusPanel = new StatusPanelWithProgressBar();
+    // Previous state rendered on the EDT — used to detect the *transition* into a bootloader state so we
+    // pull focus to the Device tab only once, not on every scan cycle (#9771).
+    private SessionState lastRenderedState;
+
+    public DevicePane(final UIContext uiContext, final DeviceSessionManager sessionManager, final JTabbedPane tabbedPane) {
+        this.sessionManager = sessionManager;
+        this.tabbedPane = tabbedPane;
+
+        // Firmware jobs run on a per-tab single executor whose output is the status/progress panel.
+        // Tab-locking is driven by render() off the session state (which already includes FLASHING as
+        // well as the DFU/OpenBLT bootloader states), so no separate job-executor listeners are needed.
+        this.jobExecutor = new SingleAsyncJobExecutor(statusPanel);
+        sessionManager.setJobExecutor(jobExecutor);
+
+        this.selector = new ProgramSelector(ConnectivityContext.INSTANCE, comboPorts);
+        selector.setJobExecutor(jobExecutor);
+        selector.setLinkManager(uiContext.getLinkManager());
+
+        // Compact controls pinned to the top; the status log + progress bar fill the rest and the bar
+        // sits at the bottom of the pane (as elsewhere in the console). No connect/disconnect here — the
+        // auto-connect watchdog owns the connection; this tab is just firmware updates. comboPorts is
+        // kept only as a populated *model* feeding ProgramSelector's flash target (no visible picker
+        // needed for the single-board case). (#9771)
+        content.setLayout(new BorderLayout());
+        JPanel column = new JPanel();
+        column.setLayout(new BoxLayout(column, BoxLayout.Y_AXIS));
+        content.add(column, BorderLayout.NORTH);
+
         JCheckBox autoUpdateBundle = new JCheckBox("Auto-update bundle", AutoupdateProperty.get());
-        autoUpdateBundle.addActionListener(e -> PersistentConfiguration.setBoolProperty(AutoupdateProperty.AUTO_UPDATE_BUNDLE_PROPERTY, autoUpdateBundle.isSelected()));
-        content.add(autoUpdateBundle);
+        autoUpdateBundle.setAlignmentX(Component.LEFT_ALIGNMENT);
+        autoUpdateBundle.addActionListener(e -> PersistentConfiguration.setBoolProperty(
+            AutoupdateProperty.AUTO_UPDATE_BUNDLE_PROPERTY, autoUpdateBundle.isSelected()));
+        column.add(autoUpdateBundle);
 
         JCheckBox migrateSettings = new JCheckBox("Migrate Settings", true);
+        migrateSettings.setAlignmentX(Component.LEFT_ALIGNMENT);
         migrateSettings.addActionListener(e -> MigrateSettingsCheckboxState.isMigrationNeeded = migrateSettings.isSelected());
         MigrateSettingsCheckboxState.isMigrationNeeded = true;
-        content.add(migrateSettings);
+        column.add(migrateSettings);
 
-        JPanel buttons = new JPanel(new FlowLayout(FlowLayout.LEFT, 0, 0));
-        content.add(buttons);
+        JComponent selectorControl = selector.getControl();
+        selectorControl.setAlignmentX(Component.LEFT_ALIGNMENT);
+        column.add(selectorControl);
 
-        StatusPanelWithProgressBar statusPanel = new StatusPanelWithProgressBar();
-        content.add(statusPanel.getContent());
+        // Status log fills the middle; the StatusPanelWithProgressBar keeps its progress bar at the
+        // very bottom of the pane.
+        content.add(statusPanel.getContent(), BorderLayout.CENTER);
 
-        if (serialPortType == SerialPortType.Ecu) {
-            buttons.add(new JLabel("Legacy Device Without OpenBLT"));
-        } else if (serialPortType == SerialPortType.EcuWithOpenblt) {
-            JButton switchButton = new JButton("Switch to OpenBLT");
-            autoUpdateButton = new JButton("Auto Update Firmware");
-            JButton autoButton = autoUpdateButton;
+        sessionManager.addListener((state, hardware) -> SwingUtilities.invokeLater(() -> render(state, hardware)));
+    }
 
-            switchButton.addActionListener(e -> {
-                switchButton.setEnabled(false);
-                autoButton.setEnabled(false);
-                statusPanel.clear();
-                OpenBltSwitchJob job = new OpenBltSwitchJob(new PortResult(port, serialPortType), content, uiContext.getLinkManager());
-                AsyncJobExecutor.INSTANCE.executeJob(job, statusPanel, () -> SwingUtilities.invokeLater(() -> {
-                    switchButton.setEnabled(true);
-                    autoButton.setEnabled(true);
-                }));
-            });
-            buttons.add(switchButton);
+    private void render(final SessionState state, final AvailableHardware hardware) {
+        final AvailableHardware effectiveHardware = (hardware != null)
+            ? hardware
+            : ConnectivityContext.INSTANCE.getCurrentHardware();
 
-            autoButton.addActionListener(e -> {
-                switchButton.setEnabled(false);
-                autoButton.setEnabled(false);
-                statusPanel.clear();
-                setNonDeviceTabsEnabled(tabbedPane, false);
-                if (tabbedPane != null) {
-                    tabbedPane.putClientProperty("isUpdating", Boolean.TRUE);
-                    tabbedPane.repaint();
-                }
-                OpenBltAutoJob job = new OpenBltAutoJob(new PortResult(port, serialPortType), content, ConnectivityContext.INSTANCE, uiContext.getLinkManager());
-                AsyncJobExecutor.INSTANCE.executeJob(job, statusPanel, () -> SwingUtilities.invokeLater(() -> {
-                    switchButton.setEnabled(true);
-                    autoButton.setEnabled(true);
-                    setNonDeviceTabsEnabled(tabbedPane, true);
-                    if (tabbedPane != null) {
-                        tabbedPane.putClientProperty("isUpdating", Boolean.FALSE);
-                        tabbedPane.repaint();
-                    }
-                }));
-            });
-            buttons.add(autoButton);
+        // Repopulate the ports combo, preserving the current selection where possible.
+        final PortResult previouslySelected = (PortResult) comboPorts.getSelectedItem();
+        final List<PortResult> ports = (effectiveHardware != null)
+            ? effectiveHardware.getKnownPorts()
+            : Collections.emptyList();
+        comboPorts.removeAllItems();
+        for (final PortResult port : ports) {
+            comboPorts.addItem(port);
+        }
+        reselectPort(ports, previouslySelected);
+
+        // ProgramSelector builds the DFU / OpenBLT menu straight from the detected hardware.
+        selector.apply(effectiveHardware);
+
+        // The board is a usable live ECU only in CONNECTED. While it is being flashed or sits in a
+        // DFU/OpenBLT bootloader, the live tabs show frozen/stale data — lock them and (on entry) pull
+        // the user to the Device tab so the only offered action is a firmware update. (#9771)
+        lockConsoleForState(state);
+
+        lastRenderedState = state;
+        content.revalidate();
+        content.repaint();
+    }
+
+    private void lockConsoleForState(final SessionState state) {
+        final boolean flashing = state == SessionState.FLASHING;
+        final boolean bootloaderPresent = isBootloaderState(state);
+        setNonDeviceTabsEnabled(!(flashing || bootloaderPresent));
+        if (tabbedPane != null) {
+            // Frame blink (#9715) signals an update *in progress* — only while actually flashing, not
+            // while merely waiting in a bootloader for the user to start the update.
+            tabbedPane.putClientProperty("isUpdating", flashing);
+            tabbedPane.repaint();
+        }
+        // Only on the transition into a bootloader state: pull focus to Device once (don't yank the user
+        // back every scan cycle) and drop a one-line hint into the status log, which replaces the old
+        // status label. (#9771)
+        if (bootloaderPresent && !isBootloaderState(lastRenderedState)) {
+            selectDeviceTab();
+            statusPanel.clear();
+            statusPanel.log(bootloaderGuidance(state), true, false);
         }
     }
 
-    public void triggerAutoUpdate() {
-        if (autoUpdateButton != null && autoUpdateButton.isEnabled()) {
-            autoUpdateButton.doClick();
+    private static String bootloaderGuidance(final SessionState state) {
+        if (state == SessionState.DEVICE_IN_DFU) {
+            // DFU flashing is Windows-only in rusEFI (STM32_Programmer_CLI.exe); elsewhere it's a dead end.
+            return FileLog.isWindows()
+                ? "Board is in the DFU bootloader — click Update Firmware to flash."
+                : "Board is in the DFU bootloader. DFU flashing requires Windows — power-cycle to exit, or use OpenBLT.";
         }
+        return "Board is in the OpenBLT bootloader — click Update Firmware to flash.";
     }
 
-    private static void setNonDeviceTabsEnabled(JTabbedPane tabbedPane, boolean enabled) {
-        if (tabbedPane == null) return;
+    private static boolean isBootloaderState(final SessionState state) {
+        return state == SessionState.DEVICE_IN_DFU || state == SessionState.DEVICE_IN_BLT;
+    }
+
+    private void selectDeviceTab() {
+        if (tabbedPane == null) {
+            return;
+        }
         for (int i = 0; i < tabbedPane.getTabCount(); i++) {
-            if (!"Device".equals(tabbedPane.getTitleAt(i))) {
+            if ("Device".equals(tabbedPane.getTitleAt(i))) {
+                tabbedPane.setSelectedIndex(i);
+                return;
+            }
+        }
+    }
+
+    private void reselectPort(final List<PortResult> ports, final PortResult previouslySelected) {
+        if (previouslySelected != null) {
+            for (final PortResult port : ports) {
+                if (port.port.equals(previouslySelected.port)) {
+                    comboPorts.setSelectedItem(port);
+                    return;
+                }
+            }
+        }
+        // No prior selection (or it disappeared): prefer the first connectable ECU.
+        for (final PortResult port : ports) {
+            if (port.isEcu()) {
+                comboPorts.setSelectedItem(port);
+                return;
+            }
+        }
+        if (!ports.isEmpty()) {
+            comboPorts.setSelectedIndex(0);
+        }
+    }
+
+    /**
+     * Programmatically start a firmware update (used by the "Update ECU" menu shortcut). No-op while a
+     * job is already running or when there is no connectable port.
+     */
+    public void triggerAutoUpdate() {
+        if (sessionManager.getState() == SessionState.FLASHING) {
+            return;
+        }
+        selector.triggerUpdateFirmware();
+    }
+
+    // Tabs usable without a live ECU: the Device tab (hosts the update controls), offline tune editing
+    // ("Tuning") and the pinout reference. These stay enabled while the board is in a bootloader or being
+    // flashed; only the live-data tabs get locked. (#9771)
+    private static boolean isOfflineCapableTab(final String title) {
+        return "Device".equals(title) || "Tuning".equals(title) || "Pinout".equals(title);
+    }
+
+    private void setNonDeviceTabsEnabled(final boolean enabled) {
+        if (tabbedPane == null) {
+            return;
+        }
+        for (int i = 0; i < tabbedPane.getTabCount(); i++) {
+            if (!isOfflineCapableTab(tabbedPane.getTitleAt(i))) {
                 tabbedPane.setEnabledAt(i, enabled);
             }
         }

--- a/java_console/ui/src/main/java/com/rusefi/DevicePane.java
+++ b/java_console/ui/src/main/java/com/rusefi/DevicePane.java
@@ -119,10 +119,14 @@ public class DevicePane {
             // Frame blink (#9715) signals an update *in progress* — only while actually flashing, not
             // while merely waiting in a bootloader for the user to start the update.
             tabbedPane.putClientProperty("isUpdating", flashing);
+            // Surface the bootloader state to the window title
+            tabbedPane.putClientProperty("bootloaderMode",
+                state == SessionState.DEVICE_IN_DFU ? "DFU"
+                    : state == SessionState.DEVICE_IN_BLT ? "OpenBLT" : null);
             tabbedPane.repaint();
         }
-        // Only on the transition into a bootloader state: pull focus to Device once (don't yank the user
-        // back every scan cycle) and drop a one-line hint into the status log, which replaces the old
+        // Only on the transition into a bootloader state: pull focus to Device once
+        // and drop a one-line hint into the status log, which replaces the old
         // status label. (#9771)
         if (bootloaderPresent && !isBootloaderState(lastRenderedState)) {
             selectDeviceTab();

--- a/java_console/ui/src/main/java/com/rusefi/DeviceSessionManager.java
+++ b/java_console/ui/src/main/java/com/rusefi/DeviceSessionManager.java
@@ -1,0 +1,172 @@
+package com.rusefi;
+
+import com.rusefi.io.ConnectionStatusLogic;
+import com.rusefi.io.ConnectionStatusValue;
+import com.rusefi.io.LinkManager;
+import com.rusefi.ui.UIContext;
+import com.rusefi.ui.basic.SingleAsyncJobExecutor;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+/**
+ * Window-independent owner of the "one console, all device states" session (#9771).
+ * <p>
+ * A single console instance must handle every board transition — hook, remove, hook-in-DFU,
+ * hook-in-OpenBLT, re-connect — without a restart. To do that the {@link SerialPortScanner} is kept
+ * alive for the whole console lifetime (instead of being stopped at splash → console handoff), and
+ * this manager derives a single {@link SessionState} from {@link ConnectionStatusLogic} plus the most
+ * recent {@link AvailableHardware} snapshot. UI (e.g. the live console's Device tab) subscribes and
+ * reflects the current reality, offering connect / disconnect / DFU / OpenBLT as appropriate.
+ * <p>
+ * Threading: {@link Listener#onSessionChanged} may be invoked off the EDT (the scanner and the
+ * connection-status pub/sub both fire from background threads). Swing consumers must marshal to the
+ * EDT themselves.
+ */
+public class DeviceSessionManager {
+    public interface Listener {
+        void onSessionChanged(SessionState state, AvailableHardware hardware);
+    }
+
+    private final UIContext uiContext;
+    private final ConnectivityContext connectivityContext;
+    private volatile SingleAsyncJobExecutor jobExecutor;
+
+    private final List<Listener> listeners = new CopyOnWriteArrayList<>();
+
+    private volatile SessionState state = SessionState.DISCONNECTED;
+    private volatile AvailableHardware currentHardware;
+    // The board this session intends to be connected to; re-cached on CONNECTED so the always-on
+    // scanner never re-probes the live port (#9771).
+    private volatile PortResult sessionPort;
+
+    public DeviceSessionManager(final UIContext uiContext,
+                                final ConnectivityContext connectivityContext,
+                                final PortResult initialPort) {
+        this.uiContext = uiContext;
+        this.connectivityContext = connectivityContext;
+        this.currentHardware = connectivityContext.getCurrentHardware();
+        this.sessionPort = initialPort;
+        this.state = computeState();
+
+        // The console keeps the scanner alive for the whole session. Pre-cache the live-connected port
+        // BEFORE the scanner is (re)started by addListener below, so the scanner never opens the port
+        // that our BinaryProtocol connection is actively reading — that race hangs the live read on
+        // Windows (mirrors the offline-tune cachePort in StartupFrame#onSplashConnected). [tag:offline_tune]
+        if (initialPort != null && !LinkManager.isSpecialNotSerial(initialPort.port)) {
+            connectivityContext.getSerialPortScanner().cachePort(initialPort);
+        }
+
+        connectivityContext.getSerialPortScanner().addListener(hardware -> {
+            this.currentHardware = hardware;
+            recomputeAndBroadcast();
+        });
+        ConnectionStatusLogic.INSTANCE.addListener(isConnected -> recomputeAndBroadcast());
+    }
+
+    /**
+     * Wire the Device tab's firmware-job executor so the session can report {@link SessionState#FLASHING}
+     * while a DFU/OpenBLT job owns the port. The executor is created by the Device tab (it owns the
+     * status/progress sink), so it is injected after construction.
+     */
+    public void setJobExecutor(final SingleAsyncJobExecutor jobExecutor) {
+        this.jobExecutor = jobExecutor;
+        if (jobExecutor != null) {
+            jobExecutor.addOnJobAboutToStartListener(this::refresh);
+            jobExecutor.addOnJobInProgressFinishedListener(this::refresh);
+        }
+        refresh();
+    }
+
+    /**
+     * Recompute the session state from the latest inputs and broadcast. Safe to call from any thread.
+     */
+    public void refresh() {
+        recomputeAndBroadcast();
+    }
+
+    private SessionState computeState() {
+        if (jobExecutor != null && !jobExecutor.isNotInProgress()) {
+            return SessionState.FLASHING;
+        }
+        final ConnectionStatusValue connectionValue = ConnectionStatusLogic.INSTANCE.getValue();
+        if (connectionValue == ConnectionStatusValue.CONNECTED) {
+            return SessionState.CONNECTED;
+        }
+        if (connectionValue == ConnectionStatusValue.LOADING) {
+            return SessionState.CONNECTING;
+        }
+        // NOT_CONNECTED: inspect the detected hardware for a board sitting in a bootloader state.
+        final AvailableHardware hardware = currentHardware;
+        if (hardware != null) {
+            if (!hardware.getKnownPorts(SerialPortType.OpenBlt).isEmpty()) {
+                return SessionState.DEVICE_IN_BLT;
+            }
+            if (hardware.isDfuFound()) {
+                return SessionState.DEVICE_IN_DFU;
+            }
+        }
+        return SessionState.DISCONNECTED;
+    }
+
+    private void recomputeAndBroadcast() {
+        this.state = computeState();
+        if (this.state == SessionState.CONNECTED) {
+            // Re-cache the live port so the always-on scanner never re-probes it. The cache is cleared
+            // when a port disappears (retainAll in the scanner), so a disconnect/replug reconnect must
+            // re-cache here or the scanner races the live BinaryProtocol read and hangs on Windows. (#9771)
+            final PortResult live = sessionPort;
+            if (live != null && !LinkManager.isSpecialNotSerial(live.port)) {
+                connectivityContext.getSerialPortScanner().cachePort(live);
+            }
+        }
+        // Always broadcast: even when the state label is unchanged the hardware snapshot may have
+        // changed (a new port appeared/disappeared), and the Device tab drives its ports combo and
+        // ProgramSelector menu off that snapshot.
+        final SessionState snapshotState = this.state;
+        final AvailableHardware snapshotHardware = this.currentHardware;
+        for (final Listener listener : listeners) {
+            listener.onSessionChanged(snapshotState, snapshotHardware);
+        }
+    }
+
+    public void addListener(final Listener listener) {
+        listeners.add(listener);
+        // Deliver the current snapshot immediately so a late subscriber renders correctly.
+        listener.onSessionChanged(state, currentHardware);
+    }
+
+    public SessionState getState() {
+        return state;
+    }
+
+    /**
+     * Connect to the given board. #9771: honours the Device tab's port selection so a board re-hooked on
+     * a different port connects to *that* port instead of blindly resuming the previous one. A non-ECU
+     * selection (DFU / OpenBLT / Unknown) is a flash target, not a connect target, so fall back to
+     * resuming the previous live ECU.
+     */
+    public void connect(final PortResult port) {
+        if (port != null && port.isEcu()) {
+            this.sessionPort = port;
+            uiContext.getLinkManager().reconnect(port.port);
+        } else {
+            uiContext.getLinkManager().reconnect();
+        }
+    }
+
+    /**
+     * User-initiated disconnect of the live ECU connection. The scanner stays alive so the board can
+     * be re-detected (and re-connected, or flashed in DFU/OpenBLT) without restarting the console.
+     */
+    public void disconnect() {
+        uiContext.getLinkManager().disconnect();
+    }
+
+    /**
+     * User-initiated reconnect of the previous live ECU (resumes {@code lastTriedPort}).
+     */
+    public void reconnect() {
+        uiContext.getLinkManager().reconnect();
+    }
+}

--- a/java_console/ui/src/main/java/com/rusefi/DeviceSessionManager.java
+++ b/java_console/ui/src/main/java/com/rusefi/DeviceSessionManager.java
@@ -2,8 +2,8 @@ package com.rusefi;
 
 import com.rusefi.io.ConnectionStatusLogic;
 import com.rusefi.io.ConnectionStatusValue;
+import com.rusefi.io.ConnectionWatchdog;
 import com.rusefi.io.LinkManager;
-import com.rusefi.ui.UIContext;
 import com.rusefi.ui.basic.SingleAsyncJobExecutor;
 
 import java.util.List;
@@ -28,7 +28,6 @@ public class DeviceSessionManager {
         void onSessionChanged(SessionState state, AvailableHardware hardware);
     }
 
-    private final UIContext uiContext;
     private final ConnectivityContext connectivityContext;
     private volatile SingleAsyncJobExecutor jobExecutor;
 
@@ -40,10 +39,8 @@ public class DeviceSessionManager {
     // scanner never re-probes the live port (#9771).
     private volatile PortResult sessionPort;
 
-    public DeviceSessionManager(final UIContext uiContext,
-                                final ConnectivityContext connectivityContext,
+    public DeviceSessionManager(final ConnectivityContext connectivityContext,
                                 final PortResult initialPort) {
-        this.uiContext = uiContext;
         this.connectivityContext = connectivityContext;
         this.currentHardware = connectivityContext.getCurrentHardware();
         this.sessionPort = initialPort;
@@ -72,8 +69,19 @@ public class DeviceSessionManager {
     public void setJobExecutor(final SingleAsyncJobExecutor jobExecutor) {
         this.jobExecutor = jobExecutor;
         if (jobExecutor != null) {
+            // Pause the watchdog during a flash job so it does not race the flasher for the port. (#9771)
+            jobExecutor.addOnJobAboutToStartListener(() -> ConnectionWatchdog.pause());
             jobExecutor.addOnJobAboutToStartListener(this::refresh);
-            jobExecutor.addOnJobInProgressFinishedListener(this::refresh);
+            jobExecutor.addOnJobInProgressFinishedListener(() -> {
+                // Flash finished (success or failure): immediately resume the scanner and force a fresh
+                // scan so the UI can detect the board's post-flash state (OpenBLT/DFU) and offer retry
+                // options. (#9771)
+                final SerialPortScanner scanner = connectivityContext.getSerialPortScanner();
+                scanner.resume();
+                scanner.restartTimer();
+                refresh();
+                ConnectionWatchdog.resume();
+            });
         }
         refresh();
     }
@@ -140,33 +148,4 @@ public class DeviceSessionManager {
         return state;
     }
 
-    /**
-     * Connect to the given board. #9771: honours the Device tab's port selection so a board re-hooked on
-     * a different port connects to *that* port instead of blindly resuming the previous one. A non-ECU
-     * selection (DFU / OpenBLT / Unknown) is a flash target, not a connect target, so fall back to
-     * resuming the previous live ECU.
-     */
-    public void connect(final PortResult port) {
-        if (port != null && port.isEcu()) {
-            this.sessionPort = port;
-            uiContext.getLinkManager().reconnect(port.port);
-        } else {
-            uiContext.getLinkManager().reconnect();
-        }
-    }
-
-    /**
-     * User-initiated disconnect of the live ECU connection. The scanner stays alive so the board can
-     * be re-detected (and re-connected, or flashed in DFU/OpenBLT) without restarting the console.
-     */
-    public void disconnect() {
-        uiContext.getLinkManager().disconnect();
-    }
-
-    /**
-     * User-initiated reconnect of the previous live ECU (resumes {@code lastTriedPort}).
-     */
-    public void reconnect() {
-        uiContext.getLinkManager().reconnect();
-    }
 }

--- a/java_console/ui/src/main/java/com/rusefi/DeviceSessionManager.java
+++ b/java_console/ui/src/main/java/com/rusefi/DeviceSessionManager.java
@@ -10,7 +10,7 @@ import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
- * Window-independent owner of the "one console, all device states" session (#9771).
+ * Window-independent owner of the "one console, all device states" session [tag:better_ux_for_flashing].
  * <p>
  * A single console instance must handle every board transition — hook, remove, hook-in-DFU,
  * hook-in-OpenBLT, re-connect — without a restart. To do that the {@link SerialPortScanner} is kept
@@ -36,7 +36,7 @@ public class DeviceSessionManager {
     private volatile SessionState state = SessionState.DISCONNECTED;
     private volatile AvailableHardware currentHardware;
     // The board this session intends to be connected to; re-cached on CONNECTED so the always-on
-    // scanner never re-probes the live port (#9771).
+    // scanner never re-probes the live port [tag:better_ux_for_flashing].
     private volatile PortResult sessionPort;
 
     public DeviceSessionManager(final ConnectivityContext connectivityContext,
@@ -69,13 +69,13 @@ public class DeviceSessionManager {
     public void setJobExecutor(final SingleAsyncJobExecutor jobExecutor) {
         this.jobExecutor = jobExecutor;
         if (jobExecutor != null) {
-            // Pause the watchdog during a flash job so it does not race the flasher for the port. (#9771)
+            // Pause the watchdog during a flash job so it does not race the flasher for the port. [tag:better_ux_for_flashing]
             jobExecutor.addOnJobAboutToStartListener(() -> ConnectionWatchdog.pause());
             jobExecutor.addOnJobAboutToStartListener(this::refresh);
             jobExecutor.addOnJobInProgressFinishedListener(() -> {
                 // Flash finished (success or failure): immediately resume the scanner and force a fresh
                 // scan so the UI can detect the board's post-flash state (OpenBLT/DFU) and offer retry
-                // options. (#9771)
+                // options. [tag:better_ux_for_flashing]
                 final SerialPortScanner scanner = connectivityContext.getSerialPortScanner();
                 scanner.resume();
                 scanner.restartTimer();
@@ -122,7 +122,7 @@ public class DeviceSessionManager {
         if (this.state == SessionState.CONNECTED) {
             // Re-cache the live port so the always-on scanner never re-probes it. The cache is cleared
             // when a port disappears (retainAll in the scanner), so a disconnect/replug reconnect must
-            // re-cache here or the scanner races the live BinaryProtocol read and hangs on Windows. (#9771)
+            // re-cache here or the scanner races the live BinaryProtocol read and hangs on Windows. [tag:better_ux_for_flashing]
             final PortResult live = sessionPort;
             if (live != null && !LinkManager.isSpecialNotSerial(live.port)) {
                 connectivityContext.getSerialPortScanner().cachePort(live);

--- a/java_console/ui/src/main/java/com/rusefi/SerialPortScanner.java
+++ b/java_console/ui/src/main/java/com/rusefi/SerialPortScanner.java
@@ -261,7 +261,7 @@ public enum SerialPortScanner {
             ports.add(new PortResult(LinkManager.SOCKET_CAN, SerialPortType.CAN));
 */
         // Surface a DFU device (STM32 built-in bootloader) as a synthetic, non-connectable port so a
-        // running console can offer DFU flashing in-session (#9771). dfuConnected stays exposed via
+        // running console can offer DFU flashing in-session [tag:better_ux_for_flashing]. dfuConnected stays exposed via
         // AvailableHardware.isDfuFound() for the existing ProgramSelector menu logic.
         if (dfuConnected) {
             ports.add(new PortResult(LinkManager.DFU, SerialPortType.Dfu));

--- a/java_console/ui/src/main/java/com/rusefi/SerialPortScanner.java
+++ b/java_console/ui/src/main/java/com/rusefi/SerialPortScanner.java
@@ -77,14 +77,27 @@ public enum SerialPortScanner {
     static PortResult inspectPort(String serialPort) {
         log.info("Determining type of serial port: " + serialPort);
 
-        boolean isOpenblt = isPortOpenblt(serialPort);
+        boolean isOpenblt;
+        try {
+            isOpenblt = isPortOpenblt(serialPort);
+        } catch (com.fazecast.jSerialComm.SerialPortInvalidPortException e) {
+            // Return null so inspectPorts filters them out entirely. [tag:better_ux_for_flashing]
+            log.info("Port " + serialPort + " is not actually available (stale OS node): " + e.getMessage());
+            return null;
+        }
         log.info("Port " + serialPort + (isOpenblt ? " looks like" : " does not look like") + " an OpenBLT bootloader");
         if (isOpenblt) {
             return new PortResult(serialPort, SerialPortType.OpenBlt);
         }
 
         for (int attempt = 1; attempt <= DETECT_MAX_ATTEMPTS; attempt++) {
-            final Optional<CalibrationsInfo> ecuCalibrations = getEcuCalibrations(serialPort);
+            final Optional<CalibrationsInfo> ecuCalibrations;
+            try {
+                ecuCalibrations = getEcuCalibrations(serialPort);
+            } catch (com.fazecast.jSerialComm.SerialPortInvalidPortException e) {
+                log.info("Port " + serialPort + " vanished during ECU detection: " + e.getMessage());
+                return null;
+            }
             final boolean isEcu = ecuCalibrations.isPresent();
             log.info("Port " + serialPort + " ECU detection attempt " + attempt + "/" + DETECT_MAX_ATTEMPTS
                 + ": " + (isEcu ? "found" : "not found"));
@@ -111,7 +124,12 @@ public enum SerialPortScanner {
         return new PortResult(serialPort, SerialPortType.Unknown);
     }
 
-    static List<PortResult> inspectPorts(final List<String> ports) {
+    // Track in-flight probe threads so suspend() can interrupt them and wait
+    // for them to release the port before a flash job proceeds.
+    // [tag:better_ux_for_flashing]
+    private final List<Thread> probeThreads = Collections.synchronizedList(new ArrayList<>());
+
+    static List<PortResult> inspectPorts(final List<String> ports, final List<Thread> probeThreadsRef) {
         if (ports.isEmpty()) {
             return new ArrayList<>();
         }
@@ -132,9 +150,9 @@ public enum SerialPortScanner {
                 try {
                     r = inspectPort(p);
                 } catch (Throwable e) {
-                    // Never let a probe exception (e.g. jSerialComm SerialPortInvalidPortException on a
-                    // vanishing/re-enumerating port) kill the inspect thread and lose the result — record
-                    // Unknown and move on. [tag:better_ux_for_flashing]
+                    // Never let a probe exception kill the inspect thread.
+                    // If inspectPort already returned null (dead port), keep it null.
+                    // Otherwise treat as Unknown. [tag:better_ux_for_flashing]
                     log.warn("inspectPort crashed for " + p + ", treating as Unknown: " + e);
                     r = new PortResult(p, SerialPortType.Unknown);
                 }
@@ -143,14 +161,12 @@ public enum SerialPortScanner {
                 synchronized (resultsLock) {
                     if (Thread.currentThread().isInterrupted()) {
                         log.trace(String.format("Thread `%s` is interrupted.", threadName));
-                        // If interrupted, don't try to write our result
                         return;
                     }
 
                     results.put(p, r);
 
                     if (results.size() == ports.size()) {
-                        // We now have all the results - interrupt the calling thread
                         callingThread.interrupt();
                     }
                 }
@@ -161,24 +177,25 @@ public enum SerialPortScanner {
             t.setDaemon(true);
             t.start();
 
+            if (probeThreadsRef != null) {
+                probeThreadsRef.add(t);
+            }
+
             return t;
         }).collect(Collectors.toList());
 
-        // Give everyone a chance to finish
         try {
-            // todo: see if everyone has already finished - make this sleep conditional!
-            // todo: lower this timeout?
             Thread.sleep(5000);
         } catch (InterruptedException e) {
             // We got interrupted because the last port got found, nothing to do
         }
 
-        // Interrupt all threads under lock to ensure no more objects are added to results
         synchronized (resultsLock) {
             ScannerHelper.interruptThreads(threads);
         }
 
-        // Now check that we got everything - if any timed out, register them as unknown
+        // Timed-out ports that don't have a result yet get Unknown;
+        // null results (dead ports) are left as-is so they get filtered out.
         for (String port : ports) {
             if (!results.containsKey(port)) {
                 log.info("Port " + port + " timed out, adding as Unknown.");
@@ -186,7 +203,14 @@ public enum SerialPortScanner {
             }
         }
 
-        return new ArrayList<>(results.values());
+        // Clean up finished threads from the tracking list
+        if (probeThreadsRef != null) {
+            probeThreadsRef.removeIf(t -> !t.isAlive());
+        }
+
+        return results.values().stream()
+            .filter(Objects::nonNull)
+            .collect(Collectors.toList());
     }
 
     private final SerialPortCache portCache = new SerialPortCache();
@@ -229,7 +253,7 @@ public enum SerialPortScanner {
             CompatibilityOptional.ifPresentOrElse(cachedPort, ports::add, () -> portsToInspect.add(serialPort));
         }
 
-        for (PortResult p : inspectPorts(portsToInspect)) {
+        for (PortResult p : inspectPorts(portsToInspect, probeThreads)) {
             log.info("Port " + p.port + " detected as: " + p.type.friendlyString);
             ports.add(p);
             // Do not cache Unknown — keep the port uninspected so the next scan cycle retries
@@ -352,10 +376,10 @@ public enum SerialPortScanner {
     private static boolean isPortOpenblt(String port) {
         try (IoStream stream = BufferedSerialIoStream.openPort(port)) {
             return OpenbltDetectorStrategy.isPortOpenblt(stream);
+        } catch (com.fazecast.jSerialComm.SerialPortInvalidPortException e) {
+            // Port is truly dead — let it propagate so inspectPort returns null.
+            throw e;
         } catch (Exception e) {
-            // jSerialComm throws SerialPortInvalidPortException (a RuntimeException), not IOException, when
-            // a port vanishes / re-enumerates mid-probe (hot-plug, reboot to bootloader). Swallow it so the
-            // inspect thread doesn't crash and lose the port result. Next cycle retries. [tag:better_ux_for_flashing]
             log.info("isPortOpenblt probe failed for " + port + ": " + e);
             return false;
         }
@@ -365,8 +389,44 @@ public enum SerialPortScanner {
         portsScanner.resume();
     }
 
+    /**
+     * Suspend the scanner and wait for all in-flight probe threads to finish,
+     * ensuring they release any open port handles before a flash job proceeds.
+     * [tag:better_ux_for_flashing]
+     */
     public CountDownLatch suspend() {
-        return portsScanner.suspend();
+        CountDownLatch latch = portsScanner.suspend();
+        // Interrupt all in-flight probe threads so they close their port handles
+        synchronized (probeThreads) {
+            for (Thread t : probeThreads) {
+                if (t.isAlive()) {
+                    t.interrupt();
+                }
+            }
+        }
+        // Wait for probe threads to finish (max 10 seconds)
+        long deadline = System.currentTimeMillis() + 10_000;
+        while (System.currentTimeMillis() < deadline) {
+            boolean allDone = true;
+            synchronized (probeThreads) {
+                for (Thread t : probeThreads) {
+                    if (t.isAlive()) {
+                        allDone = false;
+                        break;
+                    }
+                }
+            }
+            if (allDone) {
+                break;
+            }
+            try {
+                Thread.sleep(100);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                break;
+            }
+        }
+        return latch;
     }
 
     /**

--- a/java_console/ui/src/main/java/com/rusefi/SerialPortScanner.java
+++ b/java_console/ui/src/main/java/com/rusefi/SerialPortScanner.java
@@ -127,7 +127,16 @@ public enum SerialPortScanner {
 
             Thread t = new Thread(() -> {
                 log.trace(String.format("Thread `%s` is starting...", threadName));
-                PortResult r = inspectPort(p);
+                PortResult r;
+                try {
+                    r = inspectPort(p);
+                } catch (Throwable e) {
+                    // Never let a probe exception (e.g. jSerialComm SerialPortInvalidPortException on a
+                    // vanishing/re-enumerating port) kill the inspect thread and lose the result — record
+                    // Unknown and move on. [tag:better_ux_for_flashing]
+                    log.warn("inspectPort crashed for " + p + ", treating as Unknown: " + e);
+                    r = new PortResult(p, SerialPortType.Unknown);
+                }
 
                 // Record the result under lock
                 synchronized (resultsLock) {
@@ -317,7 +326,11 @@ public enum SerialPortScanner {
     private static boolean isPortOpenblt(String port) {
         try (IoStream stream = BufferedSerialIoStream.openPort(port)) {
             return OpenbltDetectorStrategy.isPortOpenblt(stream);
-        } catch (IOException e) {
+        } catch (Exception e) {
+            // jSerialComm throws SerialPortInvalidPortException (a RuntimeException), not IOException, when
+            // a port vanishes / re-enumerates mid-probe (hot-plug, reboot to bootloader). Swallow it so the
+            // inspect thread doesn't crash and lose the port result. Next cycle retries. [tag:better_ux_for_flashing]
+            log.info("isPortOpenblt probe failed for " + port + ": " + e);
             return false;
         }
     }

--- a/java_console/ui/src/main/java/com/rusefi/SerialPortScanner.java
+++ b/java_console/ui/src/main/java/com/rusefi/SerialPortScanner.java
@@ -1,6 +1,7 @@
 package com.rusefi;
 
 import com.devexperts.logging.Logging;
+import com.rusefi.io.ConnectionStatusLogic;
 import com.rusefi.io.IoStream;
 import com.rusefi.io.LinkManager;
 import com.rusefi.io.serial.BufferedSerialIoStream;
@@ -190,6 +191,20 @@ public enum SerialPortScanner {
 
     private final SerialPortCache portCache = new SerialPortCache();
 
+    // The DFU/STLink/PCAN device probes shell out to PowerShell (~800ms each). Running all three
+    // every 300ms scan cycle starves the ECU re-detection this same thread performs after a reboot,
+    // which is what makes the reconnect "loading" state drag on. Throttle them to a few seconds and
+    // skip them entirely while a live ECU is connected (a board cannot be a connected ECU and a DFU
+    // device at the same time, and the scan thread must stay responsive for the reconnect). The
+    // last-known results are reused between probes so the ProgramSelector menu stays stable.
+    // [tag:better_ux_for_flashing]
+    private static final long DEVICE_PROBE_INTERVAL_MS = 3000;
+    // Accessed only from the single "Ports Scanner" thread.
+    private long lastDeviceProbeMs = 0;
+    private boolean lastDfuConnected = false;
+    private boolean lastStLinkConnected = false;
+    private boolean lastPcanConnected = false;
+
     /**
      * Find all available serial ports and checks if simulator local TCP port is available
      */
@@ -253,9 +268,20 @@ public enum SerialPortScanner {
                     }
                 }
             }
-            dfuConnected = DfuFlasher.detectSTM32BootloaderDriverState(UpdateOperationCallbacks.DUMMY);
-            stLinkConnected = StLinkFlasher.detectStLink(UpdateOperationCallbacks.DUMMY);
-            PCANConnected = MaintenanceUtil.detectPcan(UpdateOperationCallbacks.DUMMY);
+            // Skip the expensive OS device probes while a live ECU is connected, and otherwise run them
+            // no more than once per DEVICE_PROBE_INTERVAL_MS. Reuse the last-known values in between so
+            // the update menu doesn't flicker. [tag:better_ux_for_flashing]
+            final boolean liveEcuConnected = ConnectionStatusLogic.INSTANCE.isConnected();
+            final long now = System.currentTimeMillis();
+            if (!liveEcuConnected && (now - lastDeviceProbeMs) >= DEVICE_PROBE_INTERVAL_MS) {
+                lastDfuConnected = DfuFlasher.detectSTM32BootloaderDriverState(UpdateOperationCallbacks.DUMMY);
+                lastStLinkConnected = StLinkFlasher.detectStLink(UpdateOperationCallbacks.DUMMY);
+                lastPcanConnected = MaintenanceUtil.detectPcan(UpdateOperationCallbacks.DUMMY);
+                lastDeviceProbeMs = now;
+            }
+            dfuConnected = lastDfuConnected;
+            stLinkConnected = lastStLinkConnected;
+            PCANConnected = lastPcanConnected;
         } else {
             dfuConnected = false;
             stLinkConnected = false;

--- a/java_console/ui/src/main/java/com/rusefi/SerialPortScanner.java
+++ b/java_console/ui/src/main/java/com/rusefi/SerialPortScanner.java
@@ -260,6 +260,12 @@ public enum SerialPortScanner {
         if (SHOW_SOCKETCAN)
             ports.add(new PortResult(LinkManager.SOCKET_CAN, SerialPortType.CAN));
 */
+        // Surface a DFU device (STM32 built-in bootloader) as a synthetic, non-connectable port so a
+        // running console can offer DFU flashing in-session (#9771). dfuConnected stays exposed via
+        // AvailableHardware.isDfuFound() for the existing ProgramSelector menu logic.
+        if (dfuConnected) {
+            ports.add(new PortResult(LinkManager.DFU, SerialPortType.Dfu));
+        }
         boolean isListUpdated;
         AvailableHardware currentHardware = new AvailableHardware(ports, dfuConnected, stLinkConnected, PCANConnected);
         synchronized (lock) {

--- a/java_console/ui/src/main/java/com/rusefi/SerialPortType.java
+++ b/java_console/ui/src/main/java/com/rusefi/SerialPortType.java
@@ -1,13 +1,16 @@
 package com.rusefi;
 
-// this enum covers truly serial use-cases meaning NOT 'manual DFU' scanning and not st-link scanning
+// covers both serial use-cases and the non-serial ones (DFU) that are surfaced as synthetic ports (#9771)
 public enum SerialPortType {
     Ecu("ECU", 20),
     EcuWithOpenblt("ECU w/ BL", 20),
     OpenBlt("OpenBLT Bootloader", 10),
+    // DFU is the STM32 built-in bootloader — a USB device, not a real serial port. It is surfaced as a
+    // synthetic PortResult (LinkManager.DFU) so a running console can offer DFU flashing in-session,
+    // while DFU detection also stays exposed as AvailableHardware.isDfuFound() for back-compat.
+    Dfu("DFU", 15),
     CAN("CAN", 30),
     Unknown("Unknown", 100),
-    // note that somewhere down we have DFU detection but not handled using this enum
     ;
 
     public final String friendlyString;

--- a/java_console/ui/src/main/java/com/rusefi/SerialPortType.java
+++ b/java_console/ui/src/main/java/com/rusefi/SerialPortType.java
@@ -1,6 +1,6 @@
 package com.rusefi;
 
-// covers both serial use-cases and the non-serial ones (DFU) that are surfaced as synthetic ports (#9771)
+// covers both serial use-cases and the non-serial ones (DFU) that are surfaced as synthetic ports [tag:better_ux_for_flashing]
 public enum SerialPortType {
     Ecu("ECU", 20),
     EcuWithOpenblt("ECU w/ BL", 20),

--- a/java_console/ui/src/main/java/com/rusefi/SessionState.java
+++ b/java_console/ui/src/main/java/com/rusefi/SessionState.java
@@ -1,7 +1,7 @@
 package com.rusefi;
 
 /**
- * The single-session device state shared by the splash and the live console (#9771).
+ * The single-session device state shared by the splash and the live console [tag:better_ux_for_flashing].
  * <p>
  * A single console instance must handle every board transition — hook, remove, hook-in-DFU,
  * hook-in-OpenBLT, re-connect — without a restart. {@link DeviceSessionManager} derives one of

--- a/java_console/ui/src/main/java/com/rusefi/SessionState.java
+++ b/java_console/ui/src/main/java/com/rusefi/SessionState.java
@@ -1,0 +1,25 @@
+package com.rusefi;
+
+/**
+ * The single-session device state shared by the splash and the live console (#9771).
+ * <p>
+ * A single console instance must handle every board transition — hook, remove, hook-in-DFU,
+ * hook-in-OpenBLT, re-connect — without a restart. {@link DeviceSessionManager} derives one of
+ * these values from {@link com.rusefi.io.ConnectionStatusLogic} plus the current
+ * {@link AvailableHardware} snapshot and broadcasts it so any UI (Device tab, status icon) can
+ * reflect the current reality.
+ */
+public enum SessionState {
+    /** No live ECU connection and no board detected in a bootloader/DFU state. */
+    DISCONNECTED,
+    /** A connect attempt is in flight (LinkManager started, not yet CONNECTED). */
+    CONNECTING,
+    /** Live ECU connection is up. */
+    CONNECTED,
+    /** A firmware-update job (DFU or OpenBLT) owns the port; other operations must wait. */
+    FLASHING,
+    /** A board is sitting in the STM32 built-in bootloader (DFU) — flashable, not connectable. */
+    DEVICE_IN_DFU,
+    /** A board is sitting in the OpenBLT bootloader — flashable, not connectable. */
+    DEVICE_IN_BLT,
+}

--- a/java_console/ui/src/main/java/com/rusefi/StartupFrame.java
+++ b/java_console/ui/src/main/java/com/rusefi/StartupFrame.java
@@ -303,6 +303,12 @@ public class StartupFrame {
         realHardwarePanel.add(openTunerStudio, "right, wrap");
 
         connectivityContext.getSerialPortScanner().addListener(currentHardware -> SwingUtilities.invokeLater(() -> {
+            // #9771: after a normal handoff the live console (DeviceSessionManager) owns device state —
+            // the scanner stays alive but this splash listener must stop mutating the repurposed splash
+            // widgets. The offline-tune path (isProceeding && offlineConsoleOpen) still needs the branch below.
+            if (isProceeding && !offlineConsoleOpen) {
+                return;
+            }
             if (offlineConsoleOpen) {
                 // [tag:offline_tune] Splash UI is disposed; keep only the auto-connect path alive so
                 // plugging in an ECU transitions the already-open offline console online (see onSplashConnected).
@@ -418,6 +424,10 @@ public class StartupFrame {
         outerTabs.setSelectedIndex(Math.min(savedTabIndex, outerTabs.getTabCount() - 1));
 
         connectivityContext.getSerialPortScanner().addListener(currentHardware -> SwingUtilities.invokeLater(() -> {
+            // #9771: stop updating splash firmware-tab widgets once the live console has taken over.
+            if (isProceeding && !offlineConsoleOpen) {
+                return;
+            }
             if (firmwareTabStatus != null)
                 firmwareTabStatus.stop();
             firmwareUpdateTab.getBasicUpdaterPanel().onHardwareUpdated();
@@ -536,7 +546,10 @@ public class StartupFrame {
 
     private void updateConnectButtonState() {
         PortResult selectedItem = (PortResult) portsComboBox.getComboPorts().getSelectedItem();
-        connectButton.setEnabled(selectedItem != null && selectedItem.type != OpenBlt);
+        // OpenBLT bootloader and DFU are not connectable — they are firmware-update targets (#9771).
+        connectButton.setEnabled(selectedItem != null
+            && selectedItem.type != OpenBlt
+            && selectedItem.type != SerialPortType.Dfu);
     }
 
     private void applyKnownPorts(AvailableHardware currentHardware) {
@@ -1109,7 +1122,11 @@ public class StartupFrame {
             revealControlsTimer.stop();
         if (firmwareTabStatus != null)
             firmwareTabStatus.stop();
-        connectivityContext.getSerialPortScanner().stopTimer();
+        // #9771: keep the port scanner alive through handoff so the live console (its
+        // DeviceSessionManager) keeps seeing hotplug / DFU / OpenBLT transitions. The scanner's worker
+        // is a daemon thread and the console exits via ExitUtil.exit, so no explicit stop is needed.
+        // The splash's own scanner listeners are guarded by isProceeding so they stop mutating the
+        // (now-repurposed) splash widgets after handoff.
     }
 
     public void disposeFrameAndProceed() {

--- a/java_console/ui/src/main/java/com/rusefi/StartupFrame.java
+++ b/java_console/ui/src/main/java/com/rusefi/StartupFrame.java
@@ -303,7 +303,7 @@ public class StartupFrame {
         realHardwarePanel.add(openTunerStudio, "right, wrap");
 
         connectivityContext.getSerialPortScanner().addListener(currentHardware -> SwingUtilities.invokeLater(() -> {
-            // #9771: after a normal handoff the live console (DeviceSessionManager) owns device state —
+            // [tag:better_ux_for_flashing]: after a normal handoff the live console (DeviceSessionManager) owns device state —
             // the scanner stays alive but this splash listener must stop mutating the repurposed splash
             // widgets. The offline-tune path (isProceeding && offlineConsoleOpen) still needs the branch below.
             if (isProceeding && !offlineConsoleOpen) {
@@ -424,7 +424,7 @@ public class StartupFrame {
         outerTabs.setSelectedIndex(Math.min(savedTabIndex, outerTabs.getTabCount() - 1));
 
         connectivityContext.getSerialPortScanner().addListener(currentHardware -> SwingUtilities.invokeLater(() -> {
-            // #9771: stop updating splash firmware-tab widgets once the live console has taken over.
+            // [tag:better_ux_for_flashing]: stop updating splash firmware-tab widgets once the live console has taken over.
             if (isProceeding && !offlineConsoleOpen) {
                 return;
             }
@@ -546,7 +546,7 @@ public class StartupFrame {
 
     private void updateConnectButtonState() {
         PortResult selectedItem = (PortResult) portsComboBox.getComboPorts().getSelectedItem();
-        // OpenBLT bootloader and DFU are not connectable — they are firmware-update targets (#9771).
+        // OpenBLT bootloader and DFU are not connectable — they are firmware-update targets [tag:better_ux_for_flashing].
         connectButton.setEnabled(selectedItem != null
             && selectedItem.type != OpenBlt
             && selectedItem.type != SerialPortType.Dfu);
@@ -1122,7 +1122,7 @@ public class StartupFrame {
             revealControlsTimer.stop();
         if (firmwareTabStatus != null)
             firmwareTabStatus.stop();
-        // #9771: keep the port scanner alive through handoff so the live console (its
+        // [tag:better_ux_for_flashing]: keep the port scanner alive through handoff so the live console (its
         // DeviceSessionManager) keeps seeing hotplug / DFU / OpenBLT transitions. The scanner's worker
         // is a daemon thread and the console exits via ExitUtil.exit, so no explicit stop is needed.
         // The splash's own scanner listeners are guarded by isProceeding so they stop mutating the

--- a/java_console/ui/src/main/java/com/rusefi/maintenance/CalibrationsHelper.java
+++ b/java_console/ui/src/main/java/com/rusefi/maintenance/CalibrationsHelper.java
@@ -30,6 +30,7 @@ import java.nio.file.Paths;
 import java.text.SimpleDateFormat;
 import java.util.*;
 import java.util.concurrent.ExecutionException;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
@@ -48,6 +49,11 @@ public class CalibrationsHelper {
     static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd-HH.mm.ss");
     private static final String RUSEFI_FORCE_CALIBRATIONS_RESTORE = System.getenv("RUSEFI_FORCE_CALIBRATIONS_RESTORE");
     private static final int MAX_CALIBRATION_RETRIES = 3;
+
+    /** Most recent tune successfully read+backed up off a live ECU this session. Used to restore the
+     *  tune after a manual OpenBLT flash, where the board is already in the bootloader before flashing
+     *  (no live ECU to read pre-flash like the auto path does). [tag:better_ux_for_flashing] */
+    private static volatile Optional<CalibrationsInfo> lastEcuCalibrations = Optional.empty();
 
     public static class MergeResult {
         public final Optional<CalibrationsInfo> mergedCalibrations;
@@ -118,13 +124,27 @@ public class CalibrationsHelper {
         final UpdateOperationCallbacks callbacks,
         final ConnectivityContext connectivityContext
     ) {
+        return waitForPortAppeared(
+            t -> t == desiredPortType,
+            String.format("Waiting for %s port to appear...", desiredPortType),
+            callbacks,
+            connectivityContext
+        );
+    }
+
+    private static List<PortResult> waitForPortAppeared(
+        final Predicate<SerialPortType> portTypeMatches,
+        final String description,
+        final UpdateOperationCallbacks callbacks,
+        final ConnectivityContext connectivityContext
+    ) {
         final List<PortResult> foundPorts = new ArrayList<>();
         waitForPredicate(
-            String.format("Waiting for %s port to appear...", desiredPortType),
+            description,
             () -> {
                 final List<PortResult> knownPorts = connectivityContext.getCurrentHardware().getKnownPorts();
                 foundPorts.addAll(knownPorts.stream()
-                    .filter(p -> p.type == desiredPortType)
+                    .filter(p -> portTypeMatches.test(p.type))
                     .collect(Collectors.toList()));
                 if (!foundPorts.isEmpty()) {
                     return true;
@@ -135,7 +155,7 @@ public class CalibrationsHelper {
                 // a re-probe by invalidating non-matching classifications so the scanner's
                 // next cycle re-inspects.
                 for (PortResult p : knownPorts) {
-                    if (p.type != desiredPortType) {
+                    if (!portTypeMatches.test(p.type)) {
                         connectivityContext.getSerialPortScanner().invalidatePort(p.port);
                     }
                 }
@@ -419,6 +439,85 @@ public class CalibrationsHelper {
                 return false;
             }
         }
+    }
+
+    /**
+     * Restore the tune after a <b>manual</b> OpenBLT flash.
+     * <p>
+     * The auto path reads the live ECU and restores it post-flash. The manual path starts with the
+     * board already in the bootloader (no live ECU to read), so it restores {@link #lastEcuCalibrations}
+     * - the last tune backed up off an ECU this session - onto the freshly flashed firmware.
+     * <p>
+     * Must NOT be called on the Swing EDT. [tag:better_ux_for_flashing]
+     */
+    public static void restorePreviousCalibrationsAfterManualFlash(
+        final UpdateOperationCallbacks callbacks,
+        final ConnectivityContext connectivityContext
+    ) {
+        AutoupdateUtil.assertNotAwtThread();
+
+        final Optional<CalibrationsInfo> prev = lastEcuCalibrations;
+        if (!prev.isPresent()) {
+            callbacks.logLine("No previously backed-up tune available - ECU will keep its freshly flashed configuration.");
+            return;
+        }
+
+        // A freshly flashed board comes up as either Ecu or EcuWithOpenblt depending on the port
+        // probe timing; accept both.
+        final List<PortResult> ecuPorts = waitForPortAppeared(
+            t -> t == SerialPortType.Ecu || t == SerialPortType.EcuWithOpenblt,
+            "Waiting for ECU to reappear after flash to restore tune...",
+            callbacks,
+            connectivityContext
+        );
+        if (ecuPorts.size() != 1) {
+            callbacks.logLine(String.format(
+                "Cannot restore tune: expected exactly one ECU after flash but found %d.", ecuPorts.size()));
+            return;
+        }
+        final String newEcuPort = ecuPorts.get(0).port;
+
+        final String timestamp = DATE_FORMAT.format(new Date());
+        Optional<CalibrationsInfo> freshCalibrations = Optional.empty();
+        for (int attempt = 1; attempt <= 3 && !freshCalibrations.isPresent(); attempt++) {
+            if (attempt > 1) {
+                callbacks.logLine("Retrying calibration read after flash (attempt " + attempt + ")...");
+                BinaryProtocol.sleep(5_000);
+            }
+            freshCalibrations = readAndBackupCurrentCalibrationsWithSuspendedPortScanner(
+                newEcuPort, callbacks,
+                getFileNameWithoutExtension(timestamp, "after_manual_flash"), connectivityContext);
+        }
+        if (!freshCalibrations.isPresent()) {
+            callbacks.logLine("Failed to read calibration from ECU after flash - tune not restored, ECU keeps defaults.");
+            return;
+        }
+
+        final MergeResult mergeResult = mergeCalibrationsWithPartialFailure(
+            prev.get().getIniFile(),
+            prev.get().generateMsq(),
+            freshCalibrations.get(),
+            callbacks,
+            emptySet()
+        );
+        if (!mergeResult.failedFields.isEmpty()) {
+            callbacks.logLine("WARNING: " + mergeResult.failedFields.size()
+                + " field(s) could not be migrated; leaving them at firmware defaults.");
+        }
+        if (!mergeResult.mergedCalibrations.isPresent()) {
+            callbacks.logLine("Restored tune matches firmware defaults - nothing to write.");
+            return;
+        }
+        if (!CalibrationsUpdater.INSTANCE.updateCalibrations(
+            newEcuPort,
+            mergeResult.mergedCalibrations.get().getImage().getConfigurationImage(),
+            callbacks,
+            connectivityContext
+        )) {
+            callbacks.logLine("Failed to write restored tune to ECU...");
+            return;
+        }
+        callbacks.logLine("Previous tune restored after manual flash.");
     }
 
     /**
@@ -711,6 +810,9 @@ public class CalibrationsHelper {
                     backupFileName,
                     callbacks
                 )) {
+                    // Remember the last good tune read off a live ECU so a later manual OpenBLT flash
+                    // (board already in the bootloader) can still restore it. [tag:better_ux_for_flashing]
+                    lastEcuCalibrations = calibrationsInfo;
                     return calibrationsInfo;
                 }
             }

--- a/java_console/ui/src/main/java/com/rusefi/maintenance/CalibrationsHelper.java
+++ b/java_console/ui/src/main/java/com/rusefi/maintenance/CalibrationsHelper.java
@@ -143,9 +143,20 @@ public class CalibrationsHelper {
             description,
             () -> {
                 final List<PortResult> knownPorts = connectivityContext.getCurrentHardware().getKnownPorts();
-                foundPorts.addAll(knownPorts.stream()
+                final Set<String> osPorts = LinkManager.getCommPorts();
+                // Invalidate any cached port that the OS no longer reports — forces the scanner
+                // to re-probe on the next cycle and prevents returning stale results (e.g. a
+                // port that vanished after an ECU reboot and re-enumeration).
+                for (PortResult p : knownPorts) {
+                    if (!osPorts.contains(p.port)) {
+                        connectivityContext.getSerialPortScanner().invalidatePort(p.port);
+                    }
+                }
+                final List<PortResult> matching = knownPorts.stream()
                     .filter(p -> portTypeMatches.test(p.type))
-                    .collect(Collectors.toList()));
+                    .filter(p -> osPorts.contains(p.port))
+                    .collect(Collectors.toList());
+                foundPorts.addAll(matching);
                 if (!foundPorts.isEmpty()) {
                     return true;
                 }

--- a/java_console/ui/src/main/java/com/rusefi/maintenance/DfuFlasher.java
+++ b/java_console/ui/src/main/java/com/rusefi/maintenance/DfuFlasher.java
@@ -235,6 +235,12 @@ public class DfuFlasher {
     }
 
     public static boolean detectSTM32BootloaderDriverState(UpdateOperationCallbacks callbacks) {
+        if (!FileLog.isWindows()) {
+            // The WMIC/driver check below is Windows-only. On Linux the STM32 system bootloader is
+            // visible directly over USB as 0483:df11 ("STM Device in DFU Mode"), so probe lsusb so the
+            // console at least reflects the DFU state (flashing it is still Windows-only, see #9771).
+            return FileLog.isLinux() && detectStm32DfuViaLsusb(callbacks);
+        }
         // #9714: a universal bundle's is_h7 property can't cover every board, so trust the connected
         // ECU's target first (e.g. "uaefi_pro_h7"), falling back to the bundled is_h7 property.
         String effectiveTarget = com.rusefi.core.io.ConnectedEcuTarget.effectiveTarget();
@@ -245,6 +251,28 @@ public class DfuFlasher {
         } catch (ErrorExecutingCommand e) {
             dfuDetectionCommandFailed = true;
             callbacks.logLine("detectSTM32BootloaderDriverState IOError: " + e);
+            return false;
+        }
+    }
+
+    // STM32 system bootloader enumerates as USB 0483:df11 regardless of chip family; detect it on Linux
+    // via lsusb so a board reset into DFU surfaces in the console instead of leaving the watchdog spinning
+    // on the vanished serial port. (#9771)
+    private static boolean detectStm32DfuViaLsusb(UpdateOperationCallbacks callbacks) {
+        try {
+            Process process = new ProcessBuilder("lsusb").redirectErrorStream(true).start();
+            StringBuilder output = new StringBuilder();
+            try (java.io.BufferedReader reader =
+                     new java.io.BufferedReader(new java.io.InputStreamReader(process.getInputStream()))) {
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    output.append(line).append('\n');
+                }
+            }
+            process.waitFor(3, java.util.concurrent.TimeUnit.SECONDS);
+            return output.toString().toLowerCase().contains("0483:df11");
+        } catch (Exception e) {
+            callbacks.logLine("lsusb DFU probe failed: " + e);
             return false;
         }
     }

--- a/java_console/ui/src/main/java/com/rusefi/maintenance/DfuFlasher.java
+++ b/java_console/ui/src/main/java/com/rusefi/maintenance/DfuFlasher.java
@@ -173,7 +173,7 @@ public class DfuFlasher {
                 () -> {
                     // A board sitting in DFU has no live signature, so fetch the right firmware for the
                     // persisted last-connected board first; fail closed rather than flash the bundle
-                    // default onto a different board on a universal bundle. (#9771 / #9714)
+                    // default onto a different board on a universal bundle. [tag:better_ux_for_flashing] / #9714
                     if (!MaintenanceUtil.ensureFirmwareForConnectedTarget(callbacks)) {
                         callbacks.error();
                         return;
@@ -206,7 +206,7 @@ public class DfuFlasher {
     }
 
     private static boolean executeDFU(UpdateOperationCallbacks callbacks, String firmwareBinFile) {
-        // Refuse to silently flash firmware built for a different board (brick guard, #9771).
+        // Refuse to silently flash firmware built for a different board (brick guard, [tag:better_ux_for_flashing]).
         if (!MaintenanceUtil.confirmFirmwareMatchesBoard(firmwareBinFile, callbacks)) {
             callbacks.logLine("Firmware update aborted — firmware/board mismatch.");
             return false;
@@ -252,7 +252,7 @@ public class DfuFlasher {
         if (!FileLog.isWindows()) {
             // The WMIC/driver check below is Windows-only. On Linux the STM32 system bootloader is
             // visible directly over USB as 0483:df11 ("STM Device in DFU Mode"), so probe lsusb so the
-            // console at least reflects the DFU state (flashing it is still Windows-only, see #9771).
+            // console at least reflects the DFU state (flashing it is still Windows-only, see [tag:better_ux_for_flashing]).
             return FileLog.isLinux() && detectStm32DfuViaLsusb(callbacks);
         }
         // #9714: a universal bundle's is_h7 property can't cover every board, so trust the connected
@@ -271,7 +271,7 @@ public class DfuFlasher {
 
     // STM32 system bootloader enumerates as USB 0483:df11 regardless of chip family; detect it on Linux
     // via lsusb so a board reset into DFU surfaces in the console instead of leaving the watchdog spinning
-    // on the vanished serial port. (#9771)
+    // on the vanished serial port. [tag:better_ux_for_flashing]
     private static boolean detectStm32DfuViaLsusb(UpdateOperationCallbacks callbacks) {
         try {
             Process process = new ProcessBuilder("lsusb").redirectErrorStream(true).start();

--- a/java_console/ui/src/main/java/com/rusefi/maintenance/DfuFlasher.java
+++ b/java_console/ui/src/main/java/com/rusefi/maintenance/DfuFlasher.java
@@ -79,7 +79,7 @@ public class DfuFlasher {
             }
 
             timeForDfuSwitch(callbacks);
-            if (executeDFU(callbacks, FindFileHelper.findFirmwareFile())) {
+            if (executeDFU(callbacks, FindFileHelper.findFirmwareFileForConnectedBoard())) {
                 // We need to wait to allow connection to ECU port (see #7403)
                 timeForDfuSwitch(callbacks);
                 return true;
@@ -170,7 +170,16 @@ public class DfuFlasher {
     public static void runDfuProgramming(UpdateOperationCallbacks callbacks, final Runnable onJobFinished) {
         submitAction(() -> {
             JobHelper.doJob(
-                () -> executeDfuAndPaintStatusPanel(callbacks, FindFileHelper.findFirmwareFile()),
+                () -> {
+                    // A board sitting in DFU has no live signature, so fetch the right firmware for the
+                    // persisted last-connected board first; fail closed rather than flash the bundle
+                    // default onto a different board on a universal bundle. (#9771 / #9714)
+                    if (!MaintenanceUtil.ensureFirmwareForConnectedTarget(callbacks)) {
+                        callbacks.error();
+                        return;
+                    }
+                    executeDfuAndPaintStatusPanel(callbacks, FindFileHelper.findFirmwareFileForConnectedBoard());
+                },
                 onJobFinished
             );
         });
@@ -197,6 +206,11 @@ public class DfuFlasher {
     }
 
     private static boolean executeDFU(UpdateOperationCallbacks callbacks, String firmwareBinFile) {
+        // Refuse to silently flash firmware built for a different board (brick guard, #9771).
+        if (!MaintenanceUtil.confirmFirmwareMatchesBoard(firmwareBinFile, callbacks)) {
+            callbacks.logLine("Firmware update aborted — firmware/board mismatch.");
+            return false;
+        }
         boolean driverIsHappy = detectSTM32BootloaderDriverState(callbacks);
         if (!driverIsHappy) {
             callbacks.logLine("*** DRIVER ERROR? *** Did you have a chance to try 'Install Drivers' button on top of rusEFI console start screen?");

--- a/java_console/ui/src/main/java/com/rusefi/maintenance/MaintenanceUtil.java
+++ b/java_console/ui/src/main/java/com/rusefi/maintenance/MaintenanceUtil.java
@@ -2,9 +2,14 @@ package com.rusefi.maintenance;
 
 import com.devexperts.logging.Logging;
 import com.rusefi.FileLog;
+import com.rusefi.autoupdate.Autoupdate;
 import com.rusefi.core.FindFileHelper;
+import com.rusefi.core.io.BoardCompatibility;
+import com.rusefi.core.io.BundleUtil;
+import com.rusefi.core.io.ConnectedEcuTarget;
 import com.rusefi.io.UpdateOperationCallbacks;
 
+import javax.swing.*;
 import java.io.File;
 
 import static com.devexperts.logging.Logging.getLogging;
@@ -53,5 +58,108 @@ public class MaintenanceUtil {
     public static long getBinaryModificationTimestamp() {
         String fileName = FindFileHelper.isObfuscated() ? FindFileHelper.findSrecFile() : FindFileHelper.findFirmwareFile();
         return new File(fileName).lastModified();
+    }
+
+    /**
+     * A board already sitting in a bootloader (OpenBLT or DFU) has no live signature, so — unlike the
+     * reboot path in {@link com.rusefi.io.BootloaderHelper} — nothing has fetched the right firmware yet.
+     * On a universal bundle the flashers would otherwise program whatever firmware is on disk (the bundle
+     * default), not the board that was just connected. Resolve the target from the persisted
+     * last-connected board (it survives the disconnect) and download it first; fail closed rather than
+     * flash the wrong firmware onto a different board. (#9771 / #9714)
+     *
+     * @return true if it is safe to proceed with flashing
+     */
+    public static boolean ensureFirmwareForConnectedTarget(final UpdateOperationCallbacks callbacks) {
+        final String bundleTarget = BundleUtil.getBundleTarget();
+        final String ecuTarget = ConnectedEcuTarget.effectiveTarget();
+        // A board in a bootloader cannot identify itself. If there is no live signature this session the
+        // target is only a guess (persisted last board, or the bundle default) — confirm before flashing
+        // so we never program a possibly-swapped board silently. Independent of foreign-vs-matching: even
+        // flashing the bundle's own firmware onto an unverified board deserves a check. Live-verified
+        // flashes skip this. (#9771)
+        if (!ConnectedEcuTarget.isLiveTargetKnown() && !confirmUnverifiedTarget(ecuTarget)) {
+            callbacks.logLine("Firmware update cancelled — unverified board target \"" + ecuTarget + "\".");
+            return false;
+        }
+
+        final boolean foreignBoard = bundleTarget != null && ecuTarget != null
+            && !bundleTarget.equalsIgnoreCase(ecuTarget);
+        if (!foreignBoard) {
+            // Single-board bundle, or the target matches the bundle: the on-disk firmware is already right.
+            return true;
+        }
+        if (!BoardCompatibility.matchesCompatibility(ecuTarget)) {
+            callbacks.logLine(String.format(
+                "Refusing to flash: \"%s\" is not compatible with this bundle (\"%s\").", ecuTarget, bundleTarget));
+            return false;
+        }
+        callbacks.logLine("[universal_bundle]: downloading firmware for \"" + ecuTarget + "\"...");
+        if (!Autoupdate.ensureFirmwareForTarget(ecuTarget, callbacks::updateProgress, callbacks::logLine)) {
+            callbacks.logLine(String.format(
+                "Universal bundle could not download firmware for \"%s\" — aborting to avoid flashing the wrong firmware.",
+                ecuTarget));
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Ask the user to confirm flashing an unverified (persisted-guess) board target. Runs on the EDT and
+     * blocks the calling job thread for the answer; fails closed (no flash) if interrupted. (#9771)
+     */
+    private static boolean confirmUnverifiedTarget(final String ecuTarget) {
+        return confirmOnEdt(String.format(
+            "No live ECU is connected to verify the board.\n\n" +
+            "About to flash firmware for: \"%s\".\n" +
+            "If the plugged-in board is not \"%s\", flashing the wrong firmware can brick it.\n\n" +
+            "Flash \"%s\" firmware?", ecuTarget, ecuTarget, ecuTarget),
+            "Confirm firmware target", JOptionPane.WARNING_MESSAGE);
+    }
+
+    /**
+     * Fail-safe guard against the #1 way to brick an ECU: flashing firmware built for a different,
+     * incompatible board. The firmware artifact name encodes its target (e.g. "uaefi_pro"); if that does
+     * not match — and is not compatible with — the connected board's target, make the user explicitly
+     * confirm. This catches the case where the bundle dir still holds another board's downloaded firmware
+     * and {@link FindFileHelper#findSrecFile()} blindly picks it. (#9771)
+     *
+     * @return true if it is safe to proceed with flashing {@code firmwareFile}
+     */
+    public static boolean confirmFirmwareMatchesBoard(final String firmwareFile, final UpdateOperationCallbacks callbacks) {
+        final String fileTarget = FindFileHelper.extractTargetFromFirmwareName(firmwareFile);
+        final String boardTarget = ConnectedEcuTarget.effectiveTarget();
+        if (fileTarget == null || boardTarget == null || fileTarget.equalsIgnoreCase(boardTarget)) {
+            return true;
+        }
+        // Boards that can share firmware (compatibility list / _QC_ hack) are fine.
+        if (BoardCompatibility.isEcuCompatible(fileTarget, boardTarget)) {
+            return true;
+        }
+        callbacks.logLine(String.format(
+            "*** FIRMWARE/BOARD MISMATCH *** file is built for \"%s\" but the connected board is \"%s\".",
+            fileTarget, boardTarget));
+        return confirmOnEdt(String.format(
+            "DANGER: about to flash \"%s\" firmware onto a \"%s\" board.\n\n" +
+            "This is almost certainly the WRONG firmware and will likely BRICK the board.\n\n" +
+            "Flash anyway?", fileTarget, boardTarget),
+            "Firmware / board mismatch", JOptionPane.ERROR_MESSAGE);
+    }
+
+    private static boolean confirmOnEdt(final String message, final String title, final int messageType) {
+        final boolean[] confirmed = {false};
+        final Runnable ask = () -> confirmed[0] = JOptionPane.showConfirmDialog(
+            null, message, title, JOptionPane.OK_CANCEL_OPTION, messageType) == JOptionPane.OK_OPTION;
+        try {
+            if (SwingUtilities.isEventDispatchThread()) {
+                ask.run();
+            } else {
+                SwingUtilities.invokeAndWait(ask);
+            }
+        } catch (Exception e) {
+            log.warn("confirmOnEdt interrupted, treating as cancel: " + e);
+            return false;
+        }
+        return confirmed[0];
     }
 }

--- a/java_console/ui/src/main/java/com/rusefi/maintenance/MaintenanceUtil.java
+++ b/java_console/ui/src/main/java/com/rusefi/maintenance/MaintenanceUtil.java
@@ -66,7 +66,7 @@ public class MaintenanceUtil {
      * On a universal bundle the flashers would otherwise program whatever firmware is on disk (the bundle
      * default), not the board that was just connected. Resolve the target from the persisted
      * last-connected board (it survives the disconnect) and download it first; fail closed rather than
-     * flash the wrong firmware onto a different board. (#9771 / #9714)
+     * flash the wrong firmware onto a different board. [tag:better_ux_for_flashing] / #9714
      *
      * @return true if it is safe to proceed with flashing
      */
@@ -77,7 +77,7 @@ public class MaintenanceUtil {
         // target is only a guess (persisted last board, or the bundle default) — confirm before flashing
         // so we never program a possibly-swapped board silently. Independent of foreign-vs-matching: even
         // flashing the bundle's own firmware onto an unverified board deserves a check. Live-verified
-        // flashes skip this. (#9771)
+        // flashes skip this. [tag:better_ux_for_flashing]
         if (!ConnectedEcuTarget.isLiveTargetKnown() && !confirmUnverifiedTarget(ecuTarget)) {
             callbacks.logLine("Firmware update cancelled — unverified board target \"" + ecuTarget + "\".");
             return false;
@@ -106,7 +106,7 @@ public class MaintenanceUtil {
 
     /**
      * Ask the user to confirm flashing an unverified (persisted-guess) board target. Runs on the EDT and
-     * blocks the calling job thread for the answer; fails closed (no flash) if interrupted. (#9771)
+     * blocks the calling job thread for the answer; fails closed (no flash) if interrupted. [tag:better_ux_for_flashing]
      */
     private static boolean confirmUnverifiedTarget(final String ecuTarget) {
         return confirmOnEdt(String.format(
@@ -122,7 +122,7 @@ public class MaintenanceUtil {
      * incompatible board. The firmware artifact name encodes its target (e.g. "uaefi_pro"); if that does
      * not match — and is not compatible with — the connected board's target, make the user explicitly
      * confirm. This catches the case where the bundle dir still holds another board's downloaded firmware
-     * and {@link FindFileHelper#findSrecFile()} blindly picks it. (#9771)
+     * and {@link FindFileHelper#findSrecFile()} blindly picks it. [tag:better_ux_for_flashing]
      *
      * @return true if it is safe to proceed with flashing {@code firmwareFile}
      */

--- a/java_console/ui/src/main/java/com/rusefi/maintenance/ProgramSelector.java
+++ b/java_console/ui/src/main/java/com/rusefi/maintenance/ProgramSelector.java
@@ -64,8 +64,8 @@ public class ProgramSelector {
         updateModeAndButton.add(splitButton);
 
         splitButton.addActionListener(e -> {
-            final PortResult selectedPort = (PortResult) comboPorts.getSelectedItem();
-            executeJob(splitButton, mainButtonModeFor(selectedPort), selectedPort);
+            final PortResult targetPort = resolveFlashPort();
+            executeJob(splitButton, mainButtonModeFor(targetPort), targetPort);
         });
 
         // Keep the main button label in sync with whatever port is currently selected. The combo is
@@ -89,9 +89,34 @@ public class ProgramSelector {
     }
 
     private void refreshMainButtonText() {
-        final PortResult selectedPort = (PortResult) comboPorts.getSelectedItem();
-        final boolean isOpenBltBoard = mainButtonModeFor(selectedPort) == OPENBLT_MANUAL;
+        final boolean isOpenBltBoard = mainButtonModeFor(resolveFlashPort()) == OPENBLT_MANUAL;
         splitButton.setText(isOpenBltBoard ? OPENBLT_MANUAL.displayText : "Update Firmware");
+    }
+
+    private boolean isLiveConnection() {
+        return linkManager != null && linkManager.getBinaryProtocol() != null;
+    }
+
+    /**
+     * Resolve which port the main Update-Firmware action targets. A board already in the OpenBLT
+     * bootloader is flashed manually and needs no live connection, so — when the combo selection isn't
+     * itself a bootloader and we're offline — prefer any detected OpenBLT port over the connection-
+     * dependent AUTO path (which reboots a *running* ECU and just times out with no live BinaryProtocol).
+     * This covers the offline "open a tune, plug an OpenBLT board" flow where the combo selection may be
+     * null/stale right after the hot-plug. (#9771)
+     */
+    private PortResult resolveFlashPort() {
+        final PortResult selected = (PortResult) comboPorts.getSelectedItem();
+        if (selected != null && selected.type == OpenBlt) {
+            return selected;
+        }
+        if (!isLiveConnection()) {
+            final List<PortResult> bltPorts = connectivityContext.getCurrentHardware().getKnownPorts(OpenBlt);
+            if (!bltPorts.isEmpty()) {
+                return bltPorts.get(0);
+            }
+        }
+        return selected;
     }
 
     private void executeJob(JComponent parent, UpdateMode selectedMode, PortResult selectedPort) {
@@ -157,13 +182,13 @@ public class ProgramSelector {
      * same as clicking the split button. Used by the console's "Update ECU" menu shortcut (#9771).
      */
     public void triggerUpdateFirmware() {
-        final PortResult selectedPort = (PortResult) comboPorts.getSelectedItem();
-        if (selectedPort == null) {
+        final PortResult targetPort = resolveFlashPort();
+        if (targetPort == null) {
             // Nothing detected/selected — mirrors the split button being disabled in apply(). (#9771)
-            log.info("triggerUpdateFirmware: no port selected, ignoring");
+            log.info("triggerUpdateFirmware: no port to flash, ignoring");
             return;
         }
-        executeJob(splitButton, mainButtonModeFor(selectedPort), selectedPort);
+        executeJob(splitButton, mainButtonModeFor(targetPort), targetPort);
     }
 
     public static void rebootToDfu(JComponent parent, String selectedPort, UpdateOperationCallbacks callbacks) {
@@ -379,9 +404,14 @@ public class ProgramSelector {
 
         OpenbltJni.OpenbltCallbacks cb = makeOpenbltCallbacks(callbacks);
 
-        String fileName = FindFileHelper.findSrecFile();
+        String fileName = FindFileHelper.findSrecFileForConnectedBoard();
         if (fileName == null) {
             callbacks.logLine(".srec image file not found");
+            return false;
+        }
+        // refuse to silently flash firmware built for a different board (e.g. a dev-build fallback or a naming quirk). (#9771)
+        if (!MaintenanceUtil.confirmFirmwareMatchesBoard(fileName, callbacks)) {
+            callbacks.logLine("Firmware update aborted — firmware/board mismatch.");
             return false;
         }
         try {
@@ -459,7 +489,9 @@ public class ProgramSelector {
      * #9714: is the connected ECU a different board than this bundle? If so, a universal bundle will
      * download that board's firmware on demand and we cannot yet tell whether it is obfuscated, so the
      * caller forces OpenBLT (works for every board here; DFU would fail for obfuscated firmware).
-     * When no ECU is connected {@code effectiveTarget()} equals the bundle target, so this is false.
+     * With no live ECU, {@code effectiveTarget()} falls back to the persisted last-connected board (or the
+     * bundle target if none) — so a board sitting in a bootloader after a restart is still treated as its
+     * real (foreign) board here; the flash guard confirms that unverified target before programming.
      */
     private static boolean isForeignBoardOnUniversalBundle() {
         String bundleTarget = com.rusefi.core.io.BundleUtil.getBundleTarget();

--- a/java_console/ui/src/main/java/com/rusefi/maintenance/ProgramSelector.java
+++ b/java_console/ui/src/main/java/com/rusefi/maintenance/ProgramSelector.java
@@ -152,6 +152,20 @@ public class ProgramSelector {
         this.linkManager = linkManager;
     }
 
+    /**
+     * Programmatically trigger the main "Update Firmware" action for the currently selected port —
+     * same as clicking the split button. Used by the console's "Update ECU" menu shortcut (#9771).
+     */
+    public void triggerUpdateFirmware() {
+        final PortResult selectedPort = (PortResult) comboPorts.getSelectedItem();
+        if (selectedPort == null) {
+            // Nothing detected/selected — mirrors the split button being disabled in apply(). (#9771)
+            log.info("triggerUpdateFirmware: no port selected, ignoring");
+            return;
+        }
+        executeJob(splitButton, mainButtonModeFor(selectedPort), selectedPort);
+    }
+
     public static void rebootToDfu(JComponent parent, String selectedPort, UpdateOperationCallbacks callbacks) {
         String port = selectedPort == null ? PortDetector.AUTO : selectedPort;
         DfuFlasher.rebootToDfu(parent, port, callbacks, Integration.CMD_REBOOT_DFU);

--- a/java_console/ui/src/main/java/com/rusefi/maintenance/ProgramSelector.java
+++ b/java_console/ui/src/main/java/com/rusefi/maintenance/ProgramSelector.java
@@ -103,7 +103,7 @@ public class ProgramSelector {
      * itself a bootloader and we're offline — prefer any detected OpenBLT port over the connection-
      * dependent AUTO path (which reboots a *running* ECU and just times out with no live BinaryProtocol).
      * This covers the offline "open a tune, plug an OpenBLT board" flow where the combo selection may be
-     * null/stale right after the hot-plug. (#9771)
+     * null/stale right after the hot-plug. [tag:better_ux_for_flashing]
      */
     private PortResult resolveFlashPort() {
         final PortResult selected = (PortResult) comboPorts.getSelectedItem();
@@ -179,12 +179,12 @@ public class ProgramSelector {
 
     /**
      * Programmatically trigger the main "Update Firmware" action for the currently selected port —
-     * same as clicking the split button. Used by the console's "Update ECU" menu shortcut (#9771).
+     * same as clicking the split button. Used by the console's "Update ECU" menu shortcut [tag:better_ux_for_flashing].
      */
     public void triggerUpdateFirmware() {
         final PortResult targetPort = resolveFlashPort();
         if (targetPort == null) {
-            // Nothing detected/selected — mirrors the split button being disabled in apply(). (#9771)
+            // Nothing detected/selected — mirrors the split button being disabled in apply(). [tag:better_ux_for_flashing]
             log.info("triggerUpdateFirmware: no port to flash, ignoring");
             return;
         }
@@ -409,7 +409,7 @@ public class ProgramSelector {
             callbacks.logLine(".srec image file not found");
             return false;
         }
-        // refuse to silently flash firmware built for a different board (e.g. a dev-build fallback or a naming quirk). (#9771)
+        // refuse to silently flash firmware built for a different board (e.g. a dev-build fallback or a naming quirk). [tag:better_ux_for_flashing]
         if (!MaintenanceUtil.confirmFirmwareMatchesBoard(fileName, callbacks)) {
             callbacks.logLine("Firmware update aborted — firmware/board mismatch.");
             return false;

--- a/java_console/ui/src/main/java/com/rusefi/maintenance/ProgramSelector.java
+++ b/java_console/ui/src/main/java/com/rusefi/maintenance/ProgramSelector.java
@@ -84,8 +84,18 @@ public class ProgramSelector {
      * so {@link #linkManager} is never set for it and {@link UpdateMode#OPENBLT_AUTO} (which reboots a
      * live ECU into the bootloader) cannot work. Flash it directly via {@link UpdateMode#OPENBLT_MANUAL}.
      */
-    private static UpdateMode mainButtonModeFor(@Nullable PortResult selectedPort) {
-        return (selectedPort != null && selectedPort.type == OpenBlt) ? OPENBLT_MANUAL : OPENBLT_AUTO;
+    private UpdateMode mainButtonModeFor(@Nullable PortResult selectedPort) {
+        if (selectedPort != null && selectedPort.type == OpenBlt) {
+            return OPENBLT_MANUAL;
+        }
+        // OPENBLT_AUTO reboots a *live* ECU into the bootloader; with no live connection there is nothing
+        // to reboot and awaitBinaryProtocol would just time out. So when offline — including a board
+        // sitting in a bootloader whose detection is momentarily flickering to Unknown — flash manually
+        // rather than flip-flopping into a dead AUTO job. [tag:better_ux_for_flashing]
+        if (!isLiveConnection()) {
+            return OPENBLT_MANUAL;
+        }
+        return OPENBLT_AUTO;
     }
 
     private void refreshMainButtonText() {
@@ -480,6 +490,10 @@ public class ProgramSelector {
         splitButton.setPopupMenu(menuItemCount > 0 ? popupMenu : null);
         splitButton.setMainButtonEnabled(hasSerialPorts && !isJobRunning);
         splitButton.setArrowButtonEnabled(menuItemCount > 0 && !isJobRunning);
+
+        // Keep the main-button mode/label in sync with the connection state too (not just combo changes):
+        // once the board is a live ECU again the button must go back to AUTO. [tag:better_ux_for_flashing]
+        refreshMainButtonText();
 
         AutoupdateUtil.trueLayoutAndRepaint(splitButton);
         AutoupdateUtil.trueLayoutAndRepaint(content);

--- a/java_console/ui/src/main/java/com/rusefi/maintenance/jobs/AbstractAutoFlashJob.java
+++ b/java_console/ui/src/main/java/com/rusefi/maintenance/jobs/AbstractAutoFlashJob.java
@@ -51,21 +51,46 @@ abstract class AbstractAutoFlashJob extends AsyncJobWithContext<SerialPortWithPa
             onJobFinished.run();
         }
 
-        // lm is non-null here — null path returned inside try
-        try {
-            connectivityContext.getSerialPortScanner().suspend().await(30, TimeUnit.SECONDS);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-        }
+        // lm is non-null here — null path returned inside try. Recover the live connection even when the
+        // calibration restore reported failure (the firmware itself may have flashed fine).
         lm.getCommandQueue().clearPendingCommands();
-        try {
-            lm.reconnect();
-        } finally {
-            connectivityContext.getSerialPortScanner().cachePort(
-                new PortResult(context.getPort().port, context.getPort().type)
-            );
-            connectivityContext.getSerialPortScanner().resume();
+        // The board re-enumerates after reboot, often onto a *different* port
+        // and sometimes after a delay. Let the always-on scanner detect + cache it, then reconnect to that
+        // port. We poll the scanner's snapshot rather than running a competing PortDetector probe: that
+        // probe races the scanner for the same port, fails to open it, and falls back to the stale
+        // pre-flash port. Do NOT fall back to the pre-flash port — after renumbering it's a ghost. (#9771)
+        connectivityContext.getSerialPortScanner().resume();
+        final String detectedPort = awaitEcuPort(TimeUnit.SECONDS.toMillis(60));
+        if (detectedPort != null) {
+            connectivityContext.getSerialPortScanner().cachePort(new PortResult(detectedPort, context.getPort().type));
+            lm.reconnect(detectedPort);
+        } else {
+            callbacks.logLine("ECU did not re-appear after flashing — reconnect manually once it enumerates.");
         }
+    }
+
+    /**
+     * Poll the scanner's detected hardware for a connectable ECU port (the rebooted board, possibly on a
+     * renumbered port), up to {@code timeoutMs}. Returns the port name, or null on timeout. Uses the
+     * scanner's own detection (which caches the port, so the subsequent reconnect doesn't collide with a
+     * probe) instead of a competing autodetect. (#9771)
+     */
+    private String awaitEcuPort(final long timeoutMs) {
+        final long deadline = System.currentTimeMillis() + timeoutMs;
+        while (System.currentTimeMillis() < deadline) {
+            for (final PortResult p : connectivityContext.getCurrentHardware().getKnownPorts()) {
+                if (p.isEcu()) {
+                    return p.port;
+                }
+            }
+            try {
+                Thread.sleep(500);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                break;
+            }
+        }
+        return null;
     }
 
 }

--- a/java_console/ui/src/main/java/com/rusefi/maintenance/jobs/AbstractAutoFlashJob.java
+++ b/java_console/ui/src/main/java/com/rusefi/maintenance/jobs/AbstractAutoFlashJob.java
@@ -58,7 +58,7 @@ abstract class AbstractAutoFlashJob extends AsyncJobWithContext<SerialPortWithPa
         // and sometimes after a delay. Let the always-on scanner detect + cache it, then reconnect to that
         // port. We poll the scanner's snapshot rather than running a competing PortDetector probe: that
         // probe races the scanner for the same port, fails to open it, and falls back to the stale
-        // pre-flash port. Do NOT fall back to the pre-flash port — after renumbering it's a ghost. (#9771)
+        // pre-flash port. Do NOT fall back to the pre-flash port — after renumbering it's a ghost. [tag:better_ux_for_flashing]
         connectivityContext.getSerialPortScanner().resume();
         final String detectedPort = awaitEcuPort(TimeUnit.SECONDS.toMillis(60));
         if (detectedPort != null) {
@@ -73,7 +73,7 @@ abstract class AbstractAutoFlashJob extends AsyncJobWithContext<SerialPortWithPa
      * Poll the scanner's detected hardware for a connectable ECU port (the rebooted board, possibly on a
      * renumbered port), up to {@code timeoutMs}. Returns the port name, or null on timeout. Uses the
      * scanner's own detection (which caches the port, so the subsequent reconnect doesn't collide with a
-     * probe) instead of a competing autodetect. (#9771)
+     * probe) instead of a competing autodetect. [tag:better_ux_for_flashing]
      */
     private String awaitEcuPort(final long timeoutMs) {
         final long deadline = System.currentTimeMillis() + timeoutMs;

--- a/java_console/ui/src/main/java/com/rusefi/maintenance/jobs/AbstractAutoFlashJob.java
+++ b/java_console/ui/src/main/java/com/rusefi/maintenance/jobs/AbstractAutoFlashJob.java
@@ -1,7 +1,9 @@
 package com.rusefi.maintenance.jobs;
 
+import com.rusefi.AvailableHardware;
 import com.rusefi.ConnectivityContext;
 import com.rusefi.PortResult;
+import com.rusefi.SerialPortType;
 import com.rusefi.binaryprotocol.BinaryProtocol;
 import com.rusefi.io.LinkManager;
 import com.rusefi.io.UpdateOperationCallbacks;
@@ -76,12 +78,25 @@ abstract class AbstractAutoFlashJob extends AsyncJobWithContext<SerialPortWithPa
      * probe) instead of a competing autodetect. [tag:better_ux_for_flashing]
      */
     private String awaitEcuPort(final long timeoutMs) {
-        final long deadline = System.currentTimeMillis() + timeoutMs;
+        final long start = System.currentTimeMillis();
+        final long deadline = start + timeoutMs;
+        // A *successful* flash reboots the board through the bootloader back to firmware, so a brief
+        // bootloader/Unknown flicker while it re-enumerates is normal — give the ECU time to come up
+        // before concluding (only on a *persistent* bootloader) that the flash was interrupted and no ECU
+        // is coming. This avoids bailing before the ECU is ready. [tag:better_ux_for_flashing]
+        final long bootloaderGraceMs = 5_000;
         while (System.currentTimeMillis() < deadline) {
-            for (final PortResult p : connectivityContext.getCurrentHardware().getKnownPorts()) {
+            final AvailableHardware hw = connectivityContext.getCurrentHardware();
+            for (final PortResult p : hw.getKnownPorts()) {
                 if (p.isEcu()) {
                     return p.port;
                 }
+            }
+            final boolean inBootloader = !hw.getKnownPorts(SerialPortType.OpenBlt).isEmpty() || hw.isDfuFound();
+            if (inBootloader && (System.currentTimeMillis() - start) > bootloaderGraceMs) {
+                // Persistently a bootloader (interrupted flash) — stop waiting so we don't hold the job
+                // executor and block the user's next flash attempt.
+                return null;
             }
             try {
                 Thread.sleep(500);

--- a/java_console/ui/src/main/java/com/rusefi/maintenance/jobs/OpenBltManualJob.java
+++ b/java_console/ui/src/main/java/com/rusefi/maintenance/jobs/OpenBltManualJob.java
@@ -4,6 +4,7 @@ import com.rusefi.ConnectivityContext;
 import com.rusefi.PortResult;
 import com.rusefi.SerialPortScanner;
 import com.rusefi.io.UpdateOperationCallbacks;
+import com.rusefi.maintenance.CalibrationsHelper;
 import com.rusefi.maintenance.MaintenanceUtil;
 import com.rusefi.maintenance.ProgramSelector;
 
@@ -33,17 +34,25 @@ public class OpenBltManualJob extends AsyncJobWithContext<SerialPortWithParentCo
                 } catch (InterruptedException e) {
                     Thread.currentThread().interrupt();
                 }
+                final boolean flashed;
                 try {
-                    if (ProgramSelector.flashOpenbltSerial(context.getParent(), context.getPort().port, callbacks)) {
-                        callbacks.done();
-                    } else {
-                        callbacks.error();
-                    }
+                    flashed = ProgramSelector.flashOpenbltSerial(context.getParent(), context.getPort().port, callbacks);
                 } finally {
                     // Board reboots to fresh firmware on a possibly-different port — re-inspect it.
                     scanner.invalidatePort(context.getPort().port);
                     scanner.resume();
                 }
+                if (!flashed) {
+                    callbacks.error();
+                    return;
+                }
+                // Scanner is running again so restore can wait for the rebooted ECU port to reappear.
+                // The auto path backs up+restores the tune around the flash; the manual path had no live
+                // ECU pre-flash (board was already in the bootloader), so restore the last tune backed up
+                // off an ECU this session. A hard failure here is non-fatal: the flash itself succeeded.
+                // [tag:better_ux_for_flashing]
+                CalibrationsHelper.restorePreviousCalibrationsAfterManualFlash(callbacks, ConnectivityContext.INSTANCE);
+                callbacks.done();
             },
             onJobFinished
         );

--- a/java_console/ui/src/main/java/com/rusefi/maintenance/jobs/OpenBltManualJob.java
+++ b/java_console/ui/src/main/java/com/rusefi/maintenance/jobs/OpenBltManualJob.java
@@ -26,7 +26,7 @@ public class OpenBltManualJob extends AsyncJobWithContext<SerialPortWithParentCo
                 // Take exclusive access to the port before flashing. The always-on scanner probes OpenBLT
                 // ports with XCP every cycle; if a probe overlaps the flash it corrupts the firmware image.
                 // suspend().await(...) blocks until the in-flight scan cycle has finished, mirroring the
-                // auto path's bltUpdateFirmware. (#9771)
+                // auto path's bltUpdateFirmware. [tag:better_ux_for_flashing]
                 final SerialPortScanner scanner = ConnectivityContext.INSTANCE.getSerialPortScanner();
                 try {
                     scanner.suspend().await(30, TimeUnit.SECONDS);

--- a/java_console/ui/src/main/java/com/rusefi/maintenance/jobs/OpenBltManualJob.java
+++ b/java_console/ui/src/main/java/com/rusefi/maintenance/jobs/OpenBltManualJob.java
@@ -1,10 +1,14 @@
 package com.rusefi.maintenance.jobs;
 
+import com.rusefi.ConnectivityContext;
 import com.rusefi.PortResult;
+import com.rusefi.SerialPortScanner;
 import com.rusefi.io.UpdateOperationCallbacks;
+import com.rusefi.maintenance.MaintenanceUtil;
 import com.rusefi.maintenance.ProgramSelector;
 
 import javax.swing.*;
+import java.util.concurrent.TimeUnit;
 
 public class OpenBltManualJob extends AsyncJobWithContext<SerialPortWithParentComponentJobContext> {
     public OpenBltManualJob(final PortResult port, final JComponent parent) {
@@ -15,10 +19,30 @@ public class OpenBltManualJob extends AsyncJobWithContext<SerialPortWithParentCo
     public void doJob(final UpdateOperationCallbacks callbacks, final Runnable onJobFinished) {
         JobHelper.doJob(
             () -> {
-                if (ProgramSelector.flashOpenbltSerial(context.getParent(), context.getPort().port, callbacks)) {
-                    callbacks.done();
-                } else {
+                if (!MaintenanceUtil.ensureFirmwareForConnectedTarget(callbacks)) {
                     callbacks.error();
+                    return;
+                }
+                // Take exclusive access to the port before flashing. The always-on scanner probes OpenBLT
+                // ports with XCP every cycle; if a probe overlaps the flash it corrupts the firmware image.
+                // suspend().await(...) blocks until the in-flight scan cycle has finished, mirroring the
+                // auto path's bltUpdateFirmware. (#9771)
+                final SerialPortScanner scanner = ConnectivityContext.INSTANCE.getSerialPortScanner();
+                try {
+                    scanner.suspend().await(30, TimeUnit.SECONDS);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+                try {
+                    if (ProgramSelector.flashOpenbltSerial(context.getParent(), context.getPort().port, callbacks)) {
+                        callbacks.done();
+                    } else {
+                        callbacks.error();
+                    }
+                } finally {
+                    // Board reboots to fresh firmware on a possibly-different port — re-inspect it.
+                    scanner.invalidatePort(context.getPort().port);
+                    scanner.resume();
                 }
             },
             onJobFinished

--- a/java_console/ui/src/main/java/com/rusefi/maintenance/jobs/OpenBltSwitchJob.java
+++ b/java_console/ui/src/main/java/com/rusefi/maintenance/jobs/OpenBltSwitchJob.java
@@ -27,15 +27,25 @@ public class OpenBltSwitchJob extends AsyncJobWithContext<SerialPortWithParentCo
                 if (linkManager != null) {
                     BinaryProtocol bp = linkManager.getBinaryProtocol();
                     ProgramSelector.rebootToOpenblt(context.getParent(), bp, callbacks);
-                    // Intentionally NOT calling linkManager.disconnect() here. Switching to OpenBLT is a
-                    // transient state: the board comes back either as an ECU on a (possibly renumbered) port
-                    // or, after the bootloader times out with no flash, jumps straight back to firmware. We
-                    // want auto-reconnect to resume in both cases. disconnect() sets isDisconnectedByUser=true,
-                    // which permanently blocks ConnectionWatchdog.restart() *and* the ConsoleUI
-                    // follow-renumbered-port listener, so the live session would never come back
-                    // (online → OpenBLT → online without flashing hangs forever).
-                    // The old ExitUtil.exit() hazard the disconnect guarded against is gone: restart() now
-                    // reconnects via connect(port, isScanningForEcu=true), which suppresses the exit. [tag:better_ux_for_flashing]
+                    // close() — NOT disconnect() — to release the serial port for the transient OpenBLT
+                    // state. The board comes back either as an ECU on a (possibly renumbered on Linux) port
+                    // or jumps straight back to firmware after the bootloader times out with no flash; we
+                    // want auto-reconnect to resume in both cases.
+                    //
+                    // Why close() and not either extreme:
+                    //  - disconnect() sets isDisconnectedByUser=true, permanently blocking
+                    //    ConnectionWatchdog.restart() AND the ConsoleUI follow-renumbered-port listener —
+                    //    the session would never come back.
+                    //  - Leaving the LinkManager fully active keeps the watchdog
+                    //    reconnecting while the SerialPortScanner also probes the returning node. On Linux
+                    //    the board re-enumerates onto a NEW ttyACMx that is never cached (Unknown results
+                    //    aren't cached), so the scanner re-probes it every cycle and the two openers
+                    //    mutually EBUSY ("maybe no permissions?") forever → console stuck disconnected.
+                    //    (Windows keeps a sticky COM number) This mirrors the working DFU
+                    //    path, where DfuFlasher opens/closes its own stream and the live LM is released.
+                    // close() frees the port but leaves isDisconnectedByUser=false, so the returning ECU is
+                    // classified by the scanner uncontested and a single reconnect brings the console back. [tag:better_ux_for_flashing]
+                    linkManager.close();
                 } else {
                     ProgramSelector.rebootToOpenblt(context.getParent(), context.getPort().port, callbacks);
                 }

--- a/java_console/ui/src/main/java/com/rusefi/maintenance/jobs/OpenBltSwitchJob.java
+++ b/java_console/ui/src/main/java/com/rusefi/maintenance/jobs/OpenBltSwitchJob.java
@@ -27,9 +27,15 @@ public class OpenBltSwitchJob extends AsyncJobWithContext<SerialPortWithParentCo
                 if (linkManager != null) {
                     BinaryProtocol bp = linkManager.getBinaryProtocol();
                     ProgramSelector.rebootToOpenblt(context.getParent(), bp, callbacks);
-                    // Disconnect before the ECU drops the link; prevents ConnectionWatchdog
-                    // from calling restart() → connect(port, false) → ExitUtil.exit().
-                    linkManager.disconnect();
+                    // Intentionally NOT calling linkManager.disconnect() here. Switching to OpenBLT is a
+                    // transient state: the board comes back either as an ECU on a (possibly renumbered) port
+                    // or, after the bootloader times out with no flash, jumps straight back to firmware. We
+                    // want auto-reconnect to resume in both cases. disconnect() sets isDisconnectedByUser=true,
+                    // which permanently blocks ConnectionWatchdog.restart() *and* the ConsoleUI
+                    // follow-renumbered-port listener, so the live session would never come back
+                    // (online → OpenBLT → online without flashing hangs forever).
+                    // The old ExitUtil.exit() hazard the disconnect guarded against is gone: restart() now
+                    // reconnects via connect(port, isScanningForEcu=true), which suppresses the exit. [tag:better_ux_for_flashing]
                 } else {
                     ProgramSelector.rebootToOpenblt(context.getParent(), context.getPort().port, callbacks);
                 }

--- a/java_console/ui/src/main/java/com/rusefi/ui/console/MainFrame.java
+++ b/java_console/ui/src/main/java/com/rusefi/ui/console/MainFrame.java
@@ -205,6 +205,8 @@ public class MainFrame {
     private void windowOpenedHandler() {
         setTitle();
         tabbedPane.tabbedPane.addPropertyChangeListener("isUpdating", e -> SwingUtilities.invokeLater(this::setTitle));
+        tabbedPane.tabbedPane.addPropertyChangeListener("bootloaderMode", e -> SwingUtilities.invokeLater(this::setTitle));
+
         // Offer manual update whenever the launch-time silent update did not run - either because
         // the user preference is off or because the bundle hard-disables auto-update (#9775).
         if (!Autoupdate.isAutoUpdateEnabled()) {
@@ -312,8 +314,12 @@ public class MainFrame {
     private void setTitle() {
         String consoleVersion = "Console " + Launcher.CONSOLE_VERSION;
         String frameTitle;
+        Object bootloaderMode = tabbedPane.tabbedPane.getClientProperty("bootloaderMode");
         if (Boolean.TRUE.equals(tabbedPane.tabbedPane.getClientProperty("isUpdating"))) {
             frameTitle = "UPDATING " + consoleVersion;
+        } else if (bootloaderMode != null) {
+            // Board sitting in a bootloader (#9771) — not connected, but not a plain "disconnected" state.
+            frameTitle = bootloaderMode + " BOOTLOADER " + consoleVersion;
         } else if (ConnectionStatusLogic.INSTANCE.isConnected()) {
             BinaryProtocol bp = consoleUI.uiContext.getBinaryProtocol();
             String signature = bp == null ? "not loaded" : bp.signature;

--- a/java_console/ui/src/main/java/com/rusefi/ui/console/MainFrame.java
+++ b/java_console/ui/src/main/java/com/rusefi/ui/console/MainFrame.java
@@ -318,7 +318,7 @@ public class MainFrame {
         if (Boolean.TRUE.equals(tabbedPane.tabbedPane.getClientProperty("isUpdating"))) {
             frameTitle = "UPDATING " + consoleVersion;
         } else if (bootloaderMode != null) {
-            // Board sitting in a bootloader (#9771) — not connected, but not a plain "disconnected" state.
+            // Board sitting in a bootloader [tag:better_ux_for_flashing] — not connected, but not a plain "disconnected" state.
             frameTitle = bootloaderMode + " BOOTLOADER " + consoleVersion;
         } else if (ConnectionStatusLogic.INSTANCE.isConnected()) {
             BinaryProtocol bp = consoleUI.uiContext.getBinaryProtocol();

--- a/java_console/ui/src/main/java/com/rusefi/ui/widgets/ConnectionStatusIcon.java
+++ b/java_console/ui/src/main/java/com/rusefi/ui/widgets/ConnectionStatusIcon.java
@@ -7,7 +7,7 @@ import javax.swing.*;
 import java.awt.*;
 
 public class ConnectionStatusIcon extends JButton {
-    // Board sitting in a DFU/OpenBLT bootloader (#9771) — distinct from connected (green)/disconnected (red).
+    // Board sitting in a DFU/OpenBLT bootloader [tag:better_ux_for_flashing] — distinct from connected (green)/disconnected (red).
     private static final Color BOOTLOADER_PURPLE = new Color(150, 40, 210);
 
     public ConnectionStatusIcon(LinkManager linkManager, JTabbedPane tabbedPane) {

--- a/java_console/ui/src/main/java/com/rusefi/ui/widgets/ConnectionStatusIcon.java
+++ b/java_console/ui/src/main/java/com/rusefi/ui/widgets/ConnectionStatusIcon.java
@@ -7,11 +7,22 @@ import javax.swing.*;
 import java.awt.*;
 
 public class ConnectionStatusIcon extends JButton {
-    public ConnectionStatusIcon(LinkManager linkManager) {
+    // Board sitting in a DFU/OpenBLT bootloader (#9771) — distinct from connected (green)/disconnected (red).
+    private static final Color BOOTLOADER_PURPLE = new Color(150, 40, 210);
+
+    public ConnectionStatusIcon(LinkManager linkManager, JTabbedPane tabbedPane) {
         setIcon(new Icon() {
             @Override
             public void paintIcon(Component c, Graphics g, int x, int y) {
-                g.setColor(ConnectionStatusLogic.INSTANCE.isConnected() ? Color.GREEN : Color.RED);
+                final Color color;
+                if (tabbedPane != null && tabbedPane.getClientProperty("bootloaderMode") != null) {
+                    color = BOOTLOADER_PURPLE;
+                } else if (ConnectionStatusLogic.INSTANCE.isConnected()) {
+                    color = Color.GREEN;
+                } else {
+                    color = Color.RED;
+                }
+                g.setColor(color);
                 g.fillOval(x, y, getIconWidth(), getIconHeight());
             }
 
@@ -29,12 +40,20 @@ public class ConnectionStatusIcon extends JButton {
         setContentAreaFilled(false);
 
         Runnable updateButton = () -> {
-            boolean isConnected = ConnectionStatusLogic.INSTANCE.isConnected();
-            setToolTipText(isConnected ? "Connected. Click or Ctrl+D to disconnect." : "Disconnected. Click or Ctrl+R to connect.");
+            final Object bootloaderMode = tabbedPane == null ? null : tabbedPane.getClientProperty("bootloaderMode");
+            if (bootloaderMode != null) {
+                setToolTipText(bootloaderMode + " bootloader — use the Device tab to update firmware.");
+            } else {
+                boolean isConnected = ConnectionStatusLogic.INSTANCE.isConnected();
+                setToolTipText(isConnected ? "Connected. Click or Ctrl+D to disconnect." : "Disconnected. Click or Ctrl+R to connect.");
+            }
             repaint();
         };
 
         ConnectionStatusLogic.INSTANCE.addListener(isConnected -> SwingUtilities.invokeLater(updateButton));
+        if (tabbedPane != null) {
+            tabbedPane.addPropertyChangeListener("bootloaderMode", e -> SwingUtilities.invokeLater(updateButton));
+        }
         updateButton.run();
 
         addActionListener(e -> {

--- a/java_console/ui/src/test/java/com/rusefi/ui/widgets/ConnectionStatusIconTest.java
+++ b/java_console/ui/src/test/java/com/rusefi/ui/widgets/ConnectionStatusIconTest.java
@@ -15,7 +15,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 
 /**
- * Tests for the purple bootloader indicator on the connection status icon (#9771).
+ * Tests for the purple bootloader indicator on the connection status icon [tag:better_ux_for_flashing].
  */
 public class ConnectionStatusIconTest {
 

--- a/java_console/ui/src/test/java/com/rusefi/ui/widgets/ConnectionStatusIconTest.java
+++ b/java_console/ui/src/test/java/com/rusefi/ui/widgets/ConnectionStatusIconTest.java
@@ -1,0 +1,137 @@
+package com.rusefi.ui.widgets;
+
+import com.rusefi.io.ConnectionStatusLogic;
+import com.rusefi.io.ConnectionStatusValue;
+import com.rusefi.io.LinkManager;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import javax.swing.*;
+import java.awt.*;
+import java.lang.reflect.Field;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Tests for the purple bootloader indicator on the connection status icon (#9771).
+ */
+public class ConnectionStatusIconTest {
+
+    private JTabbedPane tabbedPane;
+    private LinkManager linkManager;
+
+    @BeforeEach
+    void setUp() {
+        tabbedPane = new JTabbedPane();
+        linkManager = mock(LinkManager.class);
+        // Reset ConnectionStatusLogic to disconnected state
+        ConnectionStatusLogic.INSTANCE.setValue(ConnectionStatusValue.NOT_CONNECTED);
+    }
+
+    @AfterEach
+    void tearDown() {
+        tabbedPane = null;
+    }
+
+    @Test
+    void paintsRedWhenDisconnected() {
+        ConnectionStatusIcon icon = new ConnectionStatusIcon(linkManager, tabbedPane);
+        Icon delegate = icon.getIcon();
+        // Force a paint to a test image to capture the color
+        java.awt.image.BufferedImage img = new java.awt.image.BufferedImage(16, 16, java.awt.image.BufferedImage.TYPE_INT_ARGB);
+        Graphics2D g = img.createGraphics();
+        delegate.paintIcon(icon, g, 0, 0);
+        g.dispose();
+        // The center pixel should be red (disconnected)
+        int rgb = img.getRGB(8, 8);
+        Color c = new Color(rgb, true);
+        assertTrue(c.getRed() > c.getGreen() && c.getRed() > c.getBlue(), "Expected red when disconnected, got " + c);
+    }
+
+    @Test
+    void paintsGreenWhenConnected() {
+        ConnectionStatusLogic.INSTANCE.setValue(ConnectionStatusValue.CONNECTED);
+        ConnectionStatusIcon icon = new ConnectionStatusIcon(linkManager, tabbedPane);
+        Icon delegate = icon.getIcon();
+        java.awt.image.BufferedImage img = new java.awt.image.BufferedImage(16, 16, java.awt.image.BufferedImage.TYPE_INT_ARGB);
+        Graphics2D g = img.createGraphics();
+        delegate.paintIcon(icon, g, 0, 0);
+        g.dispose();
+        int rgb = img.getRGB(8, 8);
+        Color c = new Color(rgb, true);
+        assertTrue(c.getGreen() > c.getRed() && c.getGreen() > c.getBlue(), "Expected green when connected, got " + c);
+    }
+
+    @Test
+    void paintsPurpleWhenBootloaderMode() {
+        // Bootloader mode overrides connection state
+        ConnectionStatusLogic.INSTANCE.setValue(ConnectionStatusValue.CONNECTED);
+        tabbedPane.putClientProperty("bootloaderMode", "OpenBLT");
+        ConnectionStatusIcon icon = new ConnectionStatusIcon(linkManager, tabbedPane);
+        Icon delegate = icon.getIcon();
+        java.awt.image.BufferedImage img = new java.awt.image.BufferedImage(16, 16, java.awt.image.BufferedImage.TYPE_INT_ARGB);
+        Graphics2D g = img.createGraphics();
+        delegate.paintIcon(icon, g, 0, 0);
+        g.dispose();
+        int rgb = img.getRGB(8, 8);
+        Color c = new Color(rgb, true);
+        // Purple: high blue, medium red, low green
+        assertTrue(c.getBlue() > c.getRed() && c.getBlue() > c.getGreen(), "Expected purple in bootloader mode, got " + c);
+        assertTrue(c.getRed() > 100, "Purple should have significant red component, got " + c.getRed());
+    }
+
+    @Test
+    void tooltipShowsBootloaderMode() {
+        tabbedPane.putClientProperty("bootloaderMode", "DFU");
+        ConnectionStatusIcon icon = new ConnectionStatusIcon(linkManager, tabbedPane);
+        String tip = icon.getToolTipText();
+        assertNotNull(tip);
+        assertTrue(tip.contains("DFU"), "Tooltip should mention bootloader mode: " + tip);
+        assertTrue(tip.contains("update firmware"), "Tooltip should direct user to update firmware: " + tip);
+    }
+
+    @Test
+    void tooltipShowsConnectedWhenNotBootloader() {
+        ConnectionStatusLogic.INSTANCE.setValue(ConnectionStatusValue.CONNECTED);
+        ConnectionStatusIcon icon = new ConnectionStatusIcon(linkManager, tabbedPane);
+        String tip = icon.getToolTipText();
+        assertNotNull(tip);
+        assertTrue(tip.contains("Connected"), "Expected connected tooltip: " + tip);
+    }
+
+    @Test
+    void tooltipShowsDisconnectedWhenNotBootloaderAndNotConnected() {
+        ConnectionStatusLogic.INSTANCE.setValue(ConnectionStatusValue.NOT_CONNECTED);
+        ConnectionStatusIcon icon = new ConnectionStatusIcon(linkManager, tabbedPane);
+        String tip = icon.getToolTipText();
+        assertNotNull(tip);
+        assertTrue(tip.contains("Disconnected"), "Expected disconnected tooltip: " + tip);
+    }
+
+    @Test
+    void updatesWhenBootloaderModeChanges() {
+        // Start with no bootloader mode
+        ConnectionStatusIcon icon = new ConnectionStatusIcon(linkManager, tabbedPane);
+        String tipBefore = icon.getToolTipText();
+        assertFalse(tipBefore.contains("DFU"), "Should not mention DFU initially: " + tipBefore);
+
+        // Change the property
+        tabbedPane.putClientProperty("bootloaderMode", "DFU");
+        // Wait for the SwingUtilities.invokeLater to process
+        try {
+            SwingUtilities.invokeAndWait(() -> {});
+        } catch (Exception e) {
+            fail(e);
+        }
+        String tipAfter = icon.getToolTipText();
+        assertTrue(tipAfter.contains("DFU"), "Should mention DFU after property change: " + tipAfter);
+    }
+
+    @Test
+    void worksWithNullTabbedPane() {
+        // Should not throw, falls back to connected/disconnected only
+        assertDoesNotThrow(() -> new ConnectionStatusIcon(linkManager, null));
+    }
+}


### PR DESCRIPTION
sadly big pr since we change how the console manages the ports, 

now insteaded of "a console can know about X port, wich is Y board" is: "the console manges N sessions, where a session is Y board, than can have X1,X2,X3 ports" (this one is for catch a same board jumping between ports for OS things), the session has a custom state, defined as:

```java
public enum SessionState {
    /** No live ECU connection and no board detected in a bootloader/DFU state. */
    DISCONNECTED,
    /** A connect attempt is in flight (LinkManager started, not yet CONNECTED). */
    CONNECTING,
    /** Live ECU connection is up. */
    CONNECTED,
    /** A firmware-update job (DFU or OpenBLT) owns the port; other operations must wait. */
    FLASHING,
    /** A board is sitting in the STM32 built-in bootloader (DFU) — flashable, not connectable. */
    DEVICE_IN_DFU,
    /** A board is sitting in the OpenBLT bootloader — flashable, not connectable. */
    DEVICE_IN_BLT,
}
``` 

now:

* connected => user restarts on DFU => can flash the board without restarting the console
* connected => user restarts on OpenBLT => can flash the board without restarting the console
* connected => user flash new firmare => disconnect board => openblt update fails => reconnect => can re-flash & restore the backup tune

* connected => user restarts on DFU => user restarts again back into firmware
* connected => user restarts on OpenBLT => user restarts again back into firmware

* while offline => connects a board into DFU or OpenBLT (but we dont know what that board was before, kind of related with #9183), we show and alert before flashing, but the user can flash without restarting the console:

<img width="607" height="359" alt="image" src="https://github.com/user-attachments/assets/3d919ec2-8367-4c1a-b920-5d9589c2e8dd" />



* both DFU and OpenBLT has a new status color, purple, also the windows bar now reflects the correct state:

<img width="1280" height="164" alt="image" src="https://github.com/user-attachments/assets/ab8b8233-3372-4232-8d9b-7e320d8b5e50" />


related #9771