### PR TITLE
Add tooltips for fuel pressure sensor modes

### DIFF
--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -1705,7 +1705,7 @@ uint16_t tuneHidingKey;;"", 1, 0, 0, 20000, 0
 
 #define fuel_pressure_sensor_mode_e_enum "Absolute", "Gauge", "Differential", "INVALID"
 custom fuel_pressure_sensor_mode_e 1 bits, U08, @OFFSET@, [0:1], @@fuel_pressure_sensor_mode_e_enum@@
-fuel_pressure_sensor_mode_e fuelPressureSensorMode
+fuel_pressure_sensor_mode_e fuelPressureSensorMode;Absolute: Sensor reads ~100 kPa (14.7 psi) with engine off and no fuel pressure.\nGauge: Sensor reads 0 with engine off and no fuel pressure (most common standard 0-10 bar / 0-150 psi sensors).\nDifferential: Sensor is connected to intake manifold vacuum and measures pressure difference directly.
 
 switch_input_pin_e[LUA_DIGITAL_INPUT_COUNT iterate] luaDigitalInputPins;
 	int16_t ALSMinRPM;;"rpm", 1, 0, 0, 20000, 0


### PR DESCRIPTION
Adds help text for `fuelPressureSensorMode` in TunerStudio so users easily know which option to pick:

- **Absolute**: Reads ~100 kPa (14.7 psi) key ON / engine off.
- **Gauge**: Reads 0 with engine off (most common 0-10 bar / 0-150 psi sensors).
- **Differential**: Connected directly to intake manifold vacuum.