### PR TITLE
tooth logger testability

### DIFF
--- a/firmware/console/binary/tooth_logger.cpp
+++ b/firmware/console/binary/tooth_logger.cpp
@@ -47,6 +47,8 @@
 	fail("EFI_SHAFT_POSITION_INPUT required to have EFI_EMULATE_POSITION_SENSORS")
 #endif
 
+#include "tooth_logger_buffer.h"
+
 /**
  * Engine idles around 20Hz and revs up to 140Hz, at 60/2 and 8 cylinders we have about 20Khz events
  * If we can read buffer at 50Hz we want buffer to be about 400 elements.
@@ -109,20 +111,10 @@ void DisableToothLogger() {
 
 #else // not EFI_UNIT_TEST
 
-// Multi-buffering between producers and consumers: trigger/coil/injector edge
-// handlers (interrupt context) append composite_logger_s entries into
-// 'currentBuffer'; a buffer that fills up (or goes 5 seconds stale) is posted to
-// 'filledBuffers', where a consumer - the TS composite-log reader or the SD card
-// thread (ToothLoggerWriter) - drains it and returns it to 'freeBuffers'.
-// Buffers live in the shared BigBuffer region, so the tooth logger cannot run
-// concurrently with other BigBuffer users. See docs/AI/sd_card_logging.md
-static constexpr size_t bufferCount = BIG_BUFFER_SIZE / sizeof(CompositeBuffer);
-static_assert(bufferCount >= 2);
-
-static chibios_rt::Mailbox<CompositeBuffer*, bufferCount> freeBuffers;
-static chibios_rt::Mailbox<CompositeBuffer*, bufferCount> filledBuffers;
-
-static CompositeBuffer* currentBuffer = nullptr;
+// The buffer lifecycle itself (free/filled queues, current buffer, 5 second
+// staleness flush) lives in ToothLoggerBufferPool - see tooth_logger_buffer.h.
+// This file owns the enabled flag, the current flag state 'cur', and the
+// TS-visible ready indication.
 
 static void setToothLogReady(bool value) {
 #if EFI_TUNER_STUDIO && (EFI_PROD_CODE || EFI_SIMULATOR)
@@ -130,32 +122,13 @@ static void setToothLogReady(bool value) {
 #endif // EFI_TUNER_STUDIO
 }
 
-static BigBufferHandle bufferHandle;
+static ToothLoggerBufferPool toothBuffers{setToothLogReady};
 
 bool EnableToothLogger(TLmode mode) {
 	chibios_rt::CriticalSectionLocker csl;
 
-	bufferHandle = getBigBuffer(BigBufferUser::ToothLogger);
-	if (!bufferHandle) {
+	if (!toothBuffers.startI()) {
 		return false;
-	}
-
-	CompositeBuffer* buffers = bufferHandle.get<CompositeBuffer>();
-
-	// Reset all buffers
-	for (size_t i = 0; i < bufferCount; i++) {
-		buffers[i].nextIdx = 0;
-	}
-
-	// Reset state
-	currentBuffer = nullptr;
-
-	freeBuffers.resumeX();
-	filledBuffers.resumeX();
-
-	// Put all buffers in the free list
-	for (size_t i = 0; i < bufferCount; i++) {
-		freeBuffers.postI(&buffers[i]);
 	}
 
 	// Enable logging of edges as they come
@@ -170,118 +143,27 @@ bool EnableToothLogger(TLmode mode) {
 void DisableToothLogger() {
 	chibios_rt::CriticalSectionLocker csl;
 
-	// Resume all waiting threads
-	freeBuffers.resetI();
-	filledBuffers.resetI();
-
-	// Release the big buffer for another user
-	// C++ magic: here we are calling BigBufferHandle::operator=() with empty instance
-	bufferHandle = {};
+	toothBuffers.stopI();
 
 	ToothLoggerEnabled = false;
 	setToothLogReady(false);
 }
 
-static CompositeBuffer* GetToothLoggerBufferImpl(sysinterval_t timeout) {
-	CompositeBuffer* buffer = nullptr;
-	msg_t msg = filledBuffers.fetch(&buffer, timeout);
-
-	if (msg == MSG_TIMEOUT) {
-		setToothLogReady(false);
-		return nullptr;
-	}
-
-	if (msg != MSG_OK) {
-		// someone just disabled tooth logger and reset queues?
-		// What even happened if we didn't get timeout, but also didn't get OK?
-		return nullptr;
-	}
-
-	return buffer;
-}
-
 CompositeBuffer* GetToothLoggerBufferNonblocking() {
-	return GetToothLoggerBufferImpl(TIME_IMMEDIATE);
+	return toothBuffers.getFilled(TIME_IMMEDIATE);
 }
 
 void ReturnToothLoggerBuffer(CompositeBuffer* buffer) {
 	chibios_rt::CriticalSectionLocker csl;
 
-	// ignore return, nothing we can do in case of error.
-	// MSG_RESET is possible if tooth logger was disabled while buffer was outside
-	freeBuffers.postI(buffer);
-
-	// If the used list is empty, clear the ready flag
-	if (filledBuffers.getUsedCountI() == 0) {
-		setToothLogReady(false);
-	}
-}
-
-static CompositeBuffer* findBuffer(efitick_t timestamp) {
-	CompositeBuffer* buffer;
-
-	if (!currentBuffer) {
-		// try and find a buffer, if none available, we can't log
-		if (MSG_OK != freeBuffers.fetchI(&buffer)) {
-			return nullptr;
-		}
-
-		// Record the time of the last buffer swap so we can force a swap after a minimum period of time
-		// This ensures the user sees *something* even if they don't have enough trigger events
-		// to fill the buffer.
-		buffer->startTime.reset(timestamp);
-		buffer->nextIdx = 0;
-
-		currentBuffer = buffer;
-	}
-
-	return currentBuffer;
+	toothBuffers.returnBufferI(buffer);
 }
 
 static void SetNextCompositeEntry(efitick_t timestamp) {
 	// This is called from multiple interrupts/threads, so we need a lock.
 	chibios_rt::CriticalSectionLocker csl;
 
-	CompositeBuffer* buffer = findBuffer(timestamp);
-
-	if (!buffer) {
-		// All buffers are full, nothing to do here.
-		return;
-	}
-
-	size_t idx = buffer->nextIdx;
-	auto nextIdx = idx + 1;
-	buffer->nextIdx = nextIdx;
-
-	if (idx < efi::size(buffer->buffer)) {
-		composite_logger_s* entry = &buffer->buffer[idx];
-
-		entry->x = cur.x;
-		// timestamp is offset to buffer begin
-		entry->timestamp = NT2US(timestamp - buffer->startTime.get());
-
-		// TS uses big endian, grumble
-		// the whole order of all packet bytes is reversed, not just the 'endian-swap' integers
-		// swap whole record byteorder
-		entry->x = SWAP_UINT64(entry->x);
-	}
-
-	// if the buffer is full...
-	bool bufferFull = nextIdx >= efi::size(buffer->buffer);
-	// ... or it's been too long since the last flush
-	bool bufferTimedOut = buffer->startTime.hasElapsedSec(5);
-
-	// Then cycle buffers and set the ready flag.
-	if (bufferFull || bufferTimedOut) {
-		// Post to the output queue
-		filledBuffers.postI(buffer);
-
-		// Null the current buffer so we get a new one next time
-		currentBuffer = nullptr;
-
-		// Flag that we are ready
-		setToothLogReady(true);
-	}
+	toothBuffers.appendI(cur, timestamp);
 }
 
 #endif // not EFI_UNIT_TEST
@@ -454,9 +336,7 @@ static int ToothLoggerWriteBin(Writer &writer, CompositeBuffer* buffer) {
 bool ToothLoggerHasData() {
 	chibios_rt::CriticalSectionLocker csl;
 
-	return ((currentBuffer) ||
-		(filledBuffers.getUsedCountI() > 0));
-
+	return toothBuffers.hasDataI();
 }
 
 // binary vs CSV output format, latched at file creation - see ToothLoggerWriter()
@@ -477,8 +357,8 @@ int ToothLoggerWriter(FileBufferedWriter &writer) {
 	CompositeBuffer* buffer = nullptr;
 	bool startNewFile = false;
 
-	// manualy pick buffer, do not use GetToothLoggerBufferImpl() as it changes TS buffer ready flag
-	msg_t msg = filledBuffers.fetch(&buffer, TIME_MS2I(3000));
+	// manualy pick buffer, do not use getFilled() as it changes TS buffer ready flag
+	msg_t msg = toothBuffers.fetchFilled(&buffer, TIME_MS2I(3000));
 	if ((msg != MSG_OK) && (msg != MSG_TIMEOUT)) {
 		// error?
 		return -1;
@@ -489,10 +369,7 @@ int ToothLoggerWriter(FileBufferedWriter &writer) {
 		startNewFile = true;
 
 		// flush data from currently writing buffer!
-		if (currentBuffer) {
-			buffer = currentBuffer;
-			currentBuffer = nullptr;
-		}
+		buffer = toothBuffers.flushCurrentI();
 	}
 
 	// can return nullptr

--- a/firmware/console/binary/tooth_logger_buffer.cpp
+++ b/firmware/console/binary/tooth_logger_buffer.cpp
@@ -1,0 +1,162 @@
+/**
+ * @file tooth_logger_buffer.cpp
+ *
+ * See tooth_logger_buffer.h - buffer lifecycle extracted from tooth_logger.cpp
+ * so it can run in host unit tests.
+ */
+
+#include "pch.h"
+
+#if EFI_TOOTH_LOGGER
+
+#include "tooth_logger_buffer.h"
+
+bool ToothLoggerBufferPool::startI() {
+	m_bufferHandle = getBigBuffer(BigBufferUser::ToothLogger);
+	if (!m_bufferHandle) {
+		return false;
+	}
+
+	CompositeBuffer* buffers = m_bufferHandle.get<CompositeBuffer>();
+
+	// Reset all buffers
+	for (size_t i = 0; i < bufferCount; i++) {
+		buffers[i].nextIdx = 0;
+	}
+
+	// Reset state
+	m_currentBuffer = nullptr;
+
+	m_freeBuffers.resumeX();
+	m_filledBuffers.resumeX();
+
+	// Put all buffers in the free list
+	for (size_t i = 0; i < bufferCount; i++) {
+		m_freeBuffers.postI(&buffers[i]);
+	}
+
+	return true;
+}
+
+void ToothLoggerBufferPool::stopI() {
+	// Resume all waiting threads
+	m_freeBuffers.resetI();
+	m_filledBuffers.resetI();
+
+	// Drop the partial buffer - it lives in memory we are about to hand back
+	m_currentBuffer = nullptr;
+
+	// Release the big buffer for another user
+	// C++ magic: here we are calling BigBufferHandle::operator=() with empty instance
+	m_bufferHandle = {};
+}
+
+CompositeBuffer* ToothLoggerBufferPool::findBufferI(efitick_t timestamp) {
+	CompositeBuffer* buffer;
+
+	if (!m_currentBuffer) {
+		// try and find a buffer, if none available, we can't log
+		if (MSG_OK != m_freeBuffers.fetchI(&buffer)) {
+			return nullptr;
+		}
+
+		// Record the time of the last buffer swap so we can force a swap after a minimum period of time
+		// This ensures the user sees *something* even if they don't have enough trigger events
+		// to fill the buffer.
+		buffer->startTime.reset(timestamp);
+		buffer->nextIdx = 0;
+
+		m_currentBuffer = buffer;
+	}
+
+	return m_currentBuffer;
+}
+
+void ToothLoggerBufferPool::appendI(const composite_logger_s& state, efitick_t timestamp) {
+	CompositeBuffer* buffer = findBufferI(timestamp);
+
+	if (!buffer) {
+		// All buffers are full, nothing to do here.
+		return;
+	}
+
+	size_t idx = buffer->nextIdx;
+	auto nextIdx = idx + 1;
+	buffer->nextIdx = nextIdx;
+
+	if (idx < efi::size(buffer->buffer)) {
+		composite_logger_s* entry = &buffer->buffer[idx];
+
+		entry->x = state.x;
+		// timestamp is offset to buffer begin
+		entry->timestamp = NT2US(timestamp - buffer->startTime.get());
+
+		// TS uses big endian, grumble
+		// the whole order of all packet bytes is reversed, not just the 'endian-swap' integers
+		// swap whole record byteorder
+		entry->x = SWAP_UINT64(entry->x);
+	}
+
+	// if the buffer is full...
+	bool bufferFull = nextIdx >= efi::size(buffer->buffer);
+	// ... or it's been too long since the last flush
+	bool bufferTimedOut = buffer->startTime.hasElapsedSec(5);
+
+	// Then cycle buffers and set the ready flag.
+	if (bufferFull || bufferTimedOut) {
+		// Post to the output queue
+		m_filledBuffers.postI(buffer);
+
+		// Null the current buffer so we get a new one next time
+		m_currentBuffer = nullptr;
+
+		// Flag that we are ready
+		setReady(true);
+	}
+}
+
+void ToothLoggerBufferPool::returnBufferI(CompositeBuffer* buffer) {
+	// ignore return, nothing we can do in case of error.
+	// MSG_RESET is possible if tooth logger was disabled while buffer was outside
+	m_freeBuffers.postI(buffer);
+
+	// If the used list is empty, clear the ready flag
+	if (m_filledBuffers.getUsedCountI() == 0) {
+		setReady(false);
+	}
+}
+
+CompositeBuffer* ToothLoggerBufferPool::getFilled(sysinterval_t timeout) {
+	CompositeBuffer* buffer = nullptr;
+	msg_t msg = m_filledBuffers.fetch(&buffer, timeout);
+
+	if (msg == MSG_TIMEOUT) {
+		setReady(false);
+		return nullptr;
+	}
+
+	if (msg != MSG_OK) {
+		// someone just disabled tooth logger and reset queues?
+		// What even happened if we didn't get timeout, but also didn't get OK?
+		return nullptr;
+	}
+
+	return buffer;
+}
+
+msg_t ToothLoggerBufferPool::fetchFilled(CompositeBuffer** buffer, sysinterval_t timeout) {
+	return m_filledBuffers.fetch(buffer, timeout);
+}
+
+CompositeBuffer* ToothLoggerBufferPool::flushCurrentI() {
+	CompositeBuffer* buffer = m_currentBuffer;
+	m_currentBuffer = nullptr;
+	return buffer;
+}
+
+bool ToothLoggerBufferPool::hasDataI() {
+	return (m_currentBuffer) ||
+		(m_filledBuffers.getUsedCountI() > 0);
+}
+
+#endif // EFI_TOOTH_LOGGER

