### PR TITLE
USB serial is not stable #9860

### DIFF
--- a/firmware/hw_layer/mass_storage/mass_storage_device.cpp
+++ b/firmware/hw_layer/mass_storage/mass_storage_device.cpp
@@ -20,6 +20,7 @@
 #define MSD_CSW_SIGNATURE               0x53425355
 
 #define CBW_FLAGS_RESERVED_MASK         0b01111111
+#define CBW_FLAGS_DIRECTION_IN          0b10000000
 #define CBW_LUN_RESERVED_MASK           0b11110000
 #define CBW_CMD_LEN_RESERVED_MASK       0b11000000
 
@@ -133,10 +134,12 @@ static uint32_t scsi_transport_transmit(const SCSITransport *transport,
 	if (MSG_TIMEOUT == status) {
 		s_msdInstance->onDataPhaseTimeout();
 	}
-	if (MSG_OK == status)
+	if (MSG_OK == status) {
+		s_msdInstance->onDataPhaseBytes(len);
 		return len;
-	else
+	} else {
 		return 0;
+	}
 }
 
 static uint32_t scsi_transport_transmit_start(const SCSITransport *transport,
@@ -147,10 +150,12 @@ static uint32_t scsi_transport_transmit_start(const SCSITransport *transport,
 
 	usb_scsi_transport_handler_t *trp = reinterpret_cast<usb_scsi_transport_handler_t*>(transport->handler);
 	msg_t status = usbTransmitStart(trp->usbp, trp->ep, data, len);
-	if (MSG_OK == status)
+	if (MSG_OK == status) {
+		s_msdInstance->onDataPhaseBytes(len);
 		return len;
-	else
+	} else {
 		return 0;
+	}
 }
 
 static uint32_t scsi_transport_transmit_wait(const SCSITransport *transport) {
@@ -181,10 +186,15 @@ static uint32_t scsi_transport_receive(const SCSITransport *transport,
 		s_msdInstance->onDataPhaseTimeout();
 		return 0;
 	}
-	if (MSG_RESET != status)
+	if (MSG_RESET != status) {
+		// usbReceive returns the received byte count when non-negative
+		if (status > 0) {
+			s_msdInstance->onDataPhaseBytes(status);
+		}
 		return status;
-	else
+	} else {
 		return 0;
+	}
 }
 
 MassStorageController::MassStorageController(USBDriver* usb)
@@ -242,6 +252,8 @@ void MassStorageController::ThreadTask() {
 				m_busyOpcode = m_cbw.cmd_data[0];
 				m_busySince = chVTGetSystemTime();
 
+				m_dataPhaseBytes = 0;
+
 				uint8_t cswStatus;
 				uint32_t residue;
 				if (SCSI_SUCCESS == scsiExecCmd(target, m_cbw.cmd_data)) {
@@ -251,7 +263,11 @@ void MassStorageController::ThreadTask() {
 					m_failedCmdCount = m_failedCmdCount + 1;
 					m_lastFailedOpcode = m_cbw.cmd_data[0];
 					cswStatus = CSW_STATUS_FAILED;
-					residue = scsiResidue(target);
+					// dCSWDataResidue = expected minus actually moved. Not scsiResidue():
+					// lib_scsi only writes that on a short transfer and never resets it
+					// between commands, so for a command that moved no data at all it
+					// reports a stale value from some earlier command.
+					residue = (m_cbw.data_len > m_dataPhaseBytes) ? (m_cbw.data_len - m_dataPhaseBytes) : 0;
 				}
 
 				m_busyOpcode = -1;
@@ -264,6 +280,24 @@ void MassStorageController::ThreadTask() {
 					// this command's CSW - sending one anyway would desynchronize the
 					// transport.
 					continue;
+				}
+
+				if ((m_cbw.data_len > 0) && ((m_cbw.flags & CBW_FLAGS_DIRECTION_IN) != 0)
+						&& (m_dataPhaseBytes == 0)) {
+					// BOT "13 cases" case 4/5 (Hi > Dn): the host expects a data-IN phase
+					// but this command sent nothing (e.g. Read Capacity on a medium-less
+					// LUN), so its data URB is still armed. Sending the 13-byte CSW now
+					// would land in that buffer - if it is smaller than 13 bytes (Read
+					// Capacity posts 8) the packet overruns it and the host sees a babble
+					// error, kills the URB, loses the CSW and retries the command forever
+					// (observed: Windows in a 200 ms retry loop, babble recovery also
+					// disturbing the CDC interfaces of the composite device). Per the BOT
+					// spec, STALL bulk-IN instead: the host clear-halts the endpoint and
+					// only then collects the CSW into a proper 13-byte read.
+					osalSysLock();
+					usbStallTransmitI(m_usb, USB_MSD_DATA_EP);
+					osalSysUnlock();
+					m_noDataStallCount = m_noDataStallCount + 1;
 				}
 
 				sendCsw(cswStatus, residue);
@@ -282,8 +316,8 @@ void MassStorageController::onDataPhaseTimeout() {
 }
 
 void MassStorageController::printDiagnostics() const {
-	efiPrintf("MSD: %lu commands, %lu failed (last failed opcode 0x%02x), %lu invalid CBWs, %lu data-phase timeouts",
-			m_cmdCount, m_failedCmdCount, m_lastFailedOpcode, m_invalidCbwCount, m_timeoutCount);
+	efiPrintf("MSD: %lu commands, %lu failed (last failed opcode 0x%02x), %lu invalid CBWs, %lu data-phase timeouts, %lu no-data stalls",
+			m_cmdCount, m_failedCmdCount, m_lastFailedOpcode, m_invalidCbwCount, m_timeoutCount, m_noDataStallCount);
 
 	// snapshot: m_busySince is only meaningful while m_busyOpcode is set
 	int busyOpcode = m_busyOpcode;

--- a/firmware/hw_layer/mass_storage/mass_storage_device.h
+++ b/firmware/hw_layer/mass_storage/mass_storage_device.h
@@ -30,6 +30,14 @@ public:
 	// timed out, meaning the host abandoned the command without a Bulk-Only Reset
 	void onDataPhaseTimeout();
 
+	// called by the SCSI transport with the number of data-phase bytes actually moved,
+	// so ThreadTask can detect a command that owed the host data but sent none (BOT
+	// case 4/5, e.g. Read Capacity on a medium-less LUN). lib_scsi's scsiResidue()
+	// cannot tell: it is only written on short transfers and never reset per command.
+	void onDataPhaseBytes(uint32_t bytes) {
+		m_dataPhaseBytes = m_dataPhaseBytes + bytes;
+	}
+
 	// polled by the SCSI transport so an abandoned command stops touching USB
 	bool isCommandAbandoned() const {
 		return m_botResetPending || m_dataPhaseTimedOut;
@@ -66,6 +74,12 @@ private:
 	// the whole composite device every ~20s). Cleared when the next CBW arrives.
 	volatile bool m_dataPhaseTimedOut = false;
 	volatile uint32_t m_timeoutCount = 0;
+
+	// Data-phase bytes moved by the current command, reset before each scsiExecCmd.
+	// Zero on a command that declared a data-IN phase means the host's data URB is
+	// still armed and a straight CSW would babble into it - stall bulk-IN instead.
+	volatile uint32_t m_dataPhaseBytes = 0;
+	volatile uint32_t m_noDataStallCount = 0;
 
 	usbmsdstate_t m_state;
 


### PR DESCRIPTION
  To validate after reflashing: boot with the console connected —
  1. sdinfo should show no-data stalls climbing (Windows probes LUN0 Read Capacity at every mount/rescan) while data-phase timeouts stays 0,
  2. volume arrival should be fast (no more ~7 s of 200 ms retries at boot),
  3. a capture should show LUN0 Read Capacity(10) completing as STALL → clear-halt → CSW(failed) instead of USBD_STATUS_BABBLE_DETECTED — and no CDC URB cancellations riding along with disk re-probes.

  That last point is the real test of your CDC reliability complaint: if the babble recovery was the driver, the CDC drops that coincide with disk re-probes should be gone.