### PR TITLE
USB serial is not stable #9860

### DIFF
--- a/firmware/hw_layer/mass_storage/mass_storage_device.cpp
+++ b/firmware/hw_layer/mass_storage/mass_storage_device.cpp
@@ -224,6 +224,17 @@ void MassStorageController::ThreadTask() {
 			// Get the LUN from the incoming CBW packet
 			uint8_t target_lun = m_cbw.lun & 0x0F; // Mask out reserved bits
 			if (target_lun <= USB_MSD_LUN_COUNT) {
+				// Hold the LUN lock for the whole command, CSW included: attachLun() (the
+				// SD mode switch swapping LUN1's backing device) must not return while
+				// lib_scsi is still using the old block device. scsiExecCmd captures the
+				// blkdev pointer at command start, so an unsynchronized swap lets the SD
+				// thread mount/log on the same MMC/SPI driver this command is still
+				// reading - ChibiOS sync SPI holds a single waiter per driver, the second
+				// thread's DMA wakeup is lost and both threads suspend forever (observed
+				// on hardware). The wait is bounded because every USB data-phase wait in
+				// this command carries MSD_DATA_PHASE_TIMEOUT.
+				chibios_rt::MutexLocker lock(m_lunMutex);
+
 				auto target = &m_luns[target_lun].target;
 
 				// mark busy so 'sdinfo' can show what we are stuck on if this never returns

--- a/firmware/hw_layer/mass_storage/mass_storage_init.cpp
+++ b/firmware/hw_layer/mass_storage/mass_storage_init.cpp
@@ -130,6 +130,9 @@ void attachMsdSdCard(BaseBlockDevice* blkdev, uint8_t *blkbuf, size_t blkbufsize
 
 void deattachMsdSdCard(void) {
 	// this is safe to use same read/write buffer couse all luns are handled from one thread
+	// attachLun() blocks until any in-flight SCSI command has fully unwound (CSW included),
+	// so once we return the MSD thread can no longer touch the SD card and the caller is
+	// free to hand the MMC/SPI driver to the logger (mountMmc/f_mount)
 	msd.attachLun(1, (BaseBlockDevice*)&ND1, blkbuf0, sizeof(blkbuf0), &sdCardInquiry, nullptr);
 
 #if EFI_TUNER_STUDIO


### PR DESCRIPTION
Root cause
deattachMsdSdCard() doesn't synchronize with the in-flight command. attachLun() takes m_lunMutex (mass_storage_device.cpp:394), but ThreadTask never takes it — the detach just swaps the LUN1 pointer and returns. Meanwhile data_read10 captured the old blkdev pointer (the real card) at command start and keeps using it. The SD thread then runs mountMmc()/f_mount, driving FatFS reads into the same MMCD1/SPI3 driver the MSD thread is mid-read on. LOCK_SD_SPI is only taken once at init ("exclusive access"), so nothing serializes the two paths — and ChibiOS synchronous SPI supports a single suspended waiter per driver, so one thread's DMA wakeup gets overwritten and it sleeps forever. Result: MSD thread wedged in blkRead, SD thread wedged in f_mount, bulk-OUT never re-armed, and Windows resets the composite device every 20 s taking the CDC console with it. (Bonus race in the same window: mountMmc() memsets resources, including resources.blkbuf — the SCSI buffer the in-flight command is still using.)

The trigger sequence fits your sandbox flow: forced PC mode, host reading the card (1959 reads served), forced mode cleared → selector reverts to ECU (alwaysWriteSdCard) → switch begins while a host READ(10) is mid-flight.

Fix direction
Make LUN detach wait for the in-flight command: hold m_lunMutex around scsiExecCmd + CSW in ThreadTask, so attachLun/deattachMsdSdCard blocks until the command unwinds. The wait is now bounded (~10 s worst case) precisely because of the data-phase timeouts you just added — the two fixes compose.