### PR TITLE
EnumIniField: fix "we fail on constant migration of renamed pins, even if they content the same constant name"

### DIFF
--- a/java_console/inifile/src/main/java/com/opensr5/ConfigurationImageGetterSetter.java
+++ b/java_console/inifile/src/main/java/com/opensr5/ConfigurationImageGetterSetter.java
@@ -109,6 +109,38 @@ public class ConfigurationImageGetterSetter {
         }
     }
 
+    private static int findEnumOrdinal(EnumIniField field, String value) {
+        int ordinal = field.getEnums().indexOf(value);
+        if (ordinal != -1) {
+            return ordinal;
+        }
+        if (!field.isPinEnum()) {
+            return -1;
+        }
+
+        // MSQ files persist labels, so tolerate a unique additive suffix added by a newer INI.
+        String oldLabel = EnumIniField.isQuoted(value) ? javax.management.ObjectName.unquote(value) : value;
+        for (String currentLabel : field.getEnums().values()) {
+            if (hasDocumentationSuffix(oldLabel, currentLabel)) {
+                if (ordinal != -1) {
+                    return -1;
+                }
+                ordinal = field.getEnums().indexOf(currentLabel);
+            }
+        }
+        return ordinal;
+    }
+
+    private static boolean hasDocumentationSuffix(String oldLabel, String currentLabel) {
+        if (!currentLabel.startsWith(oldLabel)) {
+            return false;
+        }
+
+        String suffix = currentLabel.substring(oldLabel.length());
+        return suffix.startsWith(" (") || suffix.startsWith(" or ") || suffix.startsWith(" for ")
+            || suffix.startsWith(" best ") || suffix.startsWith(", ") || suffix.startsWith(" legacy ");
+    }
+
     public static void setValue2(IniField iniField, ConfigurationImage image, final String name, final String value) {
         iniField.accept(new IniFieldVisitor<Void>() {
             @Override
@@ -123,9 +155,10 @@ public class ConfigurationImageGetterSetter {
             @Override
             public Void visit(EnumIniField field) {
                 String v = value;
-                int ordinal = field.getEnums().indexOf(v);
-                if (ordinal == -1)
+                int ordinal = findEnumOrdinal(field, v);
+                if (ordinal == -1) {
                     throw new IllegalArgumentException(name + ": Enum name not found " + v);
+                }
                 image.setBitValue(field, ordinal);
                 return null;
             }

--- a/java_console/inifile/src/main/java/com/opensr5/ini/field/EnumIniField.java
+++ b/java_console/inifile/src/main/java/com/opensr5/ini/field/EnumIniField.java
@@ -14,13 +14,20 @@ public class EnumIniField extends IniField {
     private final int bitPosition;
     // weird format where 'one bit' width means 0 and "two bits" means "1"
     private final int bitSize0;
+    private final boolean pinEnum;
 
     public EnumIniField(String name, int offset, FieldType type, EnumKeyValueMap enums, int bitPosition, int bitSize0) {
+        this(name, offset, type, enums, bitPosition, bitSize0, false);
+    }
+
+    public EnumIniField(String name, int offset, FieldType type, EnumKeyValueMap enums, int bitPosition, int bitSize0,
+                        boolean pinEnum) {
         super(name, offset);
         this.type = type;
         this.enums = enums;
         this.bitPosition = bitPosition;
         this.bitSize0 = bitSize0;
+        this.pinEnum = pinEnum;
     }
 
     @Override
@@ -47,6 +54,10 @@ public class EnumIniField extends IniField {
 
     public FieldType getType() {
         return type;
+    }
+
+    public boolean isPinEnum() {
+        return pinEnum;
     }
 
     public static boolean isQuoted(String q) {

--- a/java_console/inifile/src/main/java/com/rusefi/ini/reader/EnumIniReaderHelper.java
+++ b/java_console/inifile/src/main/java/com/rusefi/ini/reader/EnumIniReaderHelper.java
@@ -8,12 +8,21 @@ import org.jetbrains.annotations.NotNull;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.regex.Pattern;
 
 public class EnumIniReaderHelper {
     private static final String STARTS_WITH_NUMBERS_OPTIONAL_SPACES_AND_EQUALS = "^\\d+\\s*=.*";
     private static final Pattern IS_KEY_VALUE_SYNTAX = Pattern.compile(STARTS_WITH_NUMBERS_OPTIONAL_SPACES_AND_EQUALS);
     private static final Pattern BIT_RANGE_DELIMITERS = Pattern.compile("[]\\[:]");
+    private static final Set<String> PIN_ENUM_LISTS = Set.of(
+        "$gpio_list",
+        "$output_pin_e_list",
+        "$brain_input_pin_e_list",
+        "$switch_input_pin_e_list",
+        "$adc_channel_e_list",
+        "$sent_input_pin_e_list"
+    );
 
     private EnumIniReaderHelper() {
     }
@@ -29,7 +38,8 @@ public class EnumIniReaderHelper {
         int bitSize0 = parseBitRange.getBitSize0();
 
         EnumIniField.EnumKeyValueMap enums = EnumIniField.EnumKeyValueMap.valueOf(line.getRawText(), defines);
-        return new EnumIniField(name, offset, type, enums, bitPosition, bitSize0);
+        boolean pinEnum = PIN_ENUM_LISTS.contains(getEnumValuesSection(line.getRawText()));
+        return new EnumIniField(name, offset, type, enums, bitPosition, bitSize0, pinEnum);
     }
 
     public static boolean isKeyValueSyntax(String rawText) {

--- a/java_console/inifile/src/test/java/com/opensr5/ConfigurationImageGetterSetterTest.java
+++ b/java_console/inifile/src/test/java/com/opensr5/ConfigurationImageGetterSetterTest.java
@@ -59,6 +59,60 @@ public class ConfigurationImageGetterSetterTest {
     }
 
     @Test
+    public void testLegacyEnumSuffixCompatibilityRejectsUnsafeMatches() {
+        TreeMap<Integer, String> map = new TreeMap<>();
+        map.put(1, "Output (variant A)");
+        map.put(2, "Output (variant B)");
+        EnumIniField field = new EnumIniField("output", 0, FieldType.UINT8,
+            new EnumIniField.EnumKeyValueMap(map), 0, 7, true);
+        ConfigurationImage image = new ConfigurationImage(new byte[4]);
+
+        assertThrows(IllegalArgumentException.class,
+            () -> ConfigurationImageGetterSetter.setValue2(field, image, "output", "\"Output\""));
+        assertThrows(IllegalArgumentException.class,
+            () -> ConfigurationImageGetterSetter.setValue2(field, image, "output", "\"Different output\""));
+
+        TreeMap<Integer, String> unrecognizedSuffixMap = new TreeMap<>();
+        unrecognizedSuffixMap.put(1, "OutputExtended");
+        EnumIniField unrecognizedSuffixField = new EnumIniField("output", 0, FieldType.UINT8,
+            new EnumIniField.EnumKeyValueMap(unrecognizedSuffixMap), 0, 7, true);
+        assertThrows(IllegalArgumentException.class,
+            () -> ConfigurationImageGetterSetter.setValue2(
+                unrecognizedSuffixField, image, "output", "\"Output\""));
+    }
+
+    @Test
+    public void testLegacyPinEnumAcceptsKnownAdditiveSuffixes() {
+        String[] currentLabels = {
+            "Output (documentation)",
+            "Output or alternate function",
+            "Output for low count wheel",
+            "Output best for normal wheels",
+            "Output, auxiliary use",
+            "Output legacy connector A",
+        };
+        for (String currentLabel : currentLabels) {
+            TreeMap<Integer, String> map = new TreeMap<>();
+            map.put(3, currentLabel);
+            EnumIniField field = new EnumIniField("output", 0, FieldType.UINT8,
+                new EnumIniField.EnumKeyValueMap(map), 0, 7, true);
+            ConfigurationImage image = new ConfigurationImage(new byte[4]);
+
+            ConfigurationImageGetterSetter.setValue2(field, image, "output", "\"Output\"");
+            assertEquals("\"" + currentLabel + "\"",
+                ConfigurationImageGetterSetter.getStringValue(field, image));
+        }
+
+        TreeMap<Integer, String> ordinaryEnumMap = new TreeMap<>();
+        ordinaryEnumMap.put(3, "Output or alternate function");
+        EnumIniField ordinaryEnum = new EnumIniField("mode", 0, FieldType.UINT8,
+            new EnumIniField.EnumKeyValueMap(ordinaryEnumMap), 0, 7);
+        assertThrows(IllegalArgumentException.class,
+            () -> ConfigurationImageGetterSetter.setValue2(
+                ordinaryEnum, new ConfigurationImage(new byte[4]), "mode", "\"Output\""));
+    }
+
+    @Test
     public void testGetStringValueWithPrecision() {
         ConfigurationImage ci = new ConfigurationImage(new byte[4]);
         // value 1.23456

--- a/java_tools/tune-tools/src/test/java/com/rusefi/tune/LegacyOnlineTuneTest.java
+++ b/java_tools/tune-tools/src/test/java/com/rusefi/tune/LegacyOnlineTuneTest.java
@@ -5,31 +5,43 @@ import com.opensr5.ConfigurationImageGetterSetter;
 import com.opensr5.ini.IniFileModel;
 import com.opensr5.ini.field.IniField;
 import com.rusefi.ini.reader.IniFileReaderUtil;
-import com.rusefi.tune.xml.Constant;
 import com.rusefi.tune.xml.Msq;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class LegacyOnlineTuneTest {
     private static final String RESOURCES = "src/test/resources/";
     private static final String CURRENT_INI = "../../firmware/tunerstudio/generated/";
 
     @Test
-    public void online2024UaefiTuneRejectsRenamedOutputLabels() throws Exception {
+    public void online2024UaefiTuneAcceptsLabelsWithNewDocumentationSuffixes() throws Exception {
         Msq tune = Msq.readTune(RESOURCES + "online-tune-1615-2024.msq");
         IniFileModel currentIni = IniFileReaderUtil.readIniFile(CURRENT_INI + "rusefi_uaefi.ini");
+        ConfigurationImage image = tune.asImage(currentIni);
 
-        for (String fieldName : new String[]{"mainRelayPin", "fuelPumpPin", "fanPin"}) {
-            Constant value = tune.findPage().findParameter(fieldName);
-            IniField field = currentIni.findIniField(fieldName).orElseThrow();
-
-            IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
-                () -> ConfigurationImageGetterSetter2.setValue(field,
-                    new ConfigurationImage(currentIni.getMetaInfo().getPageSize(0)), value));
-            assertEquals(fieldName + ": Enum name not found " + value.getValue(), exception.getMessage());
+        String[][] expected = {
+            {"mainRelayPin", "B9 Main Relay Weak Low Side output 1 (no flyback here)"},
+            {"fuelPumpPin", "B16 Low Side output 4 / Fuel Pump Relay (has flyback D5)"},
+            {"fanPin", "B8 Fan Relay Weak Low Side output 2 (no flyback here)"},
+            {"triggerInputPins1", "C17 VR2-/HALL max9924 best for normal 12+ tooth wheels"},
+        };
+        for (String[] fieldAndLabel : expected) {
+            IniField field = currentIni.findIniField(fieldAndLabel[0]).orElseThrow();
+            assertEquals("\"" + fieldAndLabel[1] + "\"",
+                ConfigurationImageGetterSetter.getStringValue(field, image));
         }
+    }
+
+    @Test
+    public void online2025UaefiTuneAcceptsAddedPinCapability() throws Exception {
+        Msq tune = Msq.readTune(RESOURCES + "online-tune-1748-2025.msq");
+        IniFileModel currentIni = IniFileReaderUtil.readIniFile(CURRENT_INI + "rusefi_uaefi.ini");
+
+        ConfigurationImage image = tune.asImage(currentIni);
+        IniField field = currentIni.findIniField("boostControlPin").orElseThrow();
+        assertEquals("\"B17 Low Side output 3 or injector 7 (has flyback D4)\"",
+            ConfigurationImageGetterSetter.getStringValue(field, image));
     }
 
     @Test

--- a/java_tools/tune-tools/src/test/resources/online-tune-1615-2024.msq
+++ b/java_tools/tune-tools/src/test/resources/online-tune-1615-2024.msq
@@ -6,5 +6,6 @@
     <constant name="mainRelayPin">"B9 Main Relay Weak Low Side output 1"</constant>
     <constant name="fuelPumpPin">"B16 Low Side output 4 / Fuel Pump Relay"</constant>
     <constant name="fanPin">"B8 Fan Relay Weak Low Side output 2"</constant>
+    <constant name="triggerInputPins1">"C17 VR2-/HALL max9924"</constant>
   </page>
 </msq>

--- a/java_tools/tune-tools/src/test/resources/online-tune-1748-2025.msq
+++ b/java_tools/tune-tools/src/test/resources/online-tune-1748-2025.msq
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!-- Reduced from https://rusefi.com/online/download.php?msq=1748 -->
+<msq xmlns="http://www.msefi.com/:msq">
+  <versionInfo fileFormat="5.0" firmwareInfo="rusEFI+v20250509%4065034" nPages="1" signature="rusEFI master.2025.05.09.uaefi.628880644"/>
+  <page number="0" size="32244">
+    <constant name="boostControlPin">"B17 Low Side output 3"</constant>
+  </page>
+</msq>


### PR DESCRIPTION
related #9882