### PR TITLE
BasicUpdaterPanel, SingleAsyncJobExecutor: preserve firmware update outcomes across reconnects

### DIFF
--- a/java_console/ui/src/main/java/com/rusefi/DevicePane.java
+++ b/java_console/ui/src/main/java/com/rusefi/DevicePane.java
@@ -6,6 +6,7 @@ import com.rusefi.ui.UIContext;
 import com.rusefi.ui.basic.MigrateSettingsCheckboxState;
 import com.rusefi.ui.basic.SingleAsyncJobExecutor;
 import com.rusefi.ui.basic.StatusPanelWithProgressBar;
+import com.rusefi.ui.basic.UpdateFirmwareResult;
 
 import javax.swing.*;
 import java.awt.*;
@@ -136,9 +137,13 @@ public class DevicePane {
             statusPanel.clear();
             statusPanel.log(bootloaderGuidance(state), true, false);
         } else if (state == SessionState.CONNECTED && lastRenderedState != SessionState.CONNECTED) {
-            // Board is a live ECU again (e.g. it rebooted to firmware after a flash) — clear any stale
-            // "Board is in the … bootloader" hint left in the status log. [tag:better_ux_for_flashing]
-            statusPanel.clear();
+            // Board is a live ECU again (e.g. it rebooted to firmware after a flash). Normally clear the
+            // stale "Board is in the … bootloader" hint — but if a firmware update just finished, preserve
+            // its (green/red) report so the success/failure survives the reconnect instead of being wiped
+            // (issue #9832). consumeLastResult() shows it once; a later unrelated reconnect clears normally.
+            if (jobExecutor.consumeLastResult() == UpdateFirmwareResult.NONE) {
+                statusPanel.clear();
+            }
         }
     }
 

--- a/java_console/ui/src/main/java/com/rusefi/StartupFrame.java
+++ b/java_console/ui/src/main/java/com/rusefi/StartupFrame.java
@@ -37,6 +37,7 @@ import com.rusefi.ui.basic.FirmwareUpdateTab;
 import com.rusefi.ui.basic.SingleAsyncJobExecutor;
 import com.rusefi.ui.basic.StatusPanelWithProgressBar;
 import com.rusefi.ui.basic.TuneManagementTab;
+import com.rusefi.ui.basic.UpdateFirmwareResult;
 import com.rusefi.ui.widgets.StatusPanel;
 import com.rusefi.ui.widgets.ToolButtons;
 import net.miginfocom.swing.MigLayout;
@@ -912,8 +913,10 @@ public class StartupFrame {
                     ConnectionStatusLogic.INSTANCE.removeListener(this);
                     if (this == postFlashReconnectListener) postFlashReconnectListener = null;
                     SwingUtilities.invokeLater(() -> {
-                        noPortsMessage.setForeground(Color.darkGray);
-                        noPortsMessage.setText("Connected to " + savedPort.port + " — click Connect to open console");
+                        // persistent success/failure indication that outlives the transient status panel (#9832)
+                        final UpdateFirmwareResult updateResult = firmwareUpdateTab.getBasicUpdaterPanel().getLastUpdateResult();
+                        noPortsMessage.setForeground(updateResult.bannerColor());
+                        noPortsMessage.setText(updateResult.bannerText(savedPort.port));
                         noPortsMessage.setVisible(true);
                         connectPanel.setVisible(true);
                         final LinkManager reconnectedLm = uiContext.getLinkManager();

--- a/java_console/ui/src/main/java/com/rusefi/ui/basic/BasicUpdaterPanel.java
+++ b/java_console/ui/src/main/java/com/rusefi/ui/basic/BasicUpdaterPanel.java
@@ -316,6 +316,11 @@ never used?
         });
     }
 
