### PR TITLE
TuneManagementTab: add offline support, tune hardware updates, ...

### DIFF
--- a/java_console/ui/src/main/java/com/rusefi/ConsoleUI.java
+++ b/java_console/ui/src/main/java/com/rusefi/ConsoleUI.java
@@ -14,7 +14,11 @@ import com.rusefi.io.CommandQueue;
 import com.rusefi.io.LinkManager;
 import com.rusefi.io.serial.BaudRateHolder;
 import com.rusefi.maintenance.StLinkFlasher;
+import com.rusefi.maintenance.jobs.ImportTuneJob;
 import com.rusefi.ui.*;
+import com.rusefi.ui.basic.SingleAsyncJobExecutor;
+import com.rusefi.ui.basic.StatusPanelWithProgressBar;
+import com.rusefi.ui.basic.TuneManagementTab;
 import com.rusefi.ui.console.MainFrame;
 import com.rusefi.ui.console.TabbedPanel;
 import com.rusefi.ui.engine.EngineSnifferPanel;
@@ -22,6 +26,7 @@ import com.rusefi.ui.lua.LuaScriptPanel;
 import com.rusefi.ui.plugins.ConsoleTabProvider;
 import com.rusefi.ui.util.JustOneInstance;
 import com.rusefi.ui.widgets.ConnectionStatusIcon;
+import com.rusefi.ui.widgets.StatusPanel;
 import com.rusefi.ui.wizard.WizardCatalog;
 import com.rusefi.ui.wizard.WizardContainer;
 import com.rusefi.ui.wizard.WizardStep;
@@ -338,8 +343,24 @@ console live data tab is broken #8402
             tabbedPane.addTab("Live Data", LiveDataPane.createLazy(uiContext).getContent());
  */
             PinoutPane pinoutPane = new PinoutPane(uiContext);
-            PortResult initialPort = (port != null) ? new PortResult(port, serialPortType) : null;
+            PortResult initialPort = null;
+            if (port != null) {
+                for (PortResult candidate : connectivityContext.getCurrentHardware().getKnownPorts()) {
+                    if (port.equals(candidate.port)) {
+                        initialPort = candidate;
+                        break;
+                    }
+                }
+                if (initialPort == null) {
+                    initialPort = new PortResult(port, serialPortType);
+                }
+            }
             DeviceSessionManager deviceSessionManager = new DeviceSessionManager(connectivityContext, initialPort);
+            StatusPanelWithProgressBar deviceStatusPanel = new StatusPanelWithProgressBar();
+            StatusPanel tuneStatusPanel = new StatusPanel(250);
+            SingleAsyncJobExecutor consoleJobExecutor = new SingleAsyncJobExecutor(job ->
+                job instanceof ImportTuneJob ? tuneStatusPanel : deviceStatusPanel,
+                job -> !(job instanceof ImportTuneJob));
 
             // [tag:offline_tune] Seed the loaded tune image so config-image-driven panes (e.g. PinoutPane's
             // "Tune use" column) have data with no live ECU — the online path gets this from BinaryProtocol.
@@ -397,10 +418,26 @@ console live data tab is broken #8402
             if (UiProperties.isPinoutEnabled()) {
                 tabbedPane.addTab("Pinout", pinoutPane.getContent());
             }
+
+            final TuneManagementTab tuneManagementTab;
+            if (TuneManagementTab.getTunesManifestUrl() != null) {
+                tuneManagementTab = new TuneManagementTab(
+                    connectivityContext,
+                    uiContext,
+                    consoleJobExecutor,
+                    tuneStatusPanel,
+                    () -> tabbedPane.selectTab("Manage Tunes")
+                );
+                tabbedPane.addTab("Manage Tunes", tuneManagementTab.getContent());
+            } else {
+                tuneManagementTab = null;
+            }
+
             // Single-session device manager [tag:better_ux_for_flashing]: the scanner is kept alive for the whole console
             // lifetime so this one instance can hook / remove / re-connect / DFU / OpenBLT the board.
             DevicePane devicePane = new DevicePane(
                 uiContext, connectivityContext, deviceSessionManager, tabbedPane.tabbedPane,
+                consoleJobExecutor, deviceStatusPanel,
                 picker -> {
                     rollbackPicker.removeAll();
                     rollbackPicker.add(picker, BorderLayout.CENTER);
@@ -415,12 +452,19 @@ console live data tab is broken #8402
 
             addCustomTabs();
 
+            AtomicReference<AvailableHardware> tuneHardware = new AtomicReference<>();
             deviceSessionManager.addListener((state, hardware) -> SwingUtilities.invokeLater(() -> {
                 boolean flashing = state == SessionState.FLASHING;
                 mainFrame.setFirmwareUpdateInProgress(flashing);
                 launchWizardButton.setEnabled(!flashing);
                 if (tuningHolder[0] != null) {
                     tuningHolder[0].setFirmwareUpdateInProgress(flashing);
+                }
+                if (tuneManagementTab != null) {
+                    AvailableHardware effectiveHardware = connectivityContext.getCurrentHardware();
+                    if (tuneHardware.getAndSet(effectiveHardware) != effectiveHardware) {
+                        tuneManagementTab.onHardwareUpdated(effectiveHardware);
+                    }
                 }
             }));
 

--- a/java_console/ui/src/main/java/com/rusefi/DevicePane.java
+++ b/java_console/ui/src/main/java/com/rusefi/DevicePane.java
@@ -36,7 +36,7 @@ public class DevicePane {
     private final ProgramSelector selector;
     private final SingleAsyncJobExecutor jobExecutor;
     private final FirmwareRollbackController rollbackController;
-    private final StatusPanelWithProgressBar statusPanel = new StatusPanelWithProgressBar();
+    private final StatusPanelWithProgressBar statusPanel;
     private final JCheckBox autoUpdateBundle = new JCheckBox("Auto-update Software", AutoupdateProperty.get());
     private final JCheckBox migrateSettings = new JCheckBox("Migrate Settings", true);
     // Previous state rendered on the EDT — used to detect the *transition* into a bootloader state so we
@@ -45,15 +45,17 @@ public class DevicePane {
 
     public DevicePane(final UIContext uiContext, final ConnectivityContext connectivityContext,
                       final DeviceSessionManager sessionManager, final JTabbedPane tabbedPane,
+                      final SingleAsyncJobExecutor jobExecutor, final StatusPanelWithProgressBar statusPanel,
                       final Consumer<JComponent> showRollbackPicker, final Runnable closeRollbackPicker) {
         this.connectivityContext = connectivityContext;
         this.sessionManager = sessionManager;
         this.tabbedPane = tabbedPane;
+        this.jobExecutor = jobExecutor;
+        this.statusPanel = statusPanel;
 
-        // Firmware jobs run on a per-tab single executor whose output is the status/progress panel.
+        // Firmware and tune-import jobs share one executor, with output routed to their own status panels.
         // Tab-locking is driven by render() off the session state (which already includes FLASHING as
         // well as the DFU/OpenBLT bootloader states), so no separate job-executor listeners are needed.
-        this.jobExecutor = new SingleAsyncJobExecutor(statusPanel);
         sessionManager.setJobExecutor(jobExecutor);
 
         this.selector = new ProgramSelector(connectivityContext, comboPorts);
@@ -239,7 +241,8 @@ public class DevicePane {
     // ("Tuning") and the pinout reference. Active flashing is stricter: Tuning can write if the old
     // BinaryProtocol is still reachable, so only Device progress and Pinout remain available.
     static boolean isOfflineCapableTab(final String title) {
-        return "Device".equals(title) || "Tuning".equals(title) || "Pinout".equals(title);
+        return "Device".equals(title) || "Tuning".equals(title) || "Pinout".equals(title)
+            || "Manage Tunes".equals(title);
     }
 
     static boolean isTabEnabled(final String title, final SessionState state) {

--- a/java_console/ui/src/main/java/com/rusefi/StartupFrame.java
+++ b/java_console/ui/src/main/java/com/rusefi/StartupFrame.java
@@ -771,7 +771,7 @@ public class StartupFrame {
         if (offlineConsoleOpen) {
             // [tag:offline_tune] Pre-cache the target so the scanner skips re-inspecting it during the
             // connect read window — otherwise a scan tick could reopen the port mid-read and hang in LOADING.
-            connectivityContext.getPortScanner().cachePort(new PortResult(target.port, target.type));
+            connectivityContext.getPortScanner().cachePort(target);
         }
         connectButton.setEnabled(false);
         connectButton.setText("Connecting...");
@@ -904,7 +904,7 @@ public class StartupFrame {
             // under a different port name — auto-reconnects (handled via onSplashDisconnected re-arming).
             // Do NOT open a second console.
             log.info("onSplashConnected: offline console online on " + target.port + " — caching port, scanner kept alive");
-            connectivityContext.getPortScanner().cachePort(new PortResult(target.port, target.type));
+            connectivityContext.getPortScanner().cachePort(target);
             return;
         }
         connectButton.setText("Connect");

--- a/java_console/ui/src/main/java/com/rusefi/maintenance/jobs/AbstractAutoFlashJob.java
+++ b/java_console/ui/src/main/java/com/rusefi/maintenance/jobs/AbstractAutoFlashJob.java
@@ -72,7 +72,14 @@ abstract class AbstractAutoFlashJob extends AsyncJobWithContext<SerialPortWithPa
             connectivityContext.getPortScanner().resume();
             final String detectedPort = awaitEcuPort(TimeUnit.SECONDS.toMillis(60), SYSTEM_CLOCK);
             if (detectedPort != null) {
-                connectivityContext.getPortScanner().cachePort(new PortResult(detectedPort, context.getPort().type));
+                PortResult portToCache = new PortResult(detectedPort, context.getPort().type);
+                for (PortResult candidate : connectivityContext.getCurrentHardware().getKnownPorts()) {
+                    if (detectedPort.equals(candidate.port)) {
+                        portToCache = candidate;
+                        break;
+                    }
+                }
+                connectivityContext.getPortScanner().cachePort(portToCache);
                 lm.reconnect(detectedPort);
             } else {
                 callbacks.logLine("ECU did not re-appear after flashing — reconnect manually once it enumerates.");

--- a/java_console/ui/src/main/java/com/rusefi/ui/basic/SingleAsyncJobExecutor.java
+++ b/java_console/ui/src/main/java/com/rusefi/ui/basic/SingleAsyncJobExecutor.java
@@ -10,9 +10,11 @@ import java.util.ArrayList;
 import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.Predicate;
 
 public class SingleAsyncJobExecutor implements com.rusefi.DeviceSessionManager.JobExecutor {
     private final Function<AsyncJob, UpdateOperationCallbacks> callbacksProvider;
+    private final Predicate<AsyncJob> recordResult;
 
     private final java.util.List<Runnable> onJobInProgressFinished = new ArrayList<>();
     private final java.util.List<Runnable> onJobAboutToStart = new ArrayList<>();
@@ -30,11 +32,17 @@ public class SingleAsyncJobExecutor implements com.rusefi.DeviceSessionManager.J
     public SingleAsyncJobExecutor(
         final UpdateOperationCallbacks updateOperationCallbacks
     ) {
-        this(job -> updateOperationCallbacks);
+        this(job -> updateOperationCallbacks, job -> true);
     }
 
     public SingleAsyncJobExecutor(Function<AsyncJob, UpdateOperationCallbacks> callbacksProvider) {
+        this(callbacksProvider, job -> true);
+    }
+
+    public SingleAsyncJobExecutor(Function<AsyncJob, UpdateOperationCallbacks> callbacksProvider,
+                                  Predicate<AsyncJob> recordResult) {
         this.callbacksProvider = callbacksProvider;
+        this.recordResult = recordResult;
     }
 
     /** Delegating callbacks that record the terminal outcome before forwarding to the selected UI. */
@@ -139,8 +147,9 @@ public class SingleAsyncJobExecutor implements com.rusefi.DeviceSessionManager.J
             for (Runnable listener : onJobAboutToStart) {
                 listener.run();
             }
-            UpdateOperationCallbacks callbacks = recordingCallbacks(callbacksProvider.apply(job));
-            callbacks.clear(); // resets lastResult to NONE and clears the selected status panel
+            UpdateOperationCallbacks delegate = callbacksProvider.apply(job);
+            UpdateOperationCallbacks callbacks = recordResult.test(job) ? recordingCallbacks(delegate) : delegate;
+            callbacks.clear(); // clears the selected status panel; recorded jobs also reset lastResult
             AsyncJobExecutor.INSTANCE.executeJob(job, callbacks, () -> {
                 for (Runnable listener : onJobWorkerAboutToStart) {
                     listener.run();

--- a/java_console/ui/src/main/java/com/rusefi/ui/basic/TuneManagementTab.java
+++ b/java_console/ui/src/main/java/com/rusefi/ui/basic/TuneManagementTab.java
@@ -20,6 +20,7 @@ import com.rusefi.tune_manifest.TuneModel;
 import com.rusefi.ui.table.ButtonEditor;
 import com.rusefi.ui.table.ButtonRenderer;
 import com.rusefi.ui.widgets.StatusPanel;
+import org.jetbrains.annotations.Nullable;
 import org.json.simple.parser.ParseException;
 
 import javax.swing.*;
@@ -73,6 +74,27 @@ public class TuneManagementTab {
                              StatusPanel statusPanelTuneTab,
                              Runnable showTuneTab,
                              java.util.function.BiConsumer<IniFileModel, ConfigurationImage> offlineConsoleLauncher) {
+        this(connectivityContext, uiContext, importTuneControl, singleAsyncJobExecutor, statusPanelTuneTab,
+            showTuneTab, offlineConsoleLauncher, true);
+    }
+
+    public TuneManagementTab(ConnectivityContext connectivityContext,
+                             UIContext uiContext,
+                             SingleAsyncJobExecutor singleAsyncJobExecutor,
+                             StatusPanel statusPanelTuneTab,
+                             Runnable showTuneTab) {
+        this(connectivityContext, uiContext, null, singleAsyncJobExecutor, statusPanelTuneTab,
+            showTuneTab, null, false);
+    }
+
+    private TuneManagementTab(ConnectivityContext connectivityContext,
+                              UIContext uiContext,
+                              @Nullable ImportTuneControl importTuneControl,
+                              SingleAsyncJobExecutor singleAsyncJobExecutor,
+                              StatusPanel statusPanelTuneTab,
+                              Runnable showTuneTab,
+                              @Nullable java.util.function.BiConsumer<IniFileModel, ConfigurationImage> offlineConsoleLauncher,
+                              boolean showSplashControls) {
         this.offlineConsoleLauncher = offlineConsoleLauncher;
         Optional<TuneManifestExtension> loadedExtension;
         RuntimeException extensionLoadError;
@@ -86,10 +108,12 @@ public class TuneManagementTab {
         manifestExtension = loadedExtension;
         final RuntimeException finalExtensionLoadError = extensionLoadError;
 
-        Component importTuneButton = importTuneControl.getContent();
+        Component importTuneButton = showSplashControls ? importTuneControl.getContent() : null;
         importStatusPanel = new TuneOperationStatusPanel(statusPanelTuneTab, this::showMainContent);
 
-        importTuneControl.setImportErrorHandler(message -> showImportError(message, statusPanelTuneTab, showTuneTab));
+        if (importTuneControl != null) {
+            importTuneControl.setImportErrorHandler(message -> showImportError(message, statusPanelTuneTab, showTuneTab));
+        }
 
         singleAsyncJobExecutor.addOnJobAboutToStartListener(() -> {
             if (singleAsyncJobExecutor.getJobInProgress().filter(ImportTuneJob.class::isInstance).isPresent()) {
@@ -161,7 +185,7 @@ public class TuneManagementTab {
                         ImportTuneJob.importTuneIntoDeviceViaLiveConnection(
                             liveBp, lm, status, connectivityContext, tuneFileName, singleAsyncJobExecutor,
                             message -> showImportError(message, statusPanelTuneTab, showTuneTab));
-                    } else if (lm != null) {
+                    } else if (lm.isActive()) {
                         log.info("Let's load " + tuneFileName + " via LM");
                         ImportTuneJob.importTuneIntoDeviceViaLiveConnection(
                             lm, status, connectivityContext, tuneFileName, singleAsyncJobExecutor,
@@ -173,58 +197,62 @@ public class TuneManagementTab {
             }
         }));
 
-        JButton loadTuneFileButton = new JButton("Load Tune File");
-        loadTuneFileButton.addActionListener(e -> loadTuneFileOffline());
-        // A bit bigger so it reads as the primary offline action (#9715).
-        loadTuneFileButton.setFont(loadTuneFileButton.getFont().deriveFont(Font.BOLD, 16f));
-        loadTuneFileButton.setMargin(new Insets(12, 28, 12, 28));
+        if (showSplashControls) {
+            JButton loadTuneFileButton = new JButton("Load Tune File");
+            loadTuneFileButton.addActionListener(e -> loadTuneFileOffline());
+            // A bit bigger so it reads as the primary offline action (#9715).
+            loadTuneFileButton.setFont(loadTuneFileButton.getFont().deriveFont(Font.BOLD, 16f));
+            loadTuneFileButton.setMargin(new Insets(12, 28, 12, 28));
 
-        // [tag:offline_tune] Explain what this screen does — without it the splash is three silent
-        // buttons and no hint that a tune can be edited with no ECU attached (#9730).
-        JLabel offlineHint = new JLabel("<html><div style='text-align:center;'>"
-                + "No ECU connected. Load a tune file to view and edit it offline,<br>"
-                + "then connect an ECU to burn your changes.</div></html>");
-        offlineHint.setForeground(Color.DARK_GRAY);
+            // [tag:offline_tune] Explain what this screen does — without it the splash is three silent
+            // buttons and no hint that a tune can be edited with no ECU attached (#9730).
+            JLabel offlineHint = new JLabel("<html><div style='text-align:center;'>"
+                    + "No ECU connected. Load a tune file to view and edit it offline,<br>"
+                    + "then connect an ECU to burn your changes.</div></html>");
+            offlineHint.setForeground(Color.DARK_GRAY);
 
-        // [tag:offline_tune] The import pair pushes a tune to a *connected* ECU; on this pre-connection
-        // splash it has nothing to talk to (clicking just prints "Not connected?"), so only show it
-        // once an ECU is actually connected.
-        Runnable updateImportVisibility = () ->
-                importTuneButton.setVisible(com.rusefi.io.ConnectionStatusLogic.INSTANCE.isConnected());
-        updateImportVisibility.run();
-        com.rusefi.io.ConnectionStatusLogic.INSTANCE.addListener(
-                c -> SwingUtilities.invokeLater(updateImportVisibility));
+            // [tag:offline_tune] The import pair pushes a tune to a *connected* ECU; on this pre-connection
+            // splash it has nothing to talk to (clicking just prints "Not connected?"), so only show it
+            // once an ECU is actually connected.
+            Runnable updateImportVisibility = () ->
+                    importTuneButton.setVisible(com.rusefi.io.ConnectionStatusLogic.INSTANCE.isConnected());
+            updateImportVisibility.run();
+            com.rusefi.io.ConnectionStatusLogic.INSTANCE.addListener(
+                    c -> SwingUtilities.invokeLater(updateImportVisibility));
 
-        JPanel buttonPanel = new JPanel();
-        buttonPanel.setLayout(new BoxLayout(buttonPanel, BoxLayout.Y_AXIS));
-        buttonPanel.add(centerHorizontally(offlineHint));
-        buttonPanel.add(Box.createVerticalStrut(20));
-        buttonPanel.add(centerHorizontally(importTuneButton));
-        buttonPanel.add(Box.createVerticalStrut(28));
-        buttonPanel.add(centerHorizontally(loadTuneFileButton));
+            JPanel buttonPanel = new JPanel();
+            buttonPanel.setLayout(new BoxLayout(buttonPanel, BoxLayout.Y_AXIS));
+            buttonPanel.add(centerHorizontally(offlineHint));
+            buttonPanel.add(Box.createVerticalStrut(20));
+            buttonPanel.add(centerHorizontally(importTuneButton));
+            buttonPanel.add(Box.createVerticalStrut(28));
+            buttonPanel.add(centerHorizontally(loadTuneFileButton));
 
-        if (tunesManifestUrl != null) {
-            // Keep the tune list but cap it at ~80% of the height, with the buttons in the lower 20%,
-            // so they aren't pinned to the very bottom edge of the now-maximized splash (#9715).
-            JPanel body = new JPanel(new GridBagLayout());
-            GridBagConstraints c = new GridBagConstraints();
-            c.gridx = 0;
-            c.gridy = 0;
-            c.weightx = 1;
-            c.weighty = 0.8;
-            c.fill = GridBagConstraints.BOTH;
-            body.add(centerPanel, c);
-            c.gridy = 1;
-            c.weighty = 0.2;
-            c.fill = GridBagConstraints.NONE;
-            c.anchor = GridBagConstraints.CENTER;
-            body.add(buttonPanel, c);
-            mainContent.add(body, BorderLayout.CENTER);
-        } else {
-            // No tune list available — just center the buttons in the tab (#9715).
-            JPanel centered = new JPanel(new GridBagLayout());
-            centered.add(buttonPanel, new GridBagConstraints());
-            mainContent.add(centered, BorderLayout.CENTER);
+            if (tunesManifestUrl != null) {
+                // Keep the tune list but cap it at ~80% of the height, with the buttons in the lower 20%,
+                // so they aren't pinned to the very bottom edge of the now-maximized splash (#9715).
+                JPanel body = new JPanel(new GridBagLayout());
+                GridBagConstraints c = new GridBagConstraints();
+                c.gridx = 0;
+                c.gridy = 0;
+                c.weightx = 1;
+                c.weighty = 0.8;
+                c.fill = GridBagConstraints.BOTH;
+                body.add(centerPanel, c);
+                c.gridy = 1;
+                c.weighty = 0.2;
+                c.fill = GridBagConstraints.NONE;
+                c.anchor = GridBagConstraints.CENTER;
+                body.add(buttonPanel, c);
+                mainContent.add(body, BorderLayout.CENTER);
+            } else {
+                // No tune list available — just center the buttons in the tab (#9715).
+                JPanel centered = new JPanel(new GridBagLayout());
+                centered.add(buttonPanel, new GridBagConstraints());
+                mainContent.add(centered, BorderLayout.CENTER);
+            }
+        } else if (tunesManifestUrl != null) {
+            mainContent.add(centerPanel, BorderLayout.CENTER);
         }
 
         totalContent.add(mainContent, MAIN_CARD);
@@ -380,6 +408,9 @@ public class TuneManagementTab {
 
     /** [tag:offline_tune] Lets the user pick an .msq and open the console offline (no ECU connection). */
     private void loadTuneFileOffline() {
+        if (offlineConsoleLauncher == null) {
+            return;
+        }
         JFileChooser chooser = new JFileChooser();
         chooser.setFileSelectionMode(JFileChooser.FILES_ONLY);
         chooser.setFileFilter(new FileNameExtensionFilter("Tune files (.msq)", "msq"));

--- a/java_console/ui/src/main/java/com/rusefi/ui/console/MainFrame.java
+++ b/java_console/ui/src/main/java/com/rusefi/ui/console/MainFrame.java
@@ -159,8 +159,8 @@ public class MainFrame {
         if (firmwareUpdateInProgress) {
             int choice = JOptionPane.showConfirmDialog(
                 frame.getFrame(),
-                "A firmware update is still in progress. Exiting now may leave the ECU unfinished. Exit anyway?",
-                "Firmware Update In Progress",
+                "An ECU update operation is still in progress. Exiting now may leave the ECU unfinished. Exit anyway?",
+                "ECU Update In Progress",
                 JOptionPane.YES_NO_OPTION,
                 JOptionPane.WARNING_MESSAGE
             );

--- a/java_console/ui/src/test/java/com/rusefi/DevicePaneTest.java
+++ b/java_console/ui/src/test/java/com/rusefi/DevicePaneTest.java
@@ -48,6 +48,7 @@ public class DevicePaneTest {
         assertTrue(DevicePane.isOfflineCapableTab("Device"));
         assertTrue(DevicePane.isOfflineCapableTab("Tuning"));
         assertTrue(DevicePane.isOfflineCapableTab("Pinout"));
+        assertTrue(DevicePane.isOfflineCapableTab("Manage Tunes"));
 
         assertFalse(DevicePane.isOfflineCapableTab("Gauges"));
         assertFalse(DevicePane.isOfflineCapableTab("Messages"));
@@ -55,7 +56,9 @@ public class DevicePaneTest {
 
         assertTrue(DevicePane.isTabEnabled("Tuning", SessionState.DEVICE_IN_BLT));
         assertTrue(DevicePane.isTabEnabled("Tuning", SessionState.DEVICE_IN_DFU));
+        assertTrue(DevicePane.isTabEnabled("Manage Tunes", SessionState.DEVICE_IN_BLT));
         assertFalse(DevicePane.isTabEnabled("Tuning", SessionState.FLASHING));
+        assertFalse(DevicePane.isTabEnabled("Manage Tunes", SessionState.FLASHING));
         assertTrue(DevicePane.isTabEnabled("Device", SessionState.FLASHING));
         assertTrue(DevicePane.isTabEnabled("Pinout", SessionState.FLASHING));
         assertFalse(DevicePane.isTabEnabled("Messages", SessionState.FLASHING));

--- a/java_console/ui/src/test/java/com/rusefi/ui/basic/SingleAsyncJobExecutorTest.java
+++ b/java_console/ui/src/test/java/com/rusefi/ui/basic/SingleAsyncJobExecutorTest.java
@@ -12,6 +12,39 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class SingleAsyncJobExecutorTest {
     @Test
+    void unrecordedJobDoesNotOverwriteRecordedResult() throws Exception {
+        final SingleAsyncJobExecutor executor = new SingleAsyncJobExecutor(
+            job -> UpdateOperationCallbacks.DUMMY,
+            job -> "firmware".equals(job.getName()));
+
+        CountDownLatch firmwareFinished = new CountDownLatch(1);
+        executor.addOnJobInProgressFinishedListener(firmwareFinished::countDown);
+        assertTrue(executor.startJob(completedJob("firmware", true), null));
+        assertTrue(firmwareFinished.await(5, TimeUnit.SECONDS));
+        assertEquals(UpdateFirmwareResult.SUCCESS, executor.getLastResult());
+
+        CountDownLatch tuneFinished = new CountDownLatch(1);
+        executor.addOnJobInProgressFinishedListener(tuneFinished::countDown);
+        assertTrue(executor.startJob(completedJob("tune", false), null));
+        assertTrue(tuneFinished.await(5, TimeUnit.SECONDS));
+        assertEquals(UpdateFirmwareResult.SUCCESS, executor.getLastResult());
+    }
+
+    private static AsyncJob completedJob(String name, boolean success) {
+        return new AsyncJob(name) {
+            @Override
+            public void doJob(UpdateOperationCallbacks callbacks, Runnable onJobFinished) {
+                if (success) {
+                    callbacks.done();
+                } else {
+                    callbacks.error();
+                }
+                onJobFinished.run();
+            }
+        };
+    }
+
+    @Test
     void blockingPreparationDoesNotBlockCallerAndFinishesBeforeJobStarts() throws Exception {
         final SingleAsyncJobExecutor executor = new SingleAsyncJobExecutor(UpdateOperationCallbacks.DUMMY);
         final CountDownLatch preparationStarted = new CountDownLatch(1);

--- a/java_tools/version/src/main/java/com/rusefi/UiVersion.java
+++ b/java_tools/version/src/main/java/com/rusefi/UiVersion.java
@@ -5,5 +5,5 @@ public interface UiVersion {
      * *** BE CAREFUL WE HAVE SEPARATE AUTOUPDATE_VERSION also managed manually ***
      * @see com.rusefi.autoupdate.Autoupdate#AUTOUPDATE_VERSION
      */
-    int CONSOLE_VERSION = 20260728;
+    int CONSOLE_VERSION = 20260729;
 }


### PR DESCRIPTION
…job execution handling for already-connected board, add to main console window.

Now that we automatically connect to the boards after the splash screen, the tune management tab was hidden; now it's also shown in the main console. (but maybe we need some ticket on future for moving the UI more close to the wizard?; rn is 1-1 to the splash screen, so is a bit ugly)