### PR TITLE
dc motor: configurable min/max duty cycle per H-bridge

### DIFF
--- a/firmware/controllers/actuators/electronic_throttle.cpp
+++ b/firmware/controllers/actuators/electronic_throttle.cpp
@@ -159,15 +159,11 @@ static TsCalMode functionToCalModeSecMax(dc_function_e func) {
 }
 #endif // EFI_TUNER_STUDIO
 
-#define ETB_DUTY_LIMIT 0.9
-// this macro clamps both positive and negative percentages from about -100% to 100%
-#define ETB_PERCENT_TO_DUTY(x) (clampF(-ETB_DUTY_LIMIT, 0.01f * (x), ETB_DUTY_LIMIT))
-
 PUBLIC_API_WEAK bool isBoardAllowingLackOfPps() {
   return false;
 }
 
-bool EtbController::init(dc_function_e function, DcMotor *motor, pid_s *pidParameters, const ValueProvider3D* pedalProvider) {
+bool EtbController::init(dc_function_e function, DcMotor *motor, pid_s *pidParameters, const ValueProvider3D* pedalProvider, float minDuty, float maxDuty) {
 	state = (uint8_t)EtbState::InInit;
 	if (function == DC_None) {
 		// if not configured, don't init.
@@ -178,6 +174,8 @@ bool EtbController::init(dc_function_e function, DcMotor *motor, pid_s *pidParam
 
 	m_function = function;
 	m_positionSensor = functionToPositionSensor(function);
+	m_minDuty = minDuty;
+	m_maxDuty = maxDuty;
 
 	// If we are a throttle, require redundant TPS sensor
 	if (isEtbMode()) {
@@ -570,7 +568,7 @@ void EtbController::setOutput(expected<percent_t> outputValue) {
 	// If not ETB, or ETB is allowed, output is valid, and we aren't paused, output to motor.
 	if (isEnabled) {
 		m_motor->enable();
-		m_motor->set(ETB_PERCENT_TO_DUTY(outputValue.Value));
+		m_motor->set(clampF(-m_minDuty, 0.01f * outputValue.Value, m_maxDuty));
 	} else {
 		// Otherwise disable the motor.
 		m_motor->disable("no-ETB");
@@ -913,7 +911,8 @@ void doInitElectronicThrottle(bool isStartupInit) {
 
 		auto pid = getPidForDcFunction(func);
 
-		bool dcConfigured = controller->init(func, motor, pid, pedal2TpsProvider());
+		bool dcConfigured = controller->init(func, motor, pid, pedal2TpsProvider(),
+				engineConfiguration->dcMinDutyCycle[i] / 100.0f, engineConfiguration->dcMaxDutyCycle[i] / 100.0f);
 		if (isStartupInit && dcConfigured) {
 			controller->reset("init");
 		}

--- a/firmware/controllers/actuators/electronic_throttle.h
+++ b/firmware/controllers/actuators/electronic_throttle.h
@@ -67,7 +67,7 @@ class IEtbController : public ClosedLoopController<percent_t, percent_t>  {
 public:
 	// Initialize the throttle.
 	// returns true if the throttle was initialized, false otherwise.
-	virtual bool init(dc_function_e function, DcMotor *motor, pid_s *pidParameters, const ValueProvider3D* pedalMap) = 0;
+	virtual bool init(dc_function_e function, DcMotor *motor, pid_s *pidParameters, const ValueProvider3D* pedalMap, float minDuty, float maxDuty) = 0;
 	virtual void reset(const char *reason) = 0;
 	virtual void setIdlePosition(percent_t pos) = 0;
 	virtual void setWastegatePosition(percent_t pos) = 0;

--- a/firmware/controllers/actuators/electronic_throttle_impl.h
+++ b/firmware/controllers/actuators/electronic_throttle_impl.h
@@ -27,7 +27,7 @@
 
 class EtbController : public IEtbController, public electronic_throttle_s {
 public:
-	bool init(dc_function_e function, DcMotor *motor, pid_s *pidParameters, const ValueProvider3D* pedalMap) override;
+	bool init(dc_function_e function, DcMotor *motor, pid_s *pidParameters, const ValueProvider3D* pedalMap, float minDuty, float maxDuty) override;
 	void setIdlePosition(percent_t pos) override;
 	void setWastegatePosition(percent_t pos) override;
 	void reset(const char *reason) override;
@@ -93,6 +93,8 @@ private:
 	dc_function_e m_function = DC_None;
 	SensorType m_positionSensor = SensorType::Invalid;
 	DcMotor *m_motor = nullptr;
+	float m_minDuty = 0.9f;
+	float m_maxDuty = 0.9f;
 	Pid m_pid;
 	bool m_shouldResetPid = false;
 

--- a/firmware/controllers/algo/defaults/default_base_engine.cpp
+++ b/firmware/controllers/algo/defaults/default_base_engine.cpp
@@ -139,6 +139,15 @@ void defaultsOrFixOnBurn() {
     engineConfiguration->mainRelayDisableTime = 1;
   }
 
+  for (int i = 0; i < ETB_COUNT; i++) {
+    if (engineConfiguration->dcMinDutyCycle[i] == 0) {
+      engineConfiguration->dcMinDutyCycle[i] = 90;
+    }
+    if (engineConfiguration->dcMaxDutyCycle[i] == 0) {
+      engineConfiguration->dcMaxDutyCycle[i] = 90;
+    }
+  }
+
   // Seed the 2D cranking flex table for tunes that predate it (all-zero ethanol axis). Mirror the existing
   // E0 coolant curve at every ethanol level so turning on flexCranking stays neutral with respect to ethanol
   // until the user calibrates it.

--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -1994,6 +1994,9 @@ end_struct
 
 	uint16_t launchRpmThreshold;Launch RPM Threshold: when above 0, launch only engages if the activation switch (button/clutch) is pressed at or below this RPM, and stays latched while held - even past this RPM. This lets a standing launch (switch pressed low, revved up) coexist with flat shift / torque reduction (switch blipped high during an upshift). 0 disables the gate (legacy behavior).;"rpm", 1, 0, 0, 20000, 0
 
+	uint8_t[ETB_COUNT iterate] dcMinDutyCycle;Min Duty Cycle: magnitude of the allowed negative-direction output, per H-bridge. 0 uses the legacy 90% default and is not persisted as a true zero - to fully disable an H-bridge use its Disable pin instead.;"%", 1, 0, 0, 100, 0
+	uint8_t[ETB_COUNT iterate] dcMaxDutyCycle;Max Duty Cycle: positive-direction output limit, per H-bridge. 0 uses the legacy 90% default and is not persisted as a true zero - to fully disable an H-bridge use its Disable pin instead.;"%", 1, 0, 0, 100, 0
+
 	! --- Misfire Detection ---
 	bit misfireDetectionEnabled,"enabled","disabled";Misfire Detection: master enable. Active at idle only. Latches check-engine light (P0300) once the count threshold is reached.
 	uint8_t misfireConsecutiveCount;Misfire Detection: minimum flagged firings within the recent-firings window before a misfire is counted.;"events", 1, 0, 1, 20, 0

--- a/firmware/tunerstudio/tunerstudio.template.ini
+++ b/firmware/tunerstudio/tunerstudio.template.ini
@@ -3509,12 +3509,16 @@ dialog = allPinsOutputs_1_and_2, "", xAxis
 		field = "No1 Direction #2",						etbIo1_directionPin2
 		field = "No1 Control",							etbIo1_controlPin
 		field = "No1 Disable",							etbIo1_disablePin
+		field = "No1 Min duty %",						dcMinDutyCycle1
+		field = "No1 Max duty %",						dcMaxDutyCycle1
 
 	dialog = dcHbridgeHardwareNo2, "H-Bridge Hardware No2"
 		field = "No2 Direction #1",						etbIo2_directionPin1
 		field = "No2 Direction #2",						etbIo2_directionPin2
 		field = "No2 Control",							etbIo2_controlPin
 		field = "No2 Disable",							etbIo2_disablePin
+		field = "No2 Min duty %",						dcMinDutyCycle2
+		field = "No2 Max duty %",						dcMaxDutyCycle2
 
 	dialog = dcHbridgeHardware, "H-Bridge Hardware"
 		field = "This is not about ETB pinout"

--- a/unit_tests/mocks.h
+++ b/unit_tests/mocks.h
@@ -22,7 +22,7 @@ public:
 	MOCK_METHOD(void, reset, (const char *reason), (override));
 	MOCK_METHOD(bool, isEtbMode, (), (const, override));
 	MOCK_METHOD(void, update, (), (override));
-	MOCK_METHOD(bool, init, (dc_function_e function, DcMotor* motor, pid_s* pidParameters, const ValueProvider3D* pedalMap), (override));
+	MOCK_METHOD(bool, init, (dc_function_e function, DcMotor* motor, pid_s* pidParameters, const ValueProvider3D* pedalMap, float minDuty, float maxDuty), (override));
 	MOCK_METHOD(void, setIdlePosition, (percent_t pos), (override));
 	MOCK_METHOD(void, setWastegatePosition, (percent_t pos), (override));
 	MOCK_METHOD(void, autoCalibrateTps, (bool), (override));

--- a/unit_tests/tests/actuators/test_etb.cpp
+++ b/unit_tests/tests/actuators/test_etb.cpp
@@ -10,6 +10,7 @@
 #include "electronic_throttle_impl.h"
 #include "dc_motor.h"
 #include "idle_thread.h"
+#include "defaults.h"
 
 #include "mocks.h"
 
@@ -27,8 +28,8 @@ TEST(etb, initializationNoPedal) {
 		engine->etbControllers[i] = &mocks[i];
 	}
 
-	EXPECT_CALL(mocks[0], init(DC_Throttle1, _, _, _)).WillOnce(Return(false));
-	EXPECT_CALL(mocks[1], init(DC_Throttle2, _, _, _)).WillOnce(Return(false));
+	EXPECT_CALL(mocks[0], init(DC_Throttle1, _, _, _, _, _)).WillOnce(Return(false));
+	EXPECT_CALL(mocks[1], init(DC_Throttle2, _, _, _, _, _)).WillOnce(Return(false));
 
 	// This shouldn't throw, since no throttles are configured, but no pedal is configured either
 	EXPECT_NO_FATAL_ERROR(doInitElectronicThrottle(true));
@@ -46,8 +47,8 @@ TEST(etb, initializationMissingThrottle) {
 		engine->etbControllers[i] = &mocks[i];
 	}
 
-	EXPECT_CALL(mocks[0], init(DC_None, _, _, _)).Times(0);
-	EXPECT_CALL(mocks[1], init(DC_None, _, _, _)).Times(0);
+	EXPECT_CALL(mocks[0], init(DC_None, _, _, _, _, _)).Times(0);
+	EXPECT_CALL(mocks[1], init(DC_None, _, _, _, _, _)).Times(0);
 
 	// Must have a sensor configured before init
 	Sensor::setMockValue(SensorType::AcceleratorPedal, 0, true);
@@ -77,10 +78,10 @@ TEST(etb, initializationSingleThrottle) {
 	Sensor::setMockValue(SensorType::AcceleratorPedalPrimary, 0);
 
 	// Expect mock0 to be init as throttle 1, and PID params
-	EXPECT_CALL(mocks[0], init(DC_Throttle1, _, &engineConfiguration->etb, Ne(nullptr))).WillOnce(Return(true));
+	EXPECT_CALL(mocks[0], init(DC_Throttle1, _, &engineConfiguration->etb, Ne(nullptr), _, _)).WillOnce(Return(true));
 
 	// Expect mock1 to be init as none
-	EXPECT_CALL(mocks[1], init(DC_None, _, _, _)).Times(0);
+	EXPECT_CALL(mocks[1], init(DC_None, _, _, _, _, _)).Times(0);
 
 	doInitElectronicThrottle(false);
 }
@@ -105,10 +106,10 @@ TEST(etb, initializationSingleThrottleInSecondSlot) {
 	Sensor::setMockValue(SensorType::AcceleratorPedalPrimary, 0, false);
 
 	// Expect mock0 to be init as none
-	EXPECT_CALL(mocks[0], init(DC_None, _, _, _)).Times(0);
+	EXPECT_CALL(mocks[0], init(DC_None, _, _, _, _, _)).Times(0);
 
 	// Expect mock1 to be init as throttle 1, and PID params
-	EXPECT_CALL(mocks[1], init(DC_Throttle1, _, &engineConfiguration->etb, Ne(nullptr))).WillOnce(Return(true));
+	EXPECT_CALL(mocks[1], init(DC_Throttle1, _, &engineConfiguration->etb, Ne(nullptr), _, _)).WillOnce(Return(true));
 
 	doInitElectronicThrottle(false);
 }
@@ -138,10 +139,10 @@ TEST(etb, initializationDualThrottle) {
 	engineConfiguration->etbFunctions[1] = DC_Throttle2;
 
 	// Expect mock0 to be init as throttle 1, and PID params
-	EXPECT_CALL(mocks[0], init(DC_Throttle1, _, &engineConfiguration->etb, Ne(nullptr))).WillOnce(Return(true));
+	EXPECT_CALL(mocks[0], init(DC_Throttle1, _, &engineConfiguration->etb, Ne(nullptr), _, _)).WillOnce(Return(true));
 
 	// Expect mock1 to be init as throttle 2, and PID params
-	EXPECT_CALL(mocks[1], init(DC_Throttle2, _, &engineConfiguration->etb, Ne(nullptr))).WillOnce(Return(true));
+	EXPECT_CALL(mocks[1], init(DC_Throttle2, _, &engineConfiguration->etb, Ne(nullptr), _, _)).WillOnce(Return(true));
 
 	doInitElectronicThrottle(false);
 }
@@ -162,10 +163,10 @@ TEST(etb, initializationWastegate) {
 	}
 
 	// Expect mock0 to be init as throttle 1, and PID wastegate params
-	EXPECT_CALL(mocks[0], init(DC_Wastegate, _, &engineConfiguration->etbWastegatePid, Ne(nullptr))).WillOnce(Return(true));
+	EXPECT_CALL(mocks[0], init(DC_Wastegate, _, &engineConfiguration->etbWastegatePid, Ne(nullptr), _, _)).WillOnce(Return(true));
 
 	// Expect mock1 to be init as none
-	EXPECT_CALL(mocks[1], init(DC_None, _, _, _)).Times(0);
+	EXPECT_CALL(mocks[1], init(DC_None, _, _, _, _, _)).Times(0);
 
 	doInitElectronicThrottle(false);
 }
@@ -176,7 +177,7 @@ TEST(etb, initializationNoFunction) {
 	EtbController dut;
 
 	// When init called with DC_None, should ignore the provided params and return false
-	EXPECT_FALSE(dut.init(DC_None, &motor, nullptr, nullptr));
+	EXPECT_FALSE(dut.init(DC_None, &motor, nullptr, nullptr, 0.9f, 0.9f));
 
 	// This should no-op, it shouldn't call motor.set(float duty)
 	dut.setOutput(0.5f);
@@ -192,7 +193,7 @@ TEST(etb, initializationNotRedundantTps) {
 	Sensor::setMockValue(SensorType::Tps1Primary, 0);
 	Sensor::setMockValue(SensorType::Tps1, 0.0f, false);
 
-	ASSERT_FALSE(dut.init(DC_Throttle1, nullptr, nullptr, nullptr));
+	ASSERT_FALSE(dut.init(DC_Throttle1, nullptr, nullptr, nullptr, 0.9f, 0.9f));
 }
 
 TEST(etb, initializationNotRedundantPedal) {
@@ -206,7 +207,7 @@ TEST(etb, initializationNotRedundantPedal) {
 	Sensor::setMockValue(SensorType::Tps1, 0.0f, true);
 
 	// we require redundancy at runtime, not at initialization time. that would allow for Lua pedal to appear later on.
-	ASSERT_TRUE(dut.init(DC_Throttle1, nullptr, nullptr, nullptr));
+	ASSERT_TRUE(dut.init(DC_Throttle1, nullptr, nullptr, nullptr, 0.9f, 0.9f));
 }
 
 TEST(etb, initializationNoSensor) {
@@ -217,13 +218,13 @@ TEST(etb, initializationNoSensor) {
 	// Needs pedal for init
 	Sensor::setMockValue(SensorType::AcceleratorPedal, 0.0f, true);
 
-	EXPECT_FALSE(dut.init(DC_Throttle1, nullptr, nullptr, nullptr));
+	EXPECT_FALSE(dut.init(DC_Throttle1, nullptr, nullptr, nullptr, 0.9f, 0.9f));
 
 	// Redundant
 	Sensor::setMockValue(SensorType::Tps1, /*value*/0, /*mockRedundant*/true);
 
 	// With primary TPS, should return true (ie, throttle was configured)
-	EXPECT_TRUE(dut.init(DC_Throttle1, nullptr, nullptr, nullptr));
+	EXPECT_TRUE(dut.init(DC_Throttle1, nullptr, nullptr, nullptr, 0.9f, 0.9f));
 }
 
 TEST(etb, initializationNoThrottles) {
@@ -286,7 +287,7 @@ TEST(etb, testSetpointOnlyPedal) {
 	Sensor::setMockValue(SensorType::Tps1, 0.0f, true);
 	Sensor::setMockValue(SensorType::AcceleratorPedal, 0.0f, true);
 
-	etb.init(DC_Throttle1, nullptr, nullptr, &pedalMap);
+	etb.init(DC_Throttle1, nullptr, nullptr, &pedalMap, 0.9f, 0.9f);
 
 	// Check endpoints and midpoint
 	Sensor::setMockValue(SensorType::AcceleratorPedal, 0.0f, true);
@@ -346,7 +347,7 @@ TEST(etb, setpointSecondThrottleTrim) {
 	Sensor::setMockValue(SensorType::AcceleratorPedal, 0.0f, true);
 
 	EtbController2 etb(throttleTrimTable);
-	etb.init(DC_Throttle1, nullptr, nullptr, &pedalMap);
+	etb.init(DC_Throttle1, nullptr, nullptr, &pedalMap, 0.9f, 0.9f);
 
 	Sensor::setMockValue(SensorType::AcceleratorPedal, 47, true);
 	EXPECT_EQ(51, etb.getSetpoint().value_or(-1));
@@ -371,7 +372,7 @@ TEST(etb, setpointIdle) {
 		.WillRepeatedly([](float xRpm, float y) {
 			return y;
 		});
-	etb.init(DC_Throttle1, nullptr, nullptr, &pedalMap);
+	etb.init(DC_Throttle1, nullptr, nullptr, &pedalMap, 0.9f, 0.9f);
 
 	// No idle range, should just pass pedal
 	Sensor::setMockValue(SensorType::AcceleratorPedal, 0.0f, true);
@@ -428,7 +429,7 @@ TEST(etb, setpointRevLimit) {
 		.WillRepeatedly([](float, float) {
 			return 80;
 		});
-	etb.init(DC_Throttle1, nullptr, nullptr, &pedalMap);
+	etb.init(DC_Throttle1, nullptr, nullptr, &pedalMap, 0.9f, 0.9f);
 
 	// Below threshold, should return unadjusted throttle
 	Sensor::setMockValue(SensorType::Rpm,  1000);
@@ -459,7 +460,7 @@ TEST(etb, setpointNoPedalMap) {
 	Sensor::setMockValue(SensorType::AcceleratorPedal, 0.0f, true);
 
 	// Don't pass a pedal map
-	etb.init(DC_Throttle1, nullptr, nullptr, nullptr);
+	etb.init(DC_Throttle1, nullptr, nullptr, nullptr, 0.9f, 0.9f);
 
 	EXPECT_EQ(etb.getSetpoint(), unexpected);
 }
@@ -467,7 +468,7 @@ TEST(etb, setpointNoPedalMap) {
 TEST(etb, setpointIdleValveController) {
 	EtbController etb;
 
-	etb.init(DC_IdleValve, nullptr, nullptr, nullptr);
+	etb.init(DC_IdleValve, nullptr, nullptr, nullptr, 0.9f, 0.9f);
 
 	etb.setIdlePosition(0);
 	EXPECT_FLOAT_EQ(0, etb.getSetpoint().value_or(-1));
@@ -486,7 +487,7 @@ TEST(etb, setpointIdleValveController) {
 TEST(etb, setpointWastegateController) {
 	EtbController etb;
 
-	etb.init(DC_Wastegate, nullptr, nullptr, nullptr);
+	etb.init(DC_Wastegate, nullptr, nullptr, nullptr, 0.9f, 0.9f);
 
 	etb.setWastegatePosition(0);
 	EXPECT_FLOAT_EQ(0, etb.getSetpoint().value_or(-1));
@@ -518,7 +519,7 @@ TEST(etb, setpointLuaAdder) {
 		.WillRepeatedly([](float, float) {
 			return 50;
 		});
-	etb.init(DC_Throttle1, nullptr, nullptr, &pedalMap);
+	etb.init(DC_Throttle1, nullptr, nullptr, &pedalMap, 0.9f, 0.9f);
 
 	// No adjustment, should be unadjusted
 	etb.setLuaAdjustment(0);
@@ -565,28 +566,28 @@ TEST(etb, etbTpsSensor) {
 	// Test first throttle
 	{
 		EtbController etb;
-		etb.init(DC_Throttle1, nullptr, nullptr, nullptr);
+		etb.init(DC_Throttle1, nullptr, nullptr, nullptr, 0.9f, 0.9f);
 		EXPECT_EQ(etb.observePlant().Value, 25.0f);
 	}
 
 	// Test second throttle
 	{
 		EtbController etb;
-		etb.init(DC_Throttle2, nullptr, nullptr, nullptr);
+		etb.init(DC_Throttle2, nullptr, nullptr, nullptr, 0.9f, 0.9f);
 		EXPECT_EQ(etb.observePlant().Value, 75.0f);
 	}
 
 	// Test wastegate control
 	{
 		EtbController etb;
-		etb.init(DC_Wastegate, nullptr, nullptr, nullptr);
+		etb.init(DC_Wastegate, nullptr, nullptr, nullptr, 0.9f, 0.9f);
 		EXPECT_EQ(etb.observePlant().Value, 33.0f);
 	}
 
 	// Test idle valve control
 	{
 		EtbController etb;
-		etb.init(DC_IdleValve, nullptr, nullptr, nullptr);
+		etb.init(DC_IdleValve, nullptr, nullptr, nullptr, 0.9f, 0.9f);
 		EXPECT_EQ(etb.observePlant().Value, 66.0f);
 	}
 }
@@ -602,7 +603,7 @@ TEST(etb, setOutputInvalid) {
 	StrictMock<MockMotor> motor;
 
 	EtbController etb;
-	etb.init(DC_Throttle1, &motor, nullptr, nullptr);
+	etb.init(DC_Throttle1, &motor, nullptr, nullptr, 0.9f, 0.9f);
 
 	// Should be disabled in case of unexpected
 	EXPECT_CALL(motor, disable(_));
@@ -620,7 +621,7 @@ TEST(etb, setOutputValid) {
 	Sensor::setMockValue(SensorType::AcceleratorPedal, 0.0f, true);
 
 	EtbController etb;
-	etb.init(DC_Throttle1, &motor, nullptr, nullptr);
+	etb.init(DC_Throttle1, &motor, nullptr, nullptr, 0.9f, 0.9f);
 
 	// Should be enabled and value set
 	EXPECT_CALL(motor, enable());
@@ -640,7 +641,7 @@ TEST(etb, setOutputValid2) {
 	Sensor::setMockValue(SensorType::AcceleratorPedal, 0.0f, true);
 
 	EtbController etb;
-	etb.init(DC_Throttle1, &motor, nullptr, nullptr);
+	etb.init(DC_Throttle1, &motor, nullptr, nullptr, 0.9f, 0.9f);
 
 	// Should be enabled and value set
 	EXPECT_CALL(motor, enable());
@@ -660,7 +661,7 @@ TEST(etb, setOutputOutOfRangeHigh) {
 	Sensor::setMockValue(SensorType::AcceleratorPedal, 0.0f, true);
 
 	EtbController etb;
-	etb.init(DC_Throttle1, &motor, nullptr, nullptr);
+	etb.init(DC_Throttle1, &motor, nullptr, nullptr, 0.9f, 0.9f);
 
 	// Should be enabled and value set
 	EXPECT_CALL(motor, enable());
@@ -680,7 +681,7 @@ TEST(etb, setOutputOutOfRangeLow) {
 	Sensor::setMockValue(SensorType::AcceleratorPedal, 0.0f, true);
 
 	EtbController etb;
-	etb.init(DC_Throttle1, &motor, nullptr, nullptr);
+	etb.init(DC_Throttle1, &motor, nullptr, nullptr, 0.9f, 0.9f);
 
 	// Should be enabled and value set
 	EXPECT_CALL(motor, enable());
@@ -688,6 +689,69 @@ TEST(etb, setOutputOutOfRangeLow) {
 
 	// Off scale - should get clamped to -90%
 	etb.setOutput(-110);
+}
+
+TEST(etb, setOutputRespectsConfiguredMax) {
+	EngineTestHelper eth(engine_type_e::TEST_ENGINE);
+	StrictMock<MockMotor> motor;
+
+	Sensor::setMockValue(SensorType::Tps1Primary, 0);
+	Sensor::setMockValue(SensorType::Tps1, 0.0f, true);
+	Sensor::setMockValue(SensorType::AcceleratorPedal, 0.0f, true);
+
+	EtbController etb;
+	etb.init(DC_Throttle1, &motor, nullptr, nullptr, 0.9f, 0.5f);
+
+	EXPECT_CALL(motor, enable());
+	EXPECT_CALL(motor, set(0.5f));
+
+	// Off scale - should get clamped to the configured 50% max, not the legacy 90%
+	etb.setOutput(110);
+}
+
+TEST(etb, setOutputRespectsConfiguredMin) {
+	EngineTestHelper eth(engine_type_e::TEST_ENGINE);
+	StrictMock<MockMotor> motor;
+
+	Sensor::setMockValue(SensorType::Tps1Primary, 0);
+	Sensor::setMockValue(SensorType::Tps1, 0.0f, true);
+	Sensor::setMockValue(SensorType::AcceleratorPedal, 0.0f, true);
+
+	EtbController etb;
+	etb.init(DC_Throttle1, &motor, nullptr, nullptr, 0.6f, 0.9f);
+
+	EXPECT_CALL(motor, enable());
+	EXPECT_CALL(motor, set(-0.6f));
+
+	// Off scale - should get clamped to the configured 60% min magnitude, not the legacy 90%
+	etb.setOutput(-110);
+}
+
+TEST(etb, dcDutyCycleMigratesToLegacyDefault) {
+	EngineTestHelper eth(engine_type_e::TEST_ENGINE);
+
+	engineConfiguration->dcMinDutyCycle[0] = 0;
+	engineConfiguration->dcMaxDutyCycle[0] = 0;
+
+	defaultsOrFixOnBurn();
+
+	EXPECT_EQ(90, engineConfiguration->dcMinDutyCycle[0]);
+	EXPECT_EQ(90, engineConfiguration->dcMaxDutyCycle[0]);
+}
+
+TEST(etb, dcDutyCycleExplicitValueIsPreserved) {
+	EngineTestHelper eth(engine_type_e::TEST_ENGINE);
+
+	engineConfiguration->dcMinDutyCycle[1] = 60;
+	engineConfiguration->dcMaxDutyCycle[1] = 50;
+
+	defaultsOrFixOnBurn();
+
+	// Instance 1's explicit values are untouched, and independent from instance 0
+	EXPECT_EQ(60, engineConfiguration->dcMinDutyCycle[1]);
+	EXPECT_EQ(50, engineConfiguration->dcMaxDutyCycle[1]);
+	EXPECT_EQ(90, engineConfiguration->dcMinDutyCycle[0]);
+	EXPECT_EQ(90, engineConfiguration->dcMaxDutyCycle[0]);
 }
 
 TEST(etb, setOutputPauseControl) {
@@ -700,7 +764,7 @@ TEST(etb, setOutputPauseControl) {
 	Sensor::setMockValue(SensorType::AcceleratorPedal, 0.0f, true);
 
 	EtbController etb;
-	etb.init(DC_Throttle1, &motor, nullptr, nullptr);
+	etb.init(DC_Throttle1, &motor, nullptr, nullptr, 0.9f, 0.9f);
 
 	// Pause control - should get no output
 	engineConfiguration->pauseEtbControl = true;
@@ -721,7 +785,7 @@ TEST(etb, setOutputLimpHome) {
 	Sensor::setMockValue(SensorType::AcceleratorPedal, 0.0f, true);
 
 	EtbController etb;
-	etb.init(DC_Throttle1, &motor, nullptr, nullptr);
+	etb.init(DC_Throttle1, &motor, nullptr, nullptr, 0.9f, 0.9f);
 
 	// Should be disabled when in ETB limp mode
 	EXPECT_CALL(motor, disable(_));
@@ -746,7 +810,7 @@ TEST(etb, closedLoopPid) {
 	Sensor::setMockValue(SensorType::AcceleratorPedal, 0.0f, true);
 
 	EtbController etb;
-	etb.init(DC_Throttle1, nullptr, &pid, nullptr);
+	etb.init(DC_Throttle1, nullptr, &pid, nullptr, 0.9f, 0.9f);
 
 	// Disable autotune for now
 	engine->etbAutoTune = false;
@@ -781,7 +845,7 @@ TEST(etb, jamDetection) {
 	engineConfiguration->etbJamTimeout = 1;
 
 	EtbController etb;
-	etb.init(DC_Throttle1, nullptr, nullptr, nullptr);
+	etb.init(DC_Throttle1, nullptr, nullptr, nullptr, 0.9f, 0.9f);
 
 	setTimeNowUs(0);
 
@@ -814,7 +878,7 @@ TEST(etb, openLoopThrottle) {
 	Sensor::setMockValue(SensorType::AcceleratorPedal, 0, true);
 
 	EtbController etb;
-	etb.init(DC_Throttle1, nullptr, nullptr, nullptr);
+	etb.init(DC_Throttle1, nullptr, nullptr, nullptr, 0.9f, 0.9f);
 
 	// Map [0, 100] -> [-50, 50]
 	setLinearCurve(config->etbBiasBins, 0, 100);
@@ -836,7 +900,7 @@ TEST(etb, openLoopDCWastegate) {
 	Sensor::setMockValue(SensorType::AcceleratorPedal, 0, true);
 
 	EtbController etb;
-	etb.init(DC_Wastegate, nullptr, nullptr, nullptr);
+	etb.init(DC_Wastegate, nullptr, nullptr, nullptr, 0.9f, 0.9f);
 
 	// Map [0, 100] -> [-50, 50]
 	setLinearCurve(config->dcWastegateBiasBins, 0, 100);
@@ -858,7 +922,7 @@ TEST(etb, openLoopNonThrottle) {
 	Sensor::setMockValue(SensorType::AcceleratorPedal, 0, true);
 
 	EtbController etb;
-	etb.init(DC_IdleValve, nullptr, nullptr, nullptr);
+	etb.init(DC_IdleValve, nullptr, nullptr, nullptr, 0.9f, 0.9f);
 
 	// Map [0, 100] -> [-50, 50]
 	setLinearCurve(config->etbBiasBins, 0, 100);
@@ -892,7 +956,7 @@ TEST(etb, tractionControlEtbDrop) {
 	Sensor::setMockValue(SensorType::AcceleratorPedal, 0.0f, true);
 
 	EtbController1 etb;
-	etb.init(DC_Throttle1, nullptr, nullptr, &pedalMap);
+	etb.init(DC_Throttle1, nullptr, nullptr, &pedalMap, 0.9f, 0.9f);
 
 	Sensor::setMockValue(SensorType::AcceleratorPedal, 47, true);
 	EXPECT_EQ(37, etb.getSetpoint().value_or(-1));


### PR DESCRIPTION
The generic H-bridge/DC-motor controller (throttle, wastegate, idlevalve) hard-clamped output to a fixed 90%. Add per-H-bridge dcMinDutyCycle/dcMaxDutyCycle (0-100%, min is the magnitude of the allowed negative-direction output) so each instance can be tuned independently instead of recompiling firmware.

0 always resets to the legacy 90% on the next boot/burn - the config format has no way to tell "never configured" from "explicitly set to 0", and existing tunes must not silently drop to 0% duty on update. A true, sticky 0% isn't representable through this field, the existing per-instance Disable pin already covers fully disabling an H-bridge for diagnostics.

Fields live in the H-bridge hardware dialogs (No1/No2), next to direction/control/disable pins, since the limit is a property of what motor is physically wired to that H-bridge slot, not of whichever function gets assigned to it later.