--- a/firmware/console/binary/tooth_logger_buffer.h
+++ b/firmware/console/binary/tooth_logger_buffer.h
@@ -1,0 +1,97 @@
+/**
+ * @file tooth_logger_buffer.h
+ *
+ * Multi-buffering between tooth-event producers (trigger/coil/injector edge
+ * handlers, interrupt context) and consumers (TunerStudio composite reader,
+ * SD card .teeth writer). Extracted from tooth_logger.cpp so the buffer
+ * lifecycle is also compiled - and testable - in host unit tests, where it
+ * runs against the mailbox mock in unit_tests/chibios-mock/mock-mailbox.h.
+ *
+ * Buffers live in the shared BigBuffer region, so the tooth logger cannot run
+ * concurrently with other BigBuffer users. See docs/AI/sd_card_logging.md
+ */
+
+#pragma once
+
+#include "tooth_logger.h"
+#include "big_buffer.h"
+
+#if EFI_UNIT_TEST
+#include "mock-mailbox.h"
+#endif
+
+#if EFI_TOOTH_LOGGER
+
+class ToothLoggerBufferPool {
+public:
+	// Consumer-visible "a filled buffer is ready" indication
+	// (drives outputChannels.toothLogReady in production)
+	using ReadyCallback = void(*)(bool ready);
+
+	ToothLoggerBufferPool() = default;
+	explicit ToothLoggerBufferPool(ReadyCallback callback)
+		: m_onReady(callback)
+	{
+	}
+
+	// Acquire the big buffer and place every buffer on the (re-armed) free
+	// list. Returns false if the big buffer is taken by another user.
+	// Caller must hold the critical section.
+	bool startI();
+
+	// Empty both queues - waking any waiting consumer with MSG_RESET - and
+	// release the big buffer. Caller must hold the critical section.
+	void stopI();
+
+	// Append one entry carrying the given flag state; the entry's timestamp is
+	// stored as a microsecond offset from the owning buffer's startTime. Posts
+	// the buffer to the filled queue when it fills up or goes 5 seconds stale.
+	// Caller must hold the critical section.
+	void appendI(const composite_logger_s& state, efitick_t timestamp);
+
+	// Return a drained buffer to the free list.
+	// Caller must hold the critical section.
+	void returnBufferI(CompositeBuffer* buffer);
+
+	// Fetch a filled buffer, maintaining the ready indication.
+	// Returns nullptr if none is available.
+	// Thread context, no critical section held.
+	CompositeBuffer* getFilled(sysinterval_t timeout);
+
+	// Raw fetch with no ready-indication side effect (SD writer path).
+	// Thread context, no critical section held.
+	msg_t fetchFilled(CompositeBuffer** buffer, sysinterval_t timeout);
+
+	// Take the partially-filled current buffer away (SD idle flush).
+	// Returns nullptr if there is no current buffer.
+	// Caller must hold the critical section.
+	CompositeBuffer* flushCurrentI();
+
+	// True if any entries are pending: a partial current buffer or a filled
+	// buffer waiting for a consumer. Caller must hold the critical section.
+	bool hasDataI();
+
+	static constexpr size_t bufferCount = BIG_BUFFER_SIZE / sizeof(CompositeBuffer);
+
+private:
+	CompositeBuffer* findBufferI(efitick_t timestamp);
+
+	void setReady(bool ready) {
+		if (m_onReady) {
+			m_onReady(ready);
+		}
+	}
+
+	chibios_rt::Mailbox<CompositeBuffer*, bufferCount> m_freeBuffers;
+	chibios_rt::Mailbox<CompositeBuffer*, bufferCount> m_filledBuffers;
+
+	CompositeBuffer* m_currentBuffer = nullptr;
+
+	BigBufferHandle m_bufferHandle;
+
+	ReadyCallback m_onReady = nullptr;
+};
+
+static_assert(ToothLoggerBufferPool::bufferCount >= 2);
+
+#endif // EFI_TOOTH_LOGGER

