### PR TITLE
stm32h7: mcuconf: switch SPI123 source clock to 52MHz source

### DIFF
--- a/firmware/hw_layer/mmc_card.cpp
+++ b/firmware/hw_layer/mmc_card.cpp
@@ -538,6 +538,8 @@ static BaseBlockDevice* initializeMmcBlockDevice() {
 	}
 
 	// max SPI rate is 25 MHz after init
+	// TODO: change to 26 MHz for some H7 devices where SPI PCLK is 52 MHz
+	// so we can get 26MHz instead of current 13MHz. This is 4% overclock.
 	spiCalcClockDiv(mmccfg.spip, &mmc_hs_spicfg, 25 * 1000 * 1000);
 	// and 250 KHz during initialization
 	spiCalcClockDiv(mmccfg.spip, &mmc_ls_spicfg, 250 * 1000);

--- a/firmware/hw_layer/ports/stm32/stm32h7/cfg/mcuconf_stm32h723.h
+++ b/firmware/hw_layer/ports/stm32/stm32h7/cfg/mcuconf_stm32h723.h
@@ -126,7 +126,7 @@
 #define STM32_DFSDM1SEL                     STM32_DFSDM1SEL_PCLK2
 #define STM32_SPDIFSEL                      STM32_SPDIFSEL_PLL1_Q_CK
 #define STM32_SPI45SEL                      STM32_SPI45SEL_PLL2_Q_CK
-#define STM32_SPI123SEL                     STM32_SPI123SEL_PLL2_P_CK
+#define STM32_SPI123SEL                     STM32_SPI123SEL_PLL1_Q_CK
 #define STM32_SAI1SEL                       STM32_SAI1SEL_PLL1_Q_CK
 #define STM32_LPTIM1SEL                     STM32_LPTIM1SEL_PCLK1
 #define STM32_CECSEL                        STM32_CECSEL_LSE_CK


### PR DESCRIPTION
Previously 20MHz source was selected. So maximum SPI clock was 10 MHz. For SD we need something closer to 25 MHz.
After this mode we can get 13MHz clock.

only:uaefi_pro_h7