### PR TITLE
FirmwareRollbackController: pick current SHA when doing multiple rollbacks on same console session

### DIFF
--- a/java_console/ui/src/main/java/com/rusefi/ui/basic/FirmwareRollbackController.java
+++ b/java_console/ui/src/main/java/com/rusefi/ui/basic/FirmwareRollbackController.java
@@ -63,6 +63,7 @@ public final class FirmwareRollbackController {
     private volatile String discoveryRetryKey;
     private volatile boolean downloadInProgress;
     private volatile FirmwareRollbackResolver.Build pendingInstalledBuild;
+    private volatile @Nullable String sessionInstalledSha;
     private volatile @Nullable LinkManager linkManager;
 
     public FirmwareRollbackController(
@@ -88,6 +89,7 @@ public final class FirmwareRollbackController {
         rollbackButton.addActionListener(event -> showRollbackPicker());
         jobExecutor.addOnJobInProgressFinishedListener(() -> SwingUtilities.invokeLater(() -> {
             if (jobExecutor.getLastResult() == UpdateFirmwareResult.SUCCESS && pendingInstalledBuild != null) {
+                sessionInstalledSha = pendingInstalledBuild.getSha();
                 PersistentConfiguration.getConfig().getRoot().setProperty(
                     lastInstalledKey(pendingInstalledBuild.getBoard(), pendingInstalledBuild.getBranch()),
                     pendingInstalledBuild.getSha());
@@ -371,16 +373,27 @@ public final class FirmwareRollbackController {
     }
 
     private String currentFirmwareSha(final PortResult port) {
-        if (port.getFirmwareHash().isPresent()) {
-            final String hash = port.getFirmwareHash().get().trim();
-            if (!hash.isEmpty()) {
-                return hash;
-            }
-        }
         final BundleInfo bundle = BundleUtil.readBundleFullNameNotNull();
         final String board = connectivityContext.getConnectedEcuTarget().effectiveTarget();
-        return PersistentConfiguration.getConfig().getRoot().getProperty(
-            lastInstalledKey(board, bundle.getBranchName()), null);
+        return selectCurrentFirmwareSha(
+            sessionInstalledSha,
+            port.getFirmwareHash(),
+            PersistentConfiguration.getConfig().getRoot().getProperty(
+                lastInstalledKey(board, bundle.getBranchName()), null));
+    }
+
+    static @Nullable String selectCurrentFirmwareSha(
+        @Nullable String sessionInstalledSha,
+        Optional<String> portFirmwareSha,
+        @Nullable String persistedFirmwareSha
+    ) {
+        if (sessionInstalledSha != null && !sessionInstalledSha.trim().isEmpty()) {
+            return sessionInstalledSha.trim();
+        }
+        if (portFirmwareSha.isPresent() && !portFirmwareSha.get().trim().isEmpty()) {
+            return portFirmwareSha.get().trim();
+        }
+        return persistedFirmwareSha;
     }
 
     private boolean hasLiveConnection() {

--- a/java_console/ui/src/test/java/com/rusefi/ui/basic/FirmwareRollbackControllerTest.java
+++ b/java_console/ui/src/test/java/com/rusefi/ui/basic/FirmwareRollbackControllerTest.java
@@ -3,8 +3,10 @@ package com.rusefi.ui.basic;
 import com.rusefi.core.io.BundleInfo;
 import org.junit.jupiter.api.Test;
 
+import java.util.Optional;
 import java.util.Properties;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -39,5 +41,15 @@ class FirmwareRollbackControllerTest {
         } finally {
             System.clearProperty("RE_FIRMWARE_ROLLBACK_ENABLED");
         }
+    }
+
+    @Test
+    void successfulSessionFlashOverridesStaleScannedHash() {
+        assertEquals("new-sha", FirmwareRollbackController.selectCurrentFirmwareSha(
+            " new-sha ", Optional.of("old-sha"), "persisted-sha"));
+        assertEquals("ecu-sha", FirmwareRollbackController.selectCurrentFirmwareSha(
+            null, Optional.of(" ecu-sha "), "persisted-sha"));
+        assertEquals("persisted-sha", FirmwareRollbackController.selectCurrentFirmwareSha(
+            null, Optional.empty(), "persisted-sha"));
     }
 }


### PR DESCRIPTION
otherwise we need to restart the console after a rollback, not good UX!
related #9907