### PR TITLE
missfire detection: report errors to log and TS

### DIFF
--- a/firmware/controllers/algo/misfire_detection.cpp
+++ b/firmware/controllers/algo/misfire_detection.cpp
@@ -80,7 +80,7 @@ void MisfireController::registerMisfire() {
 	if (!misfireLatched && threshold > 0 && misfireTotalCount >= threshold) {
 		misfireLatched = true;
 		// Engine-wide detection => generic random/multiple-cylinder misfire code (P0300).
-		addError(ObdCode::OBD_Random_Misfire);
+		warning(ObdCode::OBD_Random_Misfire, "Misfire detected");
 	}
 }
 


### PR DESCRIPTION
`addError()` looks abandoned and dead. Should blink error code using CEL indicator, but currently disabled.
Use `warning()` that will propagate ObdCode to TS and mlg log.

FYI @ElDominio