+    /** Outcome of the most recent firmware-update job, for the persistent post-reconnect banner (#9832). */
+    public UpdateFirmwareResult getLastUpdateResult() {
+        return singleAsyncJobExecutor.getLastResult();
+    }
+
     private void onUpdateFirmwareButtonClicked(final ActionEvent actionEvent) {
         disableButtons();
         CompatibilityOptional.ifPresentOrElse(updateFirmwareJob,

--- a/java_console/ui/src/main/java/com/rusefi/ui/basic/SingleAsyncJobExecutor.java
+++ b/java_console/ui/src/main/java/com/rusefi/ui/basic/SingleAsyncJobExecutor.java
@@ -17,10 +17,70 @@ public class SingleAsyncJobExecutor implements com.rusefi.DeviceSessionManager.J
 
     private volatile Optional<AsyncJob> jobInProgress = Optional.empty();
 
+    /**
+     * Terminal outcome of the last job, captured by wrapping the real callbacks — so the post-flash
+     * reconnect can show a persistent success/failure indication that outlives the transient status
+     * panel (issue #9832).
+     */
+    private volatile UpdateFirmwareResult lastResult = UpdateFirmwareResult.NONE;
+
+    /** Delegating callbacks that record the terminal outcome before forwarding to the real UI. */
+    private final UpdateOperationCallbacks recordingCallbacks;
+
     public SingleAsyncJobExecutor(
         final UpdateOperationCallbacks updateOperationCallbacks
     ) {
         this.updateOperationCallbacks = updateOperationCallbacks;
+        this.recordingCallbacks = new UpdateOperationCallbacks() {
+            @Override
+            public void log(final String message, final boolean breakLineOnTextArea, final boolean sendToLogger) {
+                updateOperationCallbacks.log(message, breakLineOnTextArea, sendToLogger);
+            }
+
+            @Override
+            public void done() {
+                lastResult = UpdateFirmwareResult.SUCCESS;
+                updateOperationCallbacks.done();
+            }
+
+            @Override
+            public void error() {
+                lastResult = UpdateFirmwareResult.FAILURE;
+                updateOperationCallbacks.error();
+            }
+
+            @Override
+            public void warning() {
+                updateOperationCallbacks.warning();
+            }
+
+            @Override
+            public void clear() {
+                lastResult = UpdateFirmwareResult.NONE;
+                updateOperationCallbacks.clear();
+            }
+
+            @Override
+            public void updateProgress(final int percent) {
+                updateOperationCallbacks.updateProgress(percent);
+            }
+        };
+    }
+
+    /** Outcome of the most recent job (reset to {@link UpdateFirmwareResult#NONE} at each job start). */
+    public UpdateFirmwareResult getLastResult() {
+        return lastResult;
+    }
+
+    /**
+     * Return the last outcome and reset it to {@link UpdateFirmwareResult#NONE}, so a one-shot consumer
+     * (e.g. the post-flash reconnect handler) shows the success/failure exactly once and a later,
+     * unrelated reconnect does not re-show a stale report (#9832).
+     */
+    public synchronized UpdateFirmwareResult consumeLastResult() {
+        final UpdateFirmwareResult result = lastResult;
+        lastResult = UpdateFirmwareResult.NONE;
+        return result;
     }
 
     public void addOnJobInProgressFinishedListener(Runnable listener) {
@@ -41,8 +101,8 @@ public class SingleAsyncJobExecutor implements com.rusefi.DeviceSessionManager.J
         if (!prevJobInProgress.isPresent()) {
             for (Runnable listener : onJobAboutToStart)
                 listener.run();
-            updateOperationCallbacks.clear();
-            AsyncJobExecutor.INSTANCE.executeJob(job, updateOperationCallbacks, this::handleJobInProgressFinished);
+            recordingCallbacks.clear(); // resets lastResult to NONE and clears the status panel
+            AsyncJobExecutor.INSTANCE.executeJob(job, recordingCallbacks, this::handleJobInProgressFinished);
         } else {
             JOptionPane.showMessageDialog(
                 parent,

--- a/java_console/ui/src/main/java/com/rusefi/ui/basic/UpdateFirmwareResult.java
+++ b/java_console/ui/src/main/java/com/rusefi/ui/basic/UpdateFirmwareResult.java
@@ -1,0 +1,44 @@
+package com.rusefi.ui.basic;
+
+import java.awt.Color;
+
+/**
+ * Terminal outcome of the most recent firmware-update job, so a persistent success/failure indication
+ * can survive the post-flash reconnect handoff (issue #9832 — the transient green report used to vanish
+ * the moment the console reconnected). The text/color mapping is pure and Swing-free so it is
+ * unit-testable without a UI (see docs/java-connectivity-ui-unit-testing.md).
+ */
+public enum UpdateFirmwareResult {
+    /** No update completed this session (or a new job just started). */
+    NONE,
+    SUCCESS,
+    FAILURE;
+
+    private static final Color GREEN = new Color(0, 128, 0);
+
+    /**
+     * Persistent banner text shown after the post-flash reconnect for a board on {@code portName}.
+     */
+    public String bannerText(final String portName) {
+        switch (this) {
+            case SUCCESS:
+                return "Firmware update complete — connected to " + portName + " — click Connect to open console";
+            case FAILURE:
+                return "Firmware update failed — see the report — connected to " + portName;
+            default:
+                return "Connected to " + portName + " — click Connect to open console";
+        }
+    }
+
+    /** Foreground color for {@link #bannerText}. */
+    public Color bannerColor() {
+        switch (this) {
+            case SUCCESS:
+                return GREEN;
+            case FAILURE:
+                return Color.RED;
+            default:
+                return Color.DARK_GRAY;
+        }
+    }
+}

--- a/java_console/ui/src/test/java/com/rusefi/ui/basic/UpdateFirmwareResultTest.java
+++ b/java_console/ui/src/test/java/com/rusefi/ui/basic/UpdateFirmwareResultTest.java
@@ -1,0 +1,37 @@
+package com.rusefi.ui.basic;
+
+import org.junit.jupiter.api.Test;
+
+import java.awt.Color;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The persistent post-reconnect banner mapping (#9832): a successful update must leave a green
+ * "complete" line, a failure a red one, and a plain reconnect (no update) the neutral line.
+ */
+public class UpdateFirmwareResultTest {
+    @Test
+    public void successIsGreenAndSaysComplete() {
+        assertEquals(new Color(0, 128, 0), UpdateFirmwareResult.SUCCESS.bannerColor());
+        String text = UpdateFirmwareResult.SUCCESS.bannerText("COM14");
+        assertTrue(text.contains("complete"), text);
+        assertTrue(text.contains("COM14"), text);
+    }
+
+    @Test
+    public void failureIsRedAndSaysFailed() {
+        assertEquals(Color.RED, UpdateFirmwareResult.FAILURE.bannerColor());
+        String text = UpdateFirmwareResult.FAILURE.bannerText("COM14");
+        assertTrue(text.contains("failed"), text);
+        assertTrue(text.contains("COM14"), text);
+    }
+
+    @Test
+    public void noneIsNeutralConnectedLine() {
+        assertEquals(Color.DARK_GRAY, UpdateFirmwareResult.NONE.bannerColor());
+        assertEquals("Connected to COM14 — click Connect to open console",
+            UpdateFirmwareResult.NONE.bannerText("COM14"));
+    }
+}


### PR DESCRIPTION
resolves #9832

<img width="1919" height="1023" alt="image" src="https://github.com/user-attachments/assets/62255107-f12f-4810-9694-bb3b7013298d" />
