### PR TITLE
TriggerImageHelper, CalibrationDialogWidget: refactor for better testing, resolve grid layout issue

### DIFF
--- a/java_console/ui/src/main/java/com/rusefi/ui/widgets/tune/CalibrationDialogWidget.java
+++ b/java_console/ui/src/main/java/com/rusefi/ui/widgets/tune/CalibrationDialogWidget.java
@@ -54,10 +54,9 @@ public class CalibrationDialogWidget {
 
     private final JPanel contentPane = new ScrollablePanel();
     private final UIContext uiContext;
-    private final TriggerImageHelper triggerImageHelper = new TriggerImageHelper();
+    private final List<Runnable> triggerImageUpdaters = new ArrayList<>();
     private ConfigurationImage workingImage;
     private IniFileModel currentIniFileModel;
-    private TriggerImageHelper.Channel triggerImageChannel = TriggerImageHelper.Channel.PRIMARY;
     private int fieldRowVerticalMargin = 3;
     private final List<ExpressionRow> expressionRows = new ArrayList<>();
     private final List<IndicatorPanel> indicatorPanels = new ArrayList<>();
@@ -194,13 +193,13 @@ public class CalibrationDialogWidget {
         indicatorPanels.clear();
         readoutEntries.clear();
         gaugeReadoutEntries.clear();
+        triggerImageUpdaters.clear();
         contentPane.removeAll();
         if (dialogModel != null) {
             String uiName = dialogModel.getUiName();
             if (uiName == null || uiName.isEmpty()) {
                 uiName = dialogModel.getKey();
             }
-            triggerImageChannel = triggerImageHelper.getChannel(dialogModel.getKey(), uiName);
             contentPane.setName(uiName);
 
             applyLayout(contentPane, dialogModel.getLayoutHint());
@@ -208,9 +207,8 @@ public class CalibrationDialogWidget {
             fillPanel(contentPane, dialogModel, iniFileModel, ci,
                 getFieldLabelWidth(dialogModel, iniFileModel, new HashSet<>()));
 
-            if (triggerImageHelper.isTriggerPanel(dialogModel.getKey(), uiName)) {
-                triggerImageHelper.addTriggerPanelExtras(contentPane);
-                updateTriggerImage();
+            if (TriggerImageHelper.isTriggerPanel(dialogModel.getKey(), uiName)) {
+                addTriggerImage(contentPane, dialogModel.getKey(), uiName);
             }
         }
         contentPane.revalidate();
@@ -520,14 +518,8 @@ public class CalibrationDialogWidget {
             fillPanel(panelWidget, subDialog, iniFileModel, ci,
                 Math.max(0, fieldLabelWidth - panelWidget.getInsets().left));
 
-            if (triggerImageHelper.isTriggerPanel(subDialog.getKey(), uiName) || "Sub Panel".equals(uiName)) {
-                triggerImageHelper.addTriggerPanelExtras(panelWidget);
-                TriggerImageHelper.Channel channel = triggerImageHelper.getChannel(subDialog.getKey(), uiName);
-                if (channel == TriggerImageHelper.Channel.SECONDARY) {
-                    triggerImageHelper.updateVvtTriggerImage(currentIniFileModel, workingImage);
-                } else {
-                    triggerImageHelper.updateTriggerImage(currentIniFileModel, workingImage, channel);
-                }
+            if (TriggerImageHelper.isTriggerPanel(subDialog.getKey(), uiName) || "Sub Panel".equals(uiName)) {
+                addTriggerImage(panelWidget, subDialog.getKey(), uiName);
             }
         } else {
             panelWidget.setName(panel.getPanelName());
@@ -581,11 +573,20 @@ public class CalibrationDialogWidget {
     }
 
     private void updateTriggerImage() {
-        if (triggerImageChannel == TriggerImageHelper.Channel.SECONDARY) {
-            triggerImageHelper.updateVvtTriggerImage(currentIniFileModel, workingImage);
-        } else {
-            triggerImageHelper.updateTriggerImage(currentIniFileModel, workingImage, triggerImageChannel);
+        for (Runnable updater : triggerImageUpdaters) {
+            updater.run();
         }
+    }
+
+    private void addTriggerImage(JPanel panel, String key, String uiName) {
+        TriggerImageHelper helper = new TriggerImageHelper();
+        helper.addTriggerPanelExtras(panel);
+        TriggerImageHelper.Channel channel = TriggerImageHelper.getChannel(key, uiName);
+        Runnable updater = channel == TriggerImageHelper.Channel.SECONDARY
+            ? () -> helper.updateVvtTriggerImage(currentIniFileModel, workingImage)
+            : () -> helper.updateTriggerImage(currentIniFileModel, workingImage, channel);
+        triggerImageUpdaters.add(updater);
+        updater.run();
     }
 
     /** Pushes the current working image to all indicator panels (called when config fields change). */

--- a/java_console/ui/src/main/java/com/rusefi/ui/widgets/tune/TriggerImageHelper.java
+++ b/java_console/ui/src/main/java/com/rusefi/ui/widgets/tune/TriggerImageHelper.java
@@ -215,13 +215,13 @@ public class TriggerImageHelper {
         return triggerImagePanel;
     }
 
-    public Channel getChannel(String key, String uiName) {
+    public static Channel getChannel(String key, String uiName) {
         return TRIGGER_CAMS.equalsIgnoreCase(key) || CAM_INPUTS_UI_NAME.equalsIgnoreCase(uiName)
             ? Channel.SECONDARY
             : Channel.PRIMARY;
     }
 
-    public boolean isTriggerPanel(String key, String uiName) {
+    public static boolean isTriggerPanel(String key, String uiName) {
         return TRIGGER_PRIMARY.equalsIgnoreCase(key) ||
                 TRIGGER_CAMS.equalsIgnoreCase(key) ||
                 PRIMARY_TRIGGER_UI_NAME.equalsIgnoreCase(uiName) ||

--- a/java_console/ui/src/test/java/com/rusefi/ui/widgets/tune/TriggerPaneTest.java
+++ b/java_console/ui/src/test/java/com/rusefi/ui/widgets/tune/TriggerPaneTest.java
@@ -156,28 +156,40 @@ public class TriggerPaneTest {
             "pageReadCommand = \"r\"\n" +
             "page = 1\n" +
             "field1 = scalar, F32, 0, \"unit\", 1, 0, 0, 100, 1\n" +
+            "trigger_type = scalar, U08, 3, \"\", 1, 0, 0, 255, 0\n" +
             "vvtMode1 = scalar, U08, 4, \"\", 1, 0, 0, 32, 0\n" +
             "vvtMode2 = scalar, U08, 5, \"\", 1, 0, 0, 32, 0\n" +
             "[SettingContextHelp]\n" +
             "; SettingContextHelpEnd\n" +
             "\n" +
+            "\tdialog = trigger_primary, \"Primary Trigger\"\n" +
+            "\t\tfield = \"Trigger type\", trigger_type\n" +
             "\tdialog = trigger_cams, \"Cam Inputs\"\n" +
             "\t\tfield = \"Cam mode\", vvtMode1\n" +
             "\t\tfield = \"Exhaust cam mode\", vvtMode2\n" +
-            "\t\tfield = \"Field 1\", field1\n";
+            "\t\tfield = \"Field 1\", field1\n" +
+            "\tdialog = triggerConfiguration, \"\", xAxis\n" +
+            "\t\tpanel = trigger_primary\n" +
+            "\t\tpanel = trigger_cams\n";
 
         RawIniFile lines = IniFileReaderUtil.read(new java.io.ByteArrayInputStream(string.getBytes()));
         IniFileModel model = IniFileReaderUtil.readIniFile(lines, "test.ini", new com.opensr5.ini.IniFileMetaInfoImpl(lines));
         ConfigurationImage image = new ConfigurationImage(new byte[100]);
+        image.getContent()[3] = 1; // TT_FORD_ASPIRE
         image.getContent()[4] = 9; // VVT_NISSAN_VQ
         image.getContent()[5] = 8; // VVT_BARRA_3_PLUS_1
 
         CalibrationDialogWidget widget = new CalibrationDialogWidget(new UIContext());
-        widget.update("trigger_cams", model, image);
+        widget.update("triggerConfiguration", model, image);
 
         JPanel content = widget.getContentPane();
+        JPanel primaryPanel = findPanelByName(content, "Primary Trigger");
         JPanel panelWidget = findPanelByName(content, "Cam Inputs");
 
+        assertNotNull(primaryPanel, "Should find a panel widget named 'Primary Trigger'");
+        assertTrue(hasEastPanel(primaryPanel), "Should find a crank preview beside the Primary Trigger fields");
+        JPanel primaryImagePanel = (JPanel) getEastPanel(primaryPanel).getComponent(0);
+        assertEquals(1, primaryImagePanel.getComponentCount(), "Primary Trigger should retain its crank wheel");
         assertNotNull(panelWidget, "Should find a panel widget named 'Cam Inputs'");
         assertTrue(hasEastPanel(panelWidget), "Should find a trigger preview beside the Cam Inputs fields");
         JPanel triggerImagePanel = (JPanel) getEastPanel(panelWidget).getComponent(0);


### PR DESCRIPTION
resolves the placement of the trigger images, we also show the second cam trigger now (like in the wizard)

<img width="1919" height="830" alt="image" src="https://github.com/user-attachments/assets/214add72-e09a-411b-b7a4-fc9cc9a12146" />


resolves #9898 