--- a/firmware/console/console.mk
+++ b/firmware/console/console.mk
@@ -1,4 +1,5 @@
 CONSOLE_COMMON_SRC_CPP = 	$(PROJECT_DIR)/console/binary/tooth_logger.cpp \
+	                        $(PROJECT_DIR)/console/binary/tooth_logger_buffer.cpp \
 	                        $(PROJECT_DIR)/console/binary_mlg_log/binary_mlg_logging.cpp \
                          	$(PROJECT_DIR)/console/status_loop.cpp \
 

--- a/unit_tests/chibios-mock/mock-mailbox.h
+++ b/unit_tests/chibios-mock/mock-mailbox.h
@@ -1,0 +1,85 @@
+// Host-side stand-in for chibios_rt::Mailbox so firmware code using the
+// free/filled buffer-queue pattern (tooth_logger_buffer.cpp) compiles and runs
+// in unit tests.
+//
+// Semantics follow ChibiOS chmboxes.c:
+// - postI()/fetchI() return MSG_RESET while the mailbox is in reset state
+// - resetI() empties the queue and enters reset state; resumeX() re-arms it
+// - non-blocking postI() returns MSG_TIMEOUT when full, fetchI() when empty
+// Unit tests are single-threaded, so the blocking fetch() degenerates to the
+// non-blocking variant regardless of the requested timeout.
+
+#pragma once
+
+#include <cstdint>
+#include <cstddef>
+
+typedef int32_t msg_t;
+typedef uint32_t sysinterval_t;
+
+#define MSG_OK      ((msg_t)0)
+#define MSG_TIMEOUT ((msg_t)-1)
+#define MSG_RESET   ((msg_t)-2)
+
+#define TIME_IMMEDIATE ((sysinterval_t)0)
+
+namespace chibios_rt {
+
+template <typename T, int N>
+class Mailbox {
+public:
+	msg_t postI(T msg) {
+		if (m_inReset) {
+			return MSG_RESET;
+		}
+
+		if (m_count >= N) {
+			return MSG_TIMEOUT;
+		}
+
+		m_items[(m_read + m_count) % N] = msg;
+		m_count++;
+		return MSG_OK;
+	}
+
+	msg_t fetchI(T* out) {
+		if (m_inReset) {
+			return MSG_RESET;
+		}
+
+		if (m_count == 0) {
+			return MSG_TIMEOUT;
+		}
+
+		*out = m_items[m_read];
+		m_read = (m_read + 1) % N;
+		m_count--;
+		return MSG_OK;
+	}
+
+	msg_t fetch(T* out, sysinterval_t /*timeout*/) {
+		return fetchI(out);
+	}
+
+	void resetI() {
+		m_inReset = true;
+		m_read = 0;
+		m_count = 0;
+	}
+
+	void resumeX() {
+		m_inReset = false;
+	}
+
+	size_t getUsedCountI() {
+		return m_count;
+	}
+
+private:
+	T m_items[N];
+	size_t m_read = 0;
+	size_t m_count = 0;
+	bool m_inReset = false;
+};
+
+} // namespace chibios_rt

