### PR TITLE
Console: better UI on tune tab

### DIFF
--- a/java_console/ui/src/main/java/com/rusefi/ui/TuningPane.java
+++ b/java_console/ui/src/main/java/com/rusefi/ui/TuningPane.java
@@ -36,6 +36,7 @@ import java.util.function.Consumer;
  * Andrey Belomutskiy, (c) 2013-2026
  */
 public class TuningPane {
+    private static final int MENU_WIDTH = 360;
     private static final Logging log = Logging.getLogging(TuningPane.class);
     private static final String TUNING_CARD = "tuning";
     private static final String LOAD_CARD = "load";
@@ -107,7 +108,9 @@ public class TuningPane {
         }
 
         JSplitPane splitPane = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT, left.getContentPane(), rightScrollPane);
-        splitPane.setResizeWeight(0.3);
+        left.getContentPane().setMinimumSize(new Dimension(180, 0));
+        splitPane.setDividerLocation(MENU_WIDTH);
+        splitPane.setResizeWeight(0);
 
         left.setOnSelect(subMenu -> {
             BinaryProtocol bp = uiContext.getBinaryProtocol();

--- a/java_console/ui/src/main/java/com/rusefi/ui/widgets/tune/CalibrationDialogWidget.java
+++ b/java_console/ui/src/main/java/com/rusefi/ui/widgets/tune/CalibrationDialogWidget.java
@@ -58,7 +58,7 @@ public class CalibrationDialogWidget {
     private ConfigurationImage workingImage;
     private IniFileModel currentIniFileModel;
     private TriggerImageHelper.Channel triggerImageChannel = TriggerImageHelper.Channel.PRIMARY;
-    private int fieldRowVerticalMargin;
+    private int fieldRowVerticalMargin = 3;
     private final List<ExpressionRow> expressionRows = new ArrayList<>();
     private final List<IndicatorPanel> indicatorPanels = new ArrayList<>();
     private final List<ReadoutLabelEntry> readoutEntries = new ArrayList<>();
@@ -205,7 +205,8 @@ public class CalibrationDialogWidget {
 
             applyLayout(contentPane, dialogModel.getLayoutHint());
             contentPane.setAlignmentX(Component.LEFT_ALIGNMENT);
-            fillPanel(contentPane, dialogModel, iniFileModel, ci);
+            fillPanel(contentPane, dialogModel, iniFileModel, ci,
+                getFieldLabelWidth(dialogModel, iniFileModel, new HashSet<>()));
 
             if (triggerImageHelper.isTriggerPanel(dialogModel.getKey(), uiName)) {
                 triggerImageHelper.addTriggerPanelExtras(contentPane);
@@ -277,7 +278,8 @@ public class CalibrationDialogWidget {
         contentPane.repaint();
     }
 
-    private void fillPanel(JPanel container, DialogModel dialogModel, IniFileModel iniFileModel, ConfigurationImage ci) {
+    private void fillPanel(JPanel container, DialogModel dialogModel, IniFileModel iniFileModel,
+                           ConfigurationImage ci, int fieldLabelWidth) {
         Runnable notifyEdit = () -> { if (onConfigChange != null) onConfigChange.accept(workingImage); };
 
         List<DialogModel.DialogEntry> entries = dialogModel.getOrderedEntries();
@@ -312,7 +314,7 @@ public class CalibrationDialogWidget {
 
             switch (entry.kind) {
                 case FIELD:
-                    renderField(container, entry.getAs(DialogModel.Field.class), iniFileModel, ci);
+                    renderField(container, entry.getAs(DialogModel.Field.class), iniFileModel, ci, fieldLabelWidth);
                     break;
                 case COMMAND:
                     container.add(CalibrationFieldFactory.createCommandRow(
@@ -327,7 +329,7 @@ public class CalibrationDialogWidget {
                     break;
                 case PANEL:
                     renderPanelEntry(container, entry.getAs(PanelModel.class), iniFileModel, ci,
-                            isBorderLayout, horizontalPanelRef, notifyEdit);
+                            isBorderLayout, horizontalPanelRef, notifyEdit, fieldLabelWidth);
                     break;
             }
         }
@@ -341,7 +343,27 @@ public class CalibrationDialogWidget {
         }
     }
 
-    private void renderField(JPanel container, DialogModel.Field field, IniFileModel iniFileModel, ConfigurationImage ci) {
+    private static int getFieldLabelWidth(DialogModel dialog, IniFileModel iniFileModel, Set<String> visited) {
+        if (dialog == null || !visited.add(dialog.getKey())) {
+            return 0;
+        }
+        int width = 0;
+        for (DialogModel.Field field : dialog.getFields()) {
+            if (!iniFileModel.findIniField(field.getKey()).isPresent()) {
+                continue;
+            }
+            JLabel label = new JLabel(field.getUiName());
+            CalibrationFieldFactory.applyStyle(label);
+            width = Math.max(width, label.getPreferredSize().width);
+        }
+        for (PanelModel panel : dialog.getPanels()) {
+            width = Math.max(width, getFieldLabelWidth(panel.resolveDialog(iniFileModel), iniFileModel, visited));
+        }
+        return Math.min(width, CalibrationFieldFactory.MAX_LABEL_WIDTH);
+    }
+
+    private void renderField(JPanel container, DialogModel.Field field, IniFileModel iniFileModel,
+                             ConfigurationImage ci, int fieldLabelWidth) {
         Runnable onChange = () -> {
             refreshExpressions();
             if ("trigger_type".equalsIgnoreCase(field.getKey()) ||
@@ -353,7 +375,8 @@ public class CalibrationDialogWidget {
         Optional<IniField> iniField = iniFileModel.findIniField(field.getKey());
         JPanel row = iniField.map(value -> {
             try {
-                return CalibrationFieldFactory.createFieldRow(field, value, ci, workingImage, onChange, onShowInPinout);
+                return CalibrationFieldFactory.createFieldRow(
+                    field, value, ci, workingImage, onChange, onShowInPinout, fieldLabelWidth);
             } catch (OrdinalOutOfRangeException e) {
                 log.warn("Skipping field " + field.getKey() + " with out-of-range ordinal: " + e.getMessage());
                 return CalibrationFieldFactory.createLabelRow(field);
@@ -423,7 +446,8 @@ public class CalibrationDialogWidget {
     }
 
     private void renderPanelEntry(JPanel container, PanelModel panel, IniFileModel iniFileModel, ConfigurationImage ci,
-                                  boolean isBorderLayout, JPanel[] horizontalPanelRef, Runnable notifyEdit) {
+                                  boolean isBorderLayout, JPanel[] horizontalPanelRef, Runnable notifyEdit,
+                                  int fieldLabelWidth) {
         String placement = panel.getPlacement();
 
         JPanel targetContainer;
@@ -493,7 +517,8 @@ public class CalibrationDialogWidget {
             }
             panelWidget.setName(uiName);
             GradientTitleBorder.installBorder(uiName, panelWidget);
-            fillPanel(panelWidget, subDialog, iniFileModel, ci);
+            fillPanel(panelWidget, subDialog, iniFileModel, ci,
+                Math.max(0, fieldLabelWidth - panelWidget.getInsets().left));
 
             if (triggerImageHelper.isTriggerPanel(subDialog.getKey(), uiName) || "Sub Panel".equals(uiName)) {
                 triggerImageHelper.addTriggerPanelExtras(panelWidget);

--- a/java_console/ui/src/main/java/com/rusefi/ui/widgets/tune/CalibrationFieldFactory.java
+++ b/java_console/ui/src/main/java/com/rusefi/ui/widgets/tune/CalibrationFieldFactory.java
@@ -4,6 +4,7 @@ import com.opensr5.ConfigurationImage;
 import com.opensr5.ConfigurationImageGetterSetter;
 import com.opensr5.ini.field.EnumIniField;
 import com.opensr5.ini.field.IniField;
+import com.opensr5.ini.field.StringIniField;
 import com.opensr5.ini.DialogModel;
 
 import javax.swing.*;
@@ -26,6 +27,8 @@ import java.util.regex.Pattern;
  * @see CalibrationDialogWidget
  */
 public class CalibrationFieldFactory {
+    static final int MAX_COMBO_WIDTH = 360;
+    static final int MAX_LABEL_WIDTH = 300;
 
     // we need to maintain this in sync with the ones used on tunerstudio.template
     private static final String[][] CheckboxPairs = {
@@ -42,11 +45,31 @@ public class CalibrationFieldFactory {
     }
 
     public static JPanel createFieldRow(DialogModel.Field field, IniField iniField, ConfigurationImage ci, ConfigurationImage workingImage, Runnable onChange, Consumer<String> onShowInPinout) {
+        return createFieldRow(field, iniField, ci, workingImage, onChange, onShowInPinout, 0);
+    }
+
+    static JPanel createFieldRow(DialogModel.Field field, IniField iniField, ConfigurationImage ci,
+                                 ConfigurationImage workingImage, Runnable onChange,
+                                 Consumer<String> onShowInPinout, int labelWidth) {
         JPanel row = createRowPanel();
         row.add(Box.createHorizontalStrut(10));
 
-        JLabel label = new JLabel(field.getUiName());
+        String labelText = field.getUiName();
+        JLabel label = new JLabel(labelText);
         applyStyle(label);
+        if (labelWidth > 0) {
+            if (labelText != null && label.getPreferredSize().width > labelWidth && !labelText.startsWith("<html>")) {
+                label.setText("<html><div style='width: " + (labelWidth - 4) + "px'>" +
+                    escapeHtml(labelText) + "</div></html>");
+                label.setToolTipText(labelText);
+            }
+            Dimension size = label.getPreferredSize();
+            size.width = labelWidth;
+            size.height = Math.min(size.height, label.getFontMetrics(label.getFont()).getHeight() * 2);
+            label.setMinimumSize(size);
+            label.setPreferredSize(size);
+            label.setMaximumSize(size);
+        }
         row.add(label);
         row.add(Box.createHorizontalStrut(16));
 
@@ -66,6 +89,10 @@ public class CalibrationFieldFactory {
 
         fixRowHeight(row);
         return row;
+    }
+
+    private static String escapeHtml(String text) {
+        return text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;");
     }
 
     /**
@@ -134,12 +161,17 @@ public class CalibrationFieldFactory {
         JComboBox<String> comboBox = new JComboBox<>(comboValues);
         applyStyle(comboBox);
         comboBox.setSelectedItem(cleanValue);
+        comboBox.setToolTipText(cleanValue);
         applyBackgroundColor(comboBox, cleanValue);
-        comboBox.setMaximumSize(comboBox.getPreferredSize());
+        Dimension size = comboBox.getPreferredSize();
+        size.width = Math.min(size.width, MAX_COMBO_WIDTH);
+        comboBox.setPreferredSize(size);
+        comboBox.setMaximumSize(size);
         comboBox.addActionListener(e -> {
             if (workingImage == null) return;
             String selected = (String) comboBox.getSelectedItem();
             if (selected != null) {
+                comboBox.setToolTipText(selected);
                 ConfigurationImageGetterSetter.setValue2(iniField, workingImage, iniField.getName(), selected);
                 if (onChange != null) onChange.run();
             }
@@ -195,7 +227,9 @@ public class CalibrationFieldFactory {
     }
 
     private static JTextField createTextField(IniField iniField, String currentValue, ConfigurationImage workingImage, Runnable onChange) {
-        JTextField textField = new JTextField(currentValue);
+        int columns = iniField instanceof StringIniField
+            ? Math.min(((StringIniField) iniField).getSize(), 32) : 0;
+        JTextField textField = new JTextField(currentValue, columns);
         applyStyle(textField);
         applyBackgroundColor(textField, currentValue);
         textField.setMaximumSize(textField.getPreferredSize());

--- a/java_console/ui/src/main/java/com/rusefi/ui/widgets/tune/IndicatorPanel.java
+++ b/java_console/ui/src/main/java/com/rusefi/ui/widgets/tune/IndicatorPanel.java
@@ -25,6 +25,7 @@ import java.util.List;
  * the user edits a field (dialog indicators) or to drive the initial render.
  */
 public class IndicatorPanel {
+    static final int GRID_INDICATOR_WIDTH = 110;
     private final JPanel panel;
     private final List<IndicatorModel> indicators;
     private final IniFileModel ini;
@@ -49,7 +50,7 @@ public class IndicatorPanel {
 
         for (IndicatorModel model : this.indicators) {
             JLabel label = makeLabel();
-            fixPreferredSize(label, model, ini);
+            fixPreferredSize(label, model, ini, columns > 0 ? GRID_INDICATOR_WIDTH : 0);
             panel.add(label);
         }
 
@@ -103,7 +104,7 @@ public class IndicatorPanel {
      * Locks the label's preferred/minimum size to the widest text it can ever show,
      * considering both on/off states and all enum options for bitStringValue labels.
      */
-    static void fixPreferredSize(JLabel label, IndicatorModel model, IniFileModel ini) {
+    static void fixPreferredSize(JLabel label, IndicatorModel model, IniFileModel ini, int fixedWidth) {
         if (ini == null) return;
         List<String> candidates = new ArrayList<>();
         candidates.addAll(TsStringFunction.allPossibleResolutions(model.getOnLabel(), ini));
@@ -119,9 +120,10 @@ public class IndicatorPanel {
         }
         label.setText(saved);
         if (maxW > 0) {
-            Dimension fixed = new Dimension(maxW, maxH);
+            Dimension fixed = new Dimension(fixedWidth > 0 ? fixedWidth : maxW, maxH);
             label.setPreferredSize(fixed);
             label.setMinimumSize(fixed);
+            label.setMaximumSize(fixed);
         }
     }
 
@@ -154,6 +156,7 @@ public class IndicatorPanel {
             fg = parseColor(indicator.getOffFg());
         }
         label.setText(text);
+        label.setToolTipText(text);
         label.setBackground(bg);
         label.setForeground(fg);
     }

--- a/java_console/ui/src/main/java/com/rusefi/ui/widgets/tune/MainMenuTreeWidget.java
+++ b/java_console/ui/src/main/java/com/rusefi/ui/widgets/tune/MainMenuTreeWidget.java
@@ -153,6 +153,7 @@ public class MainMenuTreeWidget {
         });
 
         JPanel topPanel = new JPanel(new BorderLayout());
+        searchField.putClientProperty("JTextField.placeholderText", "search here");
         searchField.getDocument().addDocumentListener(new DocumentListener() {
             @Override
             public void insertUpdate(DocumentEvent e) {
@@ -184,8 +185,8 @@ public class MainMenuTreeWidget {
         buttonPanel.add(expandAll);
         buttonPanel.add(collapseAll);
 
-        topPanel.add(searchField, BorderLayout.CENTER);
-        topPanel.add(buttonPanel, BorderLayout.EAST);
+        topPanel.add(searchField, BorderLayout.NORTH);
+        topPanel.add(buttonPanel, BorderLayout.SOUTH);
 
         contentPane.add(topPanel, BorderLayout.NORTH);
         contentPane.add(new JScrollPane(tree), BorderLayout.CENTER);

--- a/java_console/ui/src/main/java/com/rusefi/ui/widgets/tune/TuningTableView.java
+++ b/java_console/ui/src/main/java/com/rusefi/ui/widgets/tune/TuningTableView.java
@@ -18,6 +18,7 @@ import java.awt.event.MouseEvent;
 import java.util.Optional;
 
 public class TuningTableView {
+    private static final int TOOLBAR_GAP = 6;
     private final JTable table = new JTable();
     private final Surface3DView surface3DView = new Surface3DView();
     private final CardLayout cardLayout = new CardLayout();
@@ -84,6 +85,7 @@ public class TuningTableView {
         JPanel topPanel = new JPanel();
         topPanel.setLayout(new BoxLayout(topPanel, BoxLayout.X_AXIS));
         topPanel.setAlignmentX(Component.LEFT_ALIGNMENT);
+        topPanel.setBorder(BorderFactory.createEmptyBorder(4, 8, 4, 8));
         topPanel.add(new JLabel(title));
         topPanel.add(Box.createHorizontalStrut(10));
         topPanel.add(view3d);
@@ -91,9 +93,13 @@ public class TuningTableView {
         if (!viewMode) {
             topPanel.add(Box.createHorizontalStrut(10));
             topPanel.add(new JLabel("delta:"));
+            topPanel.add(Box.createHorizontalStrut(TOOLBAR_GAP));
             topPanel.add(deltaField);
+            topPanel.add(Box.createHorizontalStrut(TOOLBAR_GAP));
             topPanel.add(upButton);
+            topPanel.add(Box.createHorizontalStrut(TOOLBAR_GAP));
             topPanel.add(downButton);
+            topPanel.add(Box.createHorizontalStrut(TOOLBAR_GAP));
             topPanel.add(equalsButton);
         }
 
@@ -336,13 +342,18 @@ public class TuningTableView {
 
         private String formatNumber(Object value) {
             if (value instanceof Number) {
-                return String.format("%." + precision + "f", ((Number) value).doubleValue()).replace(',', '.');
+                return String.format("%." + precision + "f", ((Number) value).doubleValue())
+                    .replace(',', '.').replaceFirst("\\.0+$", "");
             }
             return String.valueOf(value);
         }
     }
 
     private class GradientRenderer extends DefaultTableCellRenderer {
+        GradientRenderer() {
+            setHorizontalAlignment(SwingConstants.CENTER);
+        }
+
         @Override
         public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected, boolean hasFocus, int row, int column) {
             Component c = super.getTableCellRendererComponent(table, value, isSelected, hasFocus, row, column);

--- a/java_console/ui/src/test/java/com/rusefi/ui/widgets/tune/CalibrationDialogWidgetTest.java
+++ b/java_console/ui/src/test/java/com/rusefi/ui/widgets/tune/CalibrationDialogWidgetTest.java
@@ -2,6 +2,7 @@ package com.rusefi.ui.widgets.tune;
 
 import com.opensr5.ConfigurationImage;
 import com.opensr5.ini.DialogModel;
+import com.opensr5.ini.IndicatorModel;
 import com.opensr5.ini.IniFileModel;
 import com.opensr5.ini.PanelModel;
 import com.opensr5.ini.TableModel;
@@ -414,6 +415,118 @@ public class CalibrationDialogWidgetTest {
         assertNotNull(comboBox);
         assertEquals(Color.RED, comboBox.getBackground());
         assertEquals(Color.WHITE, comboBox.getForeground());
+    }
+
+    @Test
+    public void testGridIndicatorsHaveFixedWidth() {
+        IndicatorModel indicator = new IndicatorModel("{value}",
+            "A very long disabled indicator label", "A very long enabled indicator label",
+            "white", "black", "green", "black");
+        IndicatorPanel panel = new IndicatorPanel(Collections.singletonList(indicator), mock(IniFileModel.class), 2);
+
+        assertEquals(IndicatorPanel.GRID_INDICATOR_WIDTH,
+            panel.getPanel().getComponent(0).getPreferredSize().width);
+    }
+
+    @Test
+    public void testLongComboIsWidthLimited() {
+        String longOption = "B18 VVT2 or Idle or Low Side output 2 or injector 8 with flyback protection";
+        EnumIniField field = createEnumField(longOption, "NONE");
+        ConfigurationImage image = new ConfigurationImage(new byte[1]);
+        JPanel row = CalibrationFieldFactory.createFieldRow(
+            new DialogModel.Field("test", "Output"), field, image, image.clone());
+
+        JComboBox<?> combo = null;
+        for (Component component : row.getComponents()) {
+            if (component instanceof JComboBox) {
+                combo = (JComboBox<?>) component;
+                break;
+            }
+        }
+        assertNotNull(combo);
+        assertEquals(CalibrationFieldFactory.MAX_COMBO_WIDTH, combo.getPreferredSize().width);
+        assertEquals(longOption, combo.getToolTipText());
+    }
+
+    @Test
+    public void testLongFieldLabelWrapsToTwoRows() {
+        String text = "Use absolute fuel pressure for dead time calculation";
+        com.opensr5.ini.field.StringIniField field =
+            new com.opensr5.ini.field.StringIniField("test", 0, 10);
+        ConfigurationImage image = new ConfigurationImage(new byte[10]);
+        JPanel row = CalibrationFieldFactory.createFieldRow(
+            new DialogModel.Field("test", text), field, image, image.clone(), null, null, 200);
+
+        JLabel label = getLabelFromRow(row);
+        assertNotNull(label);
+        assertTrue(label.getText().startsWith("<html>"));
+        assertEquals(text, label.getToolTipText());
+        int lineHeight = label.getFontMetrics(label.getFont()).getHeight();
+        assertTrue(label.getPreferredSize().height > lineHeight);
+        assertTrue(label.getPreferredSize().height <= lineHeight * 2);
+    }
+
+    @Test
+    public void testFieldEditorsShareColumn() {
+        IniFileModel iniFileModel = mock(IniFileModel.class);
+        when(iniFileModel.getCurves()).thenReturn(Collections.emptyMap());
+
+        com.opensr5.ini.field.StringIniField shortField =
+            new com.opensr5.ini.field.StringIniField("short", 0, 10);
+        com.opensr5.ini.field.StringIniField longField =
+            new com.opensr5.ini.field.StringIniField("long", 10, 17);
+        when(iniFileModel.findIniField("short")).thenReturn(java.util.Optional.of(shortField));
+        when(iniFileModel.findIniField("long")).thenReturn(java.util.Optional.of(longField));
+
+        DialogModel nestedDialog = new DialogModel("nested", "Nested",
+            Collections.singletonList(new DialogModel.Field("long", "A much longer field label")),
+            Collections.emptyList());
+        Map<String, DialogModel> dialogs = new HashMap<>();
+        dialogs.put("nested", nestedDialog);
+        when(iniFileModel.getDialogs()).thenReturn(dialogs);
+
+        DialogModel mainDialog = new DialogModel("main", "Main",
+            Collections.singletonList(new DialogModel.Field("short", "Mode")),
+            Collections.emptyList(),
+            Collections.singletonList(new PanelModel("nested", "north", null, null)), null);
+
+        CalibrationDialogWidget widget = new CalibrationDialogWidget(new UIContext());
+        widget.update(mainDialog, iniFileModel, new ConfigurationImage(new byte[27]));
+
+        JPanel content = widget.getContentPane();
+        JPanel firstRow = (JPanel) content.getComponent(0);
+        JPanel nestedPanel = (JPanel) content.getComponent(1);
+        JPanel secondRow = (JPanel) nestedPanel.getComponent(0);
+        layoutTree(content);
+
+        JTextField firstEditor = getTextFieldFromRow(firstRow);
+        JTextField secondEditor = getTextFieldFromRow(secondRow);
+        assertNotNull(firstEditor);
+        assertNotNull(secondEditor);
+        assertEquals(10, firstEditor.getColumns());
+        assertEquals(17, secondEditor.getColumns());
+        assertEquals(
+            SwingUtilities.convertPoint(firstRow, firstEditor.getLocation(), content).x,
+            SwingUtilities.convertPoint(secondRow, secondEditor.getLocation(), content).x);
+    }
+
+    private static void layoutTree(Container container) {
+        container.setSize(container.getPreferredSize());
+        container.doLayout();
+        for (Component component : container.getComponents()) {
+            if (component instanceof Container) {
+                layoutTree((Container) component);
+            }
+        }
+    }
+
+    private static JTextField getTextFieldFromRow(JPanel row) {
+        for (Component component : row.getComponents()) {
+            if (component instanceof JTextField) {
+                return (JTextField) component;
+            }
+        }
+        return null;
     }
 
     @Test

--- a/java_console/ui/src/test/java/com/rusefi/ui/widgets/tune/TuningTableViewTest.java
+++ b/java_console/ui/src/test/java/com/rusefi/ui/widgets/tune/TuningTableViewTest.java
@@ -8,6 +8,7 @@ import com.rusefi.config.FieldType;
 import org.junit.jupiter.api.Test;
 
 import javax.swing.*;
+import java.awt.*;
 import java.awt.event.MouseEvent;
 import java.util.Optional;
 
@@ -118,17 +119,30 @@ public class TuningTableViewTest {
     public void testDecimalPoints() {
         TuningTableView view = new TuningTableView("Test");
         JTable table = findTable(view.getContent());
-        Double[][] data = {{1.0, 2.55}, {3.0, 4.0}};
+        Double[][] data = {{1.0, 2.55}, {3.0, 1.2}};
         // Precision 2
         TuningTableView.TuningTableModel model = new TuningTableView.TuningTableModel(data, new Double[]{100.0, 200.0}, new Double[]{10.0, 20.0}, 2);
         table.setModel(model);
 
-        // data[1][0] is 3.0, with precision 2 it should be "3.00"
-        assertEquals("3.00", table.getValueAt(0, 1));
-        // data[1][1] is 4.0, with precision 2 it should be "4.00"
-        assertEquals("4.00", table.getValueAt(0, 2));
+        // Whole numbers omit an all-zero decimal part.
+        assertEquals("3", table.getValueAt(0, 1));
+        assertEquals("1", table.getValueAt(1, 1));
+        // Non-zero decimal parts keep the configured precision.
+        assertEquals("1.20", table.getValueAt(0, 2));
         // data[0][1] is 2.55, with precision 2 it should be "2.55"
         assertEquals("2.55", table.getValueAt(1, 2));
+    }
+
+    @Test
+    public void testNumbersAreCentered() {
+        TuningTableView view = new TuningTableView("Test");
+        JTable table = findTable(view.getContent());
+        table.setModel(new TuningTableView.TuningTableModel(
+            new Double[][]{{1.0}}, new Double[]{100.0}, new Double[]{10.0}, 1));
+
+        Component renderer = table.prepareRenderer(table.getCellRenderer(0, 1), 0, 1);
+        assertTrue(renderer instanceof JLabel);
+        assertEquals(SwingConstants.CENTER, ((JLabel) renderer).getHorizontalAlignment());
     }
 
     @Test


### PR DESCRIPTION
grid & correct width for inputs

<img width="827" height="540" alt="image" src="https://github.com/user-attachments/assets/fd5a3ee6-2d06-4612-9ced-e7eda3c44df0" />

also we cap the max width of the inputs, so we dont break views with center things like this one:

<img width="1577" height="624" alt="image" src="https://github.com/user-attachments/assets/0ad6e42c-654f-4bad-bf35-3a8c6a731a7c" />

added the searchbar placeholder, and a more reasonable default width:
<img width="377" height="288" alt="image" src="https://github.com/user-attachments/assets/4cf2d46b-d32b-4a66-9f1c-1fe0acccbd8b" />

tables button also have the grid layout, trimed the .0 for the values on the tables, so we dont see things like 10.000

<img width="659" height="590" alt="image" src="https://github.com/user-attachments/assets/757ab54c-39b4-485f-a6d6-00a9c5091bb4" />



related #9898