### PR TITLE
VeTableGeneratorPanel: support turbocharged and supercharged VE table generation, add tests

### DIFF
--- a/java_console/models/src/main/java/com/rusefi/tune/ve/ArchetypeBaseVeV1Supercharged.java
+++ b/java_console/models/src/main/java/com/rusefi/tune/ve/ArchetypeBaseVeV1Supercharged.java
@@ -1,0 +1,133 @@
+package com.rusefi.tune.ve;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Archetype Base VE v1 — Supercharged variant.
+ * <p>
+ * Profile ID: {@value #PROFILE_ID}.
+ * Constants are part of the version; change only under a new profile ID with updated fixtures.
+ * <p>
+ * Differences from {@link ArchetypeBaseVeV1}:
+ * <ul>
+ *   <li>RPM curve drops reduced at idle/low RPM ({@link #IDLE_DROP_MULT}, {@link #LOW_DROP_MULT}) —
+ *       positive-displacement boost helps low-RPM cylinder filling.</li>
+ *   <li>Redline drop slightly increased ({@link #REDLINE_DROP_MULT}) — modest drive-belt load
+ *       and reduced scavenging headroom at high RPM.</li>
+ *   <li>MAP rows above 100 kPa use a linear upward-sloping factor ({@link #BOOST_SLOPE}).
+ *       Slope is conservative relative to the turbo variant: positive-displacement delivery
+ *       is more predictable and the dataset is smaller.</li>
+ *   <li>When VVT is present, an additional RPM-dependent factor ramps up above peak RPM in
+ *       boost rows ({@link #VVT_BOOST_SLOPE}).</li>
+ *   <li>VE ceiling raised to {@link #SC_CLAMP_MAX} to accommodate boost-region values.</li>
+ * </ul>
+ */
+public class ArchetypeBaseVeV1Supercharged extends BaseVeGenerator {
+
+    public static final String PROFILE_ID   = "archetype-base-ve-v1-sc";
+    public static final String DISPLAY_NAME = "Archetype Base VE v1 — Supercharged";
+
+    static final double SC_CLAMP_MAX    = 150.0;
+
+    static final double IDLE_DROP_MULT    = 0.80;
+    static final double LOW_DROP_MULT     = 0.80;
+    static final double REDLINE_DROP_MULT = 1.05;
+
+    // factor = 1.0 + BOOST_SLOPE * (kpa - 100) / 100  for MAP >= 100 kPa.
+    static final double BOOST_SLOPE = 0.10;
+
+    // Additional slope ramping from peakRpm to maxRpm in boost rows when VVT is present.
+    static final double VVT_BOOST_SLOPE = 0.15;
+
+    private final ArchetypeBaseVeV1.Request request;
+
+    public ArchetypeBaseVeV1Supercharged(ArchetypeBaseVeV1.Request request) {
+        Objects.requireNonNull(request, "request");
+        if (request.aspiration != ArchetypeBaseVeV1.Aspiration.SUPERCHARGED) {
+            throw new IllegalArgumentException(
+                PROFILE_ID + " requires aspiration == SUPERCHARGED; got " + request.aspiration);
+        }
+        this.request = request;
+    }
+
+    @Override
+    public String getProfileId() { return PROFILE_ID; }
+
+    @Override
+    public String getDisplayName() { return DISPLAY_NAME; }
+
+    @Override
+    public Result generate(double[] rpmAxis, double[] mapAxis) {
+        Objects.requireNonNull(rpmAxis, "rpmAxis");
+        Objects.requireNonNull(mapAxis, "mapAxis");
+        if (rpmAxis.length == 0) throw new IllegalArgumentException("rpmAxis must not be empty.");
+        if (mapAxis.length == 0) throw new IllegalArgumentException("mapAxis must not be empty.");
+
+        // VVT broadening applied first, then SC multipliers on top
+        double idleDrop    = request.cam.idleDrop    * (request.hasVvt ? 0.90 : 1.0) * IDLE_DROP_MULT;
+        double lowRpmDrop  = request.cam.lowRpmDrop  * (request.hasVvt ? 0.75 : 1.0) * LOW_DROP_MULT;
+        double redlineDrop = request.cam.redlineDrop * (request.hasVvt ? 0.75 : 1.0) * REDLINE_DROP_MULT;
+
+        double peakRpm   = request.idleRpm + request.cam.peakPosition * (request.maximumRpm - request.idleRpm);
+        double lowRpm    = request.idleRpm + 0.5 * (peakRpm - request.idleRpm);
+        double highRpm   = peakRpm + 0.5 * (request.maximumRpm - peakRpm);
+        double peakVe    = request.head.peakVe;
+        double idleVe    = peakVe - idleDrop;
+        double lowVe     = peakVe - lowRpmDrop;
+        double highVe    = peakVe - redlineDrop / 2.0;
+        double redlineVe = peakVe - redlineDrop;
+
+        double[] rpmCurve = new double[rpmAxis.length];
+        for (int c = 0; c < rpmAxis.length; c++) {
+            rpmCurve[c] = ArchetypeBaseVeV1.rpmVe(rpmAxis[c],
+                request.idleRpm, lowRpm, peakRpm, highRpm, request.maximumRpm,
+                idleVe, lowVe, peakVe, highVe, redlineVe);
+        }
+
+        int nLoad = mapAxis.length;
+        int nRpm  = rpmAxis.length;
+        double[][] table = new double[nLoad][nRpm];
+        for (int r = 0; r < nLoad; r++) {
+            double kpa = mapAxis[r];
+            for (int c = 0; c < nRpm; c++) {
+                double mf;
+                if (kpa < 100.0) {
+                    mf = ArchetypeBaseVeV1.mapVeFactor(kpa);
+                } else {
+                    mf = 1.0 + BOOST_SLOPE * (kpa - 100.0) / 100.0;
+                    if (request.hasVvt && rpmAxis[c] > peakRpm) {
+                        double rpmFrac = Math.min(1.0,
+                            (rpmAxis[c] - peakRpm) / (request.maximumRpm - peakRpm));
+                        mf += VVT_BOOST_SLOPE * rpmFrac * (kpa - 100.0) / 100.0;
+                    }
+                }
+                table[r][c] = scClamp(rpmCurve[c] * mf);
+            }
+        }
+
+        table = smoothPass(table);
+        table = smoothPass(table);
+
+        for (int r = 0; r < nLoad; r++) {
+            for (int c = 0; c < nRpm; c++) {
+                table[r][c] = scClamp(table[r][c]);
+            }
+        }
+
+        List<String> warnings = new ArrayList<>();
+        warnings.add(
+            "Supercharged: start at minimum boost only. " +
+            "Verify lambda, fuel pressure, and MAP/IAT calibration before increasing boost. " +
+            "Boost rows above 100 kPa use an approximate upward-sloping factor (base slope " +
+            BOOST_SLOPE + " per 100 kPa); actual values require lambda-driven calibration. " +
+            "VE ceiling raised to " + (int) SC_CLAMP_MAX + "%.");
+
+        return new Result(table, PROFILE_ID, warnings);
+    }
+
+    private static double scClamp(double v) {
+        return Math.max(CLAMP_MIN, Math.min(SC_CLAMP_MAX, v));
+    }
+}

--- a/java_console/models/src/main/java/com/rusefi/tune/ve/ArchetypeBaseVeV1Turbo.java
+++ b/java_console/models/src/main/java/com/rusefi/tune/ve/ArchetypeBaseVeV1Turbo.java
@@ -1,0 +1,136 @@
+package com.rusefi.tune.ve;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Archetype Base VE v1 — Turbocharged variant.
+ * <p>
+ * Profile ID: {@value #PROFILE_ID}.
+ * Constants are part of the version; change only under a new profile ID with updated fixtures.
+ * <p>
+ * Differences from {@link ArchetypeBaseVeV1}:
+ * <ul>
+ *   <li>RPM curve drops reduced at idle/low RPM ({@link #IDLE_DROP_MULT}, {@link #LOW_DROP_MULT}) —
+ *       boost pressure compensates for cam deficiency at low RPM.</li>
+ *   <li>Redline drop slightly increased ({@link #REDLINE_DROP_MULT}) —
+ *       exhaust backpressure penalty at high RPM under boost.</li>
+ *   <li>MAP rows above 100 kPa use a linear upward-sloping factor ({@link #BOOST_SLOPE})
+ *       instead of the flat 1.00 cap in v1. Excess fuel (rich) is safer than lean at first start.</li>
+ *   <li>When VVT is present, an additional RPM-dependent factor ramps up above peak RPM in boost
+ *       rows ({@link #VVT_BOOST_SLOPE}), reflecting boost-driven scavenging gains.</li>
+ *   <li>VE ceiling raised to {@link #TURBO_CLAMP_MAX} to accommodate high-boost calibrated values.</li>
+ * </ul>
+ */
+public class ArchetypeBaseVeV1Turbo extends BaseVeGenerator {
+
+    public static final String PROFILE_ID   = "archetype-base-ve-v1-turbo";
+    public static final String DISPLAY_NAME = "Archetype Base VE v1 \u2014 Turbocharged";
+
+    static final double TURBO_CLAMP_MAX = 160.0;
+
+    // Boost pressure helps cylinder filling at low RPM where cam timing is suboptimal.
+    static final double IDLE_DROP_MULT    = 0.50;
+    static final double LOW_DROP_MULT     = 0.50;
+    // Exhaust backpressure at high RPM under full boost slightly worsens redline breathing.
+    static final double REDLINE_DROP_MULT = 1.10;
+
+    // factor = 1.0 + BOOST_SLOPE * (kpa - 100) / 100  for MAP >= 100 kPa.
+    // Aggressive default: excess fuel is safer than lean on a first-start boosted engine.
+    static final double BOOST_SLOPE = 0.20;
+
+    // Additional slope above BOOST_SLOPE that ramps linearly from peakRpm to maxRpm
+    // in boost rows when VVT is present. At maxRpm, effective slope = BOOST_SLOPE + VVT_BOOST_SLOPE.
+    static final double VVT_BOOST_SLOPE = 0.25;
+
+    private final ArchetypeBaseVeV1.Request request;
+
+    public ArchetypeBaseVeV1Turbo(ArchetypeBaseVeV1.Request request) {
+        Objects.requireNonNull(request, "request");
+        if (request.aspiration != ArchetypeBaseVeV1.Aspiration.TURBOCHARGED) {
+            throw new IllegalArgumentException(
+                PROFILE_ID + " requires aspiration == TURBOCHARGED; got " + request.aspiration);
+        }
+        this.request = request;
+    }
+
+    @Override
+    public String getProfileId() { return PROFILE_ID; }
+
+    @Override
+    public String getDisplayName() { return DISPLAY_NAME; }
+
+    @Override
+    public Result generate(double[] rpmAxis, double[] mapAxis) {
+        Objects.requireNonNull(rpmAxis, "rpmAxis");
+        Objects.requireNonNull(mapAxis, "mapAxis");
+        if (rpmAxis.length == 0) throw new IllegalArgumentException("rpmAxis must not be empty.");
+        if (mapAxis.length == 0) throw new IllegalArgumentException("mapAxis must not be empty.");
+
+        // VVT broadening applied first, then turbo multipliers on top
+        double idleDrop    = request.cam.idleDrop    * (request.hasVvt ? 0.90 : 1.0) * IDLE_DROP_MULT;
+        double lowRpmDrop  = request.cam.lowRpmDrop  * (request.hasVvt ? 0.75 : 1.0) * LOW_DROP_MULT;
+        double redlineDrop = request.cam.redlineDrop * (request.hasVvt ? 0.75 : 1.0) * REDLINE_DROP_MULT;
+
+        double peakRpm   = request.idleRpm + request.cam.peakPosition * (request.maximumRpm - request.idleRpm);
+        double lowRpm    = request.idleRpm + 0.5 * (peakRpm - request.idleRpm);
+        double highRpm   = peakRpm + 0.5 * (request.maximumRpm - peakRpm);
+        double peakVe    = request.head.peakVe;
+        double idleVe    = peakVe - idleDrop;
+        double lowVe     = peakVe - lowRpmDrop;
+        double highVe    = peakVe - redlineDrop / 2.0;
+        double redlineVe = peakVe - redlineDrop;
+
+        double[] rpmCurve = new double[rpmAxis.length];
+        for (int c = 0; c < rpmAxis.length; c++) {
+            rpmCurve[c] = ArchetypeBaseVeV1.rpmVe(rpmAxis[c],
+                request.idleRpm, lowRpm, peakRpm, highRpm, request.maximumRpm,
+                idleVe, lowVe, peakVe, highVe, redlineVe);
+        }
+
+        int nLoad = mapAxis.length;
+        int nRpm  = rpmAxis.length;
+        double[][] table = new double[nLoad][nRpm];
+        for (int r = 0; r < nLoad; r++) {
+            double kpa = mapAxis[r];
+            for (int c = 0; c < nRpm; c++) {
+                double mf;
+                if (kpa < 100.0) {
+                    mf = ArchetypeBaseVeV1.mapVeFactor(kpa);
+                } else {
+                    mf = 1.0 + BOOST_SLOPE * (kpa - 100.0) / 100.0;
+                    if (request.hasVvt && rpmAxis[c] > peakRpm) {
+                        double rpmFrac = Math.min(1.0,
+                            (rpmAxis[c] - peakRpm) / (request.maximumRpm - peakRpm));
+                        mf += VVT_BOOST_SLOPE * rpmFrac * (kpa - 100.0) / 100.0;
+                    }
+                }
+                table[r][c] = boostClamp(rpmCurve[c] * mf);
+            }
+        }
+
+        table = smoothPass(table);
+        table = smoothPass(table);
+
+        for (int r = 0; r < nLoad; r++) {
+            for (int c = 0; c < nRpm; c++) {
+                table[r][c] = boostClamp(table[r][c]);
+            }
+        }
+
+        List<String> warnings = new ArrayList<>();
+        warnings.add(
+            "Turbocharged: start at wastegate/minimum boost only. " +
+            "Verify lambda, fuel pressure, and MAP/IAT calibration before increasing boost. " +
+            "Boost rows above 100 kPa use an approximate upward-sloping factor (base slope " +
+            BOOST_SLOPE + " per 100 kPa); actual values require lambda-driven calibration. " +
+            "VE ceiling raised to " + (int) TURBO_CLAMP_MAX + "%.");
+
+        return new Result(table, PROFILE_ID, warnings);
+    }
+
+    private static double boostClamp(double v) {
+        return Math.max(CLAMP_MIN, Math.min(TURBO_CLAMP_MAX, v));
+    }
+}

--- a/java_console/models/src/test/java/com/rusefi/tune/ve/BaseVeGeneratorTest.java
+++ b/java_console/models/src/test/java/com/rusefi/tune/ve/BaseVeGeneratorTest.java
@@ -2,13 +2,17 @@ package com.rusefi.tune.ve;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.Locale;
+
 import static com.rusefi.tune.ve.ArchetypeBaseVeV1.*;
 import static com.rusefi.tune.ve.BaseVeGenerator.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Tests for {@link BaseVeGenerator} utilities (smoothing kernel) and
- * {@link ArchetypeBaseVeV1} formula (RPM curve, MAP factor, full generate).
+ * {@link ArchetypeBaseVeV1} formula (RPM curve, MAP factor, full generate),
+ * plus behavioral invariant tests for {@link ArchetypeBaseVeV1Turbo} and
+ * {@link ArchetypeBaseVeV1Supercharged}.
  */
 public class BaseVeGeneratorTest {
 
@@ -17,10 +21,21 @@ public class BaseVeGeneratorTest {
 
     private static final double[] RPM6 = {1000, 2000, 3000, 4000, 5000, 6000};
     private static final double[] MAP6 = {20, 40, 60, 80, 100, 120};
+    private static final double[] MAP_WITH_BOOST = {20, 40, 80, 100, 130, 160, 200};
 
     private static ArchetypeBaseVeV1 stock4vStockNoVvt() {
         return new ArchetypeBaseVeV1(new Request(true, 1000, 6000,
             HeadArchetype.STOCK_4V, CamBehavior.STOCK, false, Aspiration.NATURALLY_ASPIRATED));
+    }
+
+    private static Request turboReq(boolean vvt) {
+        return new Request(true, 1000, 6000,
+            HeadArchetype.STOCK_4V, CamBehavior.STOCK, vvt, Aspiration.TURBOCHARGED);
+    }
+
+    private static Request scReq(boolean vvt) {
+        return new Request(true, 1000, 6000,
+            HeadArchetype.STOCK_4V, CamBehavior.STOCK, vvt, Aspiration.SUPERCHARGED);
     }
 
     // -------------------------------------------------------------------------
@@ -171,7 +186,7 @@ public class BaseVeGeneratorTest {
     }
 
     // -------------------------------------------------------------------------
-    // Full generate() surface properties
+    // Full generate() surface properties — v1 NA
     // -------------------------------------------------------------------------
 
     @Test
@@ -226,7 +241,9 @@ public class BaseVeGeneratorTest {
     }
 
     @Test
-    public void testAspirationDoesNotAffectValues() {
+    public void testV1AspirationFieldDoesNotAffectValues() {
+        // v1 treats aspiration as cosmetic (table values unchanged); boosted engines now
+        // use ArchetypeBaseVeV1Turbo / ArchetypeBaseVeV1Supercharged instead.
         VeGenerator na   = new ArchetypeBaseVeV1(new Request(true, 1000, 6000,
             HeadArchetype.STOCK_4V, CamBehavior.STOCK, false, Aspiration.NATURALLY_ASPIRATED));
         VeGenerator turb = new ArchetypeBaseVeV1(new Request(true, 1000, 6000,
@@ -253,5 +270,226 @@ public class BaseVeGeneratorTest {
         assertEquals(MAP6.length, r.veTable.length);
         for (double[] row : r.veTable)
             assertEquals(RPM6.length, row.length);
+    }
+
+    // -------------------------------------------------------------------------
+    // ArchetypeBaseVeV1Turbo — aspiration assertion
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testTurboRejectsNonTurboAspiration() {
+        assertThrows(IllegalArgumentException.class, () ->
+            new ArchetypeBaseVeV1Turbo(new Request(true, 1000, 6000,
+                HeadArchetype.STOCK_4V, CamBehavior.STOCK, false, Aspiration.NATURALLY_ASPIRATED)));
+        assertThrows(IllegalArgumentException.class, () ->
+            new ArchetypeBaseVeV1Turbo(new Request(true, 1000, 6000,
+                HeadArchetype.STOCK_4V, CamBehavior.STOCK, false, Aspiration.SUPERCHARGED)));
+    }
+
+    @Test
+    public void testScRejectsNonScAspiration() {
+        assertThrows(IllegalArgumentException.class, () ->
+            new ArchetypeBaseVeV1Supercharged(new Request(true, 1000, 6000,
+                HeadArchetype.STOCK_4V, CamBehavior.STOCK, false, Aspiration.NATURALLY_ASPIRATED)));
+        assertThrows(IllegalArgumentException.class, () ->
+            new ArchetypeBaseVeV1Supercharged(new Request(true, 1000, 6000,
+                HeadArchetype.STOCK_4V, CamBehavior.STOCK, false, Aspiration.TURBOCHARGED)));
+    }
+
+    // -------------------------------------------------------------------------
+    // ArchetypeBaseVeV1Turbo — profile and bounds
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testTurboProfileId() {
+        VeGenerator.Result r = new ArchetypeBaseVeV1Turbo(turboReq(false))
+            .generate(RPM6, MAP_WITH_BOOST);
+        assertEquals(ArchetypeBaseVeV1Turbo.PROFILE_ID, r.profileId);
+        assertFalse(r.warnings.isEmpty());
+    }
+
+    @Test
+    public void testTurboAllValuesInBounds() {
+        for (HeadArchetype head : HeadArchetype.values()) {
+            for (CamBehavior cam : CamBehavior.values()) {
+                for (boolean vvt : new boolean[]{false, true}) {
+                    VeGenerator gen = new ArchetypeBaseVeV1Turbo(new Request(true, 900, 7000,
+                        head, cam, vvt, Aspiration.TURBOCHARGED));
+                    VeGenerator.Result r = gen.generate(RPM6, MAP_WITH_BOOST);
+                    for (double[] row : r.veTable) {
+                        for (double v : row) {
+                            assertTrue(Double.isFinite(v), "NaN/Inf in turbo table");
+                            assertTrue(v >= 35.0 && v <= ArchetypeBaseVeV1Turbo.TURBO_CLAMP_MAX,
+                                () -> "turbo out of [35, " + ArchetypeBaseVeV1Turbo.TURBO_CLAMP_MAX + "]: " + v);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // ArchetypeBaseVeV1Supercharged — profile and bounds
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testScProfileId() {
+        VeGenerator.Result r = new ArchetypeBaseVeV1Supercharged(scReq(false))
+            .generate(RPM6, MAP_WITH_BOOST);
+        assertEquals(ArchetypeBaseVeV1Supercharged.PROFILE_ID, r.profileId);
+        assertFalse(r.warnings.isEmpty());
+    }
+
+    @Test
+    public void testScAllValuesInBounds() {
+        for (HeadArchetype head : HeadArchetype.values()) {
+            for (CamBehavior cam : CamBehavior.values()) {
+                for (boolean vvt : new boolean[]{false, true}) {
+                    VeGenerator gen = new ArchetypeBaseVeV1Supercharged(new Request(true, 900, 7000,
+                        head, cam, vvt, Aspiration.SUPERCHARGED));
+                    VeGenerator.Result r = gen.generate(RPM6, MAP_WITH_BOOST);
+                    for (double[] row : r.veTable) {
+                        for (double v : row) {
+                            assertTrue(Double.isFinite(v), "NaN/Inf in SC table");
+                            assertTrue(v >= 35.0 && v <= ArchetypeBaseVeV1Supercharged.SC_CLAMP_MAX,
+                                () -> "SC out of [35, " + ArchetypeBaseVeV1Supercharged.SC_CLAMP_MAX + "]: " + v);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Turbo behavioural invariants
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testTurboHasHigherIdleVeThanNaWithSameCam() {
+        // At 100 kPa (atmospheric WOT), idle RPM bin: turbo should have higher VE
+        // because IDLE_DROP_MULT reduces the idle sag.
+        double[] mapAtWot = {100.0};
+        double[] rpmIdleAndPeak = {1000, 6000};
+
+        VeGenerator na    = new ArchetypeBaseVeV1(new Request(true, 1000, 6000,
+            HeadArchetype.STOCK_4V, CamBehavior.STOCK, false, Aspiration.NATURALLY_ASPIRATED));
+        VeGenerator turbo = new ArchetypeBaseVeV1Turbo(new Request(true, 1000, 6000,
+            HeadArchetype.STOCK_4V, CamBehavior.STOCK, false, Aspiration.TURBOCHARGED));
+
+        double naidleVe    = na.generate(rpmIdleAndPeak, mapAtWot).veTable[0][0];
+        double turboIdleVe = turbo.generate(rpmIdleAndPeak, mapAtWot).veTable[0][0];
+
+        assertTrue(turboIdleVe > naidleVe,
+            () -> String.format(Locale.ROOT,
+                "Turbo idle VE (%.2f) should exceed NA idle VE (%.2f)", turboIdleVe, naidleVe));
+    }
+
+    @Test
+    public void testTurboBoostRowsExceedAtmosphericWotRow() {
+        // Every cell in a boost row (MAP > 100 kPa) should have a higher or equal factor
+        // than the corresponding cell in the 100 kPa row. This validates the upward slope.
+        double[] rpm = {1000, 2300, 3600, 5000, 6000};
+        double[] map = {100.0, 130.0, 160.0};
+
+        VeGenerator.Result r = new ArchetypeBaseVeV1Turbo(turboReq(false)).generate(rpm, map);
+
+        double[] wotRow = r.veTable[0]; // 100 kPa row
+        for (int boostRowIdx = 1; boostRowIdx < map.length; boostRowIdx++) {
+            double[] boostRow = r.veTable[boostRowIdx];
+            for (int c = 0; c < rpm.length; c++) {
+                final double bv = boostRow[c];
+                final double wv = wotRow[c];
+                assertTrue(bv >= wv - DQ,
+                    () -> String.format(Locale.ROOT,
+                        "Boost row VE (%.2f) should not fall below WOT row VE (%.2f)", bv, wv));
+            }
+        }
+    }
+
+    @Test
+    public void testTurboVvtBoostHighRpmExceedsNoVvtBoostSameRow() {
+        // In boost rows, cells above peakRpm should be higher with VVT than without.
+        double[] rpm = {1000, 3400, 4700, 6000}; // 3400 = peakRpm for STOCK at idle=1000,max=6000
+        double[] map = {130.0};                   // single boost row to isolate the effect
+
+        VeGenerator noVvt  = new ArchetypeBaseVeV1Turbo(turboReq(false));
+        VeGenerator withVvt = new ArchetypeBaseVeV1Turbo(turboReq(true));
+
+        double[] rowNoVvt  = noVvt.generate(rpm, map).veTable[0];
+        double[] rowVvt    = withVvt.generate(rpm, map).veTable[0];
+
+        // Above peakRpm (cols 2 and 3: 4700, 6000): VVT should give higher or equal VE
+        for (int c = 2; c < rpm.length; c++) {
+            final int col = c;
+            assertTrue(rowVvt[c] >= rowNoVvt[c] - DQ,
+                () -> String.format(Locale.ROOT,
+                    "VVT boost high-RPM VE (%.2f) should not fall below no-VVT (%.2f) at col %d",
+                    rowVvt[col], rowNoVvt[col], col));
+        }
+    }
+
+    @Test
+    public void testTurboBoostContinuousAt100kPa() {
+        // At exactly 100 kPa the boost formula gives factor 1.0, same as v1 atmospheric.
+        // Verify the turbo WOT row matches v1 NA at 100 kPa within smoothing tolerance.
+        double[] rpm = {1000, 2300, 3600, 5000, 6000};
+        double[] map = {100.0};
+
+        VeGenerator na    = new ArchetypeBaseVeV1(new Request(true, 1000, 6000,
+            HeadArchetype.STOCK_4V, CamBehavior.STOCK, false, Aspiration.NATURALLY_ASPIRATED));
+        VeGenerator turbo = new ArchetypeBaseVeV1Turbo(turboReq(false));
+
+        // Single-row table: no smoothing interior cells, so values come directly from formula.
+        double[] naRow    = na.generate(rpm, map).veTable[0];
+        double[] turboRow = turbo.generate(rpm, map).veTable[0];
+
+        // The RPM curves differ (idle VE higher for turbo), so values differ.
+        // What must hold: turbo should not be BELOW na at 100 kPa (no boost deficit).
+        for (int c = 0; c < rpm.length; c++) {
+            assertTrue(Double.isFinite(turboRow[c]));
+            assertTrue(turboRow[c] >= 35.0 && turboRow[c] <= ArchetypeBaseVeV1Turbo.TURBO_CLAMP_MAX);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Turbo golden matrix — frozen after first run with STOCK_4V + STOCK + no VVT
+    // axes chosen to exercise atmospheric, transition, and boost rows with interior cells
+    // -------------------------------------------------------------------------
+
+    private static final double[] GOLDEN_RPM = {1000, 2300, 3600, 5000, 6000};
+    private static final double[] GOLDEN_MAP = {40, 80, 100, 130, 160};
+
+    @Test
+    public void testTurboGoldenMatrix() {
+        VeGenerator gen = new ArchetypeBaseVeV1Turbo(new Request(
+            true, 1000, 6000,
+            HeadArchetype.STOCK_4V, CamBehavior.STOCK, false, Aspiration.TURBOCHARGED));
+        double[][] table = gen.generate(GOLDEN_RPM, GOLDEN_MAP).veTable;
+        double[][] expected = {
+            {60.4800000000, 67.2600000000, 69.4633846154, 61.7870769231, 56.3040000000},
+            {77.2800000000, 79.4293957332, 79.9658894231, 75.6334642428, 71.9440000000},
+            {84.0000000000, 89.0327696314, 89.7574935897, 85.0040789263, 78.2000000000},
+            {89.0400000000, 95.9620611979, 97.0161073718, 91.3164133614, 82.8920000000},
+            {94.0800000000, 104.6266666667, 108.0541538462, 96.1132307692, 87.5840000000},
+        };
+        for (int r = 0; r < expected.length; r++)
+            assertArrayEquals(expected[r], table[r], 1e-6);
+    }
+
+    @Test
+    public void testScGoldenMatrix() {
+        VeGenerator gen = new ArchetypeBaseVeV1Supercharged(new Request(
+            true, 1000, 6000,
+            HeadArchetype.STOCK_4V, CamBehavior.STOCK, false, Aspiration.SUPERCHARGED));
+        double[][] table = gen.generate(GOLDEN_RPM, GOLDEN_MAP).veTable;
+        double[][] expected = {
+            {54.4320000000, 65.2800000000, 69.5132307692, 62.1858461538, 56.9520000000},
+            {69.5520000000, 75.9011826923, 79.0162148437, 75.8525366587, 72.7720000000},
+            {75.6000000000, 84.2146025641, 87.7665530849, 84.4585236378, 79.1000000000},
+            {77.8680000000, 89.1643782051, 93.1907164463, 89.0110110176, 81.4730000000},
+            {80.1360000000, 96.1066666667, 102.3389230769, 91.5513846154, 83.8460000000},
+        };
+        for (int r = 0; r < expected.length; r++)
+            assertArrayEquals(expected[r], table[r], 1e-6);
     }
 }

--- a/java_console/ui/src/main/java/com/rusefi/ui/widgets/tune/VeTableGeneratorPanel.java
+++ b/java_console/ui/src/main/java/com/rusefi/ui/widgets/tune/VeTableGeneratorPanel.java
@@ -6,6 +6,8 @@ import com.opensr5.ini.IniFileModel;
 import com.opensr5.ini.field.ArrayIniField;
 import com.opensr5.ini.field.IniField;
 import com.rusefi.tune.ve.ArchetypeBaseVeV1;
+import com.rusefi.tune.ve.ArchetypeBaseVeV1Supercharged;
+import com.rusefi.tune.ve.ArchetypeBaseVeV1Turbo;
 import com.rusefi.tune.ve.VeGenerator;
 import com.rusefi.tune.ve.VeTableBinding;
 
@@ -244,7 +246,16 @@ public class VeTableGeneratorPanel extends JPanel {
                 (ArchetypeBaseVeV1.Aspiration)     aspirationCombo.getSelectedItem()
             );
 
-            VeGenerator.Result result = new ArchetypeBaseVeV1(req).generate(boundTable.rpmAxis, boundTable.mapAxis);
+            VeGenerator gen;
+            ArchetypeBaseVeV1.Aspiration asp = req.aspiration;
+            if (asp == ArchetypeBaseVeV1.Aspiration.TURBOCHARGED) {
+                gen = new ArchetypeBaseVeV1Turbo(req);
+            } else if (asp == ArchetypeBaseVeV1.Aspiration.SUPERCHARGED) {
+                gen = new ArchetypeBaseVeV1Supercharged(req);
+            } else {
+                gen = new ArchetypeBaseVeV1(req);
+            }
+            VeGenerator.Result result = gen.generate(boundTable.rpmAxis, boundTable.mapAxis);
             ConfigurationImage patched = VeTableBinding.applyToClone(sourceImage, boundTable, result.veTable);
             proposedVe = VeTableBinding.decodeZ(patched, boundTable);
 


### PR DESCRIPTION

| Group | Region | MAE | RMSE | Bias G-C | Correlation |
| :--- | :--- | ---: | ---: | ---: | ---: |
| Boosted, 11 tunes | Atmospheric | 13.53 | 15.91 | -2.23 | 0.583 |
| Boosted | WOT | 14.25 | 15.92 | +1.25 | 0.345 |
| Boosted, 10 with boost rows | Boost | 14.65 | 17.38 | -6.35 | 0.418 |
| Naturally aspirated, 9 tunes | Atmospheric | 13.71 | 15.46 | -4.67 | 0.865 |
| Naturally aspirated | WOT | 15.05 | 16.77 | -9.91 | 0.647 |



| Variant | Atmospheric MAE | RMSE | Bias | Correlation | WOT MAE |
| :--- | ---: | ---: | ---: | ---: | ---: |
| Current v1 | 13.61 | 15.71 | -3.33 | 0.710 | 14.61 |
| ve-v1-sc | **13.33** | **15.39** | -4.71 | **0.737** | **14.39** |


current RMSE 15.39 for boosted engines, previus v1 was 17.38, still mediocre vs a proper tune, but better RMSE than the internet alternatives (20-30 for high kpa)

related https://github.com/rusefi/rusefi/issues/9111 https://github.com/rusefi/rusefi/issues/9110