### PR TITLE
Add `addOnJobWorkerAboutToStartListener` to separate blocking preparation from the caller thread

### DIFF
--- a/java_console/connectivity/src/main/java/com/rusefi/DeviceSessionManager.java
+++ b/java_console/connectivity/src/main/java/com/rusefi/DeviceSessionManager.java
@@ -37,6 +37,8 @@ public class DeviceSessionManager {
 
         void addOnJobAboutToStartListener(Runnable listener);
 
+        void addOnJobWorkerAboutToStartListener(Runnable listener);
+
         void addOnJobInProgressFinishedListener(Runnable listener);
     }
 
@@ -96,7 +98,7 @@ public class DeviceSessionManager {
             // Jobs own serial-port transitions exclusively. Suspend the lifetime scanner rather than
             // letting it probe while the live connection closes and USB re-enumerates.
             jobExecutor.addOnJobAboutToStartListener(watchdogPause);
-            jobExecutor.addOnJobAboutToStartListener(() -> {
+            jobExecutor.addOnJobWorkerAboutToStartListener(() -> {
                 try {
                     connectivityContext.getPortScanner().suspend().await(30, TimeUnit.SECONDS);
                 } catch (InterruptedException e) {

--- a/java_console/connectivity/src/test/java/com/rusefi/DeviceSessionManagerTest.java
+++ b/java_console/connectivity/src/test/java/com/rusefi/DeviceSessionManagerTest.java
@@ -174,6 +174,11 @@ public class DeviceSessionManagerTest {
         }
 
         @Override
+        public void addOnJobWorkerAboutToStartListener(Runnable listener) {
+            aboutToStart.add(listener);
+        }
+
+        @Override
         public void addOnJobInProgressFinishedListener(Runnable listener) {
             finished.add(listener);
         }

--- a/java_console/ui/src/main/java/com/rusefi/maintenance/jobs/AsyncJobExecutor.java
+++ b/java_console/ui/src/main/java/com/rusefi/maintenance/jobs/AsyncJobExecutor.java
@@ -30,7 +30,15 @@ public enum AsyncJobExecutor {
     }
 
     public void executeJob(final AsyncJob job, final UpdateOperationCallbacks callbacks, final Runnable onJobFinished) {
-        final Runnable jobWithSuspendedPortScanning = () -> job.doJob(callbacks, onJobFinished);
-        ExecHelper.submitAction(jobWithSuspendedPortScanning, "mx-" + threadNameIndex.incrementAndGet());
+        executeJob(job, callbacks, () -> {}, onJobFinished);
+    }
+
+    public void executeJob(final AsyncJob job, final UpdateOperationCallbacks callbacks,
+                           final Runnable onJobAboutToStart, final Runnable onJobFinished) {
+        final Runnable jobWithPreparation = () -> {
+            onJobAboutToStart.run();
+            job.doJob(callbacks, onJobFinished);
+        };
+        ExecHelper.submitAction(jobWithPreparation, "mx-" + threadNameIndex.incrementAndGet());
     }
 }

--- a/java_console/ui/src/main/java/com/rusefi/ui/basic/SingleAsyncJobExecutor.java
+++ b/java_console/ui/src/main/java/com/rusefi/ui/basic/SingleAsyncJobExecutor.java
@@ -16,6 +16,7 @@ public class SingleAsyncJobExecutor implements com.rusefi.DeviceSessionManager.J
 
     private final java.util.List<Runnable> onJobInProgressFinished = new ArrayList<>();
     private final java.util.List<Runnable> onJobAboutToStart = new ArrayList<>();
+    private final java.util.List<Runnable> onJobWorkerAboutToStart = new ArrayList<>();
 
     private volatile Optional<AsyncJob> jobInProgress = Optional.empty();
 
@@ -95,12 +96,17 @@ public class SingleAsyncJobExecutor implements com.rusefi.DeviceSessionManager.J
     }
 
     /**
-     * Runs before a new job is handed off to the executor. Use this to release resources the job
-     * will need exclusive access to (e.g. close a live serial connection so the firmware updater
-     * can open the same port).
+     * Runs before a new job is handed off to the executor. Use this for quick caller-thread state
+     * updates; blocking preparation belongs in {@link #addOnJobWorkerAboutToStartListener(Runnable)}.
      */
     public void addOnJobAboutToStartListener(Runnable listener) {
         onJobAboutToStart.add(listener);
+    }
+
+    /** Runs on the job worker immediately before the job, so blocking preparation cannot freeze Swing. */
+    @Override
+    public void addOnJobWorkerAboutToStartListener(Runnable listener) {
+        onJobWorkerAboutToStart.add(listener);
     }
 
     public boolean startJob(final AsyncJob job, final Component parent) {
@@ -135,7 +141,11 @@ public class SingleAsyncJobExecutor implements com.rusefi.DeviceSessionManager.J
             }
             UpdateOperationCallbacks callbacks = recordingCallbacks(callbacksProvider.apply(job));
             callbacks.clear(); // resets lastResult to NONE and clears the selected status panel
-            AsyncJobExecutor.INSTANCE.executeJob(job, callbacks, this::handleJobInProgressFinished);
+            AsyncJobExecutor.INSTANCE.executeJob(job, callbacks, () -> {
+                for (Runnable listener : onJobWorkerAboutToStart) {
+                    listener.run();
+                }
+            }, this::handleJobInProgressFinished);
             return true;
         } else {
             errorHandler.accept(String.format("Job `%s` is already in progress!", prevJobInProgress.get().getName()));

--- a/java_console/ui/src/test/java/com/rusefi/ui/basic/SingleAsyncJobExecutorTest.java
+++ b/java_console/ui/src/test/java/com/rusefi/ui/basic/SingleAsyncJobExecutorTest.java
@@ -1,0 +1,55 @@
+package com.rusefi.ui.basic;
+
+import com.rusefi.io.UpdateOperationCallbacks;
+import com.rusefi.maintenance.jobs.AsyncJob;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SingleAsyncJobExecutorTest {
+    @Test
+    void blockingPreparationDoesNotBlockCallerAndFinishesBeforeJobStarts() throws Exception {
+        final SingleAsyncJobExecutor executor = new SingleAsyncJobExecutor(UpdateOperationCallbacks.DUMMY);
+        final CountDownLatch preparationStarted = new CountDownLatch(1);
+        final CountDownLatch releasePreparation = new CountDownLatch(1);
+        final CountDownLatch callerReturned = new CountDownLatch(1);
+        final CountDownLatch jobStarted = new CountDownLatch(1);
+
+        executor.addOnJobWorkerAboutToStartListener(() -> {
+            preparationStarted.countDown();
+            try {
+                releasePreparation.await();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        });
+
+        final AsyncJob job = new AsyncJob("test") {
+            @Override
+            public void doJob(final UpdateOperationCallbacks callbacks, final Runnable onJobFinished) {
+                jobStarted.countDown();
+                onJobFinished.run();
+            }
+        };
+
+        final Thread caller = new Thread(() -> {
+            executor.startJob(job, null);
+            callerReturned.countDown();
+        });
+        caller.setDaemon(true);
+        caller.start();
+
+        assertTrue(preparationStarted.await(5, TimeUnit.SECONDS));
+        final boolean returnedBeforePreparationFinished = callerReturned.await(1, TimeUnit.SECONDS);
+        assertEquals(1, jobStarted.getCount());
+        releasePreparation.countDown();
+
+        assertTrue(returnedBeforePreparationFinished, "startJob blocked its caller during preparation");
+        assertTrue(jobStarted.await(5, TimeUnit.SECONDS));
+        caller.join(5000);
+    }
+}

--- a/java_tools/version/src/main/java/com/rusefi/UiVersion.java
+++ b/java_tools/version/src/main/java/com/rusefi/UiVersion.java
@@ -5,5 +5,5 @@ public interface UiVersion {
      * *** BE CAREFUL WE HAVE SEPARATE AUTOUPDATE_VERSION also managed manually ***
      * @see com.rusefi.autoupdate.Autoupdate#AUTOUPDATE_VERSION
      */
-    int CONSOLE_VERSION = 20260726;
+    int CONSOLE_VERSION = 20260727;
 }


### PR DESCRIPTION
resolves #9922