--- a/unit_tests/tests/test_tooth_logger_buffer.cpp
+++ b/unit_tests/tests/test_tooth_logger_buffer.cpp
@@ -1,0 +1,231 @@
+// Host tests for the tooth logger buffer lifecycle (ToothLoggerBufferPool):
+// big-buffer ownership, free/filled queue cycling, relative timestamps,
+// 5 second staleness flush, and stop/restart behavior.
+//
+// Note: EngineTestHelper's own EnableToothLogger() call uses the EFI_UNIT_TEST
+// stub in tooth_logger.cpp (events vector) and never touches the big buffer,
+// so each test is free to run its own pool instance.
+
+#include "pch.h"
+
+#include "tooth_logger_buffer.h"
+
+BigBufferUser getBigBufferCurrentUser();
+
+namespace {
+
+bool s_toothReady = false;
+
+void readyCallback(bool ready) {
+	s_toothReady = ready;
+}
+
+composite_logger_s unswap(const composite_logger_s& raw) {
+	composite_logger_s c;
+	c.x = SWAP_UINT64(raw.x);
+	return c;
+}
+
+} // namespace
+
+TEST(ToothLoggerBuffer, StartStopBigBufferOwnership) {
+	ToothLoggerBufferPool pool;
+
+	EXPECT_EQ(getBigBufferCurrentUser(), BigBufferUser::None);
+	ASSERT_TRUE(pool.startI());
+	EXPECT_EQ(getBigBufferCurrentUser(), BigBufferUser::ToothLogger);
+
+	// Freshly started: nothing pending
+	EXPECT_FALSE(pool.hasDataI());
+	EXPECT_EQ(pool.getFilled(TIME_IMMEDIATE), nullptr);
+
+	pool.stopI();
+	EXPECT_EQ(getBigBufferCurrentUser(), BigBufferUser::None);
+}
+
+TEST(ToothLoggerBuffer, StartFailsWhenBigBufferBusy) {
+	BigBufferHandle other = getBigBuffer(BigBufferUser::PerfTrace);
+	ASSERT_TRUE(bool(other));
+
+	ToothLoggerBufferPool pool;
+	EXPECT_FALSE(pool.startI());
+
+	// The failed start must not have disturbed the existing user
+	EXPECT_EQ(getBigBufferCurrentUser(), BigBufferUser::PerfTrace);
+}
+
+TEST(ToothLoggerBuffer, FillPostsBufferWithRelativeTimestamps) {
+	EngineTestHelper eth(engine_type_e::TEST_ENGINE);
+
+	s_toothReady = false;
+	ToothLoggerBufferPool pool{readyCallback};
+	ASSERT_TRUE(pool.startI());
+
+	composite_logger_s state{};
+	state.priLevel = true;
+
+	efitick_t base = getTimeNowNt();
+
+	// One entry shy of full: nothing posted yet
+	for (size_t i = 0; i < toothLoggerEntriesPerBuffer - 1; i++) {
+		pool.appendI(state, base + US2NT(i * 100));
+	}
+	EXPECT_FALSE(s_toothReady);
+	EXPECT_TRUE(pool.hasDataI());
+	EXPECT_EQ(pool.getFilled(TIME_IMMEDIATE), nullptr);
+
+	// The final entry fills the buffer and posts it
+	pool.appendI(state, base + US2NT((toothLoggerEntriesPerBuffer - 1) * 100));
+	EXPECT_TRUE(s_toothReady);
+
+	CompositeBuffer* buf = pool.getFilled(TIME_IMMEDIATE);
+	ASSERT_NE(buf, nullptr);
+	EXPECT_EQ(buf->startTime.get(), base);
+	EXPECT_EQ(buf->nextIdx, toothLoggerEntriesPerBuffer);
+
+	// Timestamps are stored as microsecond offsets from startTime
+	EXPECT_EQ(unswap(buf->buffer[0]).timestamp, 0u);
+	EXPECT_EQ(unswap(buf->buffer[1]).timestamp, 100u);
+	EXPECT_EQ(unswap(buf->buffer[toothLoggerEntriesPerBuffer - 1]).timestamp,
+		(toothLoggerEntriesPerBuffer - 1) * 100u);
+	EXPECT_TRUE(unswap(buf->buffer[0]).priLevel);
+
+	// Returning the last outstanding buffer clears the ready indication
+	pool.returnBufferI(buf);
+	EXPECT_FALSE(s_toothReady);
+
+	pool.stopI();
+}
+
+TEST(ToothLoggerBuffer, StaleBufferFlushedAfter5Seconds) {
+	EngineTestHelper eth(engine_type_e::TEST_ENGINE);
+
+	s_toothReady = false;
+	ToothLoggerBufferPool pool{readyCallback};
+	ASSERT_TRUE(pool.startI());
+
+	composite_logger_s state{};
+
+	pool.appendI(state, getTimeNowNt());
+	EXPECT_FALSE(s_toothReady);
+
+	// A partially-filled buffer goes stale after 5 seconds and is posted on
+	// the next append even though it is nowhere near full
+	eth.moveTimeForwardSec(6);
+	pool.appendI(state, getTimeNowNt());
+	EXPECT_TRUE(s_toothReady);
+
+	CompositeBuffer* buf = pool.getFilled(TIME_IMMEDIATE);
+	ASSERT_NE(buf, nullptr);
+	EXPECT_EQ(buf->nextIdx, 2u);
+	EXPECT_EQ(unswap(buf->buffer[1]).timestamp, 6'000'000u);
+
+	pool.returnBufferI(buf);
+	pool.stopI();
+}
+
+TEST(ToothLoggerBuffer, StopWhileConsumerHoldsBufferThenRestartClean) {
+	EngineTestHelper eth(engine_type_e::TEST_ENGINE);
+
+	s_toothReady = false;
+	ToothLoggerBufferPool pool{readyCallback};
+	ASSERT_TRUE(pool.startI());
+
+	composite_logger_s state{};
+	efitick_t base = getTimeNowNt();
+	for (size_t i = 0; i < toothLoggerEntriesPerBuffer; i++) {
+		pool.appendI(state, base + US2NT(i));
+	}
+
+	CompositeBuffer* buf = pool.getFilled(TIME_IMMEDIATE);
+	ASSERT_NE(buf, nullptr);
+
+	// Stop while the consumer still holds a buffer
+	pool.stopI();
+	EXPECT_EQ(getBigBufferCurrentUser(), BigBufferUser::None);
+
+	// Returning the buffer after stop must be tolerated (queues are in reset,
+	// the post is silently dropped)
+	pool.returnBufferI(buf);
+
+	// Restart: fresh state, logging works again
+	ASSERT_TRUE(pool.startI());
+	EXPECT_FALSE(pool.hasDataI());
+	EXPECT_EQ(pool.getFilled(TIME_IMMEDIATE), nullptr);
+
+	base = getTimeNowNt();
+	for (size_t i = 0; i < toothLoggerEntriesPerBuffer; i++) {
+		pool.appendI(state, base + US2NT(i));
+	}
+	EXPECT_NE(pool.getFilled(TIME_IMMEDIATE), nullptr);
+
+	pool.stopI();
+}
+
+TEST(ToothLoggerBuffer, EntriesDroppedWhenAllBuffersFull) {
+	EngineTestHelper eth(engine_type_e::TEST_ENGINE);
+
+	s_toothReady = false;
+	ToothLoggerBufferPool pool{readyCallback};
+	ASSERT_TRUE(pool.startI());
+
+	composite_logger_s state{};
+
+	// Fill every buffer in the pool with no consumer draining. Advance the
+	// virtual clock along with the event timestamps: a startTime ahead of
+	// "now" reads as a huge unsigned elapsed time in Timer::hasElapsedUs and
+	// would trip the 5 second staleness flush on every append.
+	for (size_t i = 0; i < ToothLoggerBufferPool::bufferCount * toothLoggerEntriesPerBuffer; i++) {
+		eth.moveTimeForwardUs(1);
+		pool.appendI(state, getTimeNowNt());
+	}
+
+	// Producers keep going: further entries are dropped, no crash, no overwrite
+	eth.moveTimeForwardUs(1);
+	pool.appendI(state, getTimeNowNt());
+	eth.moveTimeForwardUs(1);
+	pool.appendI(state, getTimeNowNt());
+
+	// Exactly bufferCount buffers are waiting, each completely full
+	size_t drained = 0;
+	while (CompositeBuffer* buf = pool.getFilled(TIME_IMMEDIATE)) {
+		EXPECT_EQ(buf->nextIdx, toothLoggerEntriesPerBuffer);
+		pool.returnBufferI(buf);
+		drained++;
+	}
+	EXPECT_EQ(drained, ToothLoggerBufferPool::bufferCount);
+
+	// With buffers returned to the free list, logging resumes
+	pool.appendI(state, getTimeNowNt());
+	EXPECT_TRUE(pool.hasDataI());
+
+	pool.stopI();
+}
+
+TEST(ToothLoggerBuffer, FlushCurrentTakesPartialBuffer) {
+	EngineTestHelper eth(engine_type_e::TEST_ENGINE);
+
+	ToothLoggerBufferPool pool;
+	ASSERT_TRUE(pool.startI());
+
+	// Nothing to flush on a fresh pool
+	EXPECT_EQ(pool.flushCurrentI(), nullptr);
+
+	composite_logger_s state{};
+	efitick_t base = getTimeNowNt();
+	pool.appendI(state, base);
+	pool.appendI(state, base + US2NT(100));
+	pool.appendI(state, base + US2NT(200));
+
+	CompositeBuffer* buf = pool.flushCurrentI();
+	ASSERT_NE(buf, nullptr);
+	EXPECT_EQ(buf->nextIdx, 3u);
+	EXPECT_EQ(buf->startTime.get(), base);
+
+	// The partial buffer is no longer the pool's problem
+	EXPECT_FALSE(pool.hasDataI());
+	EXPECT_EQ(pool.flushCurrentI(), nullptr);
+
+	pool.returnBufferI(buf);
+	pool.stopI();
+}

