### PR TITLE
TunerStudio: defer page 0 write to flash to be done after a CRC request, or 2s timeout

### DIFF
--- a/firmware/console/binary/tunerstudio.cpp
+++ b/firmware/console/binary/tunerstudio.cpp
@@ -425,8 +425,13 @@ void TunerStudio::handleCrc32Check(TsChannelBase *tsChannel, uint32_t page, uint
 
 	uint32_t crc = SWAP_UINT32(crc32(start, count));
 	tsChannel->sendResponse(TS_CRC, (const uint8_t *) &crc, 4);
-	// todo: rename to onConfigCrc?
-	ConfigurationWizard::onConfigOnStartUpOrBurn(false);
+	if (page == TS_PAGE_SETTINGS && offset == 0 && count == sizeof(persistent_config_s)) {
+		finishPendingBurn(tsChannel);
+	}
+	if (!tsChannel->settingsBurnPending) {
+		// todo: rename to onConfigCrc?
+		ConfigurationWizard::onConfigOnStartUpOrBurn(false);
+	}
 }
 
 #if EFI_TS_SCATTER
@@ -524,44 +529,76 @@ void requestBurn() {
 }
 
 #if EFI_TUNER_STUDIO
-#if EFI_PROD_CODE || EFI_SIMULATOR
-/**
- * 'Burn' command is a command to commit the changes
- */
-static void handleBurnCommand(TsChannelBase* tsChannel, uint16_t page) {
-	if (page == TS_PAGE_SETTINGS) {
-		Timer t;
-		t.reset();
+// TS normally waits 500ms; 2s keeps clients without a CRC check from blocking forever the write.
+static constexpr float SETTINGS_BURN_TIMEOUT_MS = 2000;
 
-		tsState.burnCommandCounter++;
+void TunerStudio::finishPendingBurn(TsChannelBase* tsChannel) {
+	if (!tsChannel->settingsBurnPending) {
+		return;
+	}
 
-		efiPrintf("TS -> Burn");
-		validateConfigOnStartUpOrBurn(true);
+	tsChannel->settingsBurnPending = false;
+	const uint32_t crcBefore = crc32(engineConfiguration, sizeof(persistent_config_s));
+	Timer t;
+	t.reset();
+
+	efiPrintf("Finishing pending TS burn");
+	validateConfigOnStartUpOrBurn(true);
 
 		// problem: 'popular vehicles' dialog has 'Burn' which is very NOT helpful on that dialog
 		// since users often click both buttons producing a conflict between ECU desire to change settings
 		// and TS desire to send TS calibration snapshot into ECU
 		// Skip the burn if a preset was just loaded - we don't want to overwrite it
 		// [tag:popular_vehicle]
-		if (!needToTriggerTsRefresh()) {
-			efiPrintf("TS -> Burn, we are allowed to burn");
-			requestBurn();
-		}
-		efiPrintf("Burned in %.1fms", t.getElapsedSeconds() * 1e3);
+  if (!needToTriggerTsRefresh()) {
+    efiPrintf("TS -> Burn, we are allowed to burn");
+		requestBurn();
+	}
+
+	if (crcBefore != crc32(engineConfiguration, sizeof(persistent_config_s))) {
+		onApplyPreset();
+	}
+
+	efiPrintf("Burned in %.1fms", t.getElapsedSeconds() * 1e3);
+}
+
+void TunerStudio::handlePendingBurnTimeout(TsChannelBase* tsChannel) {
+	if (tsChannel->settingsBurnPending && tsChannel->settingsBurnTimer.hasElapsedMs(SETTINGS_BURN_TIMEOUT_MS)) {
+		efiPrintf("TS burn CRC timeout");
+		finishPendingBurn(tsChannel);
+	}
+}
+
+/**
+ * 'Burn' command is a command to commit the changes
+ */
+void TunerStudio::handleBurnCommand(TsChannelBase* tsChannel, uint16_t page) {
+	if (page == TS_PAGE_SETTINGS) {
+		tsState.burnCommandCounter++;
+		// Only page 0 needs deferral (see #9938)
+		// Extra-page and lua are wrote normally
+		efiPrintf("TS -> Burn, waiting for CRC");
+		tsChannel->settingsBurnPending = true;
 	} else if (page == TS_PAGE_SCATTER_OFFSETS) {
 		/* do nothing */
 	} else if (page == TS_PAGE_SECOND_TABLES) {
+#if !EFI_UNIT_TEST
 		burnExtraFlashPage(EFI_SECOND_TABLES_RECORD_ID);
+#endif
 	} else if (page == TS_PAGE_LUA) {
+#if !EFI_UNIT_TEST
 		burnExtraFlashPage(EFI_LUA_PAGE_RECORD_ID);
+#endif
 	} else {
 		sendErrorCode(tsChannel, TS_RESPONSE_OUT_OF_RANGE, "ERROR: Burn invalid page");
 		return;
 	}
 
 	tsChannel->writeCrcResponse(TS_RESPONSE_BURN_OK);
+	if (page == TS_PAGE_SETTINGS) {
+		tsChannel->settingsBurnTimer.reset();
+	}
 }
-#endif // EFI_PROD_CODE || EFI_SIMULATOR
 
 #if (EFI_PROD_CODE || EFI_SIMULATOR)
 
@@ -681,6 +718,7 @@ TunerStudio tsInstance;
 
 static int tsProcessOne(TsChannelBase* tsChannel) {
 	assertStack("communication", ObdCode::STACK_USAGE_COMMUNICATION, EXPECTED_REMAINING_STACK, -1);
+	tsInstance.handlePendingBurnTimeout(tsChannel);
 
 	if (!tsChannel->isReady()) {
 		chThdSleepMilliseconds(10);

--- a/firmware/console/binary/tunerstudio_impl.h
+++ b/firmware/console/binary/tunerstudio_impl.h
@@ -34,9 +34,12 @@ public:
 	void handleWriteChunkCommand(TsChannelBase* tsChannel, uint16_t page, uint16_t offset, uint16_t count,
 			void *content);
 	void handleCrc32Check(TsChannelBase *tsChannel,  uint32_t page, uint32_t offset, uint32_t count);
+	void handleBurnCommand(TsChannelBase* tsChannel, uint16_t page);
+	void handlePendingBurnTimeout(TsChannelBase* tsChannel);
 	void handlePageReadCommand(TsChannelBase* tsChannel, uint32_t page, uint32_t offset, uint32_t count);
 	void handleScatteredReadCommand(TsChannelBase* tsChannel);
 
 private:
+	void finishPendingBurn(TsChannelBase* tsChannel);
 	void sendErrorCode(TsChannelBase* tsChannel, uint8_t code, /*empty line by default, use nullptr not to log*/const char *msg="");
 };

--- a/firmware/console/binary/tunerstudio_io.h
+++ b/firmware/console/binary/tunerstudio_io.h
@@ -20,6 +20,7 @@
 #endif
 
 #include "can.h"
+#include <rusefi/timer.h>
 
 #ifndef USART_CR2_STOP1_BITS
 // todo: acticulate why exactly does prometheus_469 as for this hack
@@ -92,6 +93,8 @@ public:
 	 * by one read. Instead after getting packet size it will try to receive one byte of
 	 * command and check if it is supported. */
 	bool in_sync = false;
+	bool settingsBurnPending = false;
+	Timer settingsBurnTimer;
 
 private:
 	bool isBigPacket(size_t size);

--- a/unit_tests/tests/test_tunerstudio.cpp
+++ b/unit_tests/tests/test_tunerstudio.cpp
@@ -92,6 +92,55 @@ TEST(TunerstudioCommands, writeChunkEngineConfig) {
 	EXPECT_EQ(configBytes[100], 50);
 }
 
+TEST(TunerstudioCommands, burnFixRunsAfterCrc) {
+	EngineTestHelper eth(engine_type_e::TEST_ENGINE);
+	BufferTsChannel channel;
+	TunerStudio ts;
+
+	engineConfiguration->mapExpAverageAlpha = 0;
+	const uint32_t expectedCrc = SWAP_UINT32(crc32(engineConfiguration, sizeof(persistent_config_s)));
+
+	ts.handleBurnCommand(&channel, TS_PAGE_SETTINGS);
+	EXPECT_TRUE(channel.settingsBurnPending);
+	EXPECT_EQ(engineConfiguration->mapExpAverageAlpha, 0);
+	ts.handleBurnCommand(&channel, TS_PAGE_SETTINGS);
+	EXPECT_TRUE(channel.settingsBurnPending);
+	EXPECT_EQ(engineConfiguration->mapExpAverageAlpha, 0);
+	uint8_t zero = 0;
+	ts.handleWriteChunkCommand(&channel, TS_PAGE_SETTINGS,
+		offsetof(engine_configuration_s, mapExpAverageAlpha), sizeof(zero), &zero);
+	EXPECT_TRUE(channel.settingsBurnPending);
+	EXPECT_EQ(engineConfiguration->mapExpAverageAlpha, 0);
+
+	channel.reset();
+	ts.handleCrc32Check(&channel, TS_PAGE_SETTINGS, 0, sizeof(persistent_config_s));
+
+	uint32_t actualCrc;
+	memcpy(&actualCrc, &st5TestBuffer[3], sizeof(actualCrc));
+	EXPECT_EQ(actualCrc, expectedCrc);
+	EXPECT_FALSE(channel.settingsBurnPending);
+	EXPECT_EQ(engineConfiguration->mapExpAverageAlpha, 1);
+}
+
+TEST(TunerstudioCommands, burnFixRunsAfterTimeout) {
+	EngineTestHelper eth(engine_type_e::TEST_ENGINE);
+	BufferTsChannel channel;
+	TunerStudio ts;
+
+	engineConfiguration->mapExpAverageAlpha = 0;
+	ts.handleBurnCommand(&channel, TS_PAGE_SETTINGS);
+
+	advanceTimeUs(1900000);
+	ts.handlePendingBurnTimeout(&channel);
+	EXPECT_TRUE(channel.settingsBurnPending);
+	EXPECT_EQ(engineConfiguration->mapExpAverageAlpha, 0);
+
+	advanceTimeUs(200000);
+	ts.handlePendingBurnTimeout(&channel);
+	EXPECT_FALSE(channel.settingsBurnPending);
+	EXPECT_EQ(engineConfiguration->mapExpAverageAlpha, 1);
+}
+
 static constexpr size_t TS_ERROR_PACKET_SIZE = 7;
 static constexpr uint16_t OVERSIZED_COUNT = 0xFFFF;
 


### PR DESCRIPTION
resolves #9938