### PR TITLE
revert to one of recent versions when on LTS branch

### DIFF
--- a/java_console/autoupdate/src/main/java/com/rusefi/autoupdate/Autoupdate.java
+++ b/java_console/autoupdate/src/main/java/com/rusefi/autoupdate/Autoupdate.java
@@ -22,6 +22,7 @@ import java.io.*;
 import java.net.URI;
 import java.net.URL;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.Date;
@@ -724,6 +725,120 @@ public class Autoupdate {
             log.info("[universal_bundle] downloadZipForTarget (" + (obfuscated ? "obfuscated" : "public")
                 + ") not available for " + info.getTarget() + ": " + e);
             return null;
+        }
+    }
+
+    public static FirmwareArtifacts downloadFirmware(FirmwareRollbackResolver.Build build,
+                                                      ConnectionAndMeta.DownloadProgressListener progress,
+                                                      Consumer<String> logger) {
+        Path ltsRoot = Paths.get(userHomeSubDirectory, "lts");
+        return downloadFirmware(build, progress, logger, ltsRoot, Autoupdate::downloadFirmwareZip);
+    }
+
+    @FunctionalInterface
+    interface FirmwareZipDownloader {
+        Path download(FirmwareRollbackResolver.Build build, Path destination, boolean obfuscated,
+                      ConnectionAndMeta.DownloadProgressListener progress, Consumer<String> logger) throws IOException;
+    }
+
+    static FirmwareArtifacts downloadFirmware(FirmwareRollbackResolver.Build build,
+                                               ConnectionAndMeta.DownloadProgressListener progress,
+                                               Consumer<String> logger,
+                                               Path ltsRoot,
+                                               FirmwareZipDownloader downloader) {
+        try {
+            Path destination = ltsRoot.resolve(build.getBoard())
+                .resolve(build.getBranch())
+                .resolve(build.getSha())
+                .toAbsolutePath();
+            Files.createDirectories(destination);
+
+            Path zip = downloader.download(build, destination, false, progress, logger);
+            if (zip == null) {
+                zip = downloader.download(build, destination, true, progress, logger);
+            }
+            if (zip == null) {
+                logger.accept("Firmware build " + build.getSha() + " is unavailable");
+                return FirmwareArtifacts.empty();
+            }
+
+            final String[] paths = new String[2];
+            FileUtil.unzip(zip.toString(), destination.toFile(), entry -> {
+                if (!isFirmwareArtifact.test(entry)) {
+                    return false;
+                }
+                String lower = entry.getName().toLowerCase();
+                String absolutePath = destination.resolve(entry.getName()).normalize().toAbsolutePath().toString();
+                if (lower.endsWith(".srec")) {
+                    paths[0] = absolutePath;
+                } else if (isDfuBin(lower)) {
+                    paths[1] = absolutePath;
+                }
+                return true;
+            });
+            FirmwareArtifacts artifacts = new FirmwareArtifacts(paths[0], paths[1]);
+            if (!artifacts.getSrecPath().isPresent() && !artifacts.getBinPath().isPresent()) {
+                logger.accept("Firmware build " + build.getSha() + " contains no SREC or BIN artifact");
+            }
+            return artifacts;
+        } catch (IOException e) {
+            log.error("Firmware download failed for " + build.getSha() + ": " + e);
+            logger.accept("Firmware download failed: " + e.getMessage());
+            return FirmwareArtifacts.empty();
+        }
+    }
+
+    private static Path downloadFirmwareZip(FirmwareRollbackResolver.Build build, Path destination,
+                                            boolean obfuscated,
+                                            ConnectionAndMeta.DownloadProgressListener progress,
+                                            Consumer<String> logger) throws IOException {
+        String suffix = obfuscated ? "_obfuscated_public" : "";
+        String fileName = ConnectionAndMeta.getWhiteLabel(ConnectionAndMeta.getProperties())
+            + "_bundle_" + build.getBoard() + suffix + "_autoupdate.zip";
+        Path localZip = destination.resolve(fileName);
+        String baseUrl = build.getDirectoryUrl() + "autoupdate/";
+        try {
+            ConnectionAndMeta connectionAndMeta = new ConnectionAndMeta(fileName).invoke(baseUrl);
+            if (AutoupdateUtil.hasExistingFile(localZip.toString(), connectionAndMeta.getCompleteFileSize(),
+                connectionAndMeta.getLastModified())) {
+                logger.accept("Using cached firmware build " + build.getSha());
+            } else {
+                logger.accept("Downloading firmware build " + build.getSha()
+                    + (obfuscated ? " (obfuscated)" : ""));
+                ConnectionAndMeta.downloadFile(localZip.toString(), connectionAndMeta, progress);
+            }
+            return localZip;
+        } catch (IOException e) {
+            Files.deleteIfExists(localZip);
+            log.info("Firmware ZIP " + fileName + " is unavailable: " + e);
+            return null;
+        }
+    }
+
+    private static boolean isDfuBin(String lowerName) {
+        return lowerName.endsWith("rusefi.bin")
+            || (lowerName.contains("rusefi_") && lowerName.endsWith(".bin"));
+    }
+
+    public static final class FirmwareArtifacts {
+        private final Optional<String> srecPath;
+        private final Optional<String> binPath;
+
+        private FirmwareArtifacts(String srecPath, String binPath) {
+            this.srecPath = Optional.ofNullable(srecPath);
+            this.binPath = Optional.ofNullable(binPath);
+        }
+
+        private static FirmwareArtifacts empty() {
+            return new FirmwareArtifacts(null, null);
+        }
+
+        public Optional<String> getSrecPath() {
+            return srecPath;
+        }
+
+        public Optional<String> getBinPath() {
+            return binPath;
         }
     }
 

--- a/java_console/autoupdate/src/test/java/com/rusefi/autoupdate/AutoupdateFirmwareDownloadTest.java
+++ b/java_console/autoupdate/src/test/java/com/rusefi/autoupdate/AutoupdateFirmwareDownloadTest.java
@@ -1,0 +1,90 @@
+package com.rusefi.autoupdate;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AutoupdateFirmwareDownloadTest {
+    private static final String SHA = "cae1680e40511aa8d798edf60f4cb0c95ce3d841";
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void fallsBackToObfuscatedZipAndExtractsOnlyFirmware() {
+        FirmwareRollbackResolver.Build build = build();
+        List<Boolean> attempts = new ArrayList<>();
+
+        Autoupdate.FirmwareArtifacts artifacts = Autoupdate.downloadFirmware(
+            build, ignored -> {}, ignored -> {}, tempDir,
+            (ignoredBuild, destination, obfuscated, progress, logger) -> {
+                attempts.add(obfuscated);
+                if (!obfuscated) {
+                    return null;
+                }
+                return createFirmwareZip(destination.resolve("firmware.zip"));
+            });
+
+        assertEquals(Arrays.asList(false, true), attempts);
+        Path expectedDirectory = tempDir.resolve("uaefi-121/lts-26-test/" + SHA).toAbsolutePath();
+        assertEquals(expectedDirectory.resolve("firmware.srec").toString(), artifacts.getSrecPath().orElse(null));
+        assertEquals(expectedDirectory.resolve("rusefi.bin").toString(), artifacts.getBinPath().orElse(null));
+        assertTrue(Files.exists(expectedDirectory.resolve("firmware.srec")));
+        assertTrue(Files.exists(expectedDirectory.resolve("rusefi.bin")));
+        assertTrue(Files.exists(expectedDirectory.resolve("openblt.bin")));
+        assertFalse(Files.exists(expectedDirectory.resolve("console/rusefi_console.jar")));
+        assertFalse(Files.exists(expectedDirectory.resolve("console/release.txt")));
+    }
+
+    @Test
+    void returnsEmptyArtifactsWhenBothZipNamesAreUnavailable() {
+        List<Boolean> attempts = new ArrayList<>();
+
+        Autoupdate.FirmwareArtifacts artifacts = Autoupdate.downloadFirmware(
+            build(), ignored -> {}, ignored -> {}, tempDir,
+            (ignoredBuild, destination, obfuscated, progress, logger) -> {
+                attempts.add(obfuscated);
+                return null;
+            });
+
+        assertEquals(Arrays.asList(false, true), attempts);
+        assertFalse(artifacts.getSrecPath().isPresent());
+        assertFalse(artifacts.getBinPath().isPresent());
+    }
+
+    private static FirmwareRollbackResolver.Build build() {
+        String html = "<a href=\"" + SHA + "/\">build</a> 2026-07-23 19:26 -";
+        return FirmwareRollbackResolver.parseIndex(html, "uaefi-121", "lts-26-test",
+            "https://example.test/uaefi-121/lts-26-test/").get(0);
+    }
+
+    private static Path createFirmwareZip(Path zip) throws IOException {
+        try (ZipOutputStream output = new ZipOutputStream(Files.newOutputStream(zip))) {
+            add(output, "firmware.srec");
+            add(output, "rusefi.bin");
+            add(output, "openblt.bin");
+            add(output, "console/rusefi_console.jar");
+            add(output, "console/release.txt");
+        }
+        return zip;
+    }
+
+    private static void add(ZipOutputStream output, String name) throws IOException {
+        output.putNextEntry(new ZipEntry(name));
+        output.write(name.getBytes(StandardCharsets.UTF_8));
+        output.closeEntry();
+    }
+}