--- a/unit_tests/tests/tests.mk
+++ b/unit_tests/tests/tests.mk
@@ -178,6 +178,7 @@ TESTS_SRC_CPP = \
 	tests/test_fuel_math.cpp \
 	tests/test_binary_log.cpp \
 	tests/test_tooth_logger.cpp \
+	tests/test_tooth_logger_buffer.cpp \
 	test-framework/csv2logicdata.cpp \
 	test-framework/logicdata2csv.cpp \
 	tests/binary_log/test_bit_logger_field.cpp \


### PR DESCRIPTION
only:testability


## 2026-07-20 - Review of tooth_logger.cpp PR #9871 (Toothlogger fixes) + coverage assessment

What was done: reviewed recent tooth_logger changes - a403d0b8a61 "Toothlogger
fixes (#9871)" (queue reset/resume on disable/enable, removal of
GetToothLoggerBufferBlocking, composite entry timestamps made relative to
buffer startTime, CSV writer recovers absolute time) plus the earlier CSV
column additions (2e34749 instantMAP, a91e2ae TPS). Assessed unit-test
coverage and identified gaps. Investigation only - no code changes.

Findings:
- Consumer regression risk (main concern): entry->timestamp on the TS wire is
  now an offset from buffer->startTime, so every composite buffer restarts
  near 0. The rusEFI console parser
  (java_console/models/.../composite/CompositeParser.java) assumes
  monotonically increasing timestamps and treats any decrease as a uint32
  overflow, adding 2^32 us (~71.6 min) - with per-buffer-relative stamps it
  will add that on nearly every buffer, wrecking the time axis of
  console composite/VCD/Logicdata output. PR #9871 did not touch the Java
  side. The absolute base (startTime) is not transmitted, so the consumer
  cannot reconstruct real time at all. TS-proper behavior unverified (closed
  source, same wire format). Upside firmware-side: the old absolute-us stamp
  wrapped uint32 at ~71.6 min uptime; relative stamps max out around 5 s
  (buffer flush period), so wrap is gone - the fix direction is right, the
  consumer contract is the problem.
