### PR TITLE
Support explicit firmware update paths, specify direction of the firmware update

### DIFF
--- a/java_console/ui/src/main/java/com/rusefi/maintenance/CalibrationsHelper.java
+++ b/java_console/ui/src/main/java/com/rusefi/maintenance/CalibrationsHelper.java
@@ -55,6 +55,10 @@ public class CalibrationsHelper {
      *  (no live ECU to read pre-flash like the auto path does). [tag:better_ux_for_flashing] */
     private static volatile Optional<CalibrationsInfo> lastEcuCalibrations = Optional.empty();
 
+    public enum FirmwareUpdatePolicy {
+        FORWARD_MIGRATION
+    }
+
     public static class MergeResult {
         public final Optional<CalibrationsInfo> mergedCalibrations;
         public final List<String> failedFields;
@@ -185,6 +189,21 @@ public class CalibrationsHelper {
         final UpdateOperationCallbacks callbacks,
         final Supplier<Boolean> updateFirmware,
         final ConnectivityContext connectivityContext
+    ) {
+        return updateFirmwareAndRestorePreviousCalibrations(
+            parent, originalEcuPort, bp, lm, callbacks, updateFirmware, connectivityContext,
+            FirmwareUpdatePolicy.FORWARD_MIGRATION);
+    }
+
+    public static boolean updateFirmwareAndRestorePreviousCalibrations(
+        final JComponent parent,
+        final PortResult originalEcuPort,
+        @Nullable final BinaryProtocol bp,
+        @Nullable final LinkManager lm,
+        final UpdateOperationCallbacks callbacks,
+        final Supplier<Boolean> updateFirmware,
+        final ConnectivityContext connectivityContext,
+        final FirmwareUpdatePolicy policy
     ) {
         AutoupdateUtil.assertNotAwtThread();
 

--- a/java_console/ui/src/main/java/com/rusefi/maintenance/DfuFlasher.java
+++ b/java_console/ui/src/main/java/com/rusefi/maintenance/DfuFlasher.java
@@ -52,17 +52,44 @@ public class DfuFlasher {
         final UpdateOperationCallbacks callbacks,
         final ConnectivityContext connectivityContext
     ) {
+        return doAutoDfu(parent, port, bp, lm, callbacks, connectivityContext, null);
+    }
+
+    public static boolean doAutoDfu(
+        final JComponent parent,
+        final PortResult port,
+        final BinaryProtocol bp,
+        final LinkManager lm,
+        final UpdateOperationCallbacks callbacks,
+        final ConnectivityContext connectivityContext,
+        final @Nullable String firmwareBinFile
+    ) {
+        return doAutoDfu(parent, port, bp, lm, callbacks, connectivityContext, firmwareBinFile,
+            CalibrationsHelper.FirmwareUpdatePolicy.FORWARD_MIGRATION);
+    }
+
+    public static boolean doAutoDfu(
+        final JComponent parent,
+        final PortResult port,
+        final BinaryProtocol bp,
+        final LinkManager lm,
+        final UpdateOperationCallbacks callbacks,
+        final ConnectivityContext connectivityContext,
+        final @Nullable String firmwareBinFile,
+        final CalibrationsHelper.FirmwareUpdatePolicy policy
+    ) {
         return CalibrationsHelper.updateFirmwareAndRestorePreviousCalibrations(
             parent, port, bp, lm, callbacks,
-            () -> dfuUpdateFirmware(parent, port.port, callbacks, connectivityContext.getConnectedEcuTarget()),
-            connectivityContext);
+            () -> dfuUpdateFirmware(parent, port.port, callbacks, connectivityContext.getConnectedEcuTarget(), firmwareBinFile),
+            connectivityContext, policy);
     }
 
     private static boolean dfuUpdateFirmware(
         final JComponent parent,
         final String port,
         final UpdateOperationCallbacks callbacks,
-        final ConnectedEcuTarget connectedEcuTarget
+        final ConnectedEcuTarget connectedEcuTarget,
+        final @Nullable String firmwareBinFile
     ) {
         if (port == null) {
             JOptionPane.showMessageDialog(parent, "Failed to locate serial ports");
@@ -80,7 +107,10 @@ public class DfuFlasher {
             }
 
             timeForDfuSwitch(callbacks);
-            if (executeDFU(callbacks, FindFileHelper.findFirmwareFileForConnectedBoard(connectedEcuTarget), connectedEcuTarget)) {
+            final String fileName = firmwareBinFile != null
+                ? firmwareBinFile
+                : FindFileHelper.findFirmwareFileForConnectedBoard(connectedEcuTarget);
+            if (executeDFU(callbacks, fileName, connectedEcuTarget)) {
                 // We need to wait to allow connection to ECU port (see #7403)
                 timeForDfuSwitch(callbacks);
                 return true;

--- a/java_console/ui/src/main/java/com/rusefi/maintenance/ProgramSelector.java
+++ b/java_console/ui/src/main/java/com/rusefi/maintenance/ProgramSelector.java
@@ -348,11 +348,40 @@ public class ProgramSelector {
         UpdateOperationCallbacks callbacks,
         ConnectivityContext connectivityContext
     ) {
-        return updateFirmwareAndRestorePreviousCalibrations(
-            parent, ecuPort, bp, lm, callbacks, () -> bltUpdateFirmware(parent, ecuPort, callbacks, connectivityContext), connectivityContext);
+        return flashOpenbltSerialAutomatic(parent, ecuPort, bp, lm, callbacks, connectivityContext, null);
     }
 
-    private static boolean bltUpdateFirmware(JComponent parent, PortResult ecuPort, UpdateOperationCallbacks callbacks, ConnectivityContext connectivityContext) {
+    public static boolean flashOpenbltSerialAutomatic(
+        JComponent parent,
+        PortResult ecuPort,
+        BinaryProtocol bp,
+        LinkManager lm,
+        UpdateOperationCallbacks callbacks,
+        ConnectivityContext connectivityContext,
+        @Nullable String firmwareSrecFile
+    ) {
+        return flashOpenbltSerialAutomatic(parent, ecuPort, bp, lm, callbacks, connectivityContext,
+            firmwareSrecFile, CalibrationsHelper.FirmwareUpdatePolicy.FORWARD_MIGRATION);
+    }
+
+    public static boolean flashOpenbltSerialAutomatic(
+        JComponent parent,
+        PortResult ecuPort,
+        BinaryProtocol bp,
+        LinkManager lm,
+        UpdateOperationCallbacks callbacks,
+        ConnectivityContext connectivityContext,
+        @Nullable String firmwareSrecFile,
+        CalibrationsHelper.FirmwareUpdatePolicy policy
+    ) {
+        return updateFirmwareAndRestorePreviousCalibrations(
+            parent, ecuPort, bp, lm, callbacks,
+            () -> bltUpdateFirmware(parent, ecuPort, callbacks, connectivityContext, firmwareSrecFile),
+            connectivityContext, policy);
+    }
+
+    private static boolean bltUpdateFirmware(JComponent parent, PortResult ecuPort, UpdateOperationCallbacks callbacks,
+                                             ConnectivityContext connectivityContext, @Nullable String firmwareSrecFile) {
         // Suspend the scanner for the entire reboot → detect → flash sequence so it
         // never races with our direct port probes for exclusive COM port access on Windows.
         try {
@@ -361,7 +390,7 @@ public class ProgramSelector {
             Thread.currentThread().interrupt();
         }
         try {
-            return bltUpdateFirmwareWithSuspendedScanner(parent, ecuPort, callbacks, connectivityContext);
+            return bltUpdateFirmwareWithSuspendedScanner(parent, ecuPort, callbacks, connectivityContext, firmwareSrecFile);
         } finally {
             // Invalidate the cache so the scanner re-inspects the port (now running new
             // firmware) on its first post-resume scan cycle.
@@ -370,7 +399,10 @@ public class ProgramSelector {
         }
     }
 
-    private static boolean bltUpdateFirmwareWithSuspendedScanner(JComponent parent, PortResult ecuPort, UpdateOperationCallbacks callbacks, ConnectivityContext connectivityContext) {
+    private static boolean bltUpdateFirmwareWithSuspendedScanner(JComponent parent, PortResult ecuPort,
+                                                                 UpdateOperationCallbacks callbacks,
+                                                                 ConnectivityContext connectivityContext,
+                                                                 @Nullable String firmwareSrecFile) {
         // Snapshot pre-existing OpenBLT ports so we can ignore them when searching
         // for the newly-appeared bootloader port after the reboot.
         final List<PortResult> openBltPortsBefore = connectivityContext.getCurrentHardware().getKnownPorts(OpenBlt);
@@ -406,7 +438,8 @@ public class ProgramSelector {
 
         callbacks.logLine("Serial port " + openbltPort + " appeared, programming firmware...");
 
-        return flashOpenbltSerial(parent, openbltPort, callbacks, connectivityContext.getConnectedEcuTarget());
+        return flashOpenbltSerial(
+            parent, openbltPort, callbacks, connectivityContext.getConnectedEcuTarget(), firmwareSrecFile);
     }
 
     private static OpenbltJni.OpenbltCallbacks makeOpenbltCallbacks(UpdateOperationCallbacks callbacks) {
@@ -439,7 +472,13 @@ public class ProgramSelector {
     }
 
     public static boolean flashOpenbltSerial(JComponent parent, String port, UpdateOperationCallbacks callbacks,
-                                             com.rusefi.core.io.ConnectedEcuTarget connectedEcuTarget) {
+                                              com.rusefi.core.io.ConnectedEcuTarget connectedEcuTarget) {
+        return flashOpenbltSerial(parent, port, callbacks, connectedEcuTarget, null);
+    }
+
+    public static boolean flashOpenbltSerial(JComponent parent, String port, UpdateOperationCallbacks callbacks,
+                                             com.rusefi.core.io.ConnectedEcuTarget connectedEcuTarget,
+                                             @Nullable String firmwareSrecFile) {
         if (FileLog.is32bitJava()) {
             showError32bitJava(parent);
             return false;
@@ -447,7 +486,9 @@ public class ProgramSelector {
 
         OpenbltJni.OpenbltCallbacks cb = makeOpenbltCallbacks(callbacks);
 
-        String fileName = FindFileHelper.findSrecFileForConnectedBoard(connectedEcuTarget);
+        String fileName = firmwareSrecFile != null
+            ? firmwareSrecFile
+            : FindFileHelper.findSrecFileForConnectedBoard(connectedEcuTarget);
         if (fileName == null) {
             callbacks.logLine(".srec image file not found");
             return false;

--- a/java_console/ui/src/main/java/com/rusefi/maintenance/jobs/DfuAutoJob.java
+++ b/java_console/ui/src/main/java/com/rusefi/maintenance/jobs/DfuAutoJob.java
@@ -6,18 +6,38 @@ import com.rusefi.binaryprotocol.BinaryProtocol;
 import com.rusefi.io.LinkManager;
 import com.rusefi.io.UpdateOperationCallbacks;
 import com.rusefi.maintenance.DfuFlasher;
+import com.rusefi.maintenance.CalibrationsHelper;
 import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
 
 public class DfuAutoJob extends AbstractAutoFlashJob {
+    @Nullable
+    private final String firmwareBinFile;
+    private final CalibrationsHelper.FirmwareUpdatePolicy policy;
+
     public DfuAutoJob(final PortResult port, final JComponent parent, final ConnectivityContext connectivityContext,
                       final @Nullable LinkManager linkManager) {
+        this(port, parent, connectivityContext, linkManager, null);
+    }
+
+    public DfuAutoJob(final PortResult port, final JComponent parent, final ConnectivityContext connectivityContext,
+                      final @Nullable LinkManager linkManager, final @Nullable String firmwareBinFile) {
+        this(port, parent, connectivityContext, linkManager, firmwareBinFile,
+            CalibrationsHelper.FirmwareUpdatePolicy.FORWARD_MIGRATION);
+    }
+
+    public DfuAutoJob(final PortResult port, final JComponent parent, final ConnectivityContext connectivityContext,
+                      final @Nullable LinkManager linkManager, final @Nullable String firmwareBinFile,
+                      final CalibrationsHelper.FirmwareUpdatePolicy policy) {
         super("DFU update", port, parent, connectivityContext, linkManager);
+        this.firmwareBinFile = firmwareBinFile;
+        this.policy = policy;
     }
 
     @Override
     protected boolean flash(final LinkManager lm, final BinaryProtocol bp, final UpdateOperationCallbacks callbacks) {
-        return DfuFlasher.doAutoDfu(context.getParent(), context.getPort(), bp, lm, callbacks, connectivityContext);
+        return DfuFlasher.doAutoDfu(
+            context.getParent(), context.getPort(), bp, lm, callbacks, connectivityContext, firmwareBinFile, policy);
     }
 }

--- a/java_console/ui/src/main/java/com/rusefi/maintenance/jobs/OpenBltAutoJob.java
+++ b/java_console/ui/src/main/java/com/rusefi/maintenance/jobs/OpenBltAutoJob.java
@@ -6,19 +6,38 @@ import com.rusefi.binaryprotocol.BinaryProtocol;
 import com.rusefi.io.LinkManager;
 import com.rusefi.io.UpdateOperationCallbacks;
 import com.rusefi.maintenance.ProgramSelector;
+import com.rusefi.maintenance.CalibrationsHelper;
 import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
 
 public class OpenBltAutoJob extends AbstractAutoFlashJob {
+    @Nullable
+    private final String firmwareSrecFile;
+    private final CalibrationsHelper.FirmwareUpdatePolicy policy;
+
     public OpenBltAutoJob(final PortResult port, final JComponent parent, final ConnectivityContext connectivityContext,
                           final @Nullable LinkManager linkManager) {
+        this(port, parent, connectivityContext, linkManager, null);
+    }
+
+    public OpenBltAutoJob(final PortResult port, final JComponent parent, final ConnectivityContext connectivityContext,
+                          final @Nullable LinkManager linkManager, final @Nullable String firmwareSrecFile) {
+        this(port, parent, connectivityContext, linkManager, firmwareSrecFile,
+            CalibrationsHelper.FirmwareUpdatePolicy.FORWARD_MIGRATION);
+    }
+
+    public OpenBltAutoJob(final PortResult port, final JComponent parent, final ConnectivityContext connectivityContext,
+                          final @Nullable LinkManager linkManager, final @Nullable String firmwareSrecFile,
+                          final CalibrationsHelper.FirmwareUpdatePolicy policy) {
         super("OpenBLT via Serial", port, parent, connectivityContext, linkManager);
+        this.firmwareSrecFile = firmwareSrecFile;
+        this.policy = policy;
     }
 
     @Override
     protected boolean flash(final LinkManager lm, final BinaryProtocol bp, final UpdateOperationCallbacks callbacks) {
         return ProgramSelector.flashOpenbltSerialAutomatic(
-            context.getParent(), context.getPort(), bp, lm, callbacks, connectivityContext);
+            context.getParent(), context.getPort(), bp, lm, callbacks, connectivityContext, firmwareSrecFile, policy);
     }
 }


### PR DESCRIPTION
here we allow custom code for the direction of the update (update/revert), and a custom file instead of the most recent one (for the revert case); still without any wiring of the revert path


related #9907