--- a/java_console/shared_io/src/main/resources/shared_io.properties
+++ b/java_console/shared_io/src/main/resources/shared_io.properties
@@ -15,3 +15,4 @@ vin_number_prefix=
 show_engine_sniffer_tab=true
 show_pinout_tab=true
 autoupdate_bundle=true
+firmware_rollback_enabled=false

--- a/java_console/ui/build.gradle
+++ b/java_console/ui/build.gradle
@@ -4,6 +4,7 @@ configurations {
 }
 
 dependencies {
+    implementation project(':autoupdate')
     implementation project(':connectivity')
     implementation project(':ts_plugin')
     implementation project(':trigger-ui')

--- a/java_console/ui/src/main/java/com/rusefi/ConsoleUI.java
+++ b/java_console/ui/src/main/java/com/rusefi/ConsoleUI.java
@@ -221,6 +221,9 @@ public class ConsoleUI {
         WizardContainer wizardContainer = new WizardContainer(uiContext);
         rootPanel.add(wizardContainer, "wizard");
 
+        JPanel rollbackPicker = new JPanel(new BorderLayout());
+        rootPanel.add(rollbackPicker, "rollback");
+
         CardLayout rootCardLayout = (CardLayout) rootPanel.getLayout();
 
         JButton launchWizardButton = getLaunchWizardButton(rootPanel, wizardContainer, rootCardLayout);
@@ -396,7 +399,14 @@ console live data tab is broken #8402
             }
             // Single-session device manager [tag:better_ux_for_flashing]: the scanner is kept alive for the whole console
             // lifetime so this one instance can hook / remove / re-connect / DFU / OpenBLT the board.
-            DevicePane devicePane = new DevicePane(uiContext, connectivityContext, deviceSessionManager, tabbedPane.tabbedPane);
+            DevicePane devicePane = new DevicePane(
+                uiContext, connectivityContext, deviceSessionManager, tabbedPane.tabbedPane,
+                picker -> {
+                    rollbackPicker.removeAll();
+                    rollbackPicker.add(picker, BorderLayout.CENTER);
+                    rootCardLayout.show(rootPanel, "rollback");
+                },
+                () -> rootCardLayout.show(rootPanel, "console"));
             tabbedPane.addTab("Device", devicePane.getContent());
             mainFrame.setUpdateEcuAction(() -> {
                 tabbedPane.selectTab("Device");

--- a/java_console/ui/src/main/java/com/rusefi/DevicePane.java
+++ b/java_console/ui/src/main/java/com/rusefi/DevicePane.java
@@ -3,6 +3,7 @@ package com.rusefi;
 import com.rusefi.core.preferences.storage.PersistentConfiguration;
 import com.rusefi.maintenance.ProgramSelector;
 import com.rusefi.ui.UIContext;
+import com.rusefi.ui.basic.FirmwareRollbackController;
 import com.rusefi.ui.basic.MigrateSettingsCheckboxState;
 import com.rusefi.ui.basic.SingleAsyncJobExecutor;
 import com.rusefi.ui.basic.StatusPanelWithProgressBar;
@@ -12,6 +13,8 @@ import javax.swing.*;
 import java.awt.*;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
+import java.util.function.Consumer;
 
 /**
  * The live console's "Device" tab — a single-session device manager [tag:better_ux_for_flashing].
@@ -32,6 +35,7 @@ public class DevicePane {
     private final JComboBox<PortResult> comboPorts = new JComboBox<>();
     private final ProgramSelector selector;
     private final SingleAsyncJobExecutor jobExecutor;
+    private final FirmwareRollbackController rollbackController;
     private final StatusPanelWithProgressBar statusPanel = new StatusPanelWithProgressBar();
     private final JCheckBox autoUpdateBundle = new JCheckBox("Auto-update Software", AutoupdateProperty.get());
     private final JCheckBox migrateSettings = new JCheckBox("Migrate Settings", true);
@@ -40,7 +44,8 @@ public class DevicePane {
     private SessionState lastRenderedState;
 
     public DevicePane(final UIContext uiContext, final ConnectivityContext connectivityContext,
-                      final DeviceSessionManager sessionManager, final JTabbedPane tabbedPane) {
+                      final DeviceSessionManager sessionManager, final JTabbedPane tabbedPane,
+                      final Consumer<JComponent> showRollbackPicker, final Runnable closeRollbackPicker) {
         this.connectivityContext = connectivityContext;
         this.sessionManager = sessionManager;
         this.tabbedPane = tabbedPane;
@@ -54,6 +59,19 @@ public class DevicePane {
         this.selector = new ProgramSelector(connectivityContext, comboPorts);
         selector.setJobExecutor(jobExecutor);
         selector.setLinkManager(uiContext.getLinkManager());
+        rollbackController = new FirmwareRollbackController(
+            connectivityContext,
+            statusPanel,
+            jobExecutor,
+            () -> Optional.ofNullable((PortResult) comboPorts.getSelectedItem()),
+            () -> sessionManager.getState() == SessionState.CONNECTED,
+            this::refreshFirmwareControls,
+            showRollbackPicker,
+            closeRollbackPicker);
+        rollbackController.setLinkManager(uiContext.getLinkManager());
+        selector.setFirmwareUpdateInterceptor(rollbackController::startLatestUpdate);
+        selector.setExternalBusySupplier(rollbackController::isBusy);
+        selector.addFirmwareControl(rollbackController.getRollbackButton());
 
         // Compact controls pinned to the top; the status log + progress bar fill the rest and the bar
         // sits at the bottom of the pane (as elsewhere in the console). No connect/disconnect here — the
@@ -103,6 +121,7 @@ public class DevicePane {
         reselectPort(ports, previouslySelected);
 
         // ProgramSelector builds the DFU / OpenBLT menu straight from the detected hardware.
+        rollbackController.refresh((PortResult) comboPorts.getSelectedItem());
         selector.apply(effectiveHardware);
         final boolean flashing = state == SessionState.FLASHING;
         autoUpdateBundle.setEnabled(!flashing);
@@ -115,6 +134,13 @@ public class DevicePane {
         lockConsoleForState(state);
 
         lastRenderedState = state;
+        content.revalidate();
+        content.repaint();
+    }
+
+    private void refreshFirmwareControls() {
+        selector.apply(connectivityContext.getCurrentHardware());
+        rollbackController.refreshButton();
         content.revalidate();
         content.repaint();
     }

--- a/java_console/ui/src/main/java/com/rusefi/StartupFrame.java
+++ b/java_console/ui/src/main/java/com/rusefi/StartupFrame.java
@@ -86,6 +86,7 @@ public class StartupFrame {
     private static final String CARD_SCANNING = "scanning";
     private static final String CARD_STARTUP = "startup";
     private static final String CARD_WIZARD = "wizard";
+    private static final String CARD_ROLLBACK = "rollback";
     // After this delay with no single-ECU auto-connect in flight, reveal the full connect controls
     // instead of holding on the large scanning animation forever (#9715). Generous enough to cover a
     // typical scan -> auto-connect on a slow machine so the controls never flash before auto-connect.
@@ -133,6 +134,7 @@ public class StartupFrame {
     private final UIContext uiContext;
     private final CompletableFuture<Autoupdate.UpdateOutcome> softwareUpdateOutcome;
     private final JPanel rootContent = new JPanel(new CardLayout());
+    private final JPanel rollbackPicker = new JPanel(new BorderLayout());
     // The large "scanning" card shown first (#9715); its status line is updated to "Connecting to X…"
     // if a single-ECU auto-connect fires before the controls are revealed.
     private JLabel scanningStatusLabel;
@@ -430,7 +432,14 @@ public class StartupFrame {
         };
         BinaryProtocol.iniFileProvider.setStatusConsumer(firmwareStatusPanel);
         startupUpdateActions = new StartupUpdateActions(connectivityContext, firmwareStatusPanel,
-            asyncJobExecutor, ecuPortToUse, softwareUpdateOutcome);
+            asyncJobExecutor, ecuPortToUse, softwareUpdateOutcome,
+            picker -> {
+                rollbackPicker.removeAll();
+                rollbackPicker.add(picker, BorderLayout.CENTER);
+                showCard(CARD_ROLLBACK);
+            },
+            () -> showCard(CARD_STARTUP));
+        startupUpdateActions.configureFirmwareSelector(selector);
 
         JPanel firmwareTopPanel = new JPanel(new BorderLayout(0, 0));
         firmwareTopPanel.add(selector.getControl(), BorderLayout.NORTH);
@@ -438,6 +447,7 @@ public class StartupFrame {
         updateButtons.add(startupUpdateActions.getUpdateSoftwareStatus());
         updateButtons.add(startupUpdateActions.getUpdateSoftwareButton());
         updateButtons.add(startupUpdateActions.getUpdateFirmwareButton());
+        updateButtons.add(startupUpdateActions.getRollbackFirmwareButton());
         firmwareTopPanel.add(updateButtons, BorderLayout.CENTER);
         firmwareTopPanel.add(startupUpdateActions.getMigrateSettings(), BorderLayout.SOUTH);
 
@@ -474,6 +484,7 @@ public class StartupFrame {
         });
         rootContent.add(outerTabs, CARD_STARTUP);
         rootContent.add(wizardContainer, CARD_WIZARD);
+        rootContent.add(rollbackPicker, CARD_ROLLBACK);
         rootContent.add(createScanningPanel(), CARD_SCANNING);
         ((CardLayout) rootContent.getLayout()).show(rootContent, CARD_SCANNING);
 

--- a/java_console/ui/src/main/java/com/rusefi/maintenance/CalibrationsHelper.java
+++ b/java_console/ui/src/main/java/com/rusefi/maintenance/CalibrationsHelper.java
@@ -10,6 +10,9 @@ import com.rusefi.SerialPortType;
 import com.rusefi.binaryprotocol.BinaryProtocol;
 import com.rusefi.binaryprotocol.BinaryProtocolLocalCache;
 import com.rusefi.binaryprotocol.IniNotFoundException;
+import com.rusefi.config.generated.Integration;
+import com.rusefi.core.RusEfiSignature;
+import com.rusefi.core.SignatureHelper;
 import com.rusefi.core.ui.AutoupdateUtil;
 import com.rusefi.core.ui.CalibrationBackupFailureAction;
 import com.rusefi.core.ui.CalibrationBackupFailureDialog;
@@ -56,7 +59,8 @@ public class CalibrationsHelper {
     private static volatile Optional<CalibrationsInfo> lastEcuCalibrations = Optional.empty();
 
     public enum FirmwareUpdatePolicy {
-        FORWARD_MIGRATION
+        FORWARD_MIGRATION,
+        ROLLBACK_RESTORE_OR_RESET
     }
 
     public static class MergeResult {
@@ -304,6 +308,13 @@ public class CalibrationsHelper {
                 ));
 
                 if (skipCalibrationRestore) {
+                    if (policy == FirmwareUpdatePolicy.ROLLBACK_RESTORE_OR_RESET) {
+                        return resetRollbackDefaults(
+                            newEcuPort,
+                            timestampFileNameComponent,
+                            callbacks,
+                            connectivityContext);
+                    }
                     callbacks.logLine("Skipping calibration restore - ECU will use default configuration.");
                     final Optional<CalibrationsInfo> freshCalibrations = readAndBackupCurrentCalibrationsWithSuspendedPortScanner(
                         newEcuPort.port,
@@ -334,6 +345,15 @@ public class CalibrationsHelper {
                 }
                 if (!updatedCalibrations.isPresent()) {
                     callbacks.logLine("Failed to back up tune from ECU after firmware update...");
+
+                    if (policy == FirmwareUpdatePolicy.ROLLBACK_RESTORE_OR_RESET) {
+                        callbacks.logLine("Unable to verify the rolled-back calibration; resetting to firmware defaults.");
+                        return resetRollbackDefaults(
+                            newEcuPort,
+                            timestampFileNameComponent,
+                            callbacks,
+                            connectivityContext);
+                    }
 
                     if (isUiContext(callbacks)) {
                         CalibrationBackupFailureAction action = showCalibrationFailureDialog(
@@ -369,6 +389,16 @@ public class CalibrationsHelper {
                     } else {
                         return false;
                     }
+                }
+
+                if (policy == FirmwareUpdatePolicy.ROLLBACK_RESTORE_OR_RESET) {
+                    return restoreOrResetAfterRollback(
+                        newEcuPort,
+                        prevCalibrations.get(),
+                        updatedCalibrations.get(),
+                        timestampFileNameComponent,
+                        callbacks,
+                        connectivityContext);
                 }
 
                 // Try the strict-equivalent merge first: migrate every field, collecting any that fail.
@@ -469,6 +499,79 @@ public class CalibrationsHelper {
                 return false;
             }
         }
+    }
+
+    static boolean rollbackLayoutsMatch(final CalibrationsInfo before, final CalibrationsInfo after) {
+        final String beforeSignature = before.getIniFile().getSignature();
+        final String afterSignature = after.getIniFile().getSignature();
+        final RusEfiSignature beforeParsed = SignatureHelper.parse(beforeSignature);
+        final RusEfiSignature afterParsed = SignatureHelper.parse(afterSignature);
+        if (beforeParsed == null || afterParsed == null
+            || beforeParsed.getHash() == null || afterParsed.getHash() == null) {
+            return beforeSignature.equals(afterSignature);
+        }
+        return beforeParsed.getHash().equals(afterParsed.getHash());
+    }
+
+    private static boolean restoreOrResetAfterRollback(
+        final PortResult ecuPort,
+        final CalibrationsInfo before,
+        final CalibrationsInfo after,
+        final String timestampFileNameComponent,
+        final UpdateOperationCallbacks callbacks,
+        final ConnectivityContext connectivityContext
+    ) {
+        if (rollbackLayoutsMatch(before, after)) {
+            callbacks.logLine("Calibration layout is unchanged; restoring the pre-rollback tune.");
+            if (!CalibrationsUpdater.INSTANCE.updateCalibrations(
+                ecuPort.port,
+                before.getImage().getConfigurationImage(),
+                callbacks,
+                connectivityContext)) {
+                return false;
+            }
+            return readAndBackupCurrentCalibrationsWithSuspendedPortScanner(
+                ecuPort.port,
+                callbacks,
+                getFileNameWithoutExtension(timestampFileNameComponent, "rollback_restored_from_ecu"),
+                connectivityContext).isPresent();
+        }
+
+        callbacks.logLine("Calibration layout changed; reverse migration is unavailable. Resetting to firmware defaults.");
+        return resetRollbackDefaults(ecuPort, timestampFileNameComponent, callbacks, connectivityContext);
+    }
+
+    private static boolean resetRollbackDefaults(
+        final PortResult ecuPort,
+        final String timestampFileNameComponent,
+        final UpdateOperationCallbacks callbacks,
+        final ConnectivityContext connectivityContext
+    ) {
+        final boolean reset = BinaryProtocolExecutor.executeWithSuspendedPortScanner(
+            ecuPort.port,
+            callbacks,
+            binaryProtocol -> {
+                final byte[] response = binaryProtocol.executeCommand(
+                    Integration.TS_EXECUTE,
+                    BinaryProtocol.getTextCommandBytesOnlyText("rewriteconfig"),
+                    "rewriteconfig");
+                return response != null
+                    && response.length == 1
+                    && response[0] == (byte) Integration.TS_RESPONSE_OK;
+            },
+            false,
+            connectivityContext,
+            "rewriteconfig");
+        if (!reset) {
+            callbacks.logLine("Failed to reset calibration after firmware rollback.");
+            return false;
+        }
+
+        return readAndBackupCurrentCalibrationsWithSuspendedPortScanner(
+            ecuPort.port,
+            callbacks,
+            getFileNameWithoutExtension(timestampFileNameComponent, "rollback_defaults_from_ecu"),
+            connectivityContext).isPresent();
     }
 
     /**

--- a/java_console/ui/src/main/java/com/rusefi/maintenance/ProgramSelector.java
+++ b/java_console/ui/src/main/java/com/rusefi/maintenance/ProgramSelector.java
@@ -28,6 +28,8 @@ import java.util.List;
 import java.util.Objects;
 import java.io.EOFException;
 import java.util.concurrent.TimeUnit;
+import java.util.function.BooleanSupplier;
+import java.util.function.Function;
 
 import static com.devexperts.logging.Logging.getLogging;
 import static com.rusefi.SerialPortType.OpenBlt;
@@ -40,14 +42,17 @@ public class ProgramSelector {
     private static final Logging log = getLogging(ProgramSelector.class);
     private final JPanel content = new JPanel(new BorderLayout());
     private final JLabel noHardware = new JLabel("Nothing detected");
-    private final JPanel updateModeAndButton = new JPanel(new FlowLayout());
+    private final JPanel updateModeAndButton = new JPanel(new FlowLayout(FlowLayout.CENTER, 32, 5));
     private final JSplitButton splitButton = new JSplitButton("Update ECU Firmware", AutoupdateUtil.loadIcon("upload48.png"));
+    private final List<JComponent> additionalFirmwareControls = new ArrayList<>();
     private final ConnectivityContext connectivityContext;
     private final JComboBox<PortResult> comboPorts;
     @Nullable
     private SingleAsyncJobExecutor jobExecutor;
     @Nullable
     private LinkManager linkManager;
+    private Function<JComponent, Boolean> firmwareUpdateInterceptor = source -> false;
+    private BooleanSupplier externalBusy = () -> false;
 
     public ProgramSelector(ConnectivityContext connectivityContext, JComboBox<PortResult> comboPorts) {
         this.connectivityContext = connectivityContext;
@@ -61,6 +66,9 @@ public class ProgramSelector {
         updateModeAndButton.add(splitButton);
 
         splitButton.addActionListener(e -> {
+            if (firmwareUpdateInterceptor.apply(splitButton)) {
+                return;
+            }
             final PortResult targetPort = resolveFlashPort();
             executeJob(splitButton, mainButtonModeFor(targetPort), targetPort);
         });
@@ -118,6 +126,7 @@ public class ProgramSelector {
         } else {
             splitButton.setText("Update Firmware");
         }
+        matchFirmwareControlSizes();
     }
 
     private boolean isLiveConnection() {
@@ -227,11 +236,22 @@ public class ProgramSelector {
         this.linkManager = linkManager;
     }
 
+    public void setFirmwareUpdateInterceptor(Function<JComponent, Boolean> firmwareUpdateInterceptor) {
+        this.firmwareUpdateInterceptor = Objects.requireNonNull(firmwareUpdateInterceptor);
+    }
+
+    public void setExternalBusySupplier(BooleanSupplier externalBusy) {
+        this.externalBusy = Objects.requireNonNull(externalBusy);
+    }
+
     /**
      * Programmatically trigger the main "Update Firmware" action for the currently selected port —
      * same as clicking the split button. Used by the console's "Update ECU" menu shortcut [tag:better_ux_for_flashing].
      */
     public void triggerUpdateFirmware() {
+        if (firmwareUpdateInterceptor.apply(splitButton)) {
+            return;
+        }
         final PortResult targetPort = resolveFlashPort();
         if (targetPort == null) {
             // Nothing detected/selected — mirrors the split button being disabled in apply(). [tag:better_ux_for_flashing]
@@ -520,9 +540,25 @@ public class ProgramSelector {
         return content;
     }
 
+    public void addFirmwareControl(JComponent control) {
+        additionalFirmwareControls.add(control);
+        updateModeAndButton.add(control, 0);
+        matchFirmwareControlSizes();
+    }
+
+    private void matchFirmwareControlSizes() {
+        Dimension size = splitButton.getPreferredSize();
+        for (JComponent control : additionalFirmwareControls) {
+            control.setPreferredSize(size);
+        }
+    }
+
     public void apply(AvailableHardware currentHardware) {
+        boolean isJobRunning = (jobExecutor != null && !jobExecutor.isNotInProgress()) || externalBusy.getAsBoolean();
+        boolean additionalControlVisible = additionalFirmwareControls.stream().anyMatch(Component::isVisible);
         noHardware.setVisible(currentHardware.isEmpty());
-        updateModeAndButton.setVisible(!currentHardware.isEmpty());
+        updateModeAndButton.setVisible(shouldShowFirmwareControls(
+            currentHardware.isEmpty(), isJobRunning, additionalControlVisible));
 
         boolean hasSerialPorts = !currentHardware.getKnownPorts().isEmpty();
         boolean hasDfuDevice = currentHardware.isDfuFound();
@@ -560,7 +596,6 @@ public class ProgramSelector {
         }
 
         int menuItemCount = popupMenu.getComponentCount();
-        boolean isJobRunning = jobExecutor != null && !jobExecutor.isNotInProgress();
 
         splitButton.setPopupMenu(menuItemCount > 0 ? popupMenu : null);
         splitButton.setMainButtonEnabled(hasSerialPorts && !isJobRunning);
@@ -572,6 +607,14 @@ public class ProgramSelector {
 
         AutoupdateUtil.trueLayoutAndRepaint(splitButton);
         AutoupdateUtil.trueLayoutAndRepaint(content);
+    }
+
+    static boolean shouldShowFirmwareControls(
+        boolean hardwareEmpty,
+        boolean jobRunning,
+        boolean additionalControlVisible
+    ) {
+        return !hardwareEmpty || jobRunning || additionalControlVisible;
     }
 
     /**

--- a/java_console/ui/src/main/java/com/rusefi/ui/basic/FirmwareRollbackController.java
+++ b/java_console/ui/src/main/java/com/rusefi/ui/basic/FirmwareRollbackController.java
@@ -1,0 +1,418 @@
+package com.rusefi.ui.basic;
+
+import com.devexperts.logging.Logging;
+import com.rusefi.ConnectivityContext;
+import com.rusefi.PortResult;
+import com.rusefi.SerialPortType;
+import com.rusefi.autoupdate.Autoupdate;
+import com.rusefi.autoupdate.FirmwareRollbackResolver;
+import com.rusefi.core.io.BundleInfo;
+import com.rusefi.core.io.BundleUtil;
+import com.rusefi.core.net.PropertiesHolder;
+import com.rusefi.core.preferences.storage.PersistentConfiguration;
+import com.rusefi.core.ui.AutoupdateUtil;
+import com.rusefi.io.LinkManager;
+import com.rusefi.io.UpdateOperationCallbacks;
+import com.rusefi.maintenance.CalibrationsHelper;
+import com.rusefi.maintenance.jobs.AsyncJob;
+import com.rusefi.maintenance.jobs.DfuAutoJob;
+import com.rusefi.maintenance.jobs.OpenBltAutoJob;
+import com.rusefi.ui.wizard.FirmwareRollbackPanel;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.*;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.function.BooleanSupplier;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import static com.devexperts.logging.Logging.getLogging;
+
+/** Shared LTS firmware history action used by both startup and live Device UIs. */
+public final class FirmwareRollbackController {
+    private static final Logging log = getLogging(FirmwareRollbackController.class);
+
+    private final ConnectivityContext connectivityContext;
+    private final UpdateOperationCallbacks callbacks;
+    private final SingleAsyncJobExecutor jobExecutor;
+    private final Supplier<Optional<PortResult>> portProvider;
+    private final BooleanSupplier externallyIdle;
+    private final Runnable stateChanged;
+    private final Consumer<JComponent> showPicker;
+    private final Runnable closePicker;
+    private final List<Runnable> stateChangedListeners = new ArrayList<>();
+    private final FirmwareRollbackResolver resolver = new FirmwareRollbackResolver(PropertiesHolder.getBaseUrl());
+    private final boolean enabled = isFirmwareRollbackEnabled(PropertiesHolder.INSTANCE.getProperties());
+    private final JButton rollbackButton = new JButton(
+        "Rollback Firmware", AutoupdateUtil.loadIcon("download48.jpg"));
+
+    private volatile List<FirmwareRollbackResolver.Build> builds = Collections.emptyList();
+    private volatile String catalogKey;
+    private volatile String discoveryKey;
+    private volatile long discoveryGeneration;
+    private volatile boolean discoveryInProgress;
+    private volatile long discoveryRetryAfter;
+    private volatile String discoveryRetryKey;
+    private volatile boolean downloadInProgress;
+    private volatile FirmwareRollbackResolver.Build pendingInstalledBuild;
+    private volatile @Nullable LinkManager linkManager;
+
+    public FirmwareRollbackController(
+        ConnectivityContext connectivityContext,
+        UpdateOperationCallbacks callbacks,
+        SingleAsyncJobExecutor jobExecutor,
+        Supplier<Optional<PortResult>> portProvider,
+        BooleanSupplier externallyIdle,
+        Runnable stateChanged,
+        Consumer<JComponent> showPicker,
+        Runnable closePicker
+    ) {
+        this.connectivityContext = connectivityContext;
+        this.callbacks = callbacks;
+        this.jobExecutor = jobExecutor;
+        this.portProvider = portProvider;
+        this.externallyIdle = externallyIdle;
+        this.stateChanged = stateChanged;
+        this.showPicker = showPicker;
+        this.closePicker = closePicker;
+
+        rollbackButton.setVisible(isRollbackButtonVisible(enabled, BundleUtil.readBundleFullNameNotNull()));
+        rollbackButton.addActionListener(event -> showRollbackPicker());
+        jobExecutor.addOnJobInProgressFinishedListener(() -> SwingUtilities.invokeLater(() -> {
+            if (jobExecutor.getLastResult() == UpdateFirmwareResult.SUCCESS && pendingInstalledBuild != null) {
+                PersistentConfiguration.getConfig().getRoot().setProperty(
+                    lastInstalledKey(pendingInstalledBuild.getBoard(), pendingInstalledBuild.getBranch()),
+                    pendingInstalledBuild.getSha());
+            }
+            pendingInstalledBuild = null;
+            notifyStateChanged();
+        }));
+    }
+
+    public JButton getRollbackButton() {
+        return rollbackButton;
+    }
+
+    public void setLinkManager(@Nullable LinkManager linkManager) {
+        this.linkManager = linkManager;
+    }
+
+    public void addStateChangedListener(Runnable listener) {
+        stateChangedListeners.add(listener);
+    }
+
+    public boolean isBusy() {
+        return discoveryInProgress || downloadInProgress;
+    }
+
+    public boolean startLatestUpdate(JComponent source) {
+        if (!enabled || !isLtsBundle()) {
+            return false;
+        }
+        final Optional<PortResult> port = portProvider.get();
+        if (!hasLiveConnection() || !port.isPresent() || !port.get().isEcu()) {
+            return false;
+        }
+        if (isBusy()) {
+            return true;
+        }
+        if (!externallyIdle.getAsBoolean()) {
+            return true;
+        }
+        if (builds.isEmpty()) {
+            return false;
+        }
+        startFirmwareJob(builds, CalibrationsHelper.FirmwareUpdatePolicy.FORWARD_MIGRATION, source, true);
+        return true;
+    }
+
+    public void refresh(@Nullable PortResult port) {
+        if (port == null) {
+            reset();
+            return;
+        }
+        discover(port);
+        refreshButton();
+    }
+
+    public void reset() {
+        synchronized (this) {
+            if (discoveryInProgress) {
+                builds = Collections.emptyList();
+                catalogKey = null;
+            }
+            discoveryKey = null;
+            discoveryGeneration++;
+            discoveryInProgress = false;
+            discoveryRetryAfter = 0;
+            discoveryRetryKey = null;
+        }
+        if (SwingUtilities.isEventDispatchThread()) {
+            refreshButton();
+        } else {
+            SwingUtilities.invokeLater(this::refreshButton);
+        }
+    }
+
+    public void refreshButton() {
+        final Optional<PortResult> port = portProvider.get();
+        final boolean visible = isRollbackButtonVisible(enabled, BundleUtil.readBundleFullNameNotNull());
+        final boolean available = visible
+            && port.isPresent()
+            && port.get().isEcu()
+            && hasLiveConnection()
+            && !resolver.rollbackCandidates(builds, currentFirmwareSha(port.get())).isEmpty();
+        rollbackButton.setVisible(visible);
+        rollbackButton.setEnabled(available && externallyIdle.getAsBoolean()
+            && jobExecutor.isNotInProgress() && !downloadInProgress);
+    }
+
+    private void showRollbackPicker() {
+        final Optional<PortResult> port = portProvider.get();
+        if (!externallyIdle.getAsBoolean() || !hasLiveConnection() || !port.isPresent() || !port.get().isEcu()) {
+            return;
+        }
+        final String currentSha = currentFirmwareSha(port.get());
+        final boolean currentKnown = containsSha(builds, currentSha);
+        final List<FirmwareRollbackResolver.Build> candidates = resolver.rollbackCandidates(builds, currentSha);
+        if (candidates.isEmpty()) {
+            return;
+        }
+
+        final SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd HH:mm");
+        final String[] labels = candidates.stream()
+            .map(build -> format.format(new Date(build.getLastModified())) + "  " + build.getSha().substring(0, 10))
+            .toArray(String[]::new);
+        showPicker.accept(new FirmwareRollbackPanel(currentKnown, labels, selectedIndex -> {
+            closePicker.run();
+            startFirmwareJob(
+                Collections.singletonList(candidates.get(selectedIndex)),
+                CalibrationsHelper.FirmwareUpdatePolicy.ROLLBACK_RESTORE_OR_RESET,
+                rollbackButton,
+                false);
+        }, closePicker));
+    }
+
+    private void discover(final PortResult port) {
+        final BundleInfo bundle = BundleUtil.readBundleFullNameNotNull();
+        if (!enabled || !isLtsBundle(bundle)) {
+            builds = Collections.emptyList();
+            return;
+        }
+        if (!port.isEcu()) {
+            return;
+        }
+
+        final String board = connectivityContext.getConnectedEcuTarget().effectiveTarget();
+        final String branch = bundle.getBranchName();
+        final String key = board + "/" + branch;
+        final long generation;
+        synchronized (this) {
+            if (key.equals(catalogKey) || (discoveryInProgress && key.equals(discoveryKey))
+                || (key.equals(discoveryRetryKey) && System.currentTimeMillis() < discoveryRetryAfter)) {
+                return;
+            }
+            builds = Collections.emptyList();
+            catalogKey = key;
+            discoveryKey = key;
+            generation = ++discoveryGeneration;
+            discoveryInProgress = true;
+        }
+        notifyStateChanged();
+
+        final Thread discovery = new Thread(() -> {
+            List<FirmwareRollbackResolver.Build> discovered = Collections.emptyList();
+            boolean success = false;
+            try {
+                discovered = resolver.discover(board, branch);
+                success = true;
+                callbacks.logLine("Found " + discovered.size() + " LTS firmware builds for " + board);
+            } catch (Exception e) {
+                log.warn("Failed to discover LTS firmware builds at " + key + ": " + e);
+                callbacks.logLine("LTS firmware history is unavailable: " + e.getMessage());
+            }
+            synchronized (FirmwareRollbackController.this) {
+                if (generation == discoveryGeneration && key.equals(catalogKey)) {
+                    builds = discovered;
+                    if (!success) {
+                        catalogKey = null;
+                        discoveryRetryKey = key;
+                        discoveryRetryAfter = System.currentTimeMillis() + 10_000;
+                    } else {
+                        discoveryRetryKey = null;
+                    }
+                }
+                if (generation == discoveryGeneration && key.equals(discoveryKey)) {
+                    discoveryInProgress = false;
+                    discoveryKey = null;
+                }
+            }
+            notifyStateChanged();
+        }, "lts-firmware-discovery");
+        discovery.setDaemon(true);
+        discovery.start();
+    }
+
+    private void startFirmwareJob(
+        final List<FirmwareRollbackResolver.Build> candidates,
+        final CalibrationsHelper.FirmwareUpdatePolicy policy,
+        final JComponent source,
+        final boolean tryNextBuild
+    ) {
+        final Optional<PortResult> port = portProvider.get();
+        if (!port.isPresent()) {
+            return;
+        }
+        synchronized (this) {
+            if (downloadInProgress) {
+                return;
+            }
+            downloadInProgress = true;
+        }
+        final String requestedCatalogKey = catalogKey;
+        final long requestedGeneration = discoveryGeneration;
+        notifyStateChanged();
+        final Thread download = new Thread(() -> {
+            AsyncJob selectedJob = null;
+            FirmwareRollbackResolver.Build selectedBuild = null;
+            for (FirmwareRollbackResolver.Build candidate : candidates) {
+                final Autoupdate.FirmwareArtifacts artifacts = Autoupdate.downloadFirmware(
+                    candidate, callbacks::updateProgress, callbacks::logLine);
+                selectedJob = createFirmwareJob(port.get(), artifacts, policy, source);
+                if (selectedJob != null || !tryNextBuild) {
+                    selectedBuild = selectedJob == null ? null : candidate;
+                    break;
+                }
+                callbacks.logLine("Skipping incomplete firmware build " + candidate.getSha().substring(0, 10));
+            }
+            final AsyncJob job = selectedJob;
+            final FirmwareRollbackResolver.Build build = selectedBuild;
+            SwingUtilities.invokeLater(() -> acceptDownloadedJob(
+                port.get(), requestedCatalogKey, requestedGeneration, job, build, source));
+        }, "lts-firmware-download");
+        download.setDaemon(true);
+        download.start();
+    }
+
+    private void acceptDownloadedJob(
+        PortResult requestedPort,
+        String requestedCatalogKey,
+        long requestedGeneration,
+        @Nullable AsyncJob job,
+        @Nullable FirmwareRollbackResolver.Build build,
+        JComponent source
+    ) {
+        downloadInProgress = false;
+        final Optional<PortResult> currentPort = portProvider.get();
+        if (!currentPort.isPresent()
+            || !currentPort.get().port.equals(requestedPort.port)
+            || currentPort.get().type != requestedPort.type
+            || !currentPort.get().isEcu()
+            || !externallyIdle.getAsBoolean()
+            || !hasLiveConnection()
+            || requestedGeneration != discoveryGeneration
+            || !Objects.equals(requestedCatalogKey, catalogKey)) {
+            callbacks.logLine("ECU changed while firmware was downloading; update cancelled.");
+            notifyStateChanged();
+            return;
+        }
+        if (job == null || build == null) {
+            callbacks.logLine("Selected firmware build has no artifact for this bootloader.");
+            callbacks.error();
+            notifyStateChanged();
+            return;
+        }
+        if (!jobExecutor.startJob(job, source, () -> pendingInstalledBuild = build)) {
+            notifyStateChanged();
+        }
+    }
+
+    private void notifyStateChanged() {
+        final Runnable notify = () -> {
+            stateChanged.run();
+            for (Runnable listener : stateChangedListeners) {
+                listener.run();
+            }
+        };
+        if (SwingUtilities.isEventDispatchThread()) {
+            notify.run();
+        } else {
+            SwingUtilities.invokeLater(notify);
+        }
+    }
+
+    private @Nullable AsyncJob createFirmwareJob(
+        PortResult port,
+        Autoupdate.FirmwareArtifacts artifacts,
+        CalibrationsHelper.FirmwareUpdatePolicy policy,
+        JComponent source
+    ) {
+        if (port.type == SerialPortType.Ecu) {
+            return artifacts.getBinPath()
+                .map(path -> (AsyncJob) new DfuAutoJob(
+                    port, source, connectivityContext, linkManager, path, policy))
+                .orElse(null);
+        }
+        if (port.type == SerialPortType.EcuWithOpenblt) {
+            return artifacts.getSrecPath()
+                .map(path -> (AsyncJob) new OpenBltAutoJob(
+                    port, source, connectivityContext, linkManager, path, policy))
+                .orElse(null);
+        }
+        return null;
+    }
+
+    private String currentFirmwareSha(final PortResult port) {
+        if (port.getFirmwareHash().isPresent()) {
+            final String hash = port.getFirmwareHash().get().trim();
+            if (!hash.isEmpty()) {
+                return hash;
+            }
+        }
+        final BundleInfo bundle = BundleUtil.readBundleFullNameNotNull();
+        final String board = connectivityContext.getConnectedEcuTarget().effectiveTarget();
+        return PersistentConfiguration.getConfig().getRoot().getProperty(
+            lastInstalledKey(board, bundle.getBranchName()), null);
+    }
+
+    private boolean hasLiveConnection() {
+        final LinkManager lm = linkManager;
+        return lm != null && lm.getBinaryProtocol() != null;
+    }
+
+    private static boolean containsSha(List<FirmwareRollbackResolver.Build> builds, @Nullable String sha) {
+        return sha != null && builds.stream().anyMatch(build -> build.getSha().equalsIgnoreCase(sha));
+    }
+
+    private static String lastInstalledKey(String board, String branch) {
+        return "lts_last_flashed_sha." + board + "." + branch;
+    }
+
+    private boolean isLtsBundle() {
+        return isLtsBundle(BundleUtil.readBundleFullNameNotNull());
+    }
+
+    static boolean isLtsBundle(BundleInfo bundle) {
+        return !BundleInfo.isUndefined(bundle)
+            && !bundle.isMaster()
+            && bundle.getBranchName() != null
+            && bundle.getBranchName().startsWith("lts");
+    }
+
+    static boolean isRollbackButtonVisible(boolean enabled, BundleInfo bundle) {
+        return enabled && isLtsBundle(bundle);
+    }
+
+    static boolean isFirmwareRollbackEnabled(Properties properties) {
+        return Boolean.parseBoolean(System.getProperty(
+            "RE_FIRMWARE_ROLLBACK_ENABLED",
+            properties.getProperty("firmware_rollback_enabled", "false")));
+    }
+}

--- a/java_console/ui/src/main/java/com/rusefi/ui/basic/SingleAsyncJobExecutor.java
+++ b/java_console/ui/src/main/java/com/rusefi/ui/basic/SingleAsyncJobExecutor.java
@@ -103,26 +103,43 @@ public class SingleAsyncJobExecutor implements com.rusefi.DeviceSessionManager.J
         onJobAboutToStart.add(listener);
     }
 
-    public void startJob(final AsyncJob job, final Component parent) {
-        startJob(job, parent, message -> JOptionPane.showMessageDialog(
+    public boolean startJob(final AsyncJob job, final Component parent) {
+        return startJob(job, parent, message -> JOptionPane.showMessageDialog(
             parent,
             message,
             "Error",
             JOptionPane.ERROR_MESSAGE
-        ));
+        ), () -> {});
     }
 
-    public void startJob(final AsyncJob job, final Component parent, Consumer<String> errorHandler) {
+    public boolean startJob(final AsyncJob job, final Component parent, Consumer<String> errorHandler) {
+        return startJob(job, parent, errorHandler, () -> {});
+    }
+
+    public boolean startJob(final AsyncJob job, final Component parent, final Runnable onAccepted) {
+        return startJob(job, parent, message -> JOptionPane.showMessageDialog(
+            parent,
+            message,
+            "Error",
+            JOptionPane.ERROR_MESSAGE
+        ), onAccepted);
+    }
+
+    private boolean startJob(final AsyncJob job, final Component parent, Consumer<String> errorHandler,
+                             final Runnable onAccepted) {
         final Optional<AsyncJob> prevJobInProgress = setJobInProgressIfEmpty(job);
         if (!prevJobInProgress.isPresent()) {
+            onAccepted.run();
             for (Runnable listener : onJobAboutToStart) {
                 listener.run();
             }
             UpdateOperationCallbacks callbacks = recordingCallbacks(callbacksProvider.apply(job));
             callbacks.clear(); // resets lastResult to NONE and clears the selected status panel
             AsyncJobExecutor.INSTANCE.executeJob(job, callbacks, this::handleJobInProgressFinished);
+            return true;
         } else {
             errorHandler.accept(String.format("Job `%s` is already in progress!", prevJobInProgress.get().getName()));
+            return false;
         }
     }
 

--- a/java_console/ui/src/main/java/com/rusefi/ui/basic/StartupUpdateActions.java
+++ b/java_console/ui/src/main/java/com/rusefi/ui/basic/StartupUpdateActions.java
@@ -21,6 +21,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import static com.devexperts.logging.Logging.getLogging;
@@ -48,6 +49,7 @@ public class StartupUpdateActions implements BasicButtonCoordinator {
     private boolean softwareUpdateAvailable;
     private boolean softwareUpdateInProgress;
     private final AtomicReference<Optional<PortResult>> ecuPortToUse;
+    private final FirmwareRollbackController rollbackController;
 
     private String latestReportedHash;
 
@@ -55,12 +57,18 @@ public class StartupUpdateActions implements BasicButtonCoordinator {
         ConnectivityContext connectivityContext,
         final UpdateOperationCallbacks updateOperationCallbacks, SingleAsyncJobExecutor singleAsyncJobExecutor,
         AtomicReference<Optional<PortResult>> ecuPortToUse,
-        CompletableFuture<Autoupdate.UpdateOutcome> softwareUpdateOutcome
+        CompletableFuture<Autoupdate.UpdateOutcome> softwareUpdateOutcome,
+        Consumer<JComponent> showRollbackPicker,
+        Runnable closeRollbackPicker
     ) {
         this.connectivityContext = connectivityContext;
         this.ecuPortToUse = ecuPortToUse;
         this.singleAsyncJobExecutor = singleAsyncJobExecutor;
         this.updateOperationCallbacks = updateOperationCallbacks;
+        rollbackController = new FirmwareRollbackController(
+            connectivityContext, updateOperationCallbacks, singleAsyncJobExecutor, ecuPortToUse::get,
+            () -> !softwareUpdateInProgress, this::refreshButtons,
+            showRollbackPicker, closeRollbackPicker);
         singleAsyncJobExecutor.addOnJobAboutToStartListener(() -> SwingUtilities.invokeLater(this::refreshButtons));
         singleAsyncJobExecutor.addOnJobInProgressFinishedListener(() -> SwingUtilities.invokeLater(this::refreshButtons));
         importTuneButton = new ImportTuneControl(singleAsyncJobExecutor, this, connectivityContext);
@@ -105,6 +113,7 @@ public class StartupUpdateActions implements BasicButtonCoordinator {
      */
     public void setSplashLinkManager(@Nullable LinkManager lm) {
         this.splashLinkManager = lm;
+        rollbackController.setLinkManager(lm);
         importTuneButton.setLinkManager(lm);
         updateUpdateFirmwareJob();
     }
@@ -115,6 +124,16 @@ public class StartupUpdateActions implements BasicButtonCoordinator {
 
     public JButton getUpdateFirmwareButton() {
         return updateFirmwareButton;
+    }
+
+    public JButton getRollbackFirmwareButton() {
+        return rollbackController.getRollbackButton();
+    }
+
+    public void configureFirmwareSelector(ProgramSelector selector) {
+        selector.setFirmwareUpdateInterceptor(rollbackController::startLatestUpdate);
+        selector.setExternalBusySupplier(() -> rollbackController.isBusy() || softwareUpdateInProgress);
+        rollbackController.addStateChangedListener(() -> selector.apply(connectivityContext.getCurrentHardware()));
     }
 
     public JButton getUpdateSoftwareButton() {
@@ -275,6 +294,7 @@ public class StartupUpdateActions implements BasicButtonCoordinator {
 
     private void setEcuPortToUse(final PortResult port) {
         ecuPortToUse.set(Optional.of(port));
+        rollbackController.refresh(port);
 
         SwingUtilities.invokeLater(() -> {
             refreshButtons();
@@ -297,6 +317,7 @@ public class StartupUpdateActions implements BasicButtonCoordinator {
 
     private void resetEcuPortToUse() {
         ecuPortToUse.set(Optional.empty());
+        rollbackController.reset();
         SwingUtilities.invokeLater(() -> {
             importTuneButton.setEnabled(false);
         });
@@ -308,6 +329,9 @@ public class StartupUpdateActions implements BasicButtonCoordinator {
     }
 
     private void onUpdateFirmwareButtonClicked(final ActionEvent actionEvent) {
+        if (rollbackController.startLatestUpdate(updateFirmwareButton)) {
+            return;
+        }
         disableButtons();
         CompatibilityOptional.ifPresentOrElse(updateFirmwareJob,
             value -> {
@@ -321,16 +345,22 @@ public class StartupUpdateActions implements BasicButtonCoordinator {
     public void refreshButtons() {
         refreshUpdateFirmwareButton();
         final Optional<PortResult> ecuPort = ecuPortToUse.get();
-        final boolean noUpdateInProgress = singleAsyncJobExecutor.isNotInProgress() && !softwareUpdateInProgress;
+        final boolean noUpdateInProgress = singleAsyncJobExecutor.isNotInProgress()
+            && !softwareUpdateInProgress
+            && !rollbackController.isBusy();
         final boolean isEcuPortJobPossible = ecuPort.isPresent() && noUpdateInProgress;
         importTuneButton.setEnabled(isEcuPortJobPossible);
         updateSoftwareButton.setEnabled(
             updateSoftwareButton.isVisible() && softwareUpdateAvailable && noUpdateInProgress);
+        rollbackController.refreshButton();
     }
 
     private void refreshUpdateFirmwareButton() {
         final boolean isFirmwareUpdatePossible =
-            updateFirmwareJob.isPresent() && singleAsyncJobExecutor.isNotInProgress() && !softwareUpdateInProgress;
+            updateFirmwareJob.isPresent()
+                && !rollbackController.isBusy()
+                && singleAsyncJobExecutor.isNotInProgress()
+                && !softwareUpdateInProgress;
         if (isFirmwareUpdatePossible) {
             final AsyncJob currentUpdateFirmwareJob = updateFirmwareJob.get();
             Optional<String> updateFirmwareButtonText = Optional.empty();
@@ -356,6 +386,7 @@ public class StartupUpdateActions implements BasicButtonCoordinator {
     @Override
     public void disableButtons() {
         updateFirmwareButton.setEnabled(false);
+        rollbackController.getRollbackButton().setEnabled(false);
         updateSoftwareButton.setEnabled(false);
         importTuneButton.setEnabled(false);
     }

--- a/java_console/ui/src/main/java/com/rusefi/ui/wizard/FirmwareRollbackPanel.java
+++ b/java_console/ui/src/main/java/com/rusefi/ui/wizard/FirmwareRollbackPanel.java
@@ -1,0 +1,112 @@
+package com.rusefi.ui.wizard;
+
+import javax.swing.*;
+import java.awt.*;
+import java.util.function.IntConsumer;
+
+public final class FirmwareRollbackPanel extends JPanel {
+    private static final int CARD_WIDTH = 760;
+
+    public FirmwareRollbackPanel(boolean currentKnown, String[] builds, IntConsumer confirm, Runnable cancel) {
+        super(new BorderLayout());
+        setBorder(BorderFactory.createEmptyBorder(
+            WizardStyle.LARGE_GAP, WizardStyle.LARGE_GAP, WizardStyle.LARGE_GAP, WizardStyle.LARGE_GAP));
+
+        JLabel heading = new JLabel("Rollback Firmware");
+        AbstractWizardStep.styleTitle(heading);
+
+        JPanel header = new JPanel(new BorderLayout());
+        header.add(heading, BorderLayout.WEST);
+        add(header, BorderLayout.NORTH);
+
+        JPanel card = new JPanel();
+        card.setLayout(new BoxLayout(card, BoxLayout.Y_AXIS));
+        card.setBorder(BorderFactory.createCompoundBorder(
+            BorderFactory.createLineBorder(WizardStyle.border()),
+            BorderFactory.createEmptyBorder(22, 26, 22, 26)));
+        card.setPreferredSize(new Dimension(CARD_WIDTH, 520));
+        card.setMaximumSize(new Dimension(CARD_WIDTH, 520));
+
+        JLabel prompt = new JLabel("Select a previous LTS firmware build");
+        AbstractWizardStep.styleTitle(prompt);
+        prompt.setAlignmentX(Component.CENTER_ALIGNMENT);
+        card.add(prompt);
+
+        JLabel explanation = new JLabel("<html><center>"
+            + (currentKnown
+                ? "Choose an older build to install."
+                : "The current build is unknown. Explicitly choose the firmware to install.")
+            + "<br>The current tune will be backed up. If the calibration layout changed, defaults will be used."
+            + "</center></html>");
+        explanation.setHorizontalAlignment(SwingConstants.CENTER);
+        explanation.setForeground(WizardStyle.muted());
+        explanation.setAlignmentX(Component.CENTER_ALIGNMENT);
+        card.add(explanation);
+        card.add(Box.createVerticalStrut(WizardStyle.LARGE_GAP));
+
+        JPanel buildButtons = new JPanel();
+        buildButtons.setLayout(new BoxLayout(buildButtons, BoxLayout.Y_AXIS));
+        ButtonGroup group = new ButtonGroup();
+        JToggleButton[] choices = new JToggleButton[builds.length];
+        for (int i = 0; i < builds.length; i++) {
+            JToggleButton choice = new JToggleButton(builds[i]);
+            AbstractWizardStep.styleButton(choice);
+            choice.setFont(choice.getFont().deriveFont(choice.getFont().getSize() * 1.2f));
+            choice.setMargin(new Insets(14, 24, 14, 24));
+            choice.setAlignmentX(Component.CENTER_ALIGNMENT);
+            choice.setMaximumSize(new Dimension(Integer.MAX_VALUE, choice.getPreferredSize().height));
+            group.add(choice);
+            buildButtons.add(choice);
+            if (i + 1 < builds.length) {
+                buildButtons.add(Box.createVerticalStrut(WizardStyle.GAP));
+            }
+            choices[i] = choice;
+        }
+
+        JScrollPane scrollPane = new JScrollPane(buildButtons);
+        scrollPane.setBorder(BorderFactory.createEmptyBorder());
+        scrollPane.setHorizontalScrollBarPolicy(ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
+        scrollPane.getVerticalScrollBar().setUnitIncrement(16);
+        scrollPane.setAlignmentX(Component.CENTER_ALIGNMENT);
+        card.add(scrollPane);
+        card.add(Box.createVerticalStrut(WizardStyle.LARGE_GAP));
+
+        int[] selection = {-1};
+        JButton rollback = new JButton("Rollback to Selected Build");
+        AbstractWizardStep.stylePrimaryAction(rollback);
+        rollback.setEnabled(false);
+        rollback.setAlignmentX(Component.CENTER_ALIGNMENT);
+        for (int i = 0; i < choices.length; i++) {
+            int index = i;
+            choices[i].addActionListener(e -> {
+                selection[0] = index;
+                rollback.setEnabled(true);
+            });
+        }
+        if (currentKnown && choices.length > 0) {
+            choices[0].setSelected(true);
+            selection[0] = 0;
+            rollback.setEnabled(true);
+        }
+        rollback.addActionListener(e -> confirm.accept(selection[0]));
+
+        JButton cancelButton = new JButton("Cancel");
+        AbstractWizardStep.styleButton(cancelButton);
+        cancelButton.addActionListener(e -> cancel.run());
+
+        JPanel actions = new JPanel(new BorderLayout(WizardStyle.GAP, 0));
+        actions.setAlignmentX(Component.CENTER_ALIGNMENT);
+        actions.setMaximumSize(new Dimension(Integer.MAX_VALUE,
+            Math.max(cancelButton.getPreferredSize().height, rollback.getPreferredSize().height)));
+        actions.add(cancelButton, BorderLayout.WEST);
+        actions.add(rollback, BorderLayout.EAST);
+        card.add(actions);
+
+        JPanel center = new JPanel(new GridBagLayout());
+        center.add(card);
+        add(center, BorderLayout.CENTER);
+
+        registerKeyboardAction(e -> cancel.run(), KeyStroke.getKeyStroke("ESCAPE"),
+            JComponent.WHEN_IN_FOCUSED_WINDOW);
+    }
+}

--- a/java_console/ui/src/test/java/com/rusefi/maintenance/CalibrationsHelperRollbackPolicyTest.java
+++ b/java_console/ui/src/test/java/com/rusefi/maintenance/CalibrationsHelperRollbackPolicyTest.java
@@ -1,0 +1,39 @@
+package com.rusefi.maintenance;
+
+import com.opensr5.ini.IniFileModel;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class CalibrationsHelperRollbackPolicyTest {
+    @Test
+    void sameLayoutHashCanRestoreAcrossBuildDates() {
+        assertTrue(CalibrationsHelper.rollbackLayoutsMatch(
+            calibrations("rusEFI lts-26.2026.07.24.uaefi.123"),
+            calibrations("rusEFI lts-26.2026.07.23.uaefi.123")));
+    }
+
+    @Test
+    void changedLayoutHashRequiresDefaults() {
+        assertFalse(CalibrationsHelper.rollbackLayoutsMatch(
+            calibrations("rusEFI lts-26.2026.07.24.uaefi.123"),
+            calibrations("rusEFI lts-26.2026.07.23.uaefi.456")));
+    }
+
+    @Test
+    void unparseableSignaturesMustMatchExactly() {
+        assertTrue(CalibrationsHelper.rollbackLayoutsMatch(calibrations("test"), calibrations("test")));
+        assertFalse(CalibrationsHelper.rollbackLayoutsMatch(calibrations("test"), calibrations("other")));
+    }
+
+    private static CalibrationsInfo calibrations(String signature) {
+        IniFileModel ini = mock(IniFileModel.class);
+        when(ini.getSignature()).thenReturn(signature);
+        CalibrationsInfo calibrations = mock(CalibrationsInfo.class);
+        when(calibrations.getIniFile()).thenReturn(ini);
+        return calibrations;
+    }
+}

--- a/java_console/ui/src/test/java/com/rusefi/maintenance/ProgramSelectorTest.java
+++ b/java_console/ui/src/test/java/com/rusefi/maintenance/ProgramSelectorTest.java
@@ -13,6 +13,7 @@ import static com.rusefi.maintenance.UpdateMode.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Unit tests for the Update-Firmware main-button decision logic that maps a detected/selected port and
@@ -137,5 +138,11 @@ public class ProgramSelectorTest {
         PortResult resolved = resolveFlashPort(blt, true, NO_PORTS, NO_PORTS);
         assertSame(blt, resolved);
         assertEquals(OPENBLT_MANUAL, mainButtonModeFor(resolved, true));
+    }
+
+    @Test
+    public void firmwareControlsStayVisibleWhileJobRunsWithoutDetectedHardware() {
+        assertTrue(ProgramSelector.shouldShowFirmwareControls(true, true, false));
+        assertTrue(ProgramSelector.shouldShowFirmwareControls(true, false, true));
     }
 }

--- a/java_console/ui/src/test/java/com/rusefi/ui/basic/FirmwareRollbackControllerTest.java
+++ b/java_console/ui/src/test/java/com/rusefi/ui/basic/FirmwareRollbackControllerTest.java
@@ -1,0 +1,43 @@
+package com.rusefi.ui.basic;
+
+import com.rusefi.core.io.BundleInfo;
+import org.junit.jupiter.api.Test;
+
+import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class FirmwareRollbackControllerTest {
+    @Test
+    void enablesHistoryOnlyForLtsBundles() {
+        BundleInfo lts = new BundleInfo("lts-26-test", null, "uaefi");
+        BundleInfo development = new BundleInfo("development", null, "uaefi");
+        BundleInfo release = new BundleInfo("release", null, "uaefi");
+        assertTrue(FirmwareRollbackController.isLtsBundle(lts));
+        assertFalse(FirmwareRollbackController.isLtsBundle(development));
+        assertFalse(FirmwareRollbackController.isLtsBundle(release));
+        assertTrue(FirmwareRollbackController.isRollbackButtonVisible(true, lts));
+        assertFalse(FirmwareRollbackController.isRollbackButtonVisible(false, lts));
+        assertFalse(FirmwareRollbackController.isRollbackButtonVisible(true, development));
+    }
+
+    @Test
+    void rollbackFeatureIsDefaultOffAndBundleConfigurable() {
+        Properties properties = new Properties();
+        assertFalse(FirmwareRollbackController.isFirmwareRollbackEnabled(properties));
+
+        properties.setProperty("firmware_rollback_enabled", "true");
+        assertTrue(FirmwareRollbackController.isFirmwareRollbackEnabled(properties));
+    }
+
+    @Test
+    void rollbackFeatureAllowsLocalJvmOverride() {
+        System.setProperty("RE_FIRMWARE_ROLLBACK_ENABLED", "true");
+        try {
+            assertTrue(FirmwareRollbackController.isFirmwareRollbackEnabled(new Properties()));
+        } finally {
+            System.clearProperty("RE_FIRMWARE_ROLLBACK_ENABLED");
+        }
+    }
+}


### PR DESCRIPTION
new button (hidden if firmware_rollback_enabled is false):
<img width="1069" height="377" alt="image" src="https://github.com/user-attachments/assets/0546f5f8-4529-4573-a39e-f63a5723b31d" />

master bundle to LTS rollback, the user need to select manually a build:

<img width="795" height="551" alt="image" src="https://github.com/user-attachments/assets/48fe2bcb-5fff-4f1b-9839-de1e364fd407" />

LTS with only one version to rollback, we show the same UI for selecting and confirm the rollback:
<img width="804" height="565" alt="image" src="https://github.com/user-attachments/assets/d110c6db-8f8f-4bea-81be-4b2428a54e4b" />

if we are on the oldest LTS build, we disable the button:
<img width="592" height="194" alt="image" src="https://github.com/user-attachments/assets/d4b36580-dafd-48b5-a347-af707b82e0a4" />



related #9907