- Re-enable while enabled: TS_SET_LOGGER_SWITCH calls EnableToothLogger()
  directly (e.g. composite enable arriving twice, or Full <-> PrimaryTooth
  switch) without DisableToothLogger(). Mailboxes are then not in reset
  state: resumeX() is a no-op, and the new code no longer drains
  filledBuffers (the old drain loop was removed), while freeBuffers was
  never drained. postI() of all bufferCount buffers into a non-empty free
  mailbox silently drops the overflow and can leave the same CompositeBuffer
  pointer queued in both freeBuffers and filledBuffers -> consumer can read
  a buffer the producer is concurrently refilling. Pre-existing weakness,
  slightly aggravated by dropping the drain. Clean path
  (disable-then-enable) is fine because chMBReset empties the mailbox.
- CSV recovery math checked OK: USF2NT(float) is integer-exact for offsets
  < 2^24 us and buffer lifetime is capped at 5 s, so no precision loss.

Coverage status:
- unit_tests/tests/test_tooth_logger.cpp covers only the CSV path
  (WriteCsvHeader + WriteCsvRows, both pass). WriteCsvRows sets
  startTime = 0, so the new "recover absolute time" logic degenerates to
  identity - a regression back to treating c.timestamp as absolute would
  still pass.
- The code PR #9871 actually changed (enable/disable queue lifecycle,
  findBuffer, production SetNextCompositeEntry, ReturnToothLoggerBuffer) is
  inside the "#else // not EFI_UNIT_TEST" block - compiled out of the test
  binary and replaced by the events-vector stub, so it has zero unit-test
  coverage and cannot gain any without refactoring (mailbox shim or
  extracting buffer management). Only the simulator exercises it.

