### PR TITLE
BaseVeGenerator: factory and first generator, "archetype-base-ve-v1"

### DIFF
--- a/java_console/models/src/main/java/com/rusefi/tune/ve/ArchetypeBaseVeV1.java
+++ b/java_console/models/src/main/java/com/rusefi/tune/ve/ArchetypeBaseVeV1.java
@@ -1,0 +1,228 @@
+package com.rusefi.tune.ve;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Archetype Base VE v1 — a transparent heuristic for conventional four-stroke SI engines.
+ * <p>
+ * Profile ID: {@value #PROFILE_ID}.
+ * Constants are part of the version; change only under a new profile ID with updated fixtures.
+ */
+public class ArchetypeBaseVeV1 extends BaseVeGenerator {
+
+    public static final String PROFILE_ID    = "archetype-base-ve-v1";
+    public static final String DISPLAY_NAME  = "Archetype Base VE v1";
+
+    // MAP factor lookup: {absoluteKpa, factor}. Must remain in ascending kPa order.
+    static final double[][] MAP_FACTORS = {
+        {10, 0.60}, {20, 0.65}, {40, 0.72}, {60, 0.82}, {80, 0.92}, {100, 1.00}
+    };
+
+    public enum HeadArchetype {
+        RESTRICTIVE_2V("Restrictive/legacy 2-valve", 85.0),
+        PORTED_2V("Good/ported 2-valve", 92.0),
+        STOCK_4V("Stock modern 4-valve", 98.0),
+        HIGHFLOW_4V("High-flow/performance 4-valve", 104.0);
+
+        public final String label;
+        public final double peakVe;
+
+        HeadArchetype(String label, double peakVe) {
+            this.label = label;
+            this.peakVe = peakVe;
+        }
+    }
+
+    public enum CamBehavior {
+        STOCK("Stock",           0.48, 28, 10, 18),
+        MILD("Mild",             0.58, 34, 14, 14),
+        AGGRESSIVE("Aggressive", 0.68, 42, 20, 10);
+
+        public final String label;
+        public final double peakPosition;
+        public final double idleDrop;
+        public final double lowRpmDrop;
+        public final double redlineDrop;
+
+        CamBehavior(String label, double peakPosition,
+                    double idleDrop, double lowRpmDrop, double redlineDrop) {
+            this.label = label;
+            this.peakPosition = peakPosition;
+            this.idleDrop = idleDrop;
+            this.lowRpmDrop = lowRpmDrop;
+            this.redlineDrop = redlineDrop;
+        }
+    }
+
+    public enum Aspiration {
+        NATURALLY_ASPIRATED("Naturally aspirated"),
+        TURBOCHARGED("Turbocharged"),
+        SUPERCHARGED("Supercharged");
+
+        public final String label;
+
+        Aspiration(String label) {
+            this.label = label;
+        }
+    }
+
+    /** Immutable configuration for one generation run. */
+    public static class Request {
+        public final double idleRpm;
+        public final double maximumRpm;
+        public final HeadArchetype head;
+        public final CamBehavior cam;
+        public final boolean hasVvt;
+        public final Aspiration aspiration;
+
+        /**
+         * @param isFourStrokeSI must be {@code true}; the generator blocks other engine types
+         */
+        public Request(boolean isFourStrokeSI,
+                       double idleRpm,
+                       double maximumRpm,
+                       HeadArchetype head,
+                       CamBehavior cam,
+                       boolean hasVvt,
+                       Aspiration aspiration) {
+            if (!isFourStrokeSI) {
+                throw new IllegalArgumentException(
+                    PROFILE_ID + " supports only conventional reciprocating " +
+                    "four-stroke spark-ignition engines.");
+            }
+            if (!Double.isFinite(idleRpm) || !Double.isFinite(maximumRpm)) {
+                throw new IllegalArgumentException("idleRpm and maximumRpm must be finite.");
+            }
+            if (maximumRpm <= idleRpm) {
+                throw new IllegalArgumentException("maximumRpm must be greater than idleRpm.");
+            }
+            if (maximumRpm - idleRpm < 500) {
+                throw new IllegalArgumentException("maximumRpm - idleRpm must be at least 500 RPM.");
+            }
+            this.idleRpm = idleRpm;
+            this.maximumRpm = maximumRpm;
+            this.head = Objects.requireNonNull(head, "head");
+            this.cam = Objects.requireNonNull(cam, "cam");
+            this.hasVvt = hasVvt;
+            this.aspiration = Objects.requireNonNull(aspiration, "aspiration");
+        }
+    }
+
+    private final Request request;
+
+    public ArchetypeBaseVeV1(Request request) {
+        this.request = Objects.requireNonNull(request, "request");
+    }
+
+    @Override
+    public String getProfileId() {
+        return PROFILE_ID;
+    }
+
+    @Override
+    public String getDisplayName() {
+        return DISPLAY_NAME;
+    }
+
+    @Override
+    public Result generate(double[] rpmAxis, double[] mapAxis) {
+        Objects.requireNonNull(rpmAxis, "rpmAxis");
+        Objects.requireNonNull(mapAxis, "mapAxis");
+        if (rpmAxis.length == 0) throw new IllegalArgumentException("rpmAxis must not be empty.");
+        if (mapAxis.length == 0) throw new IllegalArgumentException("mapAxis must not be empty.");
+
+        // Apply VVT broadening multipliers to cam drops
+        double idleDrop    = request.cam.idleDrop    * (request.hasVvt ? 0.90 : 1.0);
+        double lowRpmDrop  = request.cam.lowRpmDrop  * (request.hasVvt ? 0.75 : 1.0);
+        double redlineDrop = request.cam.redlineDrop * (request.hasVvt ? 0.75 : 1.0);
+
+        // RPM shape anchors
+        double peakRpm   = request.idleRpm + request.cam.peakPosition * (request.maximumRpm - request.idleRpm);
+        double lowRpm    = request.idleRpm + 0.5 * (peakRpm - request.idleRpm);
+        double highRpm   = peakRpm + 0.5 * (request.maximumRpm - peakRpm);
+        double peakVe    = request.head.peakVe;
+        double idleVe    = peakVe - idleDrop;
+        double lowVe     = peakVe - lowRpmDrop;
+        double highVe    = peakVe - redlineDrop / 2.0;
+        double redlineVe = peakVe - redlineDrop;
+
+        // WOT RPM curve at each axis bin
+        double[] rpmCurve = new double[rpmAxis.length];
+        for (int c = 0; c < rpmAxis.length; c++) {
+            rpmCurve[c] = rpmVe(rpmAxis[c],
+                request.idleRpm, lowRpm, peakRpm, highRpm, request.maximumRpm,
+                idleVe, lowVe, peakVe, highVe, redlineVe);
+        }
+
+        // MAP factor at each load bin
+        double[] mapFactor = new double[mapAxis.length];
+        for (int r = 0; r < mapAxis.length; r++) {
+            mapFactor[r] = mapVeFactor(mapAxis[r]);
+        }
+
+        // Build raw surface and pre-clamp
+        int nLoad = mapAxis.length;
+        int nRpm  = rpmAxis.length;
+        double[][] table = new double[nLoad][nRpm];
+        for (int r = 0; r < nLoad; r++) {
+            for (int c = 0; c < nRpm; c++) {
+                table[r][c] = clamp(rpmCurve[c] * mapFactor[r]);
+            }
+        }
+
+        // Two deterministic weighted 3×3 smoothing passes
+        table = smoothPass(table);
+        table = smoothPass(table);
+
+        // Post-smooth clamp
+        for (int r = 0; r < nLoad; r++) {
+            for (int c = 0; c < nRpm; c++) {
+                table[r][c] = clamp(table[r][c]);
+            }
+        }
+
+        List<String> warnings = new ArrayList<>();
+        if (request.aspiration != Aspiration.NATURALLY_ASPIRATED) {
+            warnings.add(
+                "Boosted: initial operation at wastegate/minimum boost only. " +
+                "Verify lambda, fuel pressure, and MAP/IAT calibration before increasing load. " +
+                "Rows above 100 kPa use the same WOT curve shape as atmospheric; " +
+                "STFT/LTFT may be disabled or limited at high load.");
+        }
+
+        return new Result(table, PROFILE_ID, warnings);
+    }
+
+    // -- formula helpers (package-private for testing) --
+
+    static double rpmVe(double rpm,
+                        double idleRpm, double lowRpm, double peakRpm,
+                        double highRpm, double maxRpm,
+                        double idleVe, double lowVe, double peakVe,
+                        double highVe, double redlineVe) {
+        if (rpm <= idleRpm) return idleVe;
+        if (rpm >= maxRpm)  return redlineVe;
+        if (rpm <= lowRpm)  return lerp(idleRpm, idleVe,  lowRpm,  lowVe,     rpm);
+        if (rpm <= peakRpm) return lerp(lowRpm,  lowVe,   peakRpm, peakVe,    rpm);
+        if (rpm <= highRpm) return lerp(peakRpm, peakVe,  highRpm, highVe,    rpm);
+        return              lerp(highRpm, highVe, maxRpm,  redlineVe, rpm);
+    }
+
+    static double mapVeFactor(double kpa) {
+        if (kpa <= MAP_FACTORS[0][0]) {
+            return MAP_FACTORS[0][1];
+        }
+        if (kpa >= MAP_FACTORS[MAP_FACTORS.length - 1][0]) {
+            return MAP_FACTORS[MAP_FACTORS.length - 1][1];
+        }
+        for (int i = 1; i < MAP_FACTORS.length; i++) {
+            if (kpa <= MAP_FACTORS[i][0]) {
+                return lerp(MAP_FACTORS[i-1][0], MAP_FACTORS[i-1][1],
+                            MAP_FACTORS[i][0],   MAP_FACTORS[i][1], kpa);
+            }
+        }
+        return MAP_FACTORS[MAP_FACTORS.length - 1][1];
+    }
+}

--- a/java_console/models/src/main/java/com/rusefi/tune/ve/BaseVeGenerator.java
+++ b/java_console/models/src/main/java/com/rusefi/tune/ve/BaseVeGenerator.java
@@ -1,0 +1,276 @@
+package com.rusefi.tune.ve;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Pure headless VE table generator — no Swing, no INI, no ConfigurationImage.
+ * <p>
+ * Profile "archetype-base-ve-v1": constants are versioned. Change only under a new
+ * profile ID with updated tests, and maybe a real engine test?.
+ */
+public class BaseVeGenerator {
+
+    public static final String PROFILE_ID = "archetype-base-ve-v1";
+
+    private static final double CLAMP_MIN = 35.0;
+    private static final double CLAMP_MAX = 125.0;
+
+    // MAP factor lookup: {absoluteKpa, factor}. Points must remain in ascending kPa order.
+    private static final double[][] MAP_FACTORS = {
+        {10, 0.60}, {20, 0.65}, {40, 0.72}, {60, 0.82}, {80, 0.92}, {100, 1.00}
+    };
+
+    public enum HeadArchetype {
+        RESTRICTIVE_2V("Restrictive/legacy 2-valve", 85.0),
+        PORTED_2V("Good/ported 2-valve", 92.0),
+        STOCK_4V("Stock modern 4-valve", 98.0),
+        HIGHFLOW_4V("High-flow/performance 4-valve", 104.0);
+
+        public final String label;
+        public final double peakVe;
+
+        HeadArchetype(String label, double peakVe) {
+            this.label = label;
+            this.peakVe = peakVe;
+        }
+    }
+
+    public enum CamBehavior {
+        STOCK("Stock",           0.48, 28, 10, 18),
+        MILD("Mild",             0.58, 34, 14, 14),
+        AGGRESSIVE("Aggressive", 0.68, 42, 20, 10);
+
+        public final String label;
+        public final double peakPosition;
+        public final double idleDrop;
+        public final double lowRpmDrop;
+        public final double redlineDrop;
+
+        CamBehavior(String label, double peakPosition,
+                    double idleDrop, double lowRpmDrop, double redlineDrop) {
+            this.label = label;
+            this.peakPosition = peakPosition;
+            this.idleDrop = idleDrop;
+            this.lowRpmDrop = lowRpmDrop;
+            this.redlineDrop = redlineDrop;
+        }
+    }
+
+    public enum Aspiration {
+        NATURALLY_ASPIRATED("Naturally aspirated"),
+        TURBOCHARGED("Turbocharged"),
+        SUPERCHARGED("Supercharged");
+
+        public final String label;
+
+        Aspiration(String label) {
+            this.label = label;
+        }
+    }
+
+    /** Immutable generation request. */
+    public static class Request {
+        public final double idleRpm;
+        public final double maximumRpm;
+        public final HeadArchetype head;
+        public final CamBehavior cam;
+        public final boolean hasVvt;
+        public final Aspiration aspiration;
+
+        /**
+         * @param isFourStrokeSI must be true; the generator blocks non-SI engine types
+         */
+        public Request(boolean isFourStrokeSI,
+                       double idleRpm,
+                       double maximumRpm,
+                       HeadArchetype head,
+                       CamBehavior cam,
+                       boolean hasVvt,
+                       Aspiration aspiration) {
+            if (!isFourStrokeSI) {
+                throw new IllegalArgumentException(
+                    "archetype-base-ve-v1 supports only conventional reciprocating " +
+                    "four-stroke spark-ignition engines.");
+            }
+            if (!Double.isFinite(idleRpm) || !Double.isFinite(maximumRpm)) {
+                throw new IllegalArgumentException("idleRpm and maximumRpm must be finite.");
+            }
+            if (maximumRpm <= idleRpm) {
+                throw new IllegalArgumentException("maximumRpm must be greater than idleRpm.");
+            }
+            if (maximumRpm - idleRpm < 500) {
+                throw new IllegalArgumentException("maximumRpm - idleRpm must be at least 500 RPM.");
+            }
+            this.idleRpm = idleRpm;
+            this.maximumRpm = maximumRpm;
+            this.head = Objects.requireNonNull(head, "head");
+            this.cam = Objects.requireNonNull(cam, "cam");
+            this.hasVvt = hasVvt;
+            this.aspiration = Objects.requireNonNull(aspiration, "aspiration");
+        }
+    }
+
+    /**
+     * Immutable generation result.
+     * veTable[loadRow][rpmCol] — same orientation as ECU storage (load is first index).
+     */
+    public static class Result {
+        public final double[][] veTable;
+        public final String profileId;
+        public final List<String> warnings;
+
+        Result(double[][] veTable, String profileId, List<String> warnings) {
+            this.veTable = veTable;
+            this.profileId = profileId;
+            this.warnings = Collections.unmodifiableList(new ArrayList<>(warnings));
+        }
+    }
+
+    /**
+     * Generate a VE surface for the given request and target axes.
+     *
+     * @param request  validated generation parameters
+     * @param rpmAxis  ECU RPM axis values, strictly ascending, finite (length >= 1)
+     * @param mapAxis  ECU MAP/load axis values in kPa, strictly ascending, finite (length >= 1)
+     * @return Result with veTable[loadRow][rpmCol], profileId, and warnings
+     */
+    public static Result generate(Request request, double[] rpmAxis, double[] mapAxis) {
+        Objects.requireNonNull(request, "request");
+        Objects.requireNonNull(rpmAxis, "rpmAxis");
+        Objects.requireNonNull(mapAxis, "mapAxis");
+        if (rpmAxis.length == 0) {
+            throw new IllegalArgumentException("rpmAxis must not be empty.");
+        }
+        if (mapAxis.length == 0) {
+            throw new IllegalArgumentException("mapAxis must not be empty.");
+        }
+
+        // Apply VVT broadening multipliers to cam drops
+        double vvtIdleMult    = request.hasVvt ? 0.90 : 1.0;
+        double vvtRangeMult   = request.hasVvt ? 0.75 : 1.0;
+        double idleDrop    = request.cam.idleDrop    * vvtIdleMult;
+        double lowRpmDrop  = request.cam.lowRpmDrop  * vvtRangeMult;
+        double redlineDrop = request.cam.redlineDrop * vvtRangeMult;
+
+        // Compute RPM shape anchors
+        double peakRpm  = request.idleRpm + request.cam.peakPosition * (request.maximumRpm - request.idleRpm);
+        double lowRpm   = request.idleRpm + 0.5 * (peakRpm - request.idleRpm);
+        double highRpm  = peakRpm + 0.5 * (request.maximumRpm - peakRpm);
+        double peakVe   = request.head.peakVe;
+        double idleVe   = peakVe - idleDrop;
+        double lowVe    = peakVe - lowRpmDrop;
+        double highVe   = peakVe - redlineDrop / 2.0;
+        double redlineVe= peakVe - redlineDrop;
+
+        // WOT RPM curve at each axis bin
+        double[] rpmCurve = new double[rpmAxis.length];
+        for (int c = 0; c < rpmAxis.length; c++) {
+            rpmCurve[c] = rpmVe(rpmAxis[c],
+                request.idleRpm, lowRpm, peakRpm, highRpm, request.maximumRpm,
+                idleVe, lowVe, peakVe, highVe, redlineVe);
+        }
+
+        // MAP factor at each load bin
+        double[] mapFactor = new double[mapAxis.length];
+        for (int r = 0; r < mapAxis.length; r++) {
+            mapFactor[r] = mapVeFactor(mapAxis[r]);
+        }
+
+        // Build raw surface, pre-clamp
+        int nLoad = mapAxis.length;
+        int nRpm  = rpmAxis.length;
+        double[][] table = new double[nLoad][nRpm];
+        for (int r = 0; r < nLoad; r++) {
+            for (int c = 0; c < nRpm; c++) {
+                table[r][c] = clamp(rpmCurve[c] * mapFactor[r]);
+            }
+        }
+
+        // Two deterministic weighted 3×3 smoothing passes
+        table = smoothPass(table);
+        table = smoothPass(table);
+
+        // Post-smooth clamp
+        for (int r = 0; r < nLoad; r++) {
+            for (int c = 0; c < nRpm; c++) {
+                table[r][c] = clamp(table[r][c]);
+            }
+        }
+
+        List<String> warnings = new ArrayList<>();
+        if (request.aspiration != Aspiration.NATURALLY_ASPIRATED) {
+            warnings.add(
+                "Boosted: initial operation at wastegate/minimum boost only. " +
+                "Verify lambda, fuel pressure, and MAP/IAT calibration before increasing load. " +
+                "Rows above 100 kPa use the same WOT curve shape as atmospheric; ");
+        }
+
+        return new Result(table, PROFILE_ID, warnings);
+    }
+
+    // -- formula helpers (package-private for testing) --
+
+    static double rpmVe(double rpm,
+                        double idleRpm, double lowRpm, double peakRpm,
+                        double highRpm, double maxRpm,
+                        double idleVe, double lowVe, double peakVe,
+                        double highVe, double redlineVe) {
+        if (rpm <= idleRpm) return idleVe;
+        if (rpm >= maxRpm)  return redlineVe;
+        if (rpm <= lowRpm)  return lerp(idleRpm, idleVe,  lowRpm,  lowVe,     rpm);
+        if (rpm <= peakRpm) return lerp(lowRpm,  lowVe,   peakRpm, peakVe,    rpm);
+        if (rpm <= highRpm) return lerp(peakRpm, peakVe,  highRpm, highVe,    rpm);
+        return              lerp(highRpm, highVe, maxRpm,  redlineVe, rpm);
+    }
+
+    static double mapVeFactor(double kpa) {
+        if (kpa <= MAP_FACTORS[0][0]) {
+            return MAP_FACTORS[0][1];
+        }
+        if (kpa >= MAP_FACTORS[MAP_FACTORS.length - 1][0]) {
+            return MAP_FACTORS[MAP_FACTORS.length - 1][1];
+        }
+        for (int i = 1; i < MAP_FACTORS.length; i++) {
+            if (kpa <= MAP_FACTORS[i][0]) {
+                return lerp(MAP_FACTORS[i-1][0], MAP_FACTORS[i-1][1],
+                            MAP_FACTORS[i][0],   MAP_FACTORS[i][1], kpa);
+            }
+        }
+        return MAP_FACTORS[MAP_FACTORS.length - 1][1];
+    }
+
+    /**
+     * One weighted 3×3 smoothing pass. Interior cells only; border cells copied unchanged.
+     * Tables with fewer than 3 rows or fewer than 3 columns have no interior cells;
+     * the output is an identical copy of the input (correct, not an error).
+     */
+    static double[][] smoothPass(double[][] in) {
+        int nRows = in.length;
+        int nCols = nRows == 0 ? 0 : in[0].length;
+        double[][] out = new double[nRows][nCols];
+        for (int r = 0; r < nRows; r++) {
+            for (int c = 0; c < nCols; c++) {
+                if (r == 0 || r == nRows - 1 || c == 0 || c == nCols - 1) {
+                    out[r][c] = in[r][c];
+                } else {
+                    out[r][c] = (4 * in[r][c]
+                        + 2 * (in[r-1][c] + in[r+1][c] + in[r][c-1] + in[r][c+1])
+                        + in[r-1][c-1] + in[r-1][c+1] + in[r+1][c-1] + in[r+1][c+1]
+                    ) / 16.0;
+                }
+            }
+        }
+        return out;
+    }
+
+    private static double lerp(double x0, double y0, double x1, double y1, double x) {
+        return y0 + (x - x0) / (x1 - x0) * (y1 - y0);
+    }
+
+    private static double clamp(double v) {
+        return Math.max(CLAMP_MIN, Math.min(CLAMP_MAX, v));
+    }
+}

--- a/java_console/models/src/main/java/com/rusefi/tune/ve/BaseVeGenerator.java
+++ b/java_console/models/src/main/java/com/rusefi/tune/ve/BaseVeGenerator.java
@@ -1,253 +1,29 @@
 package com.rusefi.tune.ve;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Objects;
-
 /**
- * Pure headless VE table generator — no Swing, no INI, no ConfigurationImage.
- * <p>
- * Profile "archetype-base-ve-v1": constants are versioned. Change only under a new
- * profile ID with updated tests, and maybe a real engine test?.
+ * Abstract base for VE table generators.
+ * Provides shared numeric utilities: 3×3 smoothing, linear interpolation, and clamping.
+ * Concrete implementations supply their own configuration types, enums, and formula.
+ *
+ * @see ArchetypeBaseVeV1
  */
-public class BaseVeGenerator {
+public abstract class BaseVeGenerator implements VeGenerator {
 
-    public static final String PROFILE_ID = "archetype-base-ve-v1";
-
-    private static final double CLAMP_MIN = 35.0;
-    private static final double CLAMP_MAX = 125.0;
-
-    // MAP factor lookup: {absoluteKpa, factor}. Points must remain in ascending kPa order.
-    private static final double[][] MAP_FACTORS = {
-        {10, 0.60}, {20, 0.65}, {40, 0.72}, {60, 0.82}, {80, 0.92}, {100, 1.00}
-    };
-
-    public enum HeadArchetype {
-        RESTRICTIVE_2V("Restrictive/legacy 2-valve", 85.0),
-        PORTED_2V("Good/ported 2-valve", 92.0),
-        STOCK_4V("Stock modern 4-valve", 98.0),
-        HIGHFLOW_4V("High-flow/performance 4-valve", 104.0);
-
-        public final String label;
-        public final double peakVe;
-
-        HeadArchetype(String label, double peakVe) {
-            this.label = label;
-            this.peakVe = peakVe;
-        }
-    }
-
-    public enum CamBehavior {
-        STOCK("Stock",           0.48, 28, 10, 18),
-        MILD("Mild",             0.58, 34, 14, 14),
-        AGGRESSIVE("Aggressive", 0.68, 42, 20, 10);
-
-        public final String label;
-        public final double peakPosition;
-        public final double idleDrop;
-        public final double lowRpmDrop;
-        public final double redlineDrop;
-
-        CamBehavior(String label, double peakPosition,
-                    double idleDrop, double lowRpmDrop, double redlineDrop) {
-            this.label = label;
-            this.peakPosition = peakPosition;
-            this.idleDrop = idleDrop;
-            this.lowRpmDrop = lowRpmDrop;
-            this.redlineDrop = redlineDrop;
-        }
-    }
-
-    public enum Aspiration {
-        NATURALLY_ASPIRATED("Naturally aspirated"),
-        TURBOCHARGED("Turbocharged"),
-        SUPERCHARGED("Supercharged");
-
-        public final String label;
-
-        Aspiration(String label) {
-            this.label = label;
-        }
-    }
-
-    /** Immutable generation request. */
-    public static class Request {
-        public final double idleRpm;
-        public final double maximumRpm;
-        public final HeadArchetype head;
-        public final CamBehavior cam;
-        public final boolean hasVvt;
-        public final Aspiration aspiration;
-
-        /**
-         * @param isFourStrokeSI must be true; the generator blocks non-SI engine types
-         */
-        public Request(boolean isFourStrokeSI,
-                       double idleRpm,
-                       double maximumRpm,
-                       HeadArchetype head,
-                       CamBehavior cam,
-                       boolean hasVvt,
-                       Aspiration aspiration) {
-            if (!isFourStrokeSI) {
-                throw new IllegalArgumentException(
-                    "archetype-base-ve-v1 supports only conventional reciprocating " +
-                    "four-stroke spark-ignition engines.");
-            }
-            if (!Double.isFinite(idleRpm) || !Double.isFinite(maximumRpm)) {
-                throw new IllegalArgumentException("idleRpm and maximumRpm must be finite.");
-            }
-            if (maximumRpm <= idleRpm) {
-                throw new IllegalArgumentException("maximumRpm must be greater than idleRpm.");
-            }
-            if (maximumRpm - idleRpm < 500) {
-                throw new IllegalArgumentException("maximumRpm - idleRpm must be at least 500 RPM.");
-            }
-            this.idleRpm = idleRpm;
-            this.maximumRpm = maximumRpm;
-            this.head = Objects.requireNonNull(head, "head");
-            this.cam = Objects.requireNonNull(cam, "cam");
-            this.hasVvt = hasVvt;
-            this.aspiration = Objects.requireNonNull(aspiration, "aspiration");
-        }
-    }
+    /** Lower clamp bound for all generated VE values (%). */
+    protected static final double CLAMP_MIN = 35.0;
+    /** Upper clamp bound for all generated VE values (%). */
+    protected static final double CLAMP_MAX = 125.0;
 
     /**
-     * Immutable generation result.
-     * veTable[loadRow][rpmCol] — same orientation as ECU storage (load is first index).
-     */
-    public static class Result {
-        public final double[][] veTable;
-        public final String profileId;
-        public final List<String> warnings;
-
-        Result(double[][] veTable, String profileId, List<String> warnings) {
-            this.veTable = veTable;
-            this.profileId = profileId;
-            this.warnings = Collections.unmodifiableList(new ArrayList<>(warnings));
-        }
-    }
-
-    /**
-     * Generate a VE surface for the given request and target axes.
-     *
-     * @param request  validated generation parameters
-     * @param rpmAxis  ECU RPM axis values, strictly ascending, finite (length >= 1)
-     * @param mapAxis  ECU MAP/load axis values in kPa, strictly ascending, finite (length >= 1)
-     * @return Result with veTable[loadRow][rpmCol], profileId, and warnings
-     */
-    public static Result generate(Request request, double[] rpmAxis, double[] mapAxis) {
-        Objects.requireNonNull(request, "request");
-        Objects.requireNonNull(rpmAxis, "rpmAxis");
-        Objects.requireNonNull(mapAxis, "mapAxis");
-        if (rpmAxis.length == 0) {
-            throw new IllegalArgumentException("rpmAxis must not be empty.");
-        }
-        if (mapAxis.length == 0) {
-            throw new IllegalArgumentException("mapAxis must not be empty.");
-        }
-
-        // Apply VVT broadening multipliers to cam drops
-        double vvtIdleMult    = request.hasVvt ? 0.90 : 1.0;
-        double vvtRangeMult   = request.hasVvt ? 0.75 : 1.0;
-        double idleDrop    = request.cam.idleDrop    * vvtIdleMult;
-        double lowRpmDrop  = request.cam.lowRpmDrop  * vvtRangeMult;
-        double redlineDrop = request.cam.redlineDrop * vvtRangeMult;
-
-        // Compute RPM shape anchors
-        double peakRpm  = request.idleRpm + request.cam.peakPosition * (request.maximumRpm - request.idleRpm);
-        double lowRpm   = request.idleRpm + 0.5 * (peakRpm - request.idleRpm);
-        double highRpm  = peakRpm + 0.5 * (request.maximumRpm - peakRpm);
-        double peakVe   = request.head.peakVe;
-        double idleVe   = peakVe - idleDrop;
-        double lowVe    = peakVe - lowRpmDrop;
-        double highVe   = peakVe - redlineDrop / 2.0;
-        double redlineVe= peakVe - redlineDrop;
-
-        // WOT RPM curve at each axis bin
-        double[] rpmCurve = new double[rpmAxis.length];
-        for (int c = 0; c < rpmAxis.length; c++) {
-            rpmCurve[c] = rpmVe(rpmAxis[c],
-                request.idleRpm, lowRpm, peakRpm, highRpm, request.maximumRpm,
-                idleVe, lowVe, peakVe, highVe, redlineVe);
-        }
-
-        // MAP factor at each load bin
-        double[] mapFactor = new double[mapAxis.length];
-        for (int r = 0; r < mapAxis.length; r++) {
-            mapFactor[r] = mapVeFactor(mapAxis[r]);
-        }
-
-        // Build raw surface, pre-clamp
-        int nLoad = mapAxis.length;
-        int nRpm  = rpmAxis.length;
-        double[][] table = new double[nLoad][nRpm];
-        for (int r = 0; r < nLoad; r++) {
-            for (int c = 0; c < nRpm; c++) {
-                table[r][c] = clamp(rpmCurve[c] * mapFactor[r]);
-            }
-        }
-
-        // Two deterministic weighted 3×3 smoothing passes
-        table = smoothPass(table);
-        table = smoothPass(table);
-
-        // Post-smooth clamp
-        for (int r = 0; r < nLoad; r++) {
-            for (int c = 0; c < nRpm; c++) {
-                table[r][c] = clamp(table[r][c]);
-            }
-        }
-
-        List<String> warnings = new ArrayList<>();
-        if (request.aspiration != Aspiration.NATURALLY_ASPIRATED) {
-            warnings.add(
-                "Boosted: initial operation at wastegate/minimum boost only. " +
-                "Verify lambda, fuel pressure, and MAP/IAT calibration before increasing load. " +
-                "Rows above 100 kPa use the same WOT curve shape as atmospheric; ");
-        }
-
-        return new Result(table, PROFILE_ID, warnings);
-    }
-
-    // -- formula helpers (package-private for testing) --
-
-    static double rpmVe(double rpm,
-                        double idleRpm, double lowRpm, double peakRpm,
-                        double highRpm, double maxRpm,
-                        double idleVe, double lowVe, double peakVe,
-                        double highVe, double redlineVe) {
-        if (rpm <= idleRpm) return idleVe;
-        if (rpm >= maxRpm)  return redlineVe;
-        if (rpm <= lowRpm)  return lerp(idleRpm, idleVe,  lowRpm,  lowVe,     rpm);
-        if (rpm <= peakRpm) return lerp(lowRpm,  lowVe,   peakRpm, peakVe,    rpm);
-        if (rpm <= highRpm) return lerp(peakRpm, peakVe,  highRpm, highVe,    rpm);
-        return              lerp(highRpm, highVe, maxRpm,  redlineVe, rpm);
-    }
-
-    static double mapVeFactor(double kpa) {
-        if (kpa <= MAP_FACTORS[0][0]) {
-            return MAP_FACTORS[0][1];
-        }
-        if (kpa >= MAP_FACTORS[MAP_FACTORS.length - 1][0]) {
-            return MAP_FACTORS[MAP_FACTORS.length - 1][1];
-        }
-        for (int i = 1; i < MAP_FACTORS.length; i++) {
-            if (kpa <= MAP_FACTORS[i][0]) {
-                return lerp(MAP_FACTORS[i-1][0], MAP_FACTORS[i-1][1],
-                            MAP_FACTORS[i][0],   MAP_FACTORS[i][1], kpa);
-            }
-        }
-        return MAP_FACTORS[MAP_FACTORS.length - 1][1];
-    }
-
-    /**
-     * One weighted 3×3 smoothing pass. Interior cells only; border cells copied unchanged.
+     * One weighted 3×3 smoothing pass over a 2D table.
+     * Only interior cells (rows 1..N-2, cols 1..M-2) are averaged; border cells are copied.
      * Tables with fewer than 3 rows or fewer than 3 columns have no interior cells;
-     * the output is an identical copy of the input (correct, not an error).
+     * the pass returns an identical copy (correct, not an error).
+     *
+     * @param in source matrix [rows][cols]
+     * @return new matrix with interior cells smoothed
      */
-    static double[][] smoothPass(double[][] in) {
+    protected static double[][] smoothPass(double[][] in) {
         int nRows = in.length;
         int nCols = nRows == 0 ? 0 : in[0].length;
         double[][] out = new double[nRows][nCols];
@@ -266,11 +42,13 @@ public class BaseVeGenerator {
         return out;
     }
 
-    private static double lerp(double x0, double y0, double x1, double y1, double x) {
+    /** Linear interpolation between {@code (x0,y0)} and {@code (x1,y1)} at {@code x}. */
+    protected static double lerp(double x0, double y0, double x1, double y1, double x) {
         return y0 + (x - x0) / (x1 - x0) * (y1 - y0);
     }
 
-    private static double clamp(double v) {
+    /** Clamp {@code v} to [{@link #CLAMP_MIN}, {@link #CLAMP_MAX}]. */
+    protected static double clamp(double v) {
         return Math.max(CLAMP_MIN, Math.min(CLAMP_MAX, v));
     }
 }

--- a/java_console/models/src/main/java/com/rusefi/tune/ve/VeGenerator.java
+++ b/java_console/models/src/main/java/com/rusefi/tune/ve/VeGenerator.java
@@ -1,0 +1,43 @@
+package com.rusefi.tune.ve;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Common interface for all VE table generator implementations.
+ * Each implementation owns its own configuration/request type and profile ID.
+ * The shared output is {@link Result}.
+ */
+public interface VeGenerator {
+
+    /** Short versioned identifier for this generator, e.g. {@code "archetype-base-ve-v1"}. */
+    String getProfileId();
+
+    /** Human-readable name shown in the generator selection UI. */
+    String getDisplayName();
+
+    /**
+     * Generate a VE surface for the provided ECU axes.
+     *
+     * @param rpmAxis strictly ascending, finite RPM axis values (length >= 1)
+     * @param mapAxis strictly ascending, finite MAP/load axis values in kPa (length >= 1)
+     * @return generated surface and any applicable warnings
+     */
+    Result generate(double[] rpmAxis, double[] mapAxis);
+
+    /**
+     * Shared immutable output for all VE generators.
+     * {@code veTable[loadRow][rpmCol]} — same orientation as ECU storage.
+     */
+    final class Result {
+        public final double[][] veTable;
+        public final String profileId;
+        public final List<String> warnings;
+
+        public Result(double[][] veTable, String profileId, List<String> warnings) {
+            this.veTable  = veTable;
+            this.profileId = profileId;
+            this.warnings  = Collections.unmodifiableList(warnings);
+        }
+    }
+}

--- a/java_console/models/src/main/java/com/rusefi/tune/ve/VeTableBinding.java
+++ b/java_console/models/src/main/java/com/rusefi/tune/ve/VeTableBinding.java
@@ -1,0 +1,283 @@
+package com.rusefi.tune.ve;
+
+import com.opensr5.ConfigurationImage;
+import com.opensr5.ini.IniFileModel;
+import com.opensr5.ini.TableModel;
+import com.opensr5.ini.field.ArrayIniField;
+import com.opensr5.ini.field.IniField;
+import com.rusefi.config.generated.VariableRegistryValues;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Binds {@code veTableTbl} from an active INI + ConfigurationImage.
+ * <p>
+ * Validates load mode, reads axes, encodes generated VE Z values into a cloned
+ * image, and proves that only VE Z bytes change.
+ */
+public class VeTableBinding {
+
+    private static final String FUEL_ALGORITHM_FIELD   = "fuelAlgorithm";
+    private static final String VE_OVERRIDE_FIELD      = "veOverrideMode";
+    private static final String SEPARATE_IDLE_VE_FIELD = "useSeparateIdleVe";
+
+    public static class BindingError extends Exception {
+        public BindingError(String message) {
+            super(message);
+        }
+    }
+
+    /** Resolved and validated binding for veTableTbl. */
+    public static class BoundTable {
+        public final ArrayIniField rpmField;    // X bins (1D)
+        public final ArrayIniField mapField;    // Y bins (1D)
+        public final ArrayIniField veField;     // Z values (2D)
+        public final double[] rpmAxis;          // decoded RPM values from image
+        public final double[] mapAxis;          // decoded load values from image (kPa)
+        public final double[][] currentVe;      // decoded current VE[loadRow][rpmCol]
+        public final int nLoad;
+        public final int nRpm;
+        public final List<String> effectiveVeWarnings;
+
+        BoundTable(ArrayIniField rpmField, ArrayIniField mapField, ArrayIniField veField,
+                   double[] rpmAxis, double[] mapAxis, double[][] currentVe,
+                   List<String> effectiveVeWarnings) {
+            this.rpmField = rpmField;
+            this.mapField = mapField;
+            this.veField  = veField;
+            this.rpmAxis  = rpmAxis;
+            this.mapAxis  = mapAxis;
+            this.currentVe = currentVe;
+            this.nLoad = mapAxis.length;
+            this.nRpm  = rpmAxis.length;
+            this.effectiveVeWarnings = Collections.unmodifiableList(new ArrayList<>(effectiveVeWarnings));
+        }
+    }
+
+    /**
+     * Resolve and validate {@code veTableTbl} from the active INI and image.
+     *
+     * @throws BindingError when the table cannot be bound (unsupported mode, bad axes, etc.)
+     */
+    public static BoundTable bind(IniFileModel ini, ConfigurationImage image) throws BindingError {
+        TableModel table = ini.getTable("veTableTbl");
+        if (table == null) {
+            throw new BindingError("veTableTbl not found in INI.");
+        }
+
+        ArrayIniField rpmField = requireArrayField(ini, table.getXBinsConstant(), "RPM axis (X)");
+        ArrayIniField mapField = requireArrayField(ini, table.getYBinsConstant(), "load axis (Y)");
+        ArrayIniField veField  = requireArrayField(ini, table.getZBinsConstant(), "VE values (Z)");
+
+        // Axes must be 1D (cols == 1 for curves in TS INI)
+        if (rpmField.getCols() != 1) {
+            throw new BindingError("RPM axis field '" + rpmField.getName() + "' must be 1D (cols==1).");
+        }
+        if (mapField.getCols() != 1) {
+            throw new BindingError("Load axis field '" + mapField.getName() + "' must be 1D (cols==1).");
+        }
+
+        int nRpm  = rpmField.getRows();
+        int nLoad = mapField.getRows();
+
+        if (veField.getCols() != nRpm) {
+            throw new BindingError("VE Z cols (" + veField.getCols() +
+                ") != RPM axis length (" + nRpm + ").");
+        }
+        if (veField.getRows() != nLoad) {
+            throw new BindingError("VE Z rows (" + veField.getRows() +
+                ") != load axis length (" + nLoad + ").");
+        }
+
+        checkRange(image, rpmField);
+        checkRange(image, mapField);
+        checkRange(image, veField);
+
+        checkLoadMode(ini, image);
+
+        double[] rpmAxis = readAxis(image, rpmField, nRpm);
+        double[] mapAxis = readAxis(image, mapField, nLoad);
+        validateAscendingFinite(rpmAxis, "RPM axis");
+        validateAscendingFinite(mapAxis, "load axis");
+
+        double[][] currentVe = readZ(image, veField, nLoad, nRpm);
+        List<String> warnings = buildEffectiveVeWarnings(ini, image);
+
+        return new BoundTable(rpmField, mapField, veField, rpmAxis, mapAxis, currentVe, warnings);
+    }
+
+    /**
+     * Encode a generated VE surface into a clone of {@code source}.
+     * Asserts byte-identity: every byte outside the VE Z field must be unchanged.
+     *
+     * @param source   current working image (not mutated)
+     * @param bt       bound table from {@link #bind}
+     * @param veTable  generated values veTable[loadRow][rpmCol]
+     * @return cloned image with only VE Z bytes changed
+     * @throws BindingError on dimension mismatch or byte-identity violation
+     */
+    public static ConfigurationImage applyToClone(ConfigurationImage source,
+                                                   BoundTable bt,
+                                                   double[][] veTable) throws BindingError {
+        if (veTable.length != bt.nLoad) {
+            throw new BindingError("veTable load rows (" + veTable.length +
+                ") != bound nLoad (" + bt.nLoad + ").");
+        }
+        for (int r = 0; r < veTable.length; r++) {
+            if (veTable[r].length != bt.nRpm) {
+                throw new BindingError("veTable row " + r + " length (" + veTable[r].length +
+                    ") != bound nRpm (" + bt.nRpm + ").");
+            }
+        }
+
+        ConfigurationImage clone = source.clone();
+        ArrayIniField z = bt.veField;
+        double multiplier = z.getMultiplier();
+
+        for (int r = 0; r < bt.nLoad; r++) {
+            for (int c = 0; c < bt.nRpm; c++) {
+                int byteOffset  = z.getOffset(r, c);
+                int storageSize = z.getType().getStorageSize();
+                ByteBuffer bb   = clone.getByteBuffer(byteOffset, storageSize);
+                int rawEncoded  = (int) Math.round(veTable[r][c] / multiplier);
+                z.getType().writeRawValue(bb, rawEncoded);
+            }
+        }
+
+        // Prove only VE Z bytes changed
+        byte[] before = source.getContent();
+        byte[] after  = clone.getContent();
+        int zStart = z.getOffset();
+        int zEnd   = zStart + z.getSize();
+        for (int i = 0; i < before.length; i++) {
+            if ((i < zStart || i >= zEnd) && before[i] != after[i]) {
+                throw new BindingError("Byte " + i + " outside VE Z range [" +
+                    zStart + "," + zEnd + ") changed during encoding.");
+            }
+        }
+
+        return clone;
+    }
+
+    /**
+     * Decode VE Z values from a (possibly cloned) image back into a double array.
+     * Use this to read back quantized values after {@link #applyToClone}.
+     */
+    public static double[][] decodeZ(ConfigurationImage image, BoundTable bt) {
+        return readZ(image, bt.veField, bt.nLoad, bt.nRpm);
+    }
+
+    // -- private helpers --
+
+    private static ArrayIniField requireArrayField(IniFileModel ini, String name, String role)
+            throws BindingError {
+        if (name == null || name.isEmpty()) {
+            throw new BindingError("INI table missing " + role + " field name.");
+        }
+        Optional<IniField> opt = ini.findIniField(name);
+        if (!opt.isPresent()) {
+            throw new BindingError(role + " field '" + name + "' not found in INI.");
+        }
+        IniField field = opt.get();
+        if (!(field instanceof ArrayIniField)) {
+            throw new BindingError(role + " field '" + name + "' is not an ArrayIniField.");
+        }
+        return (ArrayIniField) field;
+    }
+
+    private static void checkRange(ConfigurationImage image, ArrayIniField field) throws BindingError {
+        int end = field.getOffset() + field.getSize();
+        if (field.getOffset() < 0 || end > image.getSize()) {
+            throw new BindingError("Field '" + field.getName() + "' byte range [" +
+                field.getOffset() + "," + end + ") exceeds image size (" + image.getSize() + ").");
+        }
+    }
+
+    private static void checkLoadMode(IniFileModel ini, ConfigurationImage image) throws BindingError {
+        int fuelAlgo = readOrdinal(ini, image, FUEL_ALGORITHM_FIELD, "fuelAlgorithm");
+        if (fuelAlgo != VariableRegistryValues.engine_load_mode_e_LM_SPEED_DENSITY) {
+            throw new BindingError(
+                "fuelAlgorithm ordinal=" + fuelAlgo +
+                " is not LM_SPEED_DENSITY (" +
+                VariableRegistryValues.engine_load_mode_e_LM_SPEED_DENSITY +
+                "). archetype-base-ve-v1 requires Speed Density.");
+        }
+        int veOverride = readOrdinal(ini, image, VE_OVERRIDE_FIELD, "veOverrideMode");
+        if (veOverride != VariableRegistryValues.ve_override_e_VE_None &&
+            veOverride != VariableRegistryValues.ve_override_e_VE_MAP) {
+            throw new BindingError(
+                "veOverrideMode ordinal=" + veOverride +
+                " is not VE_None (0) or VE_MAP (1). VE_TPS and other overrides are not supported.");
+        }
+    }
+
+    private static int readOrdinal(IniFileModel ini, ConfigurationImage image,
+                                    String fieldName, String role) throws BindingError {
+        Optional<IniField> opt = ini.findIniField(fieldName);
+        if (!opt.isPresent()) {
+            throw new BindingError("INI field '" + fieldName + "' (" + role + ") not found.");
+        }
+        Double v = image.readNumericValue(opt.get());
+        if (v == null) {
+            throw new BindingError("Cannot read numeric ordinal for '" + fieldName +
+                "' — field type not supported by readNumericValue.");
+        }
+        return (int) Math.round(v);
+    }
+
+    private static double[] readAxis(ConfigurationImage image, ArrayIniField field, int count) {
+        double[] axis = new double[count];
+        double multiplier = field.getMultiplier();
+        for (int i = 0; i < count; i++) {
+            // 1D array: col index is always 0
+            int byteOffset  = field.getOffset(i, 0);
+            int storageSize = field.getType().getStorageSize();
+            ByteBuffer bb   = image.getByteBuffer(byteOffset, storageSize);
+            axis[i] = field.getType().readRawValue(bb) * multiplier;
+        }
+        return axis;
+    }
+
+    private static double[][] readZ(ConfigurationImage image, ArrayIniField field, int nLoad, int nRpm) {
+        double[][] z = new double[nLoad][nRpm];
+        double multiplier = field.getMultiplier();
+        for (int r = 0; r < nLoad; r++) {
+            for (int c = 0; c < nRpm; c++) {
+                int byteOffset  = field.getOffset(r, c);
+                int storageSize = field.getType().getStorageSize();
+                ByteBuffer bb   = image.getByteBuffer(byteOffset, storageSize);
+                z[r][c] = field.getType().readRawValue(bb) * multiplier;
+            }
+        }
+        return z;
+    }
+
+    private static void validateAscendingFinite(double[] axis, String name) throws BindingError {
+        for (int i = 0; i < axis.length; i++) {
+            if (!Double.isFinite(axis[i])) {
+                throw new BindingError(name + "[" + i + "] is not finite: " + axis[i]);
+            }
+            if (i > 0 && axis[i] <= axis[i - 1]) {
+                throw new BindingError(name + " is not strictly ascending at index " + i +
+                    ": " + axis[i - 1] + " >= " + axis[i]);
+            }
+        }
+    }
+
+    private static List<String> buildEffectiveVeWarnings(IniFileModel ini, ConfigurationImage image) {
+        List<String> warnings = new ArrayList<>();
+        Optional<IniField> idleVeOpt = ini.findIniField(SEPARATE_IDLE_VE_FIELD);
+        if (idleVeOpt.isPresent()) {
+            Double v = image.readNumericValue(idleVeOpt.get());
+            if (v != null && v.intValue() != 0) {
+                warnings.add("Separate idle VE is enabled: the generated primary table may not " +
+                    "be the effective VE at idle RPM.");
+            }
+        }
+        return warnings;
+    }
+}

--- a/java_console/models/src/test/java/com/rusefi/tune/ve/BaseVeGeneratorTest.java
+++ b/java_console/models/src/test/java/com/rusefi/tune/ve/BaseVeGeneratorTest.java
@@ -2,24 +2,40 @@ package com.rusefi.tune.ve;
 
 import org.junit.jupiter.api.Test;
 
+import static com.rusefi.tune.ve.ArchetypeBaseVeV1.*;
 import static com.rusefi.tune.ve.BaseVeGenerator.*;
 import static org.junit.jupiter.api.Assertions.*;
 
+/**
+ * Tests for {@link BaseVeGenerator} utilities (smoothing kernel) and
+ * {@link ArchetypeBaseVeV1} formula (RPM curve, MAP factor, full generate).
+ */
 public class BaseVeGeneratorTest {
 
-    private static final double D  = 1e-9; // exact-formula comparisons (no rounding between stages)
+    private static final double D  = 1e-9; // exact formula comparisons
     private static final double DQ = 0.15; // tolerance after smoothing
 
     private static final double[] RPM6 = {1000, 2000, 3000, 4000, 5000, 6000};
     private static final double[] MAP6 = {20, 40, 60, 80, 100, 120};
 
-    private static Request stock4vStockNoVvt() {
-        return new Request(true, 1000, 6000,
-            HeadArchetype.STOCK_4V, CamBehavior.STOCK, false, Aspiration.NATURALLY_ASPIRATED);
+    private static ArchetypeBaseVeV1 stock4vStockNoVvt() {
+        return new ArchetypeBaseVeV1(new Request(true, 1000, 6000,
+            HeadArchetype.STOCK_4V, CamBehavior.STOCK, false, Aspiration.NATURALLY_ASPIRATED));
     }
 
     // -------------------------------------------------------------------------
-    // Four-stroke SI gate
+    // Interface contract
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testImplementsVeGenerator() {
+        assertTrue(stock4vStockNoVvt() instanceof VeGenerator);
+        assertEquals(PROFILE_ID, stock4vStockNoVvt().getProfileId());
+        assertEquals(DISPLAY_NAME, stock4vStockNoVvt().getDisplayName());
+    }
+
+    // -------------------------------------------------------------------------
+    // Request gate
     // -------------------------------------------------------------------------
 
     @Test
@@ -69,9 +85,9 @@ public class BaseVeGeneratorTest {
 
     @Test
     public void testRpmMidpointInterpolation() {
-        // Midpoint between idle(1000,70) and lowRpm(2200,88) => 1600 RPM => 79.0
+        // Midpoint idle(1000,70)..lowRpm(2200,88) => 1600 => 79.0
         assertEquals(79.0, rpmVe(1600, 1000,2200,3400,4700,6000, 70,88,98,89,80), D);
-        // Midpoint between peakRpm(3400,98) and highRpm(4700,89) => 4050 => 93.5
+        // Midpoint peakRpm(3400,98)..highRpm(4700,89) => 4050 => 93.5
         assertEquals(93.5, rpmVe(4050, 1000,2200,3400,4700,6000, 70,88,98,89,80), D);
     }
 
@@ -99,16 +115,13 @@ public class BaseVeGeneratorTest {
 
     @Test
     public void testMapFactorMidpointInterpolation() {
-        // 30 kPa: midpoint 20(0.65)..40(0.72) => 0.685
-        assertEquals(0.685, mapVeFactor(30), D);
-        // 50 kPa: midpoint 40(0.72)..60(0.82) => 0.77
-        assertEquals(0.77,  mapVeFactor(50), D);
-        // 90 kPa: midpoint 80(0.92)..100(1.00) => 0.96
-        assertEquals(0.96,  mapVeFactor(90), D);
+        assertEquals(0.685, mapVeFactor(30), D); // 20(0.65)..40(0.72) midpoint
+        assertEquals(0.77,  mapVeFactor(50), D); // 40(0.72)..60(0.82) midpoint
+        assertEquals(0.96,  mapVeFactor(90), D); // 80(0.92)..100(1.00) midpoint
     }
 
     // -------------------------------------------------------------------------
-    // Smoothing kernel
+    // BaseVeGenerator smoothing kernel (shared utilities)
     // -------------------------------------------------------------------------
 
     @Test
@@ -128,13 +141,9 @@ public class BaseVeGeneratorTest {
 
     @Test
     public void testSmoothedKernelWeights() {
-        double[][] in = {
-            {10, 20, 30},
-            {40, 50, 60},
-            {70, 80, 90}
-        };
-        // center=50, N=20,S=80,E=60,W=40, NW=10,NE=30,SW=70,SE=90
-        // (4*50 + 2*(20+80+60+40) + (10+30+70+90)) / 16 = (200+400+200)/16 = 800/16 = 50
+        // 3x3: one interior cell. center=50, N=20,S=80,E=60,W=40, corners=10/30/70/90
+        // (4*50 + 2*(20+80+60+40) + (10+30+70+90)) / 16 = 800/16 = 50
+        double[][] in = {{10,20,30},{40,50,60},{70,80,90}};
         double[][] out = smoothPass(in);
         assertEquals(50.0, out[1][1], D);
         assertEquals(10.0, out[0][0], D);
@@ -143,27 +152,22 @@ public class BaseVeGeneratorTest {
 
     @Test
     public void testDegenerateTableSmoothing() {
-        // 1x1: copy
-        double[][] t1 = {{75.0}};
-        assertEquals(75.0, smoothPass(t1)[0][0], D);
+        // 1x1
+        assertEquals(75.0, smoothPass(new double[][]{{75.0}})[0][0], D);
 
         // 2x5: no interior rows
         double[][] t2 = {{50,60,70,80,90},{55,65,75,85,95}};
         double[][] r2 = smoothPass(t2);
-        for (int r = 0; r < 2; r++) {
-            for (int c = 0; c < 5; c++) {
+        for (int r = 0; r < 2; r++)
+            for (int c = 0; c < 5; c++)
                 assertEquals(t2[r][c], r2[r][c], D);
-            }
-        }
 
         // 5x2: no interior cols
         double[][] t3 = {{50,60},{55,65},{60,70},{65,75},{70,80}};
         double[][] r3 = smoothPass(t3);
-        for (int r = 0; r < 5; r++) {
-            for (int c = 0; c < 2; c++) {
+        for (int r = 0; r < 5; r++)
+            for (int c = 0; c < 2; c++)
                 assertEquals(t3[r][c], r3[r][c], D);
-            }
-        }
     }
 
     // -------------------------------------------------------------------------
@@ -175,9 +179,9 @@ public class BaseVeGeneratorTest {
         for (HeadArchetype head : HeadArchetype.values()) {
             for (CamBehavior cam : CamBehavior.values()) {
                 for (boolean vvt : new boolean[]{false, true}) {
-                    Request req = new Request(true, 900, 7000, head, cam, vvt,
-                        Aspiration.NATURALLY_ASPIRATED);
-                    Result r = generate(req, RPM6, MAP6);
+                    VeGenerator gen = new ArchetypeBaseVeV1(new Request(true, 900, 7000,
+                        head, cam, vvt, Aspiration.NATURALLY_ASPIRATED));
+                    VeGenerator.Result r = gen.generate(RPM6, MAP6);
                     for (double[] row : r.veTable) {
                         for (double v : row) {
                             assertTrue(Double.isFinite(v),
@@ -193,49 +197,46 @@ public class BaseVeGeneratorTest {
 
     @Test
     public void testDeterminism() {
-        Request req = stock4vStockNoVvt();
-        Result r1 = generate(req, RPM6, MAP6);
-        Result r2 = generate(req, RPM6, MAP6);
-        assertEquals(r1.veTable.length, r2.veTable.length);
-        for (int row = 0; row < r1.veTable.length; row++) {
+        ArchetypeBaseVeV1 gen = stock4vStockNoVvt();
+        VeGenerator.Result r1 = gen.generate(RPM6, MAP6);
+        VeGenerator.Result r2 = gen.generate(RPM6, MAP6);
+        for (int row = 0; row < r1.veTable.length; row++)
             assertArrayEquals(r1.veTable[row], r2.veTable[row], 0.0);
-        }
     }
 
     @Test
     public void testProfileId() {
-        assertEquals(PROFILE_ID, generate(stock4vStockNoVvt(), RPM6, MAP6).profileId);
+        assertEquals(PROFILE_ID, stock4vStockNoVvt().generate(RPM6, MAP6).profileId);
     }
 
     @Test
-    public void testVvtBroadensCurveAtLowAndHighRpm() {
+    public void testVvtBroadensCurve() {
         double[] rpmFull  = {900, 1500, 3828, 5500, 7000};
         double[] mapAt100 = {100};
-        Request noVvt   = new Request(true, 900, 7000, HeadArchetype.STOCK_4V,
-            CamBehavior.STOCK, false, Aspiration.NATURALLY_ASPIRATED);
-        Request withVvt = new Request(true, 900, 7000, HeadArchetype.STOCK_4V,
-            CamBehavior.STOCK, true,  Aspiration.NATURALLY_ASPIRATED);
+        VeGenerator noVvt   = new ArchetypeBaseVeV1(new Request(true, 900, 7000,
+            HeadArchetype.STOCK_4V, CamBehavior.STOCK, false, Aspiration.NATURALLY_ASPIRATED));
+        VeGenerator withVvt = new ArchetypeBaseVeV1(new Request(true, 900, 7000,
+            HeadArchetype.STOCK_4V, CamBehavior.STOCK, true,  Aspiration.NATURALLY_ASPIRATED));
 
-        Result rN = generate(noVvt,   rpmFull, mapAt100);
-        Result rV = generate(withVvt, rpmFull, mapAt100);
+        VeGenerator.Result rN = noVvt.generate(rpmFull, mapAt100);
+        VeGenerator.Result rV = withVvt.generate(rpmFull, mapAt100);
 
-        // VVT reduces idle and redline drops: idle (col 0) and redline (col 4) must be >= no-VVT
         assertTrue(rV.veTable[0][0] >= rN.veTable[0][0], "VVT should raise or maintain idle VE");
         assertTrue(rV.veTable[0][4] >= rN.veTable[0][4], "VVT should raise or maintain redline VE");
     }
 
     @Test
     public void testAspirationDoesNotAffectValues() {
-        Request naReq   = new Request(true, 1000, 6000, HeadArchetype.STOCK_4V,
-            CamBehavior.STOCK, false, Aspiration.NATURALLY_ASPIRATED);
-        Request turbReq = new Request(true, 1000, 6000, HeadArchetype.STOCK_4V,
-            CamBehavior.STOCK, false, Aspiration.TURBOCHARGED);
-        Request scReq   = new Request(true, 1000, 6000, HeadArchetype.STOCK_4V,
-            CamBehavior.STOCK, false, Aspiration.SUPERCHARGED);
+        VeGenerator na   = new ArchetypeBaseVeV1(new Request(true, 1000, 6000,
+            HeadArchetype.STOCK_4V, CamBehavior.STOCK, false, Aspiration.NATURALLY_ASPIRATED));
+        VeGenerator turb = new ArchetypeBaseVeV1(new Request(true, 1000, 6000,
+            HeadArchetype.STOCK_4V, CamBehavior.STOCK, false, Aspiration.TURBOCHARGED));
+        VeGenerator sc   = new ArchetypeBaseVeV1(new Request(true, 1000, 6000,
+            HeadArchetype.STOCK_4V, CamBehavior.STOCK, false, Aspiration.SUPERCHARGED));
 
-        Result rNa   = generate(naReq,   RPM6, MAP6);
-        Result rTurb = generate(turbReq, RPM6, MAP6);
-        Result rSc   = generate(scReq,   RPM6, MAP6);
+        VeGenerator.Result rNa   = na.generate(RPM6, MAP6);
+        VeGenerator.Result rTurb = turb.generate(RPM6, MAP6);
+        VeGenerator.Result rSc   = sc.generate(RPM6, MAP6);
 
         for (int r = 0; r < rNa.veTable.length; r++) {
             assertArrayEquals(rNa.veTable[r], rTurb.veTable[r], 0.0);
@@ -248,13 +249,9 @@ public class BaseVeGeneratorTest {
 
     @Test
     public void testTableDimensions() {
-        for (HeadArchetype head : HeadArchetype.values()) {
-            Result r = generate(new Request(true, 900, 7000, head,
-                CamBehavior.STOCK, false, Aspiration.NATURALLY_ASPIRATED), RPM6, MAP6);
-            assertEquals(MAP6.length, r.veTable.length);
-            for (double[] row : r.veTable) {
-                assertEquals(RPM6.length, row.length);
-            }
-        }
+        VeGenerator.Result r = stock4vStockNoVvt().generate(RPM6, MAP6);
+        assertEquals(MAP6.length, r.veTable.length);
+        for (double[] row : r.veTable)
+            assertEquals(RPM6.length, row.length);
     }
 }

--- a/java_console/models/src/test/java/com/rusefi/tune/ve/BaseVeGeneratorTest.java
+++ b/java_console/models/src/test/java/com/rusefi/tune/ve/BaseVeGeneratorTest.java
@@ -1,0 +1,260 @@
+package com.rusefi.tune.ve;
+
+import org.junit.jupiter.api.Test;
+
+import static com.rusefi.tune.ve.BaseVeGenerator.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class BaseVeGeneratorTest {
+
+    private static final double D  = 1e-9; // exact-formula comparisons (no rounding between stages)
+    private static final double DQ = 0.15; // tolerance after smoothing
+
+    private static final double[] RPM6 = {1000, 2000, 3000, 4000, 5000, 6000};
+    private static final double[] MAP6 = {20, 40, 60, 80, 100, 120};
+
+    private static Request stock4vStockNoVvt() {
+        return new Request(true, 1000, 6000,
+            HeadArchetype.STOCK_4V, CamBehavior.STOCK, false, Aspiration.NATURALLY_ASPIRATED);
+    }
+
+    // -------------------------------------------------------------------------
+    // Four-stroke SI gate
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testFourStrokeGateRequired() {
+        assertThrows(IllegalArgumentException.class, () ->
+            new Request(false, 1000, 6000,
+                HeadArchetype.STOCK_4V, CamBehavior.STOCK, false, Aspiration.NATURALLY_ASPIRATED));
+    }
+
+    @Test
+    public void testMinimumRpmSpan() {
+        assertThrows(IllegalArgumentException.class, () ->
+            new Request(true, 1000, 1499,
+                HeadArchetype.STOCK_4V, CamBehavior.STOCK, false, Aspiration.NATURALLY_ASPIRATED));
+    }
+
+    @Test
+    public void testMaximumRpmMustExceedIdle() {
+        assertThrows(IllegalArgumentException.class, () ->
+            new Request(true, 3000, 2000,
+                HeadArchetype.STOCK_4V, CamBehavior.STOCK, false, Aspiration.NATURALLY_ASPIRATED));
+    }
+
+    // -------------------------------------------------------------------------
+    // RPM anchor values
+    // idle=1000, max=6000, Stock cam (peakPos=0.48):
+    //   peakRpm=3400, lowRpm=2200, highRpm=4700
+    // Stock4v peakVe=98: idleVe=70, lowVe=88, highVe=89, redlineVe=80
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testRpmAnchorsAtExactPoints() {
+        assertEquals(70.0, rpmVe(1000, 1000,2200,3400,4700,6000, 70,88,98,89,80), D);
+        assertEquals(88.0, rpmVe(2200, 1000,2200,3400,4700,6000, 70,88,98,89,80), D);
+        assertEquals(98.0, rpmVe(3400, 1000,2200,3400,4700,6000, 70,88,98,89,80), D);
+        assertEquals(89.0, rpmVe(4700, 1000,2200,3400,4700,6000, 70,88,98,89,80), D);
+        assertEquals(80.0, rpmVe(6000, 1000,2200,3400,4700,6000, 70,88,98,89,80), D);
+    }
+
+    @Test
+    public void testRpmEndpointClamping() {
+        assertEquals(70.0, rpmVe(500,   1000,2200,3400,4700,6000, 70,88,98,89,80), D);
+        assertEquals(70.0, rpmVe(0,     1000,2200,3400,4700,6000, 70,88,98,89,80), D);
+        assertEquals(80.0, rpmVe(7000,  1000,2200,3400,4700,6000, 70,88,98,89,80), D);
+        assertEquals(80.0, rpmVe(10000, 1000,2200,3400,4700,6000, 70,88,98,89,80), D);
+    }
+
+    @Test
+    public void testRpmMidpointInterpolation() {
+        // Midpoint between idle(1000,70) and lowRpm(2200,88) => 1600 RPM => 79.0
+        assertEquals(79.0, rpmVe(1600, 1000,2200,3400,4700,6000, 70,88,98,89,80), D);
+        // Midpoint between peakRpm(3400,98) and highRpm(4700,89) => 4050 => 93.5
+        assertEquals(93.5, rpmVe(4050, 1000,2200,3400,4700,6000, 70,88,98,89,80), D);
+    }
+
+    // -------------------------------------------------------------------------
+    // MAP factor
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testMapFactorAtDefinedPoints() {
+        assertEquals(0.60, mapVeFactor(10),  D);
+        assertEquals(0.65, mapVeFactor(20),  D);
+        assertEquals(0.72, mapVeFactor(40),  D);
+        assertEquals(0.82, mapVeFactor(60),  D);
+        assertEquals(0.92, mapVeFactor(80),  D);
+        assertEquals(1.00, mapVeFactor(100), D);
+    }
+
+    @Test
+    public void testMapFactorEndpointClamping() {
+        assertEquals(0.60, mapVeFactor(5),   D);
+        assertEquals(0.60, mapVeFactor(0),   D);
+        assertEquals(1.00, mapVeFactor(120), D);
+        assertEquals(1.00, mapVeFactor(200), D);
+    }
+
+    @Test
+    public void testMapFactorMidpointInterpolation() {
+        // 30 kPa: midpoint 20(0.65)..40(0.72) => 0.685
+        assertEquals(0.685, mapVeFactor(30), D);
+        // 50 kPa: midpoint 40(0.72)..60(0.82) => 0.77
+        assertEquals(0.77,  mapVeFactor(50), D);
+        // 90 kPa: midpoint 80(0.92)..100(1.00) => 0.96
+        assertEquals(0.96,  mapVeFactor(90), D);
+    }
+
+    // -------------------------------------------------------------------------
+    // Smoothing kernel
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testSmoothedBorderCellsUnchanged() {
+        double[][] table = new double[5][5];
+        for (double[] row : table) java.util.Arrays.fill(row, 80.0);
+        table[1][1] = 60.0;
+        table[2][2] = 120.0;
+        double[][] after2 = smoothPass(smoothPass(table));
+        for (int i = 0; i < 5; i++) {
+            assertEquals(80.0, after2[0][i], D);
+            assertEquals(80.0, after2[4][i], D);
+            assertEquals(80.0, after2[i][0], D);
+            assertEquals(80.0, after2[i][4], D);
+        }
+    }
+
+    @Test
+    public void testSmoothedKernelWeights() {
+        double[][] in = {
+            {10, 20, 30},
+            {40, 50, 60},
+            {70, 80, 90}
+        };
+        // center=50, N=20,S=80,E=60,W=40, NW=10,NE=30,SW=70,SE=90
+        // (4*50 + 2*(20+80+60+40) + (10+30+70+90)) / 16 = (200+400+200)/16 = 800/16 = 50
+        double[][] out = smoothPass(in);
+        assertEquals(50.0, out[1][1], D);
+        assertEquals(10.0, out[0][0], D);
+        assertEquals(90.0, out[2][2], D);
+    }
+
+    @Test
+    public void testDegenerateTableSmoothing() {
+        // 1x1: copy
+        double[][] t1 = {{75.0}};
+        assertEquals(75.0, smoothPass(t1)[0][0], D);
+
+        // 2x5: no interior rows
+        double[][] t2 = {{50,60,70,80,90},{55,65,75,85,95}};
+        double[][] r2 = smoothPass(t2);
+        for (int r = 0; r < 2; r++) {
+            for (int c = 0; c < 5; c++) {
+                assertEquals(t2[r][c], r2[r][c], D);
+            }
+        }
+
+        // 5x2: no interior cols
+        double[][] t3 = {{50,60},{55,65},{60,70},{65,75},{70,80}};
+        double[][] r3 = smoothPass(t3);
+        for (int r = 0; r < 5; r++) {
+            for (int c = 0; c < 2; c++) {
+                assertEquals(t3[r][c], r3[r][c], D);
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Full generate() surface properties
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testAllValuesInBounds() {
+        for (HeadArchetype head : HeadArchetype.values()) {
+            for (CamBehavior cam : CamBehavior.values()) {
+                for (boolean vvt : new boolean[]{false, true}) {
+                    Request req = new Request(true, 900, 7000, head, cam, vvt,
+                        Aspiration.NATURALLY_ASPIRATED);
+                    Result r = generate(req, RPM6, MAP6);
+                    for (double[] row : r.veTable) {
+                        for (double v : row) {
+                            assertTrue(Double.isFinite(v),
+                                () -> head + "+" + cam + "+vvt=" + vvt + " NaN/Inf");
+                            assertTrue(v >= 35.0 && v <= 125.0,
+                                () -> head + "+" + cam + "+vvt=" + vvt + " out of bounds: " + v);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testDeterminism() {
+        Request req = stock4vStockNoVvt();
+        Result r1 = generate(req, RPM6, MAP6);
+        Result r2 = generate(req, RPM6, MAP6);
+        assertEquals(r1.veTable.length, r2.veTable.length);
+        for (int row = 0; row < r1.veTable.length; row++) {
+            assertArrayEquals(r1.veTable[row], r2.veTable[row], 0.0);
+        }
+    }
+
+    @Test
+    public void testProfileId() {
+        assertEquals(PROFILE_ID, generate(stock4vStockNoVvt(), RPM6, MAP6).profileId);
+    }
+
+    @Test
+    public void testVvtBroadensCurveAtLowAndHighRpm() {
+        double[] rpmFull  = {900, 1500, 3828, 5500, 7000};
+        double[] mapAt100 = {100};
+        Request noVvt   = new Request(true, 900, 7000, HeadArchetype.STOCK_4V,
+            CamBehavior.STOCK, false, Aspiration.NATURALLY_ASPIRATED);
+        Request withVvt = new Request(true, 900, 7000, HeadArchetype.STOCK_4V,
+            CamBehavior.STOCK, true,  Aspiration.NATURALLY_ASPIRATED);
+
+        Result rN = generate(noVvt,   rpmFull, mapAt100);
+        Result rV = generate(withVvt, rpmFull, mapAt100);
+
+        // VVT reduces idle and redline drops: idle (col 0) and redline (col 4) must be >= no-VVT
+        assertTrue(rV.veTable[0][0] >= rN.veTable[0][0], "VVT should raise or maintain idle VE");
+        assertTrue(rV.veTable[0][4] >= rN.veTable[0][4], "VVT should raise or maintain redline VE");
+    }
+
+    @Test
+    public void testAspirationDoesNotAffectValues() {
+        Request naReq   = new Request(true, 1000, 6000, HeadArchetype.STOCK_4V,
+            CamBehavior.STOCK, false, Aspiration.NATURALLY_ASPIRATED);
+        Request turbReq = new Request(true, 1000, 6000, HeadArchetype.STOCK_4V,
+            CamBehavior.STOCK, false, Aspiration.TURBOCHARGED);
+        Request scReq   = new Request(true, 1000, 6000, HeadArchetype.STOCK_4V,
+            CamBehavior.STOCK, false, Aspiration.SUPERCHARGED);
+
+        Result rNa   = generate(naReq,   RPM6, MAP6);
+        Result rTurb = generate(turbReq, RPM6, MAP6);
+        Result rSc   = generate(scReq,   RPM6, MAP6);
+
+        for (int r = 0; r < rNa.veTable.length; r++) {
+            assertArrayEquals(rNa.veTable[r], rTurb.veTable[r], 0.0);
+            assertArrayEquals(rNa.veTable[r], rSc.veTable[r],   0.0);
+        }
+        assertTrue(rNa.warnings.isEmpty());
+        assertFalse(rTurb.warnings.isEmpty());
+        assertFalse(rSc.warnings.isEmpty());
+    }
+
+    @Test
+    public void testTableDimensions() {
+        for (HeadArchetype head : HeadArchetype.values()) {
+            Result r = generate(new Request(true, 900, 7000, head,
+                CamBehavior.STOCK, false, Aspiration.NATURALLY_ASPIRATED), RPM6, MAP6);
+            assertEquals(MAP6.length, r.veTable.length);
+            for (double[] row : r.veTable) {
+                assertEquals(RPM6.length, row.length);
+            }
+        }
+    }
+}

--- a/java_tools/version/src/main/java/com/rusefi/UiVersion.java
+++ b/java_tools/version/src/main/java/com/rusefi/UiVersion.java
@@ -5,5 +5,5 @@ public interface UiVersion {
      * *** BE CAREFUL WE HAVE SEPARATE AUTOUPDATE_VERSION also managed manually ***
      * @see com.rusefi.autoupdate.Autoupdate#AUTOUPDATE_VERSION
      */
-    int CONSOLE_VERSION = 20260718;
+    int CONSOLE_VERSION = 20260719;
 }


### PR DESCRIPTION
Why `archetype-base-ve-v1` was created over the available alternatives.

### Internet random A
 has a useful UX pattern (questionnaire -> preview -> explicit apply)
but a weak engine model:

- Output is fixed 16x16;
- Inputs actually used: max RPM, load strategy, aspiration, max boost, then: Displacement,
  cylinders, bore/stroke, compression, and the existing axes are ignored.
- Torque/VE peak is hardcoded at 4500 RPM regardless of engine type.
- The load factor increases above 100 kPa. rusEFI's air-mass equation already multiplies
  by actual MAP, so raising VE above atmospheric in proportion to boost double-counts
  pressure and produces incorrect fuel delivery at boost.

### LLM-assisted generation , Internet random B

- Output is non-deterministic across runs and model versions.  regression tests
  are impossible: the same inputs produce different tables after a model update.
- Requires network access and a model endpoint at generation time. Offline tune editing
  (the primary use case) cannot rely on it.
- The model has no way to enforce rusEFI's physical VE semantics. It may embed target
  lambda, enrichment margins, or MAF-style scaling depending on what training data it
  saw, producing tables that look reasonable but mean something different.
- A "reasoning" explanation from the model is not a substitute for a versioned,
  auditable formula with unit-tested anchor values.

### Mega***** Internet random C

asks for peak torque RPM, peak horsepower RPM, displacement, and boost, then
fits a quadratic WOT curve and applies an empirical MAP factor:

- Torque does not uniquely determine airflow. Two engines with identical torque curves
  but different VE shapes (e.g. one highly tuned, one naturally flat) would receive the
  same table.
- The documented formula includes an AFR/gamma correction (`VE x gamma`) but the
  executable does not implement it
- Its MAP multiplier raises VE above atmospheric in proportion to boost, which
  double-counts pressure in our Speed Density air-mass equation for the same
  reason as Random A.
- A single quadratic cannot represent intake/cam resonance peaks, VVT plateau
  broadening, or the mild dip between low-RPM and mid-RPM that many engines show.
- Boost torque curves often reflect the boost controller strategy rather than the
  engine's physical VE, so the inputs conflate two independent quantities.


## Why `archetype-base-ve-v1`

**Deterministic ** Every constant is named, documented, and tested with
exact values. no random LLM in the middle

**Dimension-agnostic.**  generator takes the ECU's actual RPM and MAP axis arrays
and produces a surface of the correct shape

**No MAP double-counting.** well, that, dont broke the VE table on boosted case

**No hidden enrichment.** VE is physical volumetric efficiency. Target lambda lives in
the lambda table. Mixing enrichment into VE values would misrepresent what the number
means and would interfere with STFT/LTFT learning.

**Extensible.** The `VeGenerator` interface lets a second implementation (e.g. a
measured-airflow recovery mode, a v2 with log-fitted constants, or a board-specific
preset) coexist in the same dialog without touching the v1 code.

**Testable without hardware.** The pure model has no Swing, INI, or protocol
dependencies. All 24 head x cam x VVT combinations can be verified in CI


related #9111 #9110