### PR TITLE
hw: do not directly call NVIC_SystemReset()

### DIFF
--- a/firmware/controllers/core/error_handling.cpp
+++ b/firmware/controllers/core/error_handling.cpp
@@ -501,7 +501,7 @@ void chDbgPanic3(const char *msg, const char * file, int line) {
 		// All hope is now lost.
 
 		// Reboot!
-		NVIC_SystemReset();
+		rebootNow();
 	}
 
 #endif // EFI_PROD_CODE

--- a/firmware/hw_layer/main_hardfault.c
+++ b/firmware/hw_layer/main_hardfault.c
@@ -8,6 +8,9 @@
 
 #include "hal.h"
 
+//#include "mpu_util.h"
+extern void rebootNow(void);
+
 #include <string.h>
 
 /**
@@ -16,7 +19,7 @@
 #define bkpt() __asm volatile("BKPT #0\n")
 
 void NMI_Handler(void) {
-	NVIC_SystemReset();
+	rebootNow();
 }
 
 //See http://infocenter.arm.com/help/topic/com.arm.doc.dui0552a/BABBGBEC.html
@@ -63,7 +66,7 @@ void HardFault_Handler_C(void* sp) {
 	{
 		bkpt();
 	}
-	NVIC_SystemReset();
+	rebootNow();
 }
 
 void UsageFault_Handler_C(void* sp) {
@@ -97,7 +100,7 @@ void UsageFault_Handler_C(void* sp) {
 	{
 		bkpt();
 	}
-	NVIC_SystemReset();
+	rebootNow();
 }
 
 void MemManage_Handler_C(void* sp) {
@@ -132,5 +135,5 @@ void MemManage_Handler_C(void* sp) {
 	{
 		bkpt();
 	}
-	NVIC_SystemReset();
+	rebootNow();
 }

--- a/firmware/hw_layer/ports/at32/at32_common.cpp
+++ b/firmware/hw_layer/ports/at32/at32_common.cpp
@@ -103,6 +103,10 @@ int at32GetRamSizeKb(void)
 #define EFI_STORAGE_REBOOT_INTERLOCK TRUE
 #endif
 
+void rebootNow() {
+    NVIC_SystemReset();
+}
+
 static void reset_and_jump(void) {
 #ifdef EFI_STORAGE_REBOOT_INTERLOCK
     // Let any queued or in-flight settings/LTFT flash write finish before we
@@ -112,7 +116,7 @@ static void reset_and_jump(void) {
 #endif
 
     // and now reboot
-    NVIC_SystemReset();
+    rebootNow();
 }
 
 #if EFI_DFU_JUMP

--- a/firmware/hw_layer/ports/kinetis/kinetis_common.cpp
+++ b/firmware/hw_layer/ports/kinetis/kinetis_common.cpp
@@ -143,6 +143,10 @@ int getAdcChannelPin(adc_channel_e hwChannel) {
 
 #endif /* HAL_USE_ADC */
 
+void rebootNow() {
+    NVIC_SystemReset();
+}
+
 #if EFI_DFU_JUMP
 #define BOOTLOADER_LOCATION 0x1C00001CUL
 void jump_to_bootloader() {
@@ -152,7 +156,7 @@ void jump_to_bootloader() {
 	// Call the function!
 	bootloaderStart(NULL);
 	// Will not return from here
-	NVIC_SystemReset();
+	rebootNow();
 }
 #endif /* EFI_DFU_JUMP */
 

--- a/firmware/hw_layer/ports/mpu_util.h
+++ b/firmware/hw_layer/ports/mpu_util.h
@@ -137,6 +137,7 @@ extern "C"
 #endif /* __cplusplus */
 
 // these need to be declared with C linkage - they're called from C and asm files
+void rebootNow();
 void DebugMonitorVector(void);
 void UsageFaultVector(void);
 void BusFaultVector(void);

--- a/firmware/hw_layer/ports/stm32/stm32_common.cpp
+++ b/firmware/hw_layer/ports/stm32/stm32_common.cpp
@@ -42,6 +42,21 @@ extern "C" {
 #define ALLOW_JUMP_WITH_IGNITION_VOLTAGE TRUE
 #endif
 
+void rebootNow() {
+	#ifdef STM32H7XX
+		// H7 needs a forcible reset of the USB peripheral(s) in order for the bootloader to work properly.
+		// If you don't do this, the bootloader will execute, but USB doesn't work (nobody knows why)
+		// See https://community.st.com/s/question/0D53W00000vQEWsSAO/stm32h743-dfu-entry-doesnt-work-unless-boot0-held-high-at-poweron
+	#ifdef STM32H723xx
+		RCC->AHB1ENR &= ~(RCC_AHB1ENR_USB1OTGHSEN);
+	#else
+		RCC->AHB1ENR &= ~(RCC_AHB1ENR_USB1OTGHSEN | RCC_AHB1ENR_USB2OTGFSEN);
+	#endif
+	#endif
+
+	NVIC_SystemReset();
+}
+
 static bool reset_and_jump(void) {
 #if !ALLOW_JUMP_WITH_IGNITION_VOLTAGE
   if (isIgnVoltage()) {
@@ -69,7 +84,7 @@ static bool reset_and_jump(void) {
 	#endif
 
 	// and now reboot
-	NVIC_SystemReset();
+	rebootNow();
 
 	return true;
 }

--- a/firmware/rusefi.cpp
+++ b/firmware/rusefi.cpp
@@ -151,11 +151,6 @@ static char panicMessage[200];
 
 static virtual_timer_t resetTimer;
 
-// todo: move this into a hw-specific file
-void rebootNow() {
-	NVIC_SystemReset();
-}
-
 /**
  * Some configuration changes require full firmware reset.
  * Once day we will write graceful shutdown, but that would be one day.


### PR DESCRIPTION
Some devices need additional preparation before reset. Use rebootNow() wrapper.