Recommended coverage additions (in priority order):
1. CSV row test with nonzero startTime (e.g. 100 s) verifying sec.usec output
   equals startTime + offset - pins the new recovery math. Add an offset near
   the 5 s buffer max.
2. Java CompositeParserTest case feeding two consecutive buffers whose
   timestamps restart at 0 - documents/exposes the +2^32 jump and anchors
   whatever consumer-side fix is chosen.
3. Full-buffer CSV test (nextIdx = toothLoggerEntriesPerBuffer) for bounds.
4. Longer term: make the buffer/mailbox lifecycle host-testable (extract from
   the !EFI_UNIT_TEST block behind a small queue abstraction), then test:
   entries relative to startTime, post-on-full, 5 s timeout flush,
   disable/enable reset, and enable-while-enabled not duplicating buffers.

Open follow-ups:
- Decide the consumer-side story for relative timestamps (update
  CompositeParser to accumulate per-buffer, or transmit the base time);
  verify what TS itself does with the composite stream.
- Consider making EnableToothLogger() drain/reset both mailboxes
  unconditionally (resetI + resumeX) to make re-enable safe.

## 2026-07-20 - ToothLogger CSV: regression test for absolute-time recovery

Follow-up to the PR #9871 review above: implemented recommendation 1.

What was done: added ToothLogger.WriteCsvRowsRecoverAbsoluteTime to
unit_tests/tests/test_tooth_logger.cpp. The buffer's startTime is set to
100 s after boot (US2NT(100'000'000), US_TO_NT_MULTIPLIER = 100 on host)
and three entries carry microsecond offsets 0 / 1'000'002 / 4'999'999
(first entry, mid-buffer, and just under the 5 s flush period - the largest
offset a buffer can hold). The test asserts each CSV row starts with the
recovered absolute timestamp: 100.000000 / 101.000002 / 104.999999.

Validation:
- Test passes on current master (3/3 in the ToothLogger suite).
- Negative check performed: temporarily reverted the writer to the
  pre-#9871 code (printing c.timestamp as absolute) - the test failed with
  rows 0.000000 / 1.000002 / 4.999999 as expected, then restored the source.
  Confirms the test pins the recover-time math and would catch a regression
  to treating the stored offset as absolute time.

Open follow-ups: unchanged from the review entry above (Java
CompositeParser multi-buffer test, full-buffer CSV bounds test,
host-testable buffer lifecycle).

## 2026-07-20 - ToothLogger CSV: full-buffer bounds test

Follow-up to the PR #9871 review: implemented recommendation 3.

