### PR TITLE
add UI overlay when a unsupported board is connected, reject connection to unsupported ecu

### DIFF
--- a/java_console/connectivity/src/main/java/com/rusefi/DeviceSessionManager.java
+++ b/java_console/connectivity/src/main/java/com/rusefi/DeviceSessionManager.java
@@ -179,4 +179,12 @@ public class DeviceSessionManager {
         return state;
     }
 
+    /** Replace stale identity/calibration data after a different ECU is verified on the session port. */
+    public void setSessionPort(PortResult port) {
+        sessionPort = port;
+        if (state == SessionState.CONNECTED && port != null && !LinkManager.isSpecialNotSerial(port.port)) {
+            connectivityContext.getPortScanner().cachePort(port);
+        }
+    }
+
 }

--- a/java_console/connectivity/src/main/java/com/rusefi/PortResult.java
+++ b/java_console/connectivity/src/main/java/com/rusefi/PortResult.java
@@ -70,9 +70,12 @@ public class PortResult {
         if (type.friendlyString == null) {
             return this.port;
         } else {
-            String identity = type == SerialPortType.OpenBlt && bootloaderInfo != null && bootloaderInfo.raw != null
-                ? ": " + bootloaderInfo.raw
-                : "";
+            String identity = "";
+            if (type == SerialPortType.OpenBlt && bootloaderInfo != null && bootloaderInfo.raw != null) {
+                identity = ": " + bootloaderInfo.raw;
+            } else if (type == SerialPortType.UnsupportedEcu && unsupportedEcuInfo != null) {
+                identity = ": " + unsupportedEcuInfo.getEcuTarget();
+            }
             return this.port + " (" + type.friendlyString + identity + ")";
         }
     }
