### PR TITLE
DefaultTuneMigrator: dont migrate firmware SHA on upgrades

### DIFF
--- a/java_console/io/src/main/java/com/rusefi/maintenance/migration/migrators/DefaultTuneMigrator.java
+++ b/java_console/io/src/main/java/com/rusefi/maintenance/migration/migrators/DefaultTuneMigrator.java
@@ -30,7 +30,7 @@ public enum DefaultTuneMigrator implements TuneMigrator {
     private static final Logging log = getLogging(DefaultTuneMigrator.class);
 
     // ini fields to ignore on all boards
-    private static final Set<String> INI_FIELDS_TO_IGNORE = CompatibilitySet.of("byFirmwareVersion");
+    private static final Set<String> INI_FIELDS_TO_IGNORE = CompatibilitySet.of("byFirmwareVersion", "hash3");
 
     private static final Set<String> boardSpecificIniFieldsToIgnore = ConnectionAndMeta.getNonMigratableIniFields();
 

--- a/java_console/ui/src/test/java/com/rusefi/maintenance/migration/default_migration/DefaultTuneMigratorTest.java
+++ b/java_console/ui/src/test/java/com/rusefi/maintenance/migration/default_migration/DefaultTuneMigratorTest.java
@@ -228,6 +228,13 @@ public class DefaultTuneMigratorTest {
     }
 
     @Test
+    public void testFirmwareHashIsNotMigrated() {
+        assertEquals("old-firmware-sha", testContext.getPrevValue("hash3").getValue());
+        assertEquals("new-firmware-sha", testContext.getUpdatedValue("hash3").getValue());
+        assertNull(testContext.getMigratedConstants().get("hash3"));
+    }
+
+    @Test
     public void testContent() {
         assertEquals(
             "WARNING! Type of `map_samplingAngleBins` ini-field is expected to be `UINT16` instead of `FLOAT`\r\n" +
@@ -310,4 +317,3 @@ public class DefaultTuneMigratorTest {
         assertEquals(expectedValueToUpdate.getName(), valueToUpdate.getName());
     }
 }
-

--- a/java_console/ui/src/test/java/com/rusefi/maintenance/migration/default_migration/test_data/prev_calibrations.ini
+++ b/java_console/ui/src/test/java/com/rusefi/maintenance/migration/default_migration/test_data/prev_calibrations.ini
@@ -240,6 +240,7 @@ acrPin = bits, U16, 492, [0:8], $output_pin_e_list
 driveWheelRevPerKm = scalar, F32, 496, "revs/km", 1, 0, 100, 1000, 1
 canSleepPeriodMs = scalar, S32, 500, "ms", 1, 0, 0, 1000, 2
 byFirmwareVersion = scalar, S32, 504, "index", 1, 0, 0, 300, 0
+hash3 = string, ASCII, 16508, 64
 tps1_1AdcChannel = bits, U08, 508, [0:5], $adc_channel_e_list
 vbattAdcChannel = bits, U08, 509, [0:5], $adc_channel_e_list
 fuelLevelSensor = bits, U08, 510, [0:5], $adc_channel_e_list

--- a/java_console/ui/src/test/java/com/rusefi/maintenance/migration/default_migration/test_data/prev_calibrations.msq
+++ b/java_console/ui/src/test/java/com/rusefi/maintenance/migration/default_migration/test_data/prev_calibrations.msq
@@ -209,6 +209,7 @@
         <constant digits="1" name="driveWheelRevPerKm" units="revs/km">1000.0</constant>
         <constant digits="2" name="canSleepPeriodMs" units="ms">50.0</constant>
         <constant digits="0" name="byFirmwareVersion" units="index">2.0240529E7</constant>
+        <constant name="hash3">old-firmware-sha</constant>
         <constant name="tps1_1AdcChannel">"D13 TPS1"</constant>
         <constant name="vbattAdcChannel">"A7 Voltage From Key"</constant>
         <constant name="fuelLevelSensor">"NONE"</constant>

--- a/java_console/ui/src/test/java/com/rusefi/maintenance/migration/default_migration/test_data/updated_calibrations.ini
+++ b/java_console/ui/src/test/java/com/rusefi/maintenance/migration/default_migration/test_data/updated_calibrations.ini
@@ -241,6 +241,7 @@ acrPin = bits, U16, 496, [0:8], $output_pin_e_list
 driveWheelRevPerKm = scalar, F32, 500, "revs/km", 1, 0, 100, 1000, 1
 canSleepPeriodMs = scalar, S32, 504, "ms", 1, 0, 0, 1000, 2
 byFirmwareVersion = scalar, S32, 508, "index", 1, 0, 0, 300, 0
+hash3 = string, ASCII, 16508, 64
 tps1_1AdcChannel = bits, U08, 512, [0:5], $adc_channel_e_list
 vbattAdcChannel = bits, U08, 513, [0:5], $adc_channel_e_list
 fuelLevelSensor = bits, U08, 514, [0:5], $adc_channel_e_list

--- a/java_console/ui/src/test/java/com/rusefi/maintenance/migration/default_migration/test_data/updated_calibrations.msq
+++ b/java_console/ui/src/test/java/com/rusefi/maintenance/migration/default_migration/test_data/updated_calibrations.msq
@@ -211,6 +211,7 @@
         <constant digits="1" name="driveWheelRevPerKm" units="revs/km">1000.0</constant>
         <constant digits="2" name="canSleepPeriodMs" units="ms">50.0</constant>
         <constant digits="0" name="byFirmwareVersion" units="index">2.0250206E7</constant>
+        <constant name="hash3">new-firmware-sha</constant>
         <constant name="tps1_1AdcChannel">"D13 TPS1"</constant>
         <constant name="vbattAdcChannel">"A7 Voltage From Key"</constant>
         <constant name="fuelLevelSensor">"NONE"</constant>


### PR DESCRIPTION
otherwise we broke the firmware revert path! (ie, we cant see the correct fw position on the LTS builds dir)

related #9907