What was done: added ToothLogger.WriteCsvFullBuffer to
unit_tests/tests/test_tooth_logger.cpp. Fills a CompositeBuffer completely
(nextIdx = toothLoggerEntriesPerBuffer = 250) with entries 20 ms apart
(last offset 4.980000 s, under the 5 s flush period) and asserts:
- exactly 250 CRLF-terminated rows are emitted (one per entry, no
  out-of-bounds extras),
- the returned byte total equals the bytes written,
- first row starts at 0.000000 and the final row is 4.980000 followed by
  the terminating CRLF at end of output.

Validation: full ToothLogger suite passes (4/4).

Build note (tooling quirk, self-inflicted): reverting
firmware/controllers/lua/generated/value_lookup_generated.cpp via git
checkout after a build breaks the next unit_tests build - the checked-in
copy is stale vs the checked-in config (references removed boardUse*
fields), and checkout makes the file newer than its generator inputs, so
make considers it fresh and does not regenerate. Recovery: touch
firmware/integration/rusefi_config.txt (or make clean) to force
regeneration. Leave build-regenerated files modified in the working tree;
just do not commit them.

## 2026-07-20 - Tooth logger buffer lifecycle made host-testable (ToothLoggerBufferPool)

Follow-up to the PR #9871 review: implemented recommendation 4 (long term).

What was done: extracted the production buffer/mailbox lifecycle out of the
"#if !EFI_UNIT_TEST" block in tooth_logger.cpp into a class that compiles in
all builds, and added host unit tests for it.

| File | Change |
|------|--------|
| firmware/console/binary/tooth_logger_buffer.h | new: ToothLoggerBufferPool - free/filled queues, current buffer, big-buffer handle, ready-indication callback; bufferCount now a class constant |
| firmware/console/binary/tooth_logger_buffer.cpp | new: startI/stopI/appendI/returnBufferI/getFilled/fetchFilled/flushCurrentI/hasDataI, logic moved verbatim from tooth_logger.cpp |
| firmware/console/binary/tooth_logger.cpp | prod block now delegates to a static ToothLoggerBufferPool{setToothLogReady}; EFI_UNIT_TEST stub (events vector) unchanged, so EngineTestHelper-based tests are unaffected |
| unit_tests/chibios-mock/mock-mailbox.h | new: host chibios_rt::Mailbox lookalike (postI/fetchI/fetch/resetI/resumeX/getUsedCountI, MSG_OK/MSG_TIMEOUT/MSG_RESET semantics per chmboxes.c; blocking fetch degenerates to non-blocking - tests are single-threaded) |
| unit_tests/tests/test_tooth_logger_buffer.cpp | new: 7 lifecycle tests |
| firmware/console/console.mk, unit_tests/tests/tests.mk | build wiring |

Key decisions and why:
- Class + delegation instead of compiling tooth_logger.cpp's free functions on
  host: EngineTestHelper's ctor calls EnableToothLogger() per test; routing
  that to the real pool would make every test grab the BigBuffer and collide
  with test_big_buffer/perf-trace usage. The stub stays; dedicated tests
  instantiate their own pool.
- The mock mailbox lives in unit_tests/chibios-mock/ (already on the include
  path) and claims the chibios_rt::Mailbox name, so the class header needs no
  ifdef around the member declarations and the mock is reusable for future
  extractions (e.g. loggingcentral).
- One intentional behavior fix: stopI() nulls the current buffer (the old
  DisableToothLogger left currentBuffer dangling into the released big
  buffer, so ToothLoggerHasData stayed true and the SD writer could flush a
  buffer now owned by another BigBuffer user).
- The ready flag (outputChannels.toothLogReady) is a constructor-injected
  callback; production passes setToothLogReady, tests capture into a bool.

Tests (all pass):
- StartStopBigBufferOwnership, StartFailsWhenBigBufferBusy (big-buffer
  arbitration, clean empty state)
- FillPostsBufferWithRelativeTimestamps (250th entry posts; startTime =
  first-event time; entries are us offsets from startTime; ready-flag
  set/clear transitions)
- StaleBufferFlushedAfter5Seconds (partial buffer posted on next append
  after 5 s)
- StopWhileConsumerHoldsBufferThenRestartClean (MSG_RESET tolerated,
  restart is clean and functional)
- EntriesDroppedWhenAllBuffersFull (bufferCount buffers drain full, excess
  entries dropped silently, logging resumes after buffers returned)
- FlushCurrentTakesPartialBuffer (SD idle-flush path)

Validation: full unit test suite passes (1103 tests, 222 suites);
f407-discovery firmware build succeeds (production path compiles+links, so
simulator via the same console.mk should too).

Gotcha found while writing tests: Timer::hasElapsedUs casts the signed
(now - lastReset) delta to uint32_t without a negative guard, so a Timer
reset to a timestamp even slightly in the FUTURE of getTimeNowNt() reads as
"huge elapsed" -> hasElapsedSec(5) true. In tests, event timestamps must not
run ahead of the virtual clock or every append trips the staleness flush
(getElapsedNt clamps negatives to 0; hasElapsedUs does not).
NOTE: commit ff6b9afe5c7 captured EntriesDroppedWhenAllBuffersFull *before*
this fix - the in-tree (uncommitted) version of the test is the passing one.

Open follow-ups:
- Enable-while-enabled remains unhardened (now cleanly testable): startI()
  during an active session fails via getBigBuffer, but the evaluation order
  in 'm_bufferHandle = getBigBuffer(...)' releases the held buffer while
  ToothLoggerEnabled stays true - producers keep writing into a region
  another user may now own.
- Java CompositeParser multi-buffer test (relative-timestamp regression)
  still pending.
