### PR TITLE
Wizard: skip firing order step on 1/2 cyl

### DIFF
--- a/java_console/ui/src/main/java/com/rusefi/ui/wizard/WizardContainer.java
+++ b/java_console/ui/src/main/java/com/rusefi/ui/wizard/WizardContainer.java
@@ -190,8 +190,10 @@ public class WizardContainer extends JPanel {
             if (result.value != null) {
                 selectedCylinders = Integer.parseInt(result.value);
             }
-            // Create FiringOrderPanel lazily now that we know the cylinder count
-            createFiringOrderStep();
+            if (implicitFiringOrder(selectedCylinders) == null) {
+                createFiringOrderStep();
+            }
+            rebuildVisibleCatalogIndices();
             onStepCompleted(result, steps.get(0));
         });
         steps.add(cylPanel);
@@ -267,10 +269,12 @@ public class WizardContainer extends JPanel {
         completionPanel.add(doneButton, gbc);
         stepContentPanel.add(completionPanel, "complete");
 
-        // If step 0 is already done, read cylindersCount from the ECU and create FiringOrderPanel now
+        // If step 0 is already done, read cylindersCount before building the remaining flow.
         if (isStepSatisfied(0)) {
             selectedCylinders = readCylindersCountFromEcu();
-            createFiringOrderStep();
+            if (implicitFiringOrder(selectedCylinders) == null) {
+                createFiringOrderStep();
+            }
         }
 
         refreshDebugFlags();
@@ -345,7 +349,24 @@ public class WizardContainer extends JPanel {
     private void rebuildVisibleCatalogIndices() {
         visibleCatalogIndices.clear();
         visibleCatalogIndices.addAll(findVisibleCatalogIndices(uiContext, uiContext.iniFileState.getIniFileModel()));
+        hideImplicitFiringOrderStep(visibleCatalogIndices, selectedCylinders);
         refreshProgress();
+    }
+
+    static void hideImplicitFiringOrderStep(List<Integer> visibleIndices, int cylindersCount) {
+        if (implicitFiringOrder(cylindersCount) != null) {
+            visibleIndices.remove(Integer.valueOf(1));
+        }
+    }
+
+    static String implicitFiringOrder(int cylindersCount) {
+        if (cylindersCount == 1) {
+            return "One Cylinder";
+        }
+        if (cylindersCount == 2) {
+            return "1-2";
+        }
+        return null;
     }
 
     static List<Integer> findVisibleCatalogIndices(UIContext context, IniFileModel ini) {
@@ -470,6 +491,7 @@ public class WizardContainer extends JPanel {
                 log.warn("Wizard: flag field not found or not enum: " + flagName);
             }
         }
+        completeImplicitFiringOrder(flagName, result.value, ini, modified);
 
         // Upload + burn on IO thread, advance step on EDT
         uiContext.getLinkManager().submit(() -> {
@@ -492,6 +514,36 @@ public class WizardContainer extends JPanel {
                 image.setBitValue((EnumIniField) flag, 0);
             }
         }
+    }
+
+    static void completeImplicitFiringOrder(String completedFlag, String cylindersValue,
+                                             IniFileModel ini, ConfigurationImage image) {
+        if (!"wizardNumberOfCylinders".equals(completedFlag) || cylindersValue == null) {
+            return;
+        }
+
+        final int cylindersCount;
+        try {
+            cylindersCount = Integer.parseInt(cylindersValue);
+        } catch (NumberFormatException e) {
+            return;
+        }
+
+        String firingOrder = implicitFiringOrder(cylindersCount);
+        if (firingOrder == null) {
+            return;
+        }
+
+        IniField firingOrderField = ini.findIniField("firingOrder").orElse(null);
+        IniField firingOrderFlag = ini.findIniField("wizardFiringOrder").orElse(null);
+        if (firingOrderField == null || !(firingOrderFlag instanceof EnumIniField)) {
+            log.warn("Wizard: cannot complete implicit firing order for " + cylindersCount + " cylinders");
+            return;
+        }
+
+        ConfigurationImageGetterSetter.setValue2(firingOrderField, image, "firingOrder", firingOrder);
+        image.setBitValue((EnumIniField) firingOrderFlag, 1);
+        log.info("Wizard: set firingOrder = " + firingOrder + " and wizardFiringOrder = yes");
     }
 
     private void advanceToNextStep() {

--- a/java_console/ui/src/main/java/com/rusefi/ui/wizard/WizardContainer.java
+++ b/java_console/ui/src/main/java/com/rusefi/ui/wizard/WizardContainer.java
@@ -23,6 +23,8 @@ import static com.devexperts.logging.Logging.getLogging;
 public class WizardContainer extends JPanel {
     private static final Logging log = getLogging(WizardContainer.class);
     private static final List<WizardStepDescriptor> FLAGGED = WizardCatalog.flaggedSteps();
+    private static final int FO_1 = 0;
+    private static final int FO_1_2 = 8;
 
     private final UIContext uiContext;
     private final WizardProgressPanel progressPanel = new WizardProgressPanel();
@@ -190,7 +192,7 @@ public class WizardContainer extends JPanel {
             if (result.value != null) {
                 selectedCylinders = Integer.parseInt(result.value);
             }
-            if (implicitFiringOrder(selectedCylinders) == null) {
+            if (implicitFiringOrderOrdinal(selectedCylinders) == null) {
                 createFiringOrderStep();
             }
             rebuildVisibleCatalogIndices();
@@ -272,7 +274,7 @@ public class WizardContainer extends JPanel {
         // If step 0 is already done, read cylindersCount before building the remaining flow.
         if (isStepSatisfied(0)) {
             selectedCylinders = readCylindersCountFromEcu();
-            if (implicitFiringOrder(selectedCylinders) == null) {
+            if (implicitFiringOrderOrdinal(selectedCylinders) == null) {
                 createFiringOrderStep();
             }
         }
@@ -354,17 +356,17 @@ public class WizardContainer extends JPanel {
     }
 
     static void hideImplicitFiringOrderStep(List<Integer> visibleIndices, int cylindersCount) {
-        if (implicitFiringOrder(cylindersCount) != null) {
+        if (implicitFiringOrderOrdinal(cylindersCount) != null) {
             visibleIndices.remove(Integer.valueOf(1));
         }
     }
 
-    static String implicitFiringOrder(int cylindersCount) {
+    static Integer implicitFiringOrderOrdinal(int cylindersCount) {
         if (cylindersCount == 1) {
-            return "One Cylinder";
+            return FO_1;
         }
         if (cylindersCount == 2) {
-            return "1-2";
+            return FO_1_2;
         }
         return null;
     }
@@ -529,21 +531,21 @@ public class WizardContainer extends JPanel {
             return;
         }
 
-        String firingOrder = implicitFiringOrder(cylindersCount);
-        if (firingOrder == null) {
+        Integer firingOrderOrdinal = implicitFiringOrderOrdinal(cylindersCount);
+        if (firingOrderOrdinal == null) {
             return;
         }
 
         IniField firingOrderField = ini.findIniField("firingOrder").orElse(null);
         IniField firingOrderFlag = ini.findIniField("wizardFiringOrder").orElse(null);
-        if (firingOrderField == null || !(firingOrderFlag instanceof EnumIniField)) {
+        if (!(firingOrderField instanceof EnumIniField) || !(firingOrderFlag instanceof EnumIniField)) {
             log.warn("Wizard: cannot complete implicit firing order for " + cylindersCount + " cylinders");
             return;
         }
 
-        ConfigurationImageGetterSetter.setValue2(firingOrderField, image, "firingOrder", firingOrder);
+        image.setBitValue((EnumIniField) firingOrderField, firingOrderOrdinal);
         image.setBitValue((EnumIniField) firingOrderFlag, 1);
-        log.info("Wizard: set firingOrder = " + firingOrder + " and wizardFiringOrder = yes");
+        log.info("Wizard: set firingOrder ordinal = " + firingOrderOrdinal + " and wizardFiringOrder = yes");
     }
 
     private void advanceToNextStep() {

--- a/java_console/ui/src/test/java/com/rusefi/ui/wizard/WizardContainerTest.java
+++ b/java_console/ui/src/test/java/com/rusefi/ui/wizard/WizardContainerTest.java
@@ -1,17 +1,22 @@
 package com.rusefi.ui.wizard;
 
 import com.opensr5.ConfigurationImage;
+import com.opensr5.ConfigurationImageGetterSetter;
 import com.opensr5.ini.IniFileModel;
 import com.opensr5.ini.field.EnumIniField;
+import com.opensr5.ini.field.EnumIniField.EnumKeyValueMap;
+import com.rusefi.config.FieldType;
 import com.rusefi.ui.UIContext;
 import org.junit.jupiter.api.Test;
 
 import javax.swing.*;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.TreeMap;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -73,6 +78,70 @@ public class WizardContainerTest {
         verify(image).setBitValue(firingOrderFlag, 0);
         verify(image).setBitValue(ignitionOutputsFlag, 0);
         verify(image).setBitValue(injectorOutputsFlag, 0);
+    }
+
+    @Test
+    public void oneAndTwoCylindersUseImplicitFiringOrders() {
+        assertEquals("One Cylinder", WizardContainer.implicitFiringOrder(1));
+        assertEquals("1-2", WizardContainer.implicitFiringOrder(2));
+        assertNull(WizardContainer.implicitFiringOrder(3));
+        assertNull(WizardContainer.implicitFiringOrder(4));
+    }
+
+    @Test
+    public void implicitFiringOrderStepIsNotVisible() {
+        List<Integer> oneCylinderSteps = new ArrayList<>(Arrays.asList(0, 1, 2));
+        List<Integer> twoCylinderSteps = new ArrayList<>(Arrays.asList(0, 1, 2));
+        List<Integer> fourCylinderSteps = new ArrayList<>(Arrays.asList(0, 1, 2));
+
+        WizardContainer.hideImplicitFiringOrderStep(oneCylinderSteps, 1);
+        WizardContainer.hideImplicitFiringOrderStep(twoCylinderSteps, 2);
+        WizardContainer.hideImplicitFiringOrderStep(fourCylinderSteps, 4);
+
+        assertEquals(Arrays.asList(0, 2), oneCylinderSteps);
+        assertEquals(Arrays.asList(0, 2), twoCylinderSteps);
+        assertEquals(Arrays.asList(0, 1, 2), fourCylinderSteps);
+    }
+
+    @Test
+    public void completingCylinderStepWritesImplicitFiringOrderAndFlag() {
+        Map<Integer, String> orderValues = new TreeMap<>();
+        orderValues.put(0, "One Cylinder");
+        orderValues.put(8, "1-2");
+        EnumIniField firingOrder = new EnumIniField(
+            "firingOrder", 0, FieldType.UINT8, new EnumKeyValueMap(orderValues), 0, 3);
+
+        Map<Integer, String> flagValues = new TreeMap<>();
+        flagValues.put(0, "no");
+        flagValues.put(1, "yes");
+        EnumIniField firingOrderFlag = new EnumIniField(
+            "wizardFiringOrder", 4, FieldType.INT, new EnumKeyValueMap(flagValues), 0, 0);
+
+        IniFileModel ini = mock(IniFileModel.class);
+        when(ini.findIniField("firingOrder")).thenReturn(Optional.of(firingOrder));
+        when(ini.findIniField("wizardFiringOrder")).thenReturn(Optional.of(firingOrderFlag));
+
+        for (String cylinders : Arrays.asList("1", "2")) {
+            ConfigurationImage image = new ConfigurationImage(new byte[8]);
+            WizardContainer.completeImplicitFiringOrder(
+                "wizardNumberOfCylinders", cylinders, ini, image);
+
+            String expectedOrder = WizardContainer.implicitFiringOrder(Integer.parseInt(cylinders));
+            assertEquals(expectedOrder,
+                AbstractWizardStep.stripQuotes(ConfigurationImageGetterSetter.getStringValue(firingOrder, image)));
+            assertEquals("yes",
+                AbstractWizardStep.stripQuotes(ConfigurationImageGetterSetter.getStringValue(firingOrderFlag, image)));
+        }
+    }
+
+    @Test
+    public void largerCylinderCountsDoNotCompleteFiringOrder() {
+        IniFileModel ini = mock(IniFileModel.class);
+
+        WizardContainer.completeImplicitFiringOrder(
+            "wizardNumberOfCylinders", "4", ini, new ConfigurationImage(new byte[1]));
+
+        verify(ini, org.mockito.Mockito.never()).findIniField(anyString());
     }
 
     @Test

--- a/java_console/ui/src/test/java/com/rusefi/ui/wizard/WizardContainerTest.java
+++ b/java_console/ui/src/test/java/com/rusefi/ui/wizard/WizardContainerTest.java
@@ -82,10 +82,10 @@ public class WizardContainerTest {
 
     @Test
     public void oneAndTwoCylindersUseImplicitFiringOrders() {
-        assertEquals("One Cylinder", WizardContainer.implicitFiringOrder(1));
-        assertEquals("1-2", WizardContainer.implicitFiringOrder(2));
-        assertNull(WizardContainer.implicitFiringOrder(3));
-        assertNull(WizardContainer.implicitFiringOrder(4));
+        assertEquals(0, WizardContainer.implicitFiringOrderOrdinal(1));
+        assertEquals(8, WizardContainer.implicitFiringOrderOrdinal(2));
+        assertNull(WizardContainer.implicitFiringOrderOrdinal(3));
+        assertNull(WizardContainer.implicitFiringOrderOrdinal(4));
     }
 
     @Test
@@ -126,7 +126,8 @@ public class WizardContainerTest {
             WizardContainer.completeImplicitFiringOrder(
                 "wizardNumberOfCylinders", cylinders, ini, image);
 
-            String expectedOrder = WizardContainer.implicitFiringOrder(Integer.parseInt(cylinders));
+            String expectedOrder = orderValues.get(
+                WizardContainer.implicitFiringOrderOrdinal(Integer.parseInt(cylinders)));
             assertEquals(expectedOrder,
                 AbstractWizardStep.stripQuotes(ConfigurationImageGetterSetter.getStringValue(firingOrder, image)));
             assertEquals("yes",


### PR DESCRIPTION
resolves #9718

we skip the step and set the correct value in the background, also marking the step as completed