### PR TITLE
offline mode: better UX

### DIFF
--- a/docs/java-connectivity-ui-unit-testing.md
+++ b/docs/java-connectivity-ui-unit-testing.md
@@ -1,6 +1,6 @@
 # Java Console: Unit Test Approach for Connectivity Management & UI
 
-Status as of 2026-07-10. Scope: `java_console` connectivity/flashing/session path
+Status as of 2026-07-08. Scope: `java_console` connectivity/flashing/session path
 (`connectivity`, `io`, `shared_io`, `ui` modules) and the Swing UI around it.
 
 ## Why this document
@@ -106,7 +106,7 @@ rather than invent new machinery.
 | Firmware file targeting | `shared_io` `FindFileHelperTest` ×2 | `extractTargetFromFirmwareName`, `findXNumberOfFile` |
 | Persisted board target | `shared_io` `ConnectedEcuTargetTest` | live → persisted-file → bundle fallback chain |
 | Board compatibility | `shared_io` `BoardCompatibilityTest` | exact/wildcard/allowlist/QC-bypass matching |
-| UI status | `ui` `ConnectionStatusIconTest` | red/green/purple priority, bootloader tooltip, property-change reaction, null tab pane |
+| UI status | `ui` `ConnectionStatusIconTest` | red/green/purple priority, bootloader tooltip, offline tooltip (offline+disconnected, connected/bootloader precedence, property-change reaction), null tab pane |
 | Update-available check | `ui` `MainFrameUpdateCheckTest` | `needsFirmwareUpdate` null/unparseable inputs, new-format hash compare, legacy date compare |
 | Connectivity value types & helpers | `connectivity` `SerialPortCacheTest`, `AvailableHardwareTest`, `PortResultTest`, `SerialPortTypeTest`, `SerialPortScannerInspectPortsTest`, `RecurringStepTest` | cache eviction semantics, snapshot filtering/equality, PortResult identity contract, sort ranks, probe fan-out (dead port dropped, crash ⇒ Unknown), suspend-latch handshake — the Tier 1 batch, added 2026-07-08 |
 | Flash brick guard | `ui` `MaintenanceUtilTest` | `confirmFirmwareMatchesBoard`: matching/case-insensitive target, unparseable name no-false-alarm, `_QC_` compatibility, mismatch declined/accepted via `UserConfirm` seam; `ensureFirmwareForConnectedTarget` unverified-declined + live-verified-skip; plus the `containsPattern` normalization (Tiers 2–3, 2026-07-08) |
@@ -114,12 +114,24 @@ rather than invent new machinery.
 | Device tab presentation decisions | `ui` `DevicePaneTest` | bootloader-state classification, DFU/OpenBLT guidance text (platform-aware), offline-capable tab lock list; Tier 2, added 2026-07-08 |
 | Port classification pipeline | `ui` `EcuHardwareProbesInspectTest` | OpenBLT-first probing, stale-node/vanish ⇒ dropped, ECU-with/without-OpenBLT + calibrations, 3-attempt retry with between-attempts backoff, interrupt handling; Tier 3 item 1, added 2026-07-08 |
 | Post-flash reconnect wait | `ui` `AbstractAutoFlashJobAwaitEcuPortTest` | `awaitEcuPort`: immediate ECU, follow renumbered port, bootloader-grace flicker vs persistent OpenBLT/DFU giveup, timeout, interrupt; Tier 3 item 3, added 2026-07-08 |
+| Offline-mode UI state | `ui` `UIContextOfflineModeTest`, `TuningToolbarStateLabelTest` | `UIContext` offline flag default + setter + listener fan-out to every listener; Tuning toolbar dirty/offline label wording across all 4 offline×dirty combos (#9730, 2026-07-10) |
 | OpenBLT job choreography | `ui` `OpenBltManualJobTest`, `OpenBltSwitchJobTest` | manual flash: suspend-before-flash / invalidate+resume-after (also on failure and flasher crash), restore-only-after-resume, ensure-firmware abort before touching the scanner; switch: reboot-then-`close()` ordering, never `disconnect()` (renumber-follow invariant), port released even with no `BinaryProtocol`; Tier 3 item 4, added 2026-07-10 |
 | ECU-follow-across-reboot rule | `ui` `ConsoleUiEcuPortToFollowTest` | `ConsoleUI.ecuPortToFollow`: follows the single new ECU (incl. `EcuWithOpenblt`) once the old port vanished; stays put when disconnected-by-user, current port still present, never-connected, zero/multiple candidates, or candidate == current; Tier 3 item 6, added 2026-07-10 |
 
 Not covered anywhere: `EcuHardwareProbes.inspect()`
 classification/retry, `MainFrame` title composition, `StartupFrame` port-list
 presentation and splash connection state machine.
+
+The offline-tune UI glue added with #9730 (2026-07-10) is only unit-tested at
+its pure edges (the two rows above). The Swing/IO-bound parts remain
+sandbox/manual-only, consistent with the tiering: `PinoutPane.showOfflineBoard`
+(needs the `pinouts_raw` board data + image render), `TuneManagementTab`'s
+import-pair visibility gating, and the splash→offline-console frame-reuse
+handoff (`StartupFrame.openOfflineConsole`, which the "not recommended" list
+already excludes as splash-machine territory). If any of these regress, the
+cheap seam is the same pattern used above — lift the decision (which board
+signature, whether to show the import pair) out of the Swing wiring into a pure
+helper and test that.
 
 ## Test backlog
 

--- a/java_console/ui/src/main/java/com/rusefi/ConsoleUI.java
+++ b/java_console/ui/src/main/java/com/rusefi/ConsoleUI.java
@@ -111,8 +111,12 @@ public class ConsoleUI {
      * @param initialImage   ConfigurationImage loaded from the MSQ file
      * @param connectivityContext
      */
-    public ConsoleUI(UIContext uiContext, IniFileModel ini, ConfigurationImage initialImage, ConnectivityContext connectivityContext) {
-        this(uiContext, null, SerialPortType.Unknown, false, ini, initialImage, null, connectivityContext);
+    /**
+     * [tag:offline_tune] Offline console that reuses the already-visible, maximized splash
+     * {@code reuseFrame} instead of opening a second window — same handoff the online path uses (#9715).
+     */
+    public ConsoleUI(UIContext uiContext, IniFileModel ini, ConfigurationImage initialImage, JFrame reuseFrame, ConnectivityContext connectivityContext) {
+        this(uiContext, null, SerialPortType.Unknown, false, ini, initialImage, reuseFrame, connectivityContext);
     }
 
     /**
@@ -185,6 +189,12 @@ public class ConsoleUI {
         // Pass the tabbed pane so the icon can turn purple when a board is in a DFU/OpenBLT bootloader
         // (DevicePane publishes the "bootloaderMode" client property on it). [tag:better_ux_for_flashing]
         ConnectionStatusIcon connectionStatus = new ConnectionStatusIcon(linkManager, tabbedPane.tabbedPane);
+
+        // [tag:offline_tune] Mirror offline mode onto a tabbedPane client property so the connection
+        // status icon (and anything else watching) can surface it, same mechanism as "bootloaderMode".
+        tabbedPane.tabbedPane.putClientProperty("offlineMode", uiContext.isOfflineMode() ? Boolean.TRUE : null);
+        uiContext.addOfflineModeListener(offline -> SwingUtilities.invokeLater(() ->
+                tabbedPane.tabbedPane.putClientProperty("offlineMode", offline ? Boolean.TRUE : null)));
         this.port = port;
 
         // Follow a renumbered ECU across a bootloader round-trip. After a reboot to DFU/OpenBLT *without*
@@ -324,6 +334,12 @@ console live data tab is broken #8402
             tabbedPane.addTab("Live Data", LiveDataPane.createLazy(uiContext).getContent());
  */
             PinoutPane pinoutPane = new PinoutPane(uiContext);
+
+            // [tag:offline_tune] Seed the loaded tune image so config-image-driven panes (e.g. PinoutPane's
+            // "Tune use" column) have data with no live ECU — the online path gets this from BinaryProtocol.
+            if (isOffline && offlineImage != null) {
+                uiContext.fireConfigImageChanged(offlineImage);
+            }
 
             // Tuning is heavy (~60ms) and not always the startup tab. Build it on first use — tab
             // shown, File>Load/Save Tune, or Pinout→Tune nav — unless it's the restored tab (#9715).

--- a/java_console/ui/src/main/java/com/rusefi/StartupFrame.java
+++ b/java_console/ui/src/main/java/com/rusefi/StartupFrame.java
@@ -638,32 +638,19 @@ public class StartupFrame {
     /**
      * [tag:offline_tune]
      * Opens the full console in offline mode with a pre-loaded tune, reusing the shared {@link UIContext}.
-     * Disposes the splash window but keeps the serial-port scanner running so that plugging in an ECU
-     * later auto-connects and the offline console transitions itself online — without spawning a second
+     * Reuses this maximized splash frame (same handoff as {@link #connect}, #9715) instead of opening a
+     * second window, and keeps the serial-port scanner running so that plugging in an ECU later
+     * auto-connects and the offline console transitions itself online — without spawning a second
      * console (see the {@link #offlineConsoleOpen} guards).
      */
     public void openOfflineConsole(IniFileModel ini, ConfigurationImage image) {
-        log.info("openOfflineConsole: launching offline console on shared uiContext");
+        log.info("openOfflineConsole: handing off splash frame to offline ConsoleUI");
         offlineConsoleOpen = true;
-        isProceeding = true;
-        // Drop the splash-scoped connection listener so it can't mutate the disposed splash widgets.
-        if (splashListener != null) {
-            ConnectionStatusLogic.INSTANCE.removeListener(splashListener);
-            splashListener = null;
-        }
-        saveTabIndex();
-        getConfig().save();
-        frame.dispose();
-        status.stop();
-        if (revealControlsTimer != null) {
-            revealControlsTimer.stop();
-        }
-        if (firmwareTabStatus != null) {
-            firmwareTabStatus.stop();
-        }
-        // NOTE: intentionally do NOT call serialPortScanner.stopTimer() — the offline console relies on
-        // the scanner's auto-connect to go online.
-        new ConsoleUI(uiContext, ini, image, connectivityContext);
+        // Shared teardown-without-dispose; keeps the scanner alive for later auto-connect.
+        prepareForHandoff();
+        LoadingOverlay.show(frame, "Loading console…", LogoHelper.createLogoLabel());
+        SwingUtilities.invokeLater(() ->
+            new ConsoleUI(uiContext, ini, image, frame, connectivityContext));
     }
 
     /**

--- a/java_console/ui/src/main/java/com/rusefi/ui/PinoutPane.java
+++ b/java_console/ui/src/main/java/com/rusefi/ui/PinoutPane.java
@@ -391,12 +391,16 @@ public class PinoutPane {
         content.add(northPanel, BorderLayout.NORTH);
 
         ConnectionStatusLogic.INSTANCE.addAndFireListener(isConnected -> SwingUtilities.invokeLater(() -> {
-            if (!isConnected) {
-                showDisconnected();
-            } else {
+            if (isConnected) {
                 BinaryProtocol bp = uiContext.getBinaryProtocol();
                 String signature = bp != null ? bp.signature : null;
                 showBoard(signature);
+            } else if (uiContext.isOfflineMode()) {
+                // [tag:offline_tune] No ECU, but a tune is loaded — show its board pinout + Tune use
+                // from the offline INI signature and image instead of the "Not connected" placeholder.
+                showOfflineBoard();
+            } else {
+                showDisconnected();
             }
         }));
 
@@ -426,6 +430,19 @@ public class PinoutPane {
         connectorTabs = null;
         liveConfigImage = null;
         setCenterPanel(null);
+    }
+
+    /** [tag:offline_tune] Renders the board pinout for an offline-loaded tune, identified by the INI signature. */
+    private void showOfflineBoard() {
+        IniFileModel ini = uiContext.iniFileState.getIniFileModel();
+        String signature = ini != null ? ini.getSignature() : null;
+        if (signature == null) {
+            statusLabel.setText("Offline tune — board unknown");
+            activeImagePanels.clear();
+            setCenterPanel(null);
+            return;
+        }
+        showBoard(signature);
     }
 
     private void showBoard(String signature) {
@@ -953,6 +970,8 @@ public class PinoutPane {
         if (ConnectionStatusLogic.INSTANCE.isConnected()) {
             BinaryProtocol bp = uiContext.getBinaryProtocol();
             showBoard(bp != null ? bp.signature : null);
+        } else if (uiContext.isOfflineMode()) {
+            showOfflineBoard();
         }
     }
 

--- a/java_console/ui/src/main/java/com/rusefi/ui/UIContext.java
+++ b/java_console/ui/src/main/java/com/rusefi/ui/UIContext.java
@@ -54,12 +54,20 @@ public class UIContext {
         return linkManager.getCommandQueue();
     }
 
+    private final List<Consumer<Boolean>> offlineModeListeners = new ArrayList<>();
+
     public boolean isOfflineMode() {
         return offlineMode;
     }
 
     public void setOfflineMode(boolean offlineMode) {
         this.offlineMode = offlineMode;
+        for (Consumer<Boolean> l : offlineModeListeners) l.accept(offlineMode);
+    }
+
+    /** [tag:offline_tune] Notified (on the calling thread) whenever offline mode is toggled. */
+    public void addOfflineModeListener(Consumer<Boolean> listener) {
+        offlineModeListeners.add(listener);
     }
 
     /**

--- a/java_console/ui/src/main/java/com/rusefi/ui/basic/TuneManagementTab.java
+++ b/java_console/ui/src/main/java/com/rusefi/ui/basic/TuneManagementTab.java
@@ -8,6 +8,7 @@ import com.rusefi.binaryprotocol.BinaryProtocol;
 import com.rusefi.core.net.PropertiesHolder;
 import com.rusefi.core.ui.AutoupdateUtil;
 import com.rusefi.core.ui.ErrorMessageHelper;
+import com.rusefi.io.ConnectionStatusLogic;
 import com.rusefi.io.LinkManager;
 import com.rusefi.maintenance.OfflineTuneLoader;
 import com.rusefi.maintenance.jobs.ImportTuneJob;
@@ -159,8 +160,26 @@ public class TuneManagementTab {
         loadTuneFileButton.setFont(loadTuneFileButton.getFont().deriveFont(Font.BOLD, 16f));
         loadTuneFileButton.setMargin(new Insets(12, 28, 12, 28));
 
+        // [tag:offline_tune] Explain what this screen does — without it the splash is three silent
+        // buttons and no hint that a tune can be edited with no ECU attached (#9730).
+        JLabel offlineHint = new JLabel("<html><div style='text-align:center;'>"
+                + "No ECU connected. Load a tune file to view and edit it offline,<br>"
+                + "then connect an ECU to burn your changes.</div></html>");
+        offlineHint.setForeground(Color.DARK_GRAY);
+
+        // [tag:offline_tune] The import pair pushes a tune to a *connected* ECU; on this pre-connection
+        // splash it has nothing to talk to (clicking just prints "Not connected?"), so only show it
+        // once an ECU is actually connected.
+        Runnable updateImportVisibility = () ->
+                importTuneButton.setVisible(com.rusefi.io.ConnectionStatusLogic.INSTANCE.isConnected());
+        updateImportVisibility.run();
+        com.rusefi.io.ConnectionStatusLogic.INSTANCE.addListener(
+                c -> SwingUtilities.invokeLater(updateImportVisibility));
+
         JPanel buttonPanel = new JPanel();
         buttonPanel.setLayout(new BoxLayout(buttonPanel, BoxLayout.Y_AXIS));
+        buttonPanel.add(centerHorizontally(offlineHint));
+        buttonPanel.add(Box.createVerticalStrut(20));
         buttonPanel.add(centerHorizontally(importTuneButton));
         buttonPanel.add(Box.createVerticalStrut(28));
         buttonPanel.add(centerHorizontally(loadTuneFileButton));

--- a/java_console/ui/src/main/java/com/rusefi/ui/widgets/ConnectionStatusIcon.java
+++ b/java_console/ui/src/main/java/com/rusefi/ui/widgets/ConnectionStatusIcon.java
@@ -41,8 +41,11 @@ public class ConnectionStatusIcon extends JButton {
 
         Runnable updateButton = () -> {
             final Object bootloaderMode = tabbedPane == null ? null : tabbedPane.getClientProperty("bootloaderMode");
+            final Object offlineMode = tabbedPane == null ? null : tabbedPane.getClientProperty("offlineMode");
             if (bootloaderMode != null) {
                 setToolTipText(bootloaderMode + " bootloader — use the Device tab to update firmware.");
+            } else if (offlineMode != null && !ConnectionStatusLogic.INSTANCE.isConnected()) {
+                setToolTipText("Offline tune loaded. Connect ECU to burn or compare.");
             } else {
                 boolean isConnected = ConnectionStatusLogic.INSTANCE.isConnected();
                 setToolTipText(isConnected ? "Connected. Click or Ctrl+D to disconnect." : "Disconnected. Click or Ctrl+R to connect.");
@@ -53,6 +56,7 @@ public class ConnectionStatusIcon extends JButton {
         ConnectionStatusLogic.INSTANCE.addListener(isConnected -> SwingUtilities.invokeLater(updateButton));
         if (tabbedPane != null) {
             tabbedPane.addPropertyChangeListener("bootloaderMode", e -> SwingUtilities.invokeLater(updateButton));
+            tabbedPane.addPropertyChangeListener("offlineMode", e -> SwingUtilities.invokeLater(updateButton));
         }
         updateButton.run();
 

--- a/java_console/ui/src/main/java/com/rusefi/ui/widgets/tune/TuningToolbarWidget.java
+++ b/java_console/ui/src/main/java/com/rusefi/ui/widgets/tune/TuningToolbarWidget.java
@@ -36,6 +36,11 @@ public class TuningToolbarWidget {
 
     private final JPanel panel;
 
+    /** [tag:offline_tune] Shows offline / unburned-edit state. Empty when connected and clean. */
+    private final JLabel stateLabel = new JLabel();
+    private final UIContext uiContext;
+    private final AtomicReference<ConfigurationImage> sessionImage;
+
     private final ArrayDeque<ConfigurationImage> undoStack = new ArrayDeque<>();
     private final ArrayDeque<ConfigurationImage> redoStack = new ArrayDeque<>();
     private final AtomicReference<ConfigurationImage> undoBaseline = new AtomicReference<>();
@@ -64,6 +69,8 @@ public class TuningToolbarWidget {
                                 AtomicReference<String> currentKey,
                                 AtomicReference<ConfigurationImage> sessionImage,
                                 ConfigurationImage baselineImage) {
+        this.uiContext = uiContext;
+        this.sessionImage = sessionImage;
         this.baselineImage = baselineImage;
         undoButton.setEnabled(false);
         redoButton.setEnabled(false);
@@ -149,6 +156,33 @@ public class TuningToolbarWidget {
         panel.add(discardButton);
         panel.add(undoButton);
         panel.add(redoButton);
+        panel.add(stateLabel);
+
+        // [tag:offline_tune] Refresh the state label whenever offline mode toggles (e.g. Load Tune
+        // while disconnected). Edit/discard/burn/connect/disconnect paths call refreshState() directly.
+        uiContext.addOfflineModeListener(offline -> SwingUtilities.invokeLater(this::refreshState));
+        refreshState();
+    }
+
+    /**
+     * [tag:offline_tune] Updates the toolbar state label from current offline mode + dirty state.
+     * Empty (invisible) when connected with no pending edits.
+     */
+    public void refreshState() {
+        boolean dirty = hasUnsavedChanges(sessionImage.get());
+        stateLabel.setText(stateLabelText(uiContext.isOfflineMode(), dirty));
+        stateLabel.setForeground(dirty ? new Color(0xB0, 0x60, 0x00) : Color.GRAY);
+    }
+
+    /**
+     * Pure label-text logic for the offline/dirty toolbar indicator. Package-private and static so it
+     * can be unit-tested without Swing (see {@code TuningToolbarStateLabelTest}).
+     */
+    static String stateLabelText(boolean offline, boolean dirty) {
+        if (dirty) {
+            return offline ? "Local changes not burned to ECU" : "Pending changes not burned";
+        }
+        return offline ? "Offline tune" : "";
     }
 
     private @NotNull JButton getBurnToEcuButton(UIContext uiContext,
@@ -169,6 +203,8 @@ public class TuningToolbarWidget {
             uiContext.getLinkManager().submit(() -> {
                 bp.burn();
                 bp.setConfigurationImage(image);
+                // Burned image is now the ECU's state — adopt it as baseline so dirty state clears.
+                SwingUtilities.invokeLater(() -> setBaselineImage(image.clone()));
             });
         });
         return burnButton;
@@ -183,6 +219,7 @@ public class TuningToolbarWidget {
                 break;
             }
         }
+        refreshState();
     }
 
     private @NotNull JButton getDiscardButton(UIContext uiContext,
@@ -206,6 +243,7 @@ public class TuningToolbarWidget {
             redoStack.clear();
             undoBaseline.set(null);
             updateButtons.run();
+            refreshState();
         });
 
         return discardButton;
@@ -263,21 +301,19 @@ public class TuningToolbarWidget {
                                         latch.await();
                                     }
 
+                                    final boolean loadedWhileDisconnected = (bp == null);
                                     SwingUtilities.invokeLater(() -> {
                                         sessionImage.set(newImage);
-                                        baselineImage = newImage.clone();
+                                        // [tag:offline_tune] Loading a tune with no ECU attached is an offline session.
+                                        if (loadedWhileDisconnected) {
+                                            uiContext.setOfflineMode(true);
+                                        }
                                         String key = currentKey.get();
                                         if (key != null) {
                                             right.update(key, result.ini, newImage);
                                         }
-                                        // Enable discard now that we have a baseline
-                                        Component[] components = panel.getComponents();
-                                        for (Component c : components) {
-                                            if (c instanceof JButton && "Discard changes".equals(((JButton) c).getText())) {
-                                                ((JButton) c).setEnabled(true);
-                                                break;
-                                            }
-                                        }
+                                        // Adopt the loaded tune as baseline (enables discard + refreshes state label).
+                                        setBaselineImage(newImage.clone());
                                         uiContext.fireConfigImageChanged(newImage);
                                         cb.done();
                                     });
@@ -368,6 +404,7 @@ public class TuningToolbarWidget {
                 break;
             }
         }
+        refreshState();
     }
 
     private static @NotNull JFileChooser createMsqFileChooser() {
@@ -389,6 +426,7 @@ public class TuningToolbarWidget {
         undoBaseline.compareAndSet(null, previousSessionImage);
         undoCommitTimer.restart();
         uploadTimer.restart();
+        refreshState();
     }
 
     /**
@@ -438,5 +476,6 @@ public class TuningToolbarWidget {
                 break;
             }
         }
+        refreshState();
     }
 }

--- a/java_console/ui/src/test/java/com/rusefi/ui/UIContextOfflineModeTest.java
+++ b/java_console/ui/src/test/java/com/rusefi/ui/UIContextOfflineModeTest.java
@@ -1,0 +1,49 @@
+package com.rusefi.ui;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * The offline-mode flag + listener notification that drives the connection-status tooltip, the
+ * Tuning toolbar state label and the Pinout offline board (#9730).
+ */
+public class UIContextOfflineModeTest {
+
+    @Test
+    void defaultsToOnline() {
+        assertFalse(new UIContext().isOfflineMode());
+    }
+
+    @Test
+    void setterUpdatesFlagAndNotifiesListener() {
+        UIContext ctx = new UIContext();
+        List<Boolean> events = new ArrayList<>();
+        ctx.addOfflineModeListener(events::add);
+
+        ctx.setOfflineMode(true);
+        assertTrue(ctx.isOfflineMode());
+        assertEquals(List.of(Boolean.TRUE), events);
+
+        ctx.setOfflineMode(false);
+        assertFalse(ctx.isOfflineMode());
+        assertEquals(List.of(Boolean.TRUE, Boolean.FALSE), events);
+    }
+
+    @Test
+    void notifiesEveryListener() {
+        UIContext ctx = new UIContext();
+        List<Boolean> a = new ArrayList<>();
+        List<Boolean> b = new ArrayList<>();
+        ctx.addOfflineModeListener(a::add);
+        ctx.addOfflineModeListener(b::add);
+
+        ctx.setOfflineMode(true);
+
+        assertEquals(List.of(Boolean.TRUE), a);
+        assertEquals(List.of(Boolean.TRUE), b);
+    }
+}

--- a/java_console/ui/src/test/java/com/rusefi/ui/widgets/ConnectionStatusIconTest.java
+++ b/java_console/ui/src/test/java/com/rusefi/ui/widgets/ConnectionStatusIconTest.java
@@ -129,6 +129,53 @@ public class ConnectionStatusIconTest {
     }
 
     @Test
+    void tooltipShowsOfflineWhenOfflineModeAndDisconnected() {
+        ConnectionStatusLogic.INSTANCE.setValue(ConnectionStatusValue.NOT_CONNECTED);
+        tabbedPane.putClientProperty("offlineMode", Boolean.TRUE);
+        ConnectionStatusIcon icon = new ConnectionStatusIcon(linkManager, tabbedPane);
+        String tip = icon.getToolTipText();
+        assertNotNull(tip);
+        assertTrue(tip.contains("Offline tune"), "Expected offline tooltip: " + tip);
+    }
+
+    @Test
+    void connectedTakesPrecedenceOverOfflineTooltip() {
+        // Offline flag can be stale; a live connection must win.
+        ConnectionStatusLogic.INSTANCE.setValue(ConnectionStatusValue.CONNECTED);
+        tabbedPane.putClientProperty("offlineMode", Boolean.TRUE);
+        ConnectionStatusIcon icon = new ConnectionStatusIcon(linkManager, tabbedPane);
+        String tip = icon.getToolTipText();
+        assertNotNull(tip);
+        assertTrue(tip.contains("Connected"), "Connected should win over offline: " + tip);
+    }
+
+    @Test
+    void bootloaderTakesPrecedenceOverOfflineTooltip() {
+        ConnectionStatusLogic.INSTANCE.setValue(ConnectionStatusValue.NOT_CONNECTED);
+        tabbedPane.putClientProperty("offlineMode", Boolean.TRUE);
+        tabbedPane.putClientProperty("bootloaderMode", "DFU");
+        ConnectionStatusIcon icon = new ConnectionStatusIcon(linkManager, tabbedPane);
+        String tip = icon.getToolTipText();
+        assertNotNull(tip);
+        assertTrue(tip.contains("DFU"), "Bootloader should win over offline: " + tip);
+    }
+
+    @Test
+    void updatesWhenOfflineModeChanges() {
+        ConnectionStatusLogic.INSTANCE.setValue(ConnectionStatusValue.NOT_CONNECTED);
+        ConnectionStatusIcon icon = new ConnectionStatusIcon(linkManager, tabbedPane);
+        assertFalse(icon.getToolTipText().contains("Offline tune"), "Should not be offline initially");
+
+        tabbedPane.putClientProperty("offlineMode", Boolean.TRUE);
+        try {
+            SwingUtilities.invokeAndWait(() -> {});
+        } catch (Exception e) {
+            fail(e);
+        }
+        assertTrue(icon.getToolTipText().contains("Offline tune"), "Should show offline after property change");
+    }
+
+    @Test
     void worksWithNullTabbedPane() {
         // Should not throw, falls back to connected/disconnected only
         assertDoesNotThrow(() -> new ConnectionStatusIcon(linkManager, null));

--- a/java_console/ui/src/test/java/com/rusefi/ui/widgets/tune/TuningToolbarStateLabelTest.java
+++ b/java_console/ui/src/test/java/com/rusefi/ui/widgets/tune/TuningToolbarStateLabelTest.java
@@ -1,0 +1,35 @@
+package com.rusefi.ui.widgets.tune;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * The offline/dirty toolbar label wording (#9730). Pure logic, no Swing.
+ */
+public class TuningToolbarStateLabelTest {
+
+    @Test
+    void offlineAndDirty() {
+        assertEquals("Local changes not burned to ECU",
+                TuningToolbarWidget.stateLabelText(true, true));
+    }
+
+    @Test
+    void connectedAndDirty() {
+        assertEquals("Pending changes not burned",
+                TuningToolbarWidget.stateLabelText(false, true));
+    }
+
+    @Test
+    void offlineAndClean() {
+        assertEquals("Offline tune",
+                TuningToolbarWidget.stateLabelText(true, false));
+    }
+
+    @Test
+    void connectedAndClean() {
+        // Empty label = invisible; nothing to say when connected with no pending edits.
+        assertEquals("", TuningToolbarWidget.stateLabelText(false, false));
+    }
+}


### PR DESCRIPTION
now console says offline on the status bar: #9730
<img width="1187" height="507" alt="image" src="https://github.com/user-attachments/assets/8edaaed6-35b2-4701-8f72-abea4bfbfae3" />

removed confusing buttons on offline case, added a small label: #9730
<img width="1919" height="1049" alt="image" src="https://github.com/user-attachments/assets/6bcf23ce-57d0-4de3-9561-f17ebc6e6fbb" />

splash offline => full console offline now shares same window #9715

also tests for offline connectivity https://github.com/rusefi/rusefi/issues/9771