@@ -112,6 +115,10 @@ public class PortResult {
 
     public UnsupportedEcuInfo getUnsupportedEcuInfo() {
         return unsupportedEcuInfo;
+    }
+
+    public RusEfiSignature getSignature() {
+        return signature;
     }
 
     public Optional<String> getFirmwareHash() {

--- a/java_console/connectivity/src/main/java/com/rusefi/SerialPortCache.java
+++ b/java_console/connectivity/src/main/java/com/rusefi/SerialPortCache.java
@@ -10,24 +10,48 @@ import java.util.Set;
 public class SerialPortCache {
     private final static Logging log = Logging.getLogging(SerialPortCache.class);
 
-    private final Map<String, PortResult> cachedPorts = new HashMap<>();
+    private static final class Entry {
+        final PortResult port;
+        final long expiresAt;
 
-    Optional<PortResult> get(final String serialPort) {
-        return Optional.ofNullable(cachedPorts.get(serialPort));
+        private Entry(PortResult port, long expiresAt) {
+            this.port = port;
+            this.expiresAt = expiresAt;
+        }
     }
 
-    void put(final PortResult port) {
-        cachedPorts.put(port.port, port);
+    private final Map<String, Entry> cachedPorts = new HashMap<>();
+
+    synchronized Optional<PortResult> get(final String serialPort) {
+        Entry entry = cachedPorts.get(serialPort);
+        return Optional.ofNullable(entry == null ? null : entry.port);
     }
 
-    void retainAll(final Set<String> serialPortsToRetain) {
+    synchronized Optional<PortResult> get(final String serialPort, long now) {
+        Entry entry = cachedPorts.get(serialPort);
+        if (entry != null && entry.expiresAt <= now) {
+            cachedPorts.remove(serialPort);
+            entry = null;
+        }
+        return Optional.ofNullable(entry == null ? null : entry.port);
+    }
+
+    synchronized void put(final PortResult port) {
+        put(port, Long.MAX_VALUE);
+    }
+
+    synchronized void put(final PortResult port, long expiresAt) {
+        cachedPorts.put(port.port, new Entry(port, expiresAt));
+    }
+
+    synchronized void retainAll(final Set<String> serialPortsToRetain) {
         final int cachedPortCount = cachedPorts.size();
         if (cachedPorts.keySet().retainAll(serialPortsToRetain)) {
             log.info(String.format("%d disappeared ports are removed", cachedPortCount - cachedPorts.size()));
         }
     }
 
-    void invalidate(final String portName) {
+    synchronized void invalidate(final String portName) {
         cachedPorts.remove(portName);
     }
 }

--- a/java_console/connectivity/src/main/java/com/rusefi/SerialPortScanner.java
+++ b/java_console/connectivity/src/main/java/com/rusefi/SerialPortScanner.java
@@ -29,6 +29,7 @@ public class SerialPortScanner implements PortScanner {
     private final static Logging log = Logging.getLogging(SerialPortScanner.class);
 
     private static final boolean SHOW_SOCKETCAN = FileLog.isLinux();
+    private static final long DETECTED_ECU_CACHE_MS = 3000;
 
     /**
      * The hardware/OS probes the scan loop performs, separated from the scan *policy* (caching,
@@ -228,7 +229,7 @@ public class SerialPortScanner implements PortScanner {
 
         for (String serialPort : serialPorts) {
             // First, check the port cache
-            final Optional<PortResult> cachedPort = portCache.get(serialPort);
+            final Optional<PortResult> cachedPort = portCache.get(serialPort, probes.now());
             if (cachedPort.isPresent()) {
                 ports.add(cachedPort.get());
             } else {
@@ -241,8 +242,8 @@ public class SerialPortScanner implements PortScanner {
             ports.add(p);
             // Do not cache Unknown — keep the port uninspected so the next scan cycle retries
             // detection automatically without waiting for the port to disappear and reappear.
-            if (p.type != SerialPortType.Unknown) {
-                portCache.put(p);
+            if (p.type != SerialPortType.Unknown && p.type != SerialPortType.UnsupportedEcu) {
+                cacheDetectedPort(p);
             }
         }
 
@@ -259,7 +260,7 @@ public class SerialPortScanner implements PortScanner {
 
         if (includeSlowLookup) {
             for (String tcpPort : tcpPorts) {
-                final Optional<PortResult> cachedPort = portCache.get(tcpPort);
+                final Optional<PortResult> cachedPort = portCache.get(tcpPort, probes.now());
                 if (cachedPort.isPresent()) {
                     ports.add(cachedPort.get());
                 } else {
@@ -268,7 +269,7 @@ public class SerialPortScanner implements PortScanner {
 
                     // Preserve the previous policy: cache only a positively identified usable ECU.
                     if (tcpResult.isEcu()) {
-                        portCache.put(tcpResult);
+                        cacheDetectedPort(tcpResult);
                     }
                 }
             }
@@ -319,6 +320,14 @@ public class SerialPortScanner implements PortScanner {
 
     private void startTimer() {
         portsScanner.start();
+    }
+
+    private void cacheDetectedPort(PortResult port) {
+        if (port.isEcu()) {
+            portCache.put(port, probes.now() + DETECTED_ECU_CACHE_MS);
+        } else {
+            portCache.put(port);
+        }
     }
 
     public void stopTimer() {

--- a/java_console/connectivity/src/main/java/com/rusefi/SerialPortType.java
+++ b/java_console/connectivity/src/main/java/com/rusefi/SerialPortType.java
@@ -9,6 +9,7 @@ public enum SerialPortType {
     // synthetic PortResult (LinkManager.DFU) so a running console can offer DFU flashing in-session,
     // while DFU detection also stays exposed as AvailableHardware.isDfuFound() for back-compat.
     Dfu("DFU", 15),
+    EcuUnknown("ECU (bootloader unknown)", 20),
     UnsupportedEcu("Unsupported ECU", 25),
     CAN("CAN", 30),
     Unknown("Unknown", 100),

--- a/java_console/connectivity/src/test/java/com/rusefi/DeviceSessionManagerTest.java
+++ b/java_console/connectivity/src/test/java/com/rusefi/DeviceSessionManagerTest.java
@@ -66,6 +66,21 @@ public class DeviceSessionManagerTest {
     }
 
     @Test
+    public void verifiedReplacementClearsStaleSessionPortIdentity() {
+        PortResult oldPort = new PortResult("COM7", SerialPortType.EcuWithOpenblt);
+        DeviceSessionManager manager = new DeviceSessionManager(connectivityContext, oldPort);
+        scanner.cachedPorts.clear();
+        ConnectionStatusLogic.INSTANCE.setValue(ConnectionStatusValue.CONNECTED);
+        scanner.cachedPorts.clear();
+
+        PortResult replacement = new PortResult("COM7", SerialPortType.Ecu);
+        manager.setSessionPort(replacement);
+
+        assertEquals(1, scanner.cachedPorts.size());
+        assertSame(replacement, scanner.cachedPorts.get(0));
+    }
+
+    @Test
     public void openBltPortAppearingMovesSessionToDeviceInBlt() {
         DeviceSessionManager manager = new DeviceSessionManager(connectivityContext, null);
 

--- a/java_console/connectivity/src/test/java/com/rusefi/PortResultTest.java
+++ b/java_console/connectivity/src/test/java/com/rusefi/PortResultTest.java
@@ -49,6 +49,7 @@ public class PortResultTest {
         assertFalse(new PortResult("p", SerialPortType.CAN).isEcu());
         assertFalse(new PortResult("p", SerialPortType.UnsupportedEcu).isEcu());
         assertFalse(new PortResult("p", SerialPortType.Unknown).isEcu());
+        assertFalse(new PortResult("p", SerialPortType.EcuUnknown).isEcu());
     }
 
     @Test
@@ -59,6 +60,7 @@ public class PortResultTest {
         assertEquals(SerialPortType.UnsupportedEcu, unsupported.type);
         assertTrue(unsupported.isUnsupportedEcu());
         assertSame(info, unsupported.getUnsupportedEcuInfo());
+        assertEquals("COM4 (Unsupported ECU: hellen121nissan)", unsupported.toString());
         assertEquals(unsupported,
             PortResult.unsupportedEcu("COM4", new UnsupportedEcuInfo("other", "universal")),
             "port identity remains port and type, not the scan metadata");
@@ -77,4 +79,5 @@ public class PortResultTest {
         assertEquals("COM3 (OpenBLT Bootloader: rusefi.uaefi)",
             new PortResult("COM3", SerialPortType.OpenBlt, null, new OpenbltInfo(true, "rusefi.uaefi")).toString());
     }
+
 }

--- a/java_console/connectivity/src/test/java/com/rusefi/SerialPortCacheTest.java
+++ b/java_console/connectivity/src/test/java/com/rusefi/SerialPortCacheTest.java
@@ -36,6 +36,19 @@ public class SerialPortCacheTest {
     }
 
     @Test
+    public void detectedEntryExpiresButPinnedEntryDoesNot() {
+        SerialPortCache cache = new SerialPortCache();
+        PortResult detected = new PortResult("COM1", SerialPortType.Ecu);
+        cache.put(detected, 100);
+
+        assertTrue(cache.get("COM1", 99).isPresent());
+        assertFalse(cache.get("COM1", 100).isPresent());
+
+        cache.put(detected);
+        assertTrue(cache.get("COM1", 1_000_000).isPresent());
+    }
+
+    @Test
     public void putOverwritesPreviousEntryForSamePortName() {
         SerialPortCache cache = new SerialPortCache();
         cache.put(new PortResult("COM1", SerialPortType.Unknown));

--- a/java_console/connectivity/src/test/java/com/rusefi/SerialPortScannerTest.java
+++ b/java_console/connectivity/src/test/java/com/rusefi/SerialPortScannerTest.java
@@ -139,6 +139,19 @@ public class SerialPortScannerTest {
     }
 
     @Test
+    public void unconnectedEcuIdentityIsRecheckedAfterCacheTtl() {
+        addPort("COM5", SerialPortType.Ecu);
+        scan(false);
+
+        probes.inspectResults.put("COM5", new PortResult("COM5", SerialPortType.UnsupportedEcu));
+        probes.time += 3001;
+        scan(false);
+
+        assertEquals(2, (int) probes.inspectCalls.get("COM5"));
+        assertEquals(SerialPortType.UnsupportedEcu, knownPorts().get(0).type);
+    }
+
+    @Test
     public void unknownPortIsNotCachedSoDetectionRetriesEveryCycle() {
         addPort("COM5", SerialPortType.Unknown);
 
@@ -147,6 +160,21 @@ public class SerialPortScannerTest {
 
         assertEquals(2, (int) probes.inspectCalls.get("COM5"),
             "Unknown must be retried without waiting for the port to disappear and reappear");
+    }
+
+    @Test
+    public void unsupportedEcuIsReinspectedForSamePortHardwareReplacement() {
+        addPort("COM5", SerialPortType.UnsupportedEcu);
+
+        scan(false);
+        scan(false);
+
+        assertEquals(2, (int) probes.inspectCalls.get("COM5"));
+        assertEquals(SerialPortType.UnsupportedEcu, knownPorts().get(0).type);
+
+        probes.inspectResults.put("COM5", new PortResult("COM5", SerialPortType.Ecu));
+        scan(false);
+        assertEquals(SerialPortType.Ecu, knownPorts().get(0).type);
     }
 
     @Test
@@ -254,13 +282,14 @@ public class SerialPortScannerTest {
     }
 
     @Test
-    public void unsupportedTcpEcuKeepsItsClassification() {
+    public void unsupportedTcpEcuKeepsItsClassificationAndIsReinspected() {
         probes.tcpPorts.add("29001");
         probes.tcpResult = new PortResult("29001", SerialPortType.UnsupportedEcu);
 
         scan(true);
+        scan(true);
 
-        assertEquals(1, probes.tcpInspectionCalls);
+        assertEquals(2, probes.tcpInspectionCalls);
         assertEquals(SerialPortType.UnsupportedEcu, knownPorts().get(0).type);
     }
 
@@ -271,6 +300,7 @@ public class SerialPortScannerTest {
         probes.inspectResults.put("COM7", new PortResult("COM7", SerialPortType.EcuWithOpenblt));
 
         scanner.cachePort(live);
+        probes.time += 10_000;
         scan(false);
         assertFalse(probes.inspectCalls.containsKey("COM7"),
             "cachePort must prevent the scanner from opening a port a live connection is using");
@@ -291,5 +321,19 @@ public class SerialPortScannerTest {
         List<PortResult> ports = knownPorts();
         assertEquals(2, ports.size());
         assertEquals(SerialPortType.Ecu, ports.get(0).type, "your ECU belongs at the top of the list");
+    }
+
+    @Test
+    public void unsupportedEcuSortsAfterUsableEcuAndBeforeUnknown() {
+        addPort("COM1", SerialPortType.Unknown);
+        addPort("COM2", SerialPortType.UnsupportedEcu);
+        addPort("COM3", SerialPortType.Ecu);
+
+        scan(false);
+
+        List<PortResult> ports = knownPorts();
+        assertEquals(SerialPortType.Ecu, ports.get(0).type);
+        assertEquals(SerialPortType.UnsupportedEcu, ports.get(1).type);
+        assertEquals(SerialPortType.Unknown, ports.get(2).type);
     }
 }

--- a/java_console/connectivity/src/test/java/com/rusefi/SerialPortTypeTest.java
+++ b/java_console/connectivity/src/test/java/com/rusefi/SerialPortTypeTest.java
@@ -16,6 +16,7 @@ public class SerialPortTypeTest {
     public void bootloadersSortFirstAndUnknownSortsLast() {
         assertTrue(SerialPortType.OpenBlt.sortOrder < SerialPortType.Dfu.sortOrder);
         assertTrue(SerialPortType.Dfu.sortOrder < SerialPortType.Ecu.sortOrder);
+        assertEquals(SerialPortType.Ecu.sortOrder, SerialPortType.EcuUnknown.sortOrder);
         assertTrue(SerialPortType.Ecu.sortOrder < SerialPortType.UnsupportedEcu.sortOrder);
         assertTrue(SerialPortType.UnsupportedEcu.sortOrder < SerialPortType.CAN.sortOrder);
         assertTrue(SerialPortType.CAN.sortOrder < SerialPortType.Unknown.sortOrder);

--- a/java_console/io/src/main/java/com/rusefi/binaryprotocol/BinaryProtocol.java
+++ b/java_console/io/src/main/java/com/rusefi/binaryprotocol/BinaryProtocol.java
@@ -214,29 +214,23 @@ public class BinaryProtocol {
         // Check for bundle/ECU mismatch before attempting to read configuration
         // Skip check if bundle target is unknown (e.g., simulator, local development)
         RusEfiSignature ecuSignature = SignatureHelper.parse(signature);
-        if (ecuSignature != null) {
-            // remember the connected board so universal bundles can pick the right firmware / hardware kind
-            linkManager.getConnectedEcuTarget().set(ecuSignature.getBundleTarget());
-        }
         String bundleTarget = BundleUtil.getBundleTarget();
         if (ecuSignature != null && bundleTarget != null && !"unknown".equalsIgnoreCase(bundleTarget)) {
             // exact target, _QC_ hack and board_compatibility (* / allowlist) all handled here [tag:QC_firmware]
             if (!com.rusefi.core.io.BoardCompatibility.isEcuCompatible(bundleTarget, ecuSignature.getBundleTarget())) {
-                linkManager.reportUnsupportedEcu(new UnsupportedEcuInfo(
-                    ecuSignature.getBundleTarget(), bundleTarget));
-                String errorMsg = String.format(
-                    "Bundle/ECU mismatch detected!\n\n" +
-                    "Connected ECU: %s\n" +
-                    "Bundle target: %s\n\n" +
-                    "Please download the correct bundle for your ECU from:\n" +
-                    RUSEFI_WIKI_DOWNLOAD_PAGE + "\n\n" +
-                    "The .ini file in this bundle is not compatible with your ECU's memory layout.",
-                    ecuSignature.getBundleTarget(), bundleTarget
-                );
+                UnsupportedEcuInfo unsupported = new UnsupportedEcuInfo(
+                    ecuSignature.getBundleTarget(), bundleTarget);
+                linkManager.reportUnsupportedEcu(unsupported);
+                String errorMsg = unsupported.getMessage();
                 log.info(errorMsg);
                 close();
                 return errorMsg;
             }
+        }
+        if (ecuSignature != null) {
+            linkManager.reportCompatibleEcu(ecuSignature);
+            // Remember only a target this bundle is allowed to serve.
+            linkManager.getConnectedEcuTarget().set(ecuSignature.getBundleTarget());
         }
 
         try {

--- a/java_console/io/src/main/java/com/rusefi/io/LinkManager.java
+++ b/java_console/io/src/main/java/com/rusefi/io/LinkManager.java
@@ -6,6 +6,7 @@ import com.rusefi.Callable;
 import com.rusefi.binaryprotocol.BinaryProtocol;
 import com.rusefi.binaryprotocol.BinaryProtocolState;
 import com.rusefi.core.EngineState;
+import com.rusefi.core.RusEfiSignature;
 import com.rusefi.core.io.UnsupportedEcuInfo;
 import com.rusefi.io.serial.BufferedSerialIoStream;
 import com.rusefi.io.serial.StreamConnector;
@@ -45,6 +46,9 @@ public class LinkManager implements Closeable {
         EcuCompatibilityListener VOID = (port, info) -> { };
 
         void onUnsupportedEcu(String port, UnsupportedEcuInfo info);
+
+        default void onCompatibleEcu(String port, RusEfiSignature signature) {
+        }
     }
 
     @NotNull
@@ -106,6 +110,10 @@ public class LinkManager implements Closeable {
 
     public void reportUnsupportedEcu(UnsupportedEcuInfo info) {
         ecuCompatibilityListener.onUnsupportedEcu(lastTriedPort, info);
+    }
+
+    public void reportCompatibleEcu(RusEfiSignature signature) {
+        ecuCompatibilityListener.onCompatibleEcu(lastTriedPort, signature);
     }
 
     @NotNull

--- a/java_console/io/src/main/java/com/rusefi/io/tcp/TcpConnector.java
+++ b/java_console/io/src/main/java/com/rusefi/io/tcp/TcpConnector.java
@@ -3,6 +3,7 @@ package com.rusefi.io.tcp;
 import com.devexperts.logging.Logging;
 
 import java.io.IOException;
+import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.util.Collection;
 import java.util.Collections;
@@ -72,13 +73,16 @@ public class TcpConnector {
     }
 
     public static boolean isTcpPortOpened() {
+        return isPortOpened("" + DEFAULT_PORT);
+    }
+
+    public static boolean isPortOpened(String port) {
         long now = System.currentTimeMillis();
-        try {
-            Socket s = new Socket(LOCALHOST, DEFAULT_PORT);
-            s.close();
+        try (Socket s = new Socket()) {
+            s.connect(new InetSocketAddress(getHostname(port), getTcpPort(port)), 200);
             return true;
         } catch (IOException e) {
-            log.info("Connection refused in getAvailablePorts(): simulator not running in " + (System.currentTimeMillis() - now) + "ms");
+            log.info("Connection refused for " + port + " in " + (System.currentTimeMillis() - now) + "ms");
             return false;
         }
     }

--- a/java_console/io/src/test/java/com/rusefi/io/LinkManagerCompatibilityListenerTest.java
+++ b/java_console/io/src/test/java/com/rusefi/io/LinkManagerCompatibilityListenerTest.java
@@ -1,8 +1,12 @@
 package com.rusefi.io;
 
+import com.rusefi.core.RusEfiSignature;
+import com.rusefi.core.SignatureHelper;
 import com.rusefi.core.io.UnsupportedEcuInfo;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -25,5 +29,29 @@ public class LinkManagerCompatibilityListenerTest {
 
         assertEquals(LinkManager.LOG_VIEWER, reportedPort.get());
         assertSame(info, reportedInfo.get());
+    }
+
+    @Test
+    public void compatibleEventRetainsPortAcrossClose() {
+        List<String> events = new ArrayList<>();
+        LinkManager linkManager = new LinkManager().setEcuCompatibilityListener(
+            new LinkManager.EcuCompatibilityListener() {
+                @Override
+                public void onUnsupportedEcu(String port, UnsupportedEcuInfo info) {
+                }
+
+                @Override
+                public void onCompatibleEcu(String port, RusEfiSignature signature) {
+                    events.add("compatible:" + port + ":" + signature.getBundleTarget());
+                }
+            });
+        linkManager.start(LinkManager.LOG_VIEWER, ConnectionStatusLogic.Listener.VOID);
+
+        linkManager.close();
+        linkManager.reportCompatibleEcu(
+            SignatureHelper.parse("rusEFI master.2026.07.30.board-b.123456"));
+
+        assertEquals(java.util.Collections.singletonList(
+            "compatible:log viewer:board-b"), events);
     }
 }

--- a/java_console/shared_io/src/main/java/com/rusefi/core/io/UnsupportedEcuInfo.java
+++ b/java_console/shared_io/src/main/java/com/rusefi/core/io/UnsupportedEcuInfo.java
@@ -1,5 +1,10 @@
 package com.rusefi.core.io;
 
+import com.rusefi.core.net.PropertiesHolder;
+
+import static com.rusefi.core.net.ConnectionAndMeta.RUSEFI_WIKI_DOWNLOAD_PAGE;
+
+/** A positively identified ECU target that the current bundle is not allowed to serve. */
 public final class UnsupportedEcuInfo {
     private final String ecuTarget;
     private final String bundleTarget;
@@ -15,5 +20,20 @@ public final class UnsupportedEcuInfo {
 
     public String getBundleTarget() {
         return bundleTarget;
+    }
+
+    public String getDownloadUrl() {
+        return PropertiesHolder.getUpdateHelpUrl(RUSEFI_WIKI_DOWNLOAD_PAGE);
+    }
+
+    public String getMessage() {
+        return String.format(
+            "Unsupported ECU detected!\n\n" +
+                "Connected ECU: %s\n" +
+                "Bundle target: %s\n\n" +
+                "This bundle cannot safely connect to, tune, or update this ECU.\n\n" +
+                "Download a compatible bundle from:\n%s",
+            ecuTarget, bundleTarget, getDownloadUrl()
+        );
     }
 }

--- a/java_console/shared_io/src/main/java/com/rusefi/core/net/PropertiesHolder.java
+++ b/java_console/shared_io/src/main/java/com/rusefi/core/net/PropertiesHolder.java
@@ -58,6 +58,14 @@ public enum PropertiesHolder {
         return result;
     }
 
+    public static String getUpdateHelpUrl(String defaultUrl) {
+        return getUpdateHelpUrl(INSTANCE.getProperties(), defaultUrl);
+    }
+
+    static String getUpdateHelpUrl(Properties properties, String defaultUrl) {
+        return properties.getProperty("UPDATE_FW_HELP_URL", defaultUrl);
+    }
+
     public static String getFirmwareRollbackRootUrl() {
         return getFirmwareRollbackRootUrl(INSTANCE.getProperties());
     }

--- a/java_console/shared_io/src/test/java/com/rusefi/core/io/BoardCompatibilityTest.java
+++ b/java_console/shared_io/src/test/java/com/rusefi/core/io/BoardCompatibilityTest.java
@@ -45,4 +45,14 @@ public class BoardCompatibilityTest {
     public void nullEcuTargetIsTolerant() {
         assertTrue(BoardCompatibility.isEcuCompatible("uaefi", null, null));
     }
+
+    @Test
+    public void unsupportedMessageNamesBothTargetsAndDoesNotBlameBundledIni() {
+        String message = new UnsupportedEcuInfo("hellen121nissan", "universal").getMessage();
+
+        assertTrue(message.contains("hellen121nissan"));
+        assertTrue(message.contains("universal"));
+        assertTrue(message.contains("https://"));
+        assertFalse(message.contains(".ini"));
+    }
 }

--- a/java_console/shared_io/src/test/java/com/rusefi/core/net/PropertiesHolderTest.java
+++ b/java_console/shared_io/src/test/java/com/rusefi/core/net/PropertiesHolderTest.java
@@ -18,4 +18,15 @@ class PropertiesHolderTest {
         assertEquals("https://example.test/build_server/lts",
             PropertiesHolder.getFirmwareRollbackRootUrl(properties));
     }
+
+    @Test
+    void updateHelpUrlCanBeWhiteLabelSpecific() {
+        Properties properties = new Properties();
+        assertEquals(ConnectionAndMeta.RUSEFI_WIKI_DOWNLOAD_PAGE,
+            PropertiesHolder.getUpdateHelpUrl(properties, ConnectionAndMeta.RUSEFI_WIKI_DOWNLOAD_PAGE));
+
+        properties.setProperty("UPDATE_FW_HELP_URL", "https://example.test/controller-downloads");
+        assertEquals("https://example.test/controller-downloads",
+            PropertiesHolder.getUpdateHelpUrl(properties, ConnectionAndMeta.RUSEFI_WIKI_DOWNLOAD_PAGE));
+    }
 }

--- a/java_console/ui/src/main/java/com/rusefi/ConsoleUI.java
+++ b/java_console/ui/src/main/java/com/rusefi/ConsoleUI.java
@@ -83,6 +83,7 @@ public class ConsoleUI {
     private final String port;
 
     public final UIContext uiContext;
+    private final ConnectivityContext connectivityContext;
 
     /**
      * We can listen to tab activation event if we so desire
@@ -90,11 +91,12 @@ public class ConsoleUI {
     private final Map<Component, ActionListener> tabSelectedListeners = new HashMap<>();
 
     public ConsoleUI(String port, SerialPortType serialPortType, ConnectivityContext connectivityContext) {
-        this(new UIContext(connectivityContext.getConnectedEcuTarget()), port, serialPortType, false, null, null, null, connectivityContext);
+        this(new UIContext(connectivityContext.getConnectedEcuTarget()), port, serialPortType, false,
+            null, null, null, null, connectivityContext);
     }
 
     public ConsoleUI(UIContext uiContext, String port, SerialPortType serialPortType, boolean alreadyConnected, ConnectivityContext connectivityContext) {
-        this(uiContext, port, serialPortType, alreadyConnected, null, null, null, connectivityContext);
+        this(uiContext, port, serialPortType, alreadyConnected, null, null, null, null, connectivityContext);
     }
 
     /**
@@ -102,7 +104,14 @@ public class ConsoleUI {
      * instead of opening a second window (#9715).
      */
     public ConsoleUI(UIContext uiContext, String port, SerialPortType serialPortType, boolean alreadyConnected, JFrame reuseFrame, ConnectivityContext connectivityContext) {
-        this(uiContext, port, serialPortType, alreadyConnected, null, null, reuseFrame, connectivityContext);
+        this(uiContext, port, serialPortType, alreadyConnected, null, null, reuseFrame, null, connectivityContext);
+    }
+
+    public ConsoleUI(UIContext uiContext, String port, SerialPortType serialPortType, boolean alreadyConnected,
+                     JFrame reuseFrame, UnsupportedEcuCardHost unsupportedEcuHost,
+                     ConnectivityContext connectivityContext) {
+        this(uiContext, port, serialPortType, alreadyConnected, null, null, reuseFrame,
+            unsupportedEcuHost, connectivityContext);
     }
 
     /**
@@ -120,7 +129,13 @@ public class ConsoleUI {
      * {@code reuseFrame} instead of opening a second window — same handoff the online path uses (#9715).
      */
     public ConsoleUI(UIContext uiContext, IniFileModel ini, ConfigurationImage initialImage, JFrame reuseFrame, ConnectivityContext connectivityContext) {
-        this(uiContext, null, SerialPortType.Unknown, false, ini, initialImage, reuseFrame, connectivityContext);
+        this(uiContext, null, SerialPortType.Unknown, false, ini, initialImage, reuseFrame, null, connectivityContext);
+    }
+
+    public ConsoleUI(UIContext uiContext, IniFileModel ini, ConfigurationImage initialImage, JFrame reuseFrame,
+                     UnsupportedEcuCardHost unsupportedEcuHost, ConnectivityContext connectivityContext) {
+        this(uiContext, null, SerialPortType.Unknown, false, ini, initialImage, reuseFrame,
+            unsupportedEcuHost, connectivityContext);
     }
 
     /**
@@ -173,9 +188,14 @@ public class ConsoleUI {
 
     private ConsoleUI(UIContext uiContext, String port, SerialPortType serialPortType,
                       boolean alreadyConnected, IniFileModel offlineIni, ConfigurationImage offlineImage,
-                      JFrame reuseFrame, ConnectivityContext connectivityContext) {
+                      JFrame reuseFrame, UnsupportedEcuCardHost existingUnsupportedEcuHost,
+                      ConnectivityContext connectivityContext) {
         this.uiContext = uiContext;
+        this.connectivityContext = connectivityContext;
         LinkManager linkManager = uiContext.getLinkManager();
+        UnsupportedEcuCardHost unsupportedEcuHost = existingUnsupportedEcuHost != null
+            ? existingUnsupportedEcuHost
+            : new UnsupportedEcuCardHost(connectivityContext, linkManager);
 
         boolean isOffline = (offlineIni != null && offlineImage != null);
         if (isOffline) {
@@ -200,6 +220,11 @@ public class ConsoleUI {
         uiContext.addOfflineModeListener(offline -> SwingUtilities.invokeLater(() ->
                 tabbedPane.tabbedPane.putClientProperty("offlineMode", offline ? Boolean.TRUE : null)));
         this.port = port;
+        ConnectionStatusLogic.INSTANCE.addListener(isConnected -> {
+            if (!isConnected && linkManager.isDisconnectedByUser()) {
+                invalidatePort(linkManager.getLastTriedPort());
+            }
+        });
 
         // Follow a renumbered ECU across a bootloader round-trip. After a reboot to DFU/OpenBLT *without*
         // flashing, the board can re-enumerate onto a different ttyACMx. ConnectionWatchdog.restart() only
@@ -268,7 +293,7 @@ public class ConsoleUI {
 
         // ---------------
 
-        MainFrame mainFrame = new MainFrame(this, tabbedPane, reuseFrame);
+        MainFrame mainFrame = new MainFrame(this, tabbedPane, reuseFrame, unsupportedEcuHost);
         JFrame frame = mainFrame.getFrame().getFrame();
         setFrameIcon(frame);
         log.info("Console " + UiVersion.CONSOLE_VERSION);
@@ -356,6 +381,7 @@ console live data tab is broken #8402
                 }
             }
             DeviceSessionManager deviceSessionManager = new DeviceSessionManager(connectivityContext, initialPort);
+            unsupportedEcuHost.addCompatiblePortListener(deviceSessionManager::setSessionPort);
             StatusPanelWithProgressBar deviceStatusPanel = new StatusPanelWithProgressBar();
             StatusPanel tuneStatusPanel = new StatusPanel(250);
             SingleAsyncJobExecutor consoleJobExecutor = new SingleAsyncJobExecutor(job ->
@@ -523,10 +549,12 @@ console live data tab is broken #8402
         });
 
         ShortcutsHelper.installConnectAndDisconnect(uiContext, tabbedPane.tabbedPane,
-            () -> !Boolean.TRUE.equals(tabbedPane.tabbedPane.getClientProperty("isUpdating")));
+            () -> !Boolean.TRUE.equals(tabbedPane.tabbedPane.getClientProperty("isUpdating"))
+                && !unsupportedEcuHost.isBlocking());
         AutoupdateUtil.setAppIcon(mainFrame.getFrame().getFrame());
 
-        mainFrame.getFrame().showFrame(rootPanel);
+        unsupportedEcuHost.setNormalContent(rootPanel);
+        mainFrame.getFrame().showFrame(unsupportedEcuHost.getContent());
     }
 
     private @NotNull JButton getLaunchWizardButton(JPanel rootPanel, WizardContainer wizardContainer, CardLayout rootCardLayout) {
@@ -546,6 +574,12 @@ console live data tab is broken #8402
 
     public String getPort() {
         return port;
+    }
+
+    public void invalidatePort(String portToInvalidate) {
+        if (portToInvalidate != null) {
+            connectivityContext.getPortScanner().invalidatePort(portToInvalidate);
+        }
     }
 
     private void addCustomTabs() {

--- a/java_console/ui/src/main/java/com/rusefi/StartupFrame.java
+++ b/java_console/ui/src/main/java/com/rusefi/StartupFrame.java
@@ -134,6 +134,7 @@ public class StartupFrame {
     private final UIContext uiContext;
     private final CompletableFuture<Autoupdate.UpdateOutcome> softwareUpdateOutcome;
     private final JPanel rootContent = new JPanel(new CardLayout());
+    private UnsupportedEcuCardHost unsupportedEcuHost;
     private final JPanel rollbackPicker = new JPanel(new BorderLayout());
     // The large "scanning" card shown first (#9715); its status line is updated to "Connecting to X…"
     // if a single-ECU auto-connect fires before the controls are revealed.
@@ -221,6 +222,14 @@ public class StartupFrame {
     }
 
     public void showUi() {
+        unsupportedEcuHost = new UnsupportedEcuCardHost(connectivityContext, uiContext.getLinkManager());
+        unsupportedEcuHost.addBlockingListener(blocking -> {
+            if (blocking && autoConnectedPort != null) {
+                firstTimeAutoConnect = true;
+                onSplashDisconnected();
+            }
+            updateConnectButtonState();
+        });
         miscPanel.setBorder(new TitledBorder(BorderFactory.createLineBorder(Color.darkGray), "Miscellaneous"));
 
         connectPanel.add(portsComboBox.getComboPorts());
@@ -492,9 +501,11 @@ public class StartupFrame {
         rootContent.add(createScanningPanel(), CARD_SCANNING);
         ((CardLayout) rootContent.getLayout()).show(rootContent, CARD_SCANNING);
 
-        TunerStudioHelper.checkTunerStudio(frame.getContentPane(), () -> restoreContent(rootContent));
+        unsupportedEcuHost.setNormalContent(rootContent);
+        TunerStudioHelper.checkTunerStudio(
+            unsupportedEcuHost.getNormalContent(), () -> restoreContent(rootContent));
 
-        frame.add(rootContent);
+        frame.add(unsupportedEcuHost.getContent());
         // Maximize for the whole splash lifecycle so it doesn't jump to center then get replaced by
         // a second maximized console window (#9715). Mirrors FrameHelper.initFrame.
         frame.setSize(GraphicsEnvironment.getLocalGraphicsEnvironment().getMaximumWindowBounds().getSize());
@@ -584,8 +595,7 @@ public class StartupFrame {
     }
 
     private void restoreContent(JComponent root) {
-        frame.getContentPane().removeAll();
-        frame.add(root);
+        unsupportedEcuHost.setNormalContent(root);
         // Frame stays fixed-maximized (#9715) — relayout in place instead of pack()/resize.
         AutoupdateUtil.trueLayoutAndRepaint(frame);
     }
@@ -595,7 +605,10 @@ public class StartupFrame {
         // OpenBLT bootloader and DFU are not connectable — they are firmware-update targets [tag:better_ux_for_flashing].
         connectButton.setEnabled(selectedItem != null
             && selectedItem.type != OpenBlt
-            && selectedItem.type != SerialPortType.Dfu);
+            && selectedItem.type != SerialPortType.Dfu
+            && selectedItem.type != SerialPortType.EcuUnknown
+            && selectedItem.type != SerialPortType.UnsupportedEcu
+            && !unsupportedEcuHost.isBlocking());
     }
 
     private void applyKnownPorts(AvailableHardware currentHardware) {
@@ -670,8 +683,11 @@ public class StartupFrame {
     }
 
     private void connect(PortResult selectedPort) {
-        if (!asyncJobExecutor.isNotInProgress()) {
+        if (!asyncJobExecutor.isNotInProgress() || unsupportedEcuHost.isBlocking()) {
             return;
+        }
+        if (selectedPort.isEcu()) {
+            connectivityContext.getPortScanner().cachePort(selectedPort);
         }
         log.info("connect: port=" + selectedPort.port);
         boolean alreadyConnected = isAutoConnected(selectedPort);
@@ -688,7 +704,8 @@ public class StartupFrame {
         prepareForHandoff();
         LoadingOverlay.show(frame, "Loading console…", LogoHelper.createLogoLabel());
         SwingUtilities.invokeLater(() ->
-            new ConsoleUI(uiContext, selectedPort.port, selectedPort.type, alreadyConnected, frame, connectivityContext));
+            new ConsoleUI(uiContext, selectedPort.port, selectedPort.type, alreadyConnected,
+                frame, unsupportedEcuHost, connectivityContext));
     }
 
     /**
@@ -709,7 +726,7 @@ public class StartupFrame {
         prepareForHandoff();
         LoadingOverlay.show(frame, "Loading console…", LogoHelper.createLogoLabel());
         SwingUtilities.invokeLater(() ->
-            new ConsoleUI(uiContext, ini, image, frame, connectivityContext));
+            new ConsoleUI(uiContext, ini, image, frame, unsupportedEcuHost, connectivityContext));
     }
 
     /**
@@ -730,7 +747,7 @@ public class StartupFrame {
      * different startup tab last session.
      */
     private boolean shouldAutoConnect() {
-        return asyncJobExecutor.isNotInProgress();
+        return asyncJobExecutor.isNotInProgress() && !unsupportedEcuHost.isBlocking();
     }
 
     private boolean isFirmwareOperationInProgress() {
@@ -768,11 +785,9 @@ public class StartupFrame {
         if (scanningStatusLabel != null) {
             scanningStatusLabel.setText("Connecting to " + target.port + "…");
         }
-        if (offlineConsoleOpen) {
-            // [tag:offline_tune] Pre-cache the target so the scanner skips re-inspecting it during the
-            // connect read window — otherwise a scan tick could reopen the port mid-read and hang in LOADING.
-            connectivityContext.getPortScanner().cachePort(target);
-        }
+        // Pin the target while connecting so the scanner never reopens the same stream when its
+        // normal identity-cache TTL expires. DeviceSessionManager keeps it pinned after handoff.
+        connectivityContext.getPortScanner().cachePort(target);
         connectButton.setEnabled(false);
         connectButton.setText("Connecting...");
         portsComboBox.getComboPorts().setEnabled(false);
@@ -895,6 +910,11 @@ public class StartupFrame {
             // User cancelled or moved on — ignore the late event.
             return;
         }
+        if (unsupportedEcuHost.isBlocking()) {
+            firstTimeAutoConnect = true;
+            onSplashDisconnected();
+            return;
+        }
         if (offlineConsoleOpen) {
             // [tag:offline_tune] The offline console (already open on the shared uiContext) is now connected
             // via autoConnect.
@@ -908,7 +928,7 @@ public class StartupFrame {
             return;
         }
         connectButton.setText("Connect");
-        connectButton.setEnabled(true);
+        updateConnectButtonState();
         portsComboBox.getComboPorts().setEnabled(true);
         String launchingMsg = "Connected to " + target.port + " — launching console…";
         noPortsMessage.setForeground(Color.darkGray);
@@ -1088,17 +1108,19 @@ public class StartupFrame {
         startupUpdateActions.setSplashLinkManager(null);
         // Sets isStarted=false so the next connect() can create a new LinkManager connector.
         uiContext.getLinkManager().close();
+        if (autoConnectedPort != null) {
+            connectivityContext.getPortScanner().invalidatePort(autoConnectedPort.port);
+        }
         if (offlineConsoleOpen && autoConnectedPort != null) {
             // [tag:offline_tune] The offline console is still up. Re-arm scanner-driven auto-connect and
             // let the scanner re-inspect the (now stale) port so the console reconnects when the board
             // comes back — possibly under a different port name (USB re-enumeration).
-            connectivityContext.getPortScanner().invalidatePort(autoConnectedPort.port);
             firstTimeAutoConnect = true;
         }
         autoConnectedPort = null;
         autoConnectThread = null;
         connectButton.setText("Connect");
-        connectButton.setEnabled(true);
+        updateConnectButtonState();
         portsComboBox.getComboPorts().setEnabled(true);
         // Auto-connect dropped — make sure the user isn't stranded on the scanning animation (#9715).
         revealControls();
@@ -1114,10 +1136,13 @@ public class StartupFrame {
         }
         // Per design: keep auto-connect gate closed for the rest of the session.
         uiContext.getLinkManager().close();
+        if (autoConnectedPort != null) {
+            connectivityContext.getPortScanner().invalidatePort(autoConnectedPort.port);
+        }
         autoConnectedPort = null;
         autoConnectThread = null;
-        connectButton.setEnabled(true);
         connectButton.setText("Connect");
+        updateConnectButtonState();
         portsComboBox.getComboPorts().setEnabled(true);
         noPortsMessage.setForeground(Color.red);
         noPortsMessage.setText("Auto-connect failed: " + msg);

--- a/java_console/ui/src/main/java/com/rusefi/UiProperties.java
+++ b/java_console/ui/src/main/java/com/rusefi/UiProperties.java
@@ -19,7 +19,7 @@ public class UiProperties {
     }
 
     public static String getUpdateHelpUrl() {
-        return PropertiesHolder.getProperty("UPDATE_FW_HELP_URL", "https://wiki.rusefi.com/HOWTO-Update-Firmware");
+        return PropertiesHolder.getUpdateHelpUrl("https://wiki.rusefi.com/HOWTO-Update-Firmware");
     }
 
     public static boolean skipEcuTypeDetection() {

--- a/java_console/ui/src/main/java/com/rusefi/UnsupportedEcuCardHost.java
+++ b/java_console/ui/src/main/java/com/rusefi/UnsupportedEcuCardHost.java
@@ -1,0 +1,364 @@
+package com.rusefi;
+
+import com.rusefi.core.RusEfiSignature;
+import com.rusefi.core.io.UnsupportedEcuInfo;
+import com.rusefi.io.LinkManager;
+import com.rusefi.io.tcp.TcpConnector;
+import com.rusefi.ui.util.URLLabel;
+
+import javax.swing.*;
+import java.awt.*;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.Consumer;
+
+/** Full-window, hardware-driven blocker shared by startup and the full console. */
+public final class UnsupportedEcuCardHost implements LinkManager.EcuCompatibilityListener {
+    private static final String NORMAL = "normal";
+    private static final String UNSUPPORTED = "unsupported";
+
+    private static final class Blocker {
+        final UnsupportedEcuInfo info;
+        final boolean typed;
+
+        private Blocker(UnsupportedEcuInfo info, boolean typed) {
+            this.info = info;
+            this.typed = typed;
+        }
+    }
+
+    private final PortScanner portScanner;
+    private final JPanel content = new JPanel(new CardLayout());
+    private final JPanel normalContent = new JPanel(new BorderLayout());
+    private final JTextArea detectedTargets = new JTextArea();
+    private final JTextArea detectedPorts = new JTextArea();
+    private final JLabel bundleTarget = new JLabel();
+    private final JButton downloadButton = new JButton("Download compatible bundle");
+    private final Map<String, Blocker> blockers = new HashMap<>();
+    private final Map<String, String> compatibleIdentities = new HashMap<>();
+    private final Set<String> presentPorts = new HashSet<>();
+    private final List<Consumer<Boolean>> blockingListeners = new CopyOnWriteArrayList<>();
+    private final List<Consumer<PortResult>> compatiblePortListeners = new CopyOnWriteArrayList<>();
+
+    private volatile boolean blocking;
+    private volatile String downloadUrl;
+    private boolean renderedBlocking;
+    private long renderVersion;
+
+    public UnsupportedEcuCardHost(ConnectivityContext connectivityContext, LinkManager linkManager) {
+        portScanner = connectivityContext.getPortScanner();
+        content.add(normalContent, NORMAL);
+        content.add(createUnsupportedPanel(), UNSUPPORTED);
+        linkManager.setEcuCompatibilityListener(this);
+        portScanner.addListener(this::onHardwareChanged);
+        onHardwareChanged(portScanner.getCurrentHardware());
+    }
+
+    public JComponent getContent() {
+        return content;
+    }
+
+    public JPanel getNormalContent() {
+        return normalContent;
+    }
+
+    public void setNormalContent(JComponent component) {
+        normalContent.removeAll();
+        normalContent.add(component, BorderLayout.CENTER);
+        normalContent.revalidate();
+        normalContent.repaint();
+    }
+
+    public boolean isBlocking() {
+        return blocking;
+    }
+
+    public synchronized boolean isBlocked(String port) {
+        return blockers.containsKey(port);
+    }
+
+    public void addBlockingListener(Consumer<Boolean> listener) {
+        blockingListeners.add(listener);
+        runOnEdt(() -> listener.accept(blocking));
+    }
+
+    public void addCompatiblePortListener(Consumer<PortResult> listener) {
+        compatiblePortListeners.add(listener);
+    }
+
+    @Override
+    public void onUnsupportedEcu(String port, UnsupportedEcuInfo info) {
+        if (port == null) {
+            return;
+        }
+        synchronized (this) {
+            if (!isPortPresentLocked(port)) {
+                return;
+            }
+            blockers.put(port, new Blocker(info, true));
+            refreshLocked();
+        }
+        // A watchdog reconnect can discover a replacement ECU while the scanner still holds the old ECU.
+        portScanner.invalidatePort(port);
+    }
+
+    @Override
+    public void onCompatibleEcu(String port, RusEfiSignature signature) {
+        if (port == null) {
+            return;
+        }
+        boolean identityChanged;
+        synchronized (this) {
+            boolean wasBlocked = blockers.remove(port) != null;
+            String identity = signature == null ? "" : signature.toString();
+            String previousIdentity = compatibleIdentities.put(port, identity);
+            identityChanged = wasBlocked
+                || (previousIdentity != null && !previousIdentity.equals(identity));
+            refreshLocked();
+        }
+        if (identityChanged) {
+            // The live stream proves compatibility but cannot safely be probed for DFU/OpenBLT support.
+            PortResult recoveredPort = new PortResult(port, SerialPortType.EcuUnknown);
+            portScanner.cachePort(recoveredPort);
+            for (Consumer<PortResult> listener : compatiblePortListeners) {
+                listener.accept(recoveredPort);
+            }
+        }
+    }
+
+    private void onHardwareChanged(AvailableHardware hardware) {
+        Map<String, PortResult> ports = new HashMap<>();
+        for (PortResult port : hardware.getKnownPorts()) {
+            ports.put(port.port, port);
+        }
+
+        synchronized (this) {
+            presentPorts.clear();
+            presentPorts.addAll(ports.keySet());
+            blockers.entrySet().removeIf(entry -> !ports.containsKey(entry.getKey())
+                && !(entry.getValue().typed && LinkManager.isSpecialNotSerial(entry.getKey())));
+            compatibleIdentities.keySet().removeIf(port -> !ports.containsKey(port));
+            for (PortResult port : ports.values()) {
+                Blocker current = blockers.get(port.port);
+                if (port.isUnsupportedEcu() && port.getUnsupportedEcuInfo() != null
+                    && (current == null || !current.typed)) {
+                    blockers.put(port.port, new Blocker(port.getUnsupportedEcuInfo(), false));
+                } else if (port.isEcu() && current != null && !current.typed) {
+                    blockers.remove(port.port);
+                }
+                if (port.isEcu() && port.getSignature() != null) {
+                    compatibleIdentities.put(port.port, port.getSignature().toString());
+                }
+            }
+            refreshLocked();
+        }
+    }
+
+    private boolean isPortPresentLocked(String port) {
+        if (presentPorts.contains(port)) {
+            return true;
+        }
+        if (TcpConnector.isTcpPort(port)) {
+            return TcpConnector.isPortOpened(port);
+        }
+        return !LinkManager.isSpecialNotSerial(port) && LinkManager.getCommPorts().contains(port);
+    }
+
+    private void refreshLocked() {
+        List<Map.Entry<String, Blocker>> snapshot = new ArrayList<>(blockers.entrySet());
+        snapshot.sort(Comparator.comparing(Map.Entry::getKey));
+        blocking = !snapshot.isEmpty();
+        long version = ++renderVersion;
+
+        runOnEdt(() -> {
+            synchronized (UnsupportedEcuCardHost.this) {
+                if (version != renderVersion) {
+                    return;
+                }
+            }
+            render(snapshot);
+            boolean snapshotBlocking = !snapshot.isEmpty();
+            if (renderedBlocking != snapshotBlocking) {
+                renderedBlocking = snapshotBlocking;
+                for (Consumer<Boolean> listener : blockingListeners) {
+                    listener.accept(snapshotBlocking);
+                }
+            }
+        });
+    }
+
+    private void render(List<Map.Entry<String, Blocker>> snapshot) {
+        StringBuilder targets = new StringBuilder();
+        StringBuilder ports = new StringBuilder();
+        String bundle = "";
+        String resolvedDownloadUrl = null;
+        for (Map.Entry<String, Blocker> entry : snapshot) {
+            if (targets.length() > 0) {
+                targets.append('\n');
+                ports.append('\n');
+            }
+            UnsupportedEcuInfo info = entry.getValue().info;
+            targets.append(info.getEcuTarget());
+            ports.append(entry.getKey());
+            bundle = info.getBundleTarget();
+            resolvedDownloadUrl = info.getDownloadUrl();
+        }
+        detectedTargets.setText(targets.toString());
+        detectedPorts.setText(ports.toString());
+        bundleTarget.setText(bundle);
+        downloadUrl = resolvedDownloadUrl;
+        downloadButton.setEnabled(resolvedDownloadUrl != null && !resolvedDownloadUrl.trim().isEmpty());
+        CardLayout cards = (CardLayout) content.getLayout();
+        cards.show(content, snapshot.isEmpty() ? NORMAL : UNSUPPORTED);
+        content.revalidate();
+        content.repaint();
+    }
+
+    private JPanel createUnsupportedPanel() {
+        Color surface = color("TextField.background", Color.WHITE);
+        Color border = color("Component.borderColor", new Color(0xc8ccd2));
+        Color muted = color("Label.disabledForeground", new Color(0x6b7280));
+        Color danger = color("Actions.Red", new Color(0xb42318));
+        Color accent = color("Component.accentColor", new Color(0x2f6fed));
+
+        JPanel card = new JPanel();
+        card.setLayout(new BoxLayout(card, BoxLayout.Y_AXIS));
+        card.setBackground(surface);
+        card.setBorder(BorderFactory.createCompoundBorder(
+            BorderFactory.createLineBorder(border),
+            BorderFactory.createEmptyBorder(36, 44, 34, 44)));
+
+        JLabel status = new JLabel("CONNECTION BLOCKED");
+        status.setForeground(danger);
+        status.setFont(status.getFont().deriveFont(Font.BOLD, status.getFont().getSize() * 0.9f));
+        status.setAlignmentX(Component.LEFT_ALIGNMENT);
+        card.add(status);
+        card.add(Box.createVerticalStrut(14));
+
+        JLabel title = new JLabel("Unsupported ECU", UIManager.getIcon("OptionPane.warningIcon"), JLabel.LEFT);
+        title.setIconTextGap(14);
+        title.setFont(title.getFont().deriveFont(Font.BOLD, title.getFont().getSize() * 2.0f));
+        title.setAlignmentX(Component.LEFT_ALIGNMENT);
+        card.add(title);
+        card.add(Box.createVerticalStrut(14));
+
+        JTextArea explanation = transparentText(
+            "This console bundle does not support the detected controller. " +
+                "Connection, tuning, and firmware updates are blocked to protect the ECU.");
+        explanation.setColumns(48);
+        explanation.setForeground(muted);
+        explanation.setAlignmentX(Component.LEFT_ALIGNMENT);
+        card.add(explanation);
+        card.add(Box.createVerticalStrut(26));
+
+        JPanel details = new JPanel(new GridBagLayout());
+        details.setBackground(color("Panel.background", new Color(0xf5f6f8)));
+        details.setBorder(BorderFactory.createCompoundBorder(
+            BorderFactory.createLineBorder(border),
+            BorderFactory.createEmptyBorder(16, 18, 16, 18)));
+        details.setAlignmentX(Component.LEFT_ALIGNMENT);
+
+        JLabel targetHeader = new JLabel("ECU TARGET");
+        JLabel portHeader = new JLabel("PORT");
+        JLabel bundleHeader = new JLabel("CURRENT BUNDLE");
+        for (JLabel header : new JLabel[]{targetHeader, portHeader, bundleHeader}) {
+            header.setForeground(muted);
+            header.setFont(header.getFont().deriveFont(Font.BOLD, header.getFont().getSize() * 0.85f));
+        }
+
+        for (JTextArea values : new JTextArea[]{detectedTargets, detectedPorts}) {
+            values.setEditable(false);
+            values.setOpaque(false);
+            values.setFocusable(false);
+            values.setFont(values.getFont().deriveFont(Font.BOLD, values.getFont().getSize() * 1.15f));
+        }
+        bundleTarget.setFont(bundleTarget.getFont().deriveFont(Font.BOLD));
+
+        GridBagConstraints cell = new GridBagConstraints();
+        cell.anchor = GridBagConstraints.WEST;
+        cell.gridx = 0;
+        cell.gridy = 0;
+        cell.insets = new Insets(0, 0, 7, 32);
+        details.add(targetHeader, cell);
+        cell.gridx = 1;
+        cell.weightx = 1;
+        cell.insets = new Insets(0, 0, 7, 0);
+        details.add(portHeader, cell);
+        cell.gridx = 0;
+        cell.gridy = 1;
+        cell.weightx = 0;
+        cell.insets = new Insets(0, 0, 14, 32);
+        details.add(detectedTargets, cell);
+        cell.gridx = 1;
+        cell.weightx = 1;
+        cell.insets = new Insets(0, 0, 14, 0);
+        details.add(detectedPorts, cell);
+        cell.gridx = 0;
+        cell.gridy = 2;
+        cell.weightx = 0;
+        cell.insets = new Insets(0, 0, 0, 32);
+        details.add(bundleHeader, cell);
+        cell.gridx = 1;
+        cell.weightx = 1;
+        cell.insets = new Insets(0, 0, 0, 0);
+        details.add(bundleTarget, cell);
+        card.add(details);
+        card.add(Box.createVerticalStrut(24));
+
+        downloadButton.putClientProperty("JButton.buttonType", "roundRect");
+        downloadButton.setBackground(accent);
+        downloadButton.setForeground(Color.WHITE);
+        downloadButton.setFont(downloadButton.getFont().deriveFont(Font.BOLD));
+        downloadButton.setMargin(new Insets(10, 20, 10, 20));
+        downloadButton.setAlignmentX(Component.LEFT_ALIGNMENT);
+        downloadButton.setEnabled(false);
+        downloadButton.addActionListener(e -> {
+            String url = downloadUrl;
+            if (url != null && !url.trim().isEmpty()) {
+                URLLabel.open(url);
+            }
+        });
+        card.add(downloadButton);
+        card.add(Box.createVerticalStrut(16));
+
+        JLabel instruction = new JLabel("Disconnect every unsupported ECU to continue.");
+        instruction.setForeground(muted);
+        instruction.setAlignmentX(Component.LEFT_ALIGNMENT);
+        card.add(instruction);
+
+        JPanel centered = new JPanel(new GridBagLayout());
+        centered.setBorder(BorderFactory.createEmptyBorder(28, 28, 28, 28));
+        centered.add(card, new GridBagConstraints());
+        return centered;
+    }
+
+    private static JTextArea transparentText(String text) {
+        JTextArea area = new JTextArea(text);
+        area.setEditable(false);
+        area.setOpaque(false);
+        area.setFocusable(false);
+        area.setLineWrap(true);
+        area.setWrapStyleWord(true);
+        area.setFont(UIManager.getFont("Label.font"));
+        return area;
+    }
+
+    private static Color color(String key, Color fallback) {
+        Color value = UIManager.getColor(key);
+        return value != null ? value : fallback;
+    }
+
+    private static void runOnEdt(Runnable runnable) {
+        if (SwingUtilities.isEventDispatchThread()) {
+            runnable.run();
+        } else {
+            SwingUtilities.invokeLater(runnable);
+        }
+    }
+}

--- a/java_console/ui/src/main/java/com/rusefi/maintenance/ProgramSelector.java
+++ b/java_console/ui/src/main/java/com/rusefi/maintenance/ProgramSelector.java
@@ -70,6 +70,9 @@ public class ProgramSelector {
                 return;
             }
             final PortResult targetPort = resolveFlashPort();
+            if (targetPort == null) {
+                return;
+            }
             executeJob(splitButton, mainButtonModeFor(targetPort), targetPort);
         });
 
@@ -176,7 +179,7 @@ public class ProgramSelector {
                 return bltPorts.get(0);
             }
         }
-        return selected;
+        return isUnflashableEcu(selected) ? null : selected;
     }
 
     private void executeJob(JComponent parent, UpdateMode selectedMode, PortResult selectedPort) {
@@ -616,7 +619,7 @@ public class ProgramSelector {
     }
 
     static boolean hasRealSerialPort(List<PortResult> ports) {
-        return ports.stream().anyMatch(port -> port.type != SerialPortType.Dfu);
+        return ports.stream().anyMatch(port -> port.type != SerialPortType.Dfu && !isUnflashableEcu(port));
     }
 
     static boolean shouldEnableMainButton(
@@ -655,8 +658,18 @@ public class ProgramSelector {
 
     private void addMenuItem(JPopupMenu menu, UpdateMode mode) {
         JMenuItem item = new JMenuItem(mode.displayText);
-        item.addActionListener(e -> executeJob(splitButton, mode, (PortResult) comboPorts.getSelectedItem()));
+        item.addActionListener(e -> {
+            PortResult selected = (PortResult) comboPorts.getSelectedItem();
+            if (isUnflashableEcu(selected)) {
+                return;
+            }
+            executeJob(splitButton, mode, selected);
+        });
         menu.add(item);
+    }
+
+    private static boolean isUnflashableEcu(@Nullable PortResult port) {
+        return port != null && (port.isUnsupportedEcu() || port.type == SerialPortType.EcuUnknown);
     }
 
     @NotNull

--- a/java_console/ui/src/main/java/com/rusefi/ui/console/MainFrame.java
+++ b/java_console/ui/src/main/java/com/rusefi/ui/console/MainFrame.java
@@ -64,9 +64,11 @@ public class MainFrame {
     private boolean firmwareUpdateInProgress;
     private boolean updateSoftwareAvailable;
     private boolean updateEcuAvailable;
+    private boolean unsupportedEcuBlocking;
+    private final UnsupportedEcuCardHost unsupportedEcuHost;
 
     public MainFrame(ConsoleUI consoleUI, TabbedPanel tabbedPane) {
-        this(consoleUI, tabbedPane, null);
+        this(consoleUI, tabbedPane, null, null);
     }
 
     /**
@@ -74,8 +76,14 @@ public class MainFrame {
      *                   (handed off from {@link StartupFrame}) instead of creating a new window (#9715).
      */
     public MainFrame(ConsoleUI consoleUI, TabbedPanel tabbedPane, JFrame reuseFrame) {
+        this(consoleUI, tabbedPane, reuseFrame, null);
+    }
+
+    public MainFrame(ConsoleUI consoleUI, TabbedPanel tabbedPane, JFrame reuseFrame,
+                     UnsupportedEcuCardHost unsupportedEcuHost) {
         this.consoleUI = Objects.requireNonNull(consoleUI);
         this.tabbedPane = tabbedPane;
+        this.unsupportedEcuHost = unsupportedEcuHost;
         listener = ConnectionStatusLogic.Listener.VOID;
         // reuseFrame == null creates a new window; non-null reuses the splash frame in place (#9715).
         this.frame = new FrameHelper(reuseFrame, JFrame.DO_NOTHING_ON_CLOSE) {
@@ -99,6 +107,12 @@ public class MainFrame {
         };
 
         createMenuBar();
+        if (unsupportedEcuHost != null) {
+            unsupportedEcuHost.addBlockingListener(blocking -> {
+                unsupportedEcuBlocking = blocking;
+                refreshFirmwareUpdateExclusion();
+            });
+        }
     }
 
     private void createMenuBar() {
@@ -299,7 +313,11 @@ public class MainFrame {
                 @Override
                 public void onConnectionFailed(String errorMessage) {
                     log.error("onConnectionFailed " + errorMessage);
-                    SwingUtilities.invokeLater(() -> showConnectionFailedDialog(errorMessage));
+                    consoleUI.invalidatePort(linkManager.getLastTriedPort());
+                    if (unsupportedEcuHost == null
+                        || !unsupportedEcuHost.isBlocked(linkManager.getLastTriedPort())) {
+                        SwingUtilities.invokeLater(() -> showConnectionFailedDialog(errorMessage));
+                    }
                 }
 
                 @Override
@@ -337,7 +355,19 @@ public class MainFrame {
         saveTuneItem.setAction(saveAction);
         saveTuneItem.setText(LoadTuneHelper.SAVE_TUNE_TEXT);
         saveTuneItem.setMnemonic(KeyEvent.VK_S);
+        loadAction.addPropertyChangeListener(e -> refreshActionsAfterActionStateChange(e.getPropertyName()));
+        saveAction.addPropertyChangeListener(e -> refreshActionsAfterActionStateChange(e.getPropertyName()));
         refreshFirmwareUpdateExclusion();
+    }
+
+    private void refreshActionsAfterActionStateChange(String propertyName) {
+        if ("enabled".equals(propertyName)) {
+            if (SwingUtilities.isEventDispatchThread()) {
+                refreshFirmwareUpdateExclusion();
+            } else {
+                SwingUtilities.invokeLater(this::refreshFirmwareUpdateExclusion);
+            }
+        }
     }
 
     public void setFirmwareUpdateInProgress(boolean firmwareUpdateInProgress) {
@@ -357,9 +387,12 @@ public class MainFrame {
 
     private void refreshFirmwareUpdateExclusion() {
         Action loadAction = loadTuneItem.getAction();
-        loadTuneItem.setEnabled(!firmwareUpdateInProgress && loadAction != null && loadAction.isEnabled());
-        updateSoftwareItem.setEnabled(!firmwareUpdateInProgress && updateSoftwareAvailable);
-        updateEcuItem.setEnabled(!firmwareUpdateInProgress && updateEcuAvailable);
+        Action saveAction = saveTuneItem.getAction();
+        boolean applicationActionsAllowed = !firmwareUpdateInProgress && !unsupportedEcuBlocking;
+        loadTuneItem.setEnabled(applicationActionsAllowed && loadAction != null && loadAction.isEnabled());
+        saveTuneItem.setEnabled(applicationActionsAllowed && saveAction != null && saveAction.isEnabled());
+        updateSoftwareItem.setEnabled(applicationActionsAllowed && updateSoftwareAvailable);
+        updateEcuItem.setEnabled(applicationActionsAllowed && updateEcuAvailable);
     }
 
     public FrameHelper getFrame() {

--- a/java_console/ui/src/test/java/com/rusefi/UnsupportedEcuCardHostTest.java
+++ b/java_console/ui/src/test/java/com/rusefi/UnsupportedEcuCardHostTest.java
@@ -1,0 +1,140 @@
+package com.rusefi;
+
+import com.rusefi.core.io.UnsupportedEcuInfo;
+import com.rusefi.core.RusEfiSignature;
+import com.rusefi.io.LinkManager;
+import org.junit.jupiter.api.Test;
+
+import javax.swing.*;
+import java.awt.*;
+import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class UnsupportedEcuCardHostTest {
+    private static final String PORT = "COM7";
+
+    @Test
+    public void unsupportedAlwaysBlocksUntilThatPortIsResolved() throws Exception {
+        FakePortScanner scanner = new FakePortScanner();
+        LinkManager linkManager = new LinkManager();
+        UnsupportedEcuCardHost host = createHost(scanner, linkManager);
+        UnsupportedEcuInfo info = new UnsupportedEcuInfo("board-a", "universal");
+
+        scanner.fireHardwareChange(hardware(
+            new PortResult("COM1", SerialPortType.Ecu),
+            PortResult.unsupportedEcu(PORT, info)));
+        flushEdt();
+        assertTrue(host.isBlocking(), "an unsupported second ECU must interrupt a supported session");
+
+        host.onCompatibleEcu("COM1", null);
+        flushEdt();
+        assertTrue(host.isBlocking(), "a compatible identity on another port must not dismiss the modal");
+
+        AtomicReference<PortResult> recovered = new AtomicReference<>();
+        host.addCompatiblePortListener(recovered::set);
+        host.onCompatibleEcu(PORT, null);
+        flushEdt();
+        assertFalse(host.isBlocking());
+        assertTrue(recovered.get().type == SerialPortType.EcuUnknown);
+    }
+
+    @Test
+    public void typedWatchdogRejectionSurvivesStaleSupportedSnapshot() throws Exception {
+        FakePortScanner scanner = new FakePortScanner();
+        UnsupportedEcuCardHost host = createHost(scanner, new LinkManager());
+
+        scanner.fireHardwareChange(hardware(new PortResult(PORT, SerialPortType.Ecu)));
+        host.onUnsupportedEcu(PORT, new UnsupportedEcuInfo("board-a", "universal"));
+        scanner.fireHardwareChange(hardware(new PortResult(PORT, SerialPortType.Ecu)));
+        flushEdt();
+
+        assertTrue(host.isBlocking());
+        assertTrue(scanner.invalidatedPorts.contains(PORT));
+
+        scanner.fireHardwareChange(hardware());
+        flushEdt();
+        assertFalse(host.isBlocking(), "physical removal is the hardware-driven dismissal");
+    }
+
+    @Test
+    public void modalPreservesNormalContentAndHasOnlyDownloadAction() throws Exception {
+        FakePortScanner scanner = new FakePortScanner();
+        UnsupportedEcuCardHost host = createHost(scanner, new LinkManager());
+        JPanel normal = new JPanel();
+        SwingUtilities.invokeAndWait(() -> host.setNormalContent(normal));
+
+        scanner.fireHardwareChange(hardware(new PortResult(PORT, SerialPortType.Ecu)));
+        host.onUnsupportedEcu(PORT, new UnsupportedEcuInfo("board-a", "universal"));
+        flushEdt();
+        host.onCompatibleEcu(PORT, null);
+        flushEdt();
+
+        assertSame(normal, host.getNormalContent().getComponent(0));
+        assertTrue(containsButton(host.getContent(), "Download compatible bundle"));
+        assertFalse(containsButton(host.getContent(), "Dismiss"));
+        assertFalse(containsButton(host.getContent(), "Continue"));
+    }
+
+    @Test
+    public void lateRejectionAfterRemovalDoesNotReopenModal() throws Exception {
+        FakePortScanner scanner = new FakePortScanner();
+        UnsupportedEcuCardHost host = createHost(scanner, new LinkManager());
+
+        scanner.fireHardwareChange(hardware(new PortResult(PORT, SerialPortType.Ecu)));
+        scanner.fireHardwareChange(hardware());
+        host.onUnsupportedEcu(PORT, new UnsupportedEcuInfo("board-a", "universal"));
+        flushEdt();
+
+        assertFalse(host.isBlocking());
+    }
+
+    @Test
+    public void differentCompatibleIdentityClearsStaleSessionMetadata() throws Exception {
+        FakePortScanner scanner = new FakePortScanner();
+        UnsupportedEcuCardHost host = createHost(scanner, new LinkManager());
+        host.onCompatibleEcu(PORT, signature("board-a", "hash-a"));
+        AtomicReference<PortResult> recovered = new AtomicReference<>();
+        host.addCompatiblePortListener(recovered::set);
+
+        host.onCompatibleEcu(PORT, signature("board-a", "hash-b"));
+
+        assertTrue(recovered.get().type == SerialPortType.EcuUnknown);
+    }
+
+    private static UnsupportedEcuCardHost createHost(FakePortScanner scanner, LinkManager linkManager)
+        throws Exception {
+        AtomicReference<UnsupportedEcuCardHost> result = new AtomicReference<>();
+        SwingUtilities.invokeAndWait(() -> result.set(
+            new UnsupportedEcuCardHost(new ConnectivityContext(scanner), linkManager)));
+        flushEdt();
+        return result.get();
+    }
+
+    private static AvailableHardware hardware(PortResult... ports) {
+        return new AvailableHardware(Arrays.asList(ports), false, false, false);
+    }
+
+    private static RusEfiSignature signature(String target, String hash) {
+        return new RusEfiSignature("master", "2026", "07", "30", target, hash, false);
+    }
+
+    private static void flushEdt() throws Exception {
+        SwingUtilities.invokeAndWait(() -> {
+        });
+    }
+
+    private static boolean containsButton(Component component, String text) {
+        if (component instanceof AbstractButton) {
+            return text.equals(((AbstractButton) component).getText());
+        }
+        if (component instanceof Container) {
+            return Arrays.stream(((Container) component).getComponents())
+                .anyMatch(child -> containsButton(child, text));
+        }
+        return false;
+    }
+}

--- a/java_console/ui/src/test/java/com/rusefi/maintenance/ProgramSelectorTest.java
+++ b/java_console/ui/src/test/java/com/rusefi/maintenance/ProgramSelectorTest.java
@@ -97,6 +97,14 @@ public class ProgramSelectorTest {
         assertNull(resolveFlashPort(null, false, NO_PORTS, NO_PORTS));
     }
 
+    @Test
+    public void unsupportedEcuCannotBeSelectedForFlashing() {
+        PortResult unsupported = port(SerialPortType.UnsupportedEcu);
+        assertNull(resolveFlashPort(unsupported, false, NO_PORTS, NO_PORTS));
+        assertNull(resolveFlashPort(unsupported, true, NO_PORTS, NO_PORTS));
+        assertNull(resolveFlashPort(port(SerialPortType.EcuUnknown), true, NO_PORTS, NO_PORTS));
+    }
+
     // ---- combined: resolved port feeds the button mode ----
 
     @Test
@@ -150,6 +158,8 @@ public class ProgramSelectorTest {
     @Test
     public void syntheticDfuTargetIsNotTreatedAsSerialPort() {
         assertFalse(ProgramSelector.hasRealSerialPort(Collections.singletonList(port(SerialPortType.Dfu))));
+        assertFalse(ProgramSelector.hasRealSerialPort(Collections.singletonList(port(SerialPortType.UnsupportedEcu))));
+        assertFalse(ProgramSelector.hasRealSerialPort(Collections.singletonList(port(SerialPortType.EcuUnknown))));
         assertTrue(ProgramSelector.hasRealSerialPort(Collections.singletonList(port(SerialPortType.Ecu))));
     }
 


### PR DESCRIPTION
also add UI overlay when a unsuported board is connected, takes full screen both on splash or already openened full console

~draft, i will split the UI changes from the PortResult and friends to have this more readable~


<img width="640" height="432" alt="image" src="https://github.com/user-attachments/assets/87654dd7-f0bd-44e8-b9d4-95d6a72724fb" />

resolves #9945