### PR TITLE
SerialPortScanner: add support for detecting unsupported ECUs by bundle/universal

### DIFF
--- a/java_console/connectivity/src/main/java/com/rusefi/PortResult.java
+++ b/java_console/connectivity/src/main/java/com/rusefi/PortResult.java
@@ -5,6 +5,7 @@ import com.opensr5.ConfigurationImageMeta;
 import com.opensr5.ini.field.IniField;
 import com.rusefi.core.RusEfiSignature;
 import com.rusefi.core.SignatureHelper;
+import com.rusefi.core.io.UnsupportedEcuInfo;
 import com.rusefi.maintenance.CalibrationsInfo;
 import com.rusefi.updater.OpenbltDetectorStrategy.OpenbltInfo;
 
@@ -18,6 +19,7 @@ public class PortResult {
     private final CalibrationsInfo calibrations;
     private final RusEfiSignature signature;
     public final OpenbltInfo bootloaderInfo;
+    private final UnsupportedEcuInfo unsupportedEcuInfo;
 
     public PortResult(final String port, final SerialPortType type, final CalibrationsInfo calibrations) {
         this(port, type, calibrations, null);
@@ -25,10 +27,16 @@ public class PortResult {
 
     public PortResult(final String port, final SerialPortType type, final CalibrationsInfo calibrations,
                       final OpenbltInfo bootloaderInfo) {
+        this(port, type, calibrations, bootloaderInfo, null);
+    }
+
+    private PortResult(final String port, final SerialPortType type, final CalibrationsInfo calibrations,
+                       final OpenbltInfo bootloaderInfo, final UnsupportedEcuInfo unsupportedEcuInfo) {
         this.port = port;
         this.type = type;
         this.calibrations = calibrations;
         this.bootloaderInfo = bootloaderInfo;
+        this.unsupportedEcuInfo = unsupportedEcuInfo;
         if (calibrations == null) {
             signature = null;
         } else {
@@ -44,12 +52,17 @@ public class PortResult {
         this(port, type, null);
     }
 
+    public static PortResult unsupportedEcu(String port, UnsupportedEcuInfo info) {
+        return new PortResult(port, SerialPortType.UnsupportedEcu, null, null, info);
+    }
+
     protected PortResult(final PortResult origin) {
         this.port = origin.port;
         this.type = origin.type;
         this.calibrations = origin.calibrations;
         this.signature = origin.signature;
         this.bootloaderInfo = origin.bootloaderInfo;
+        this.unsupportedEcuInfo = origin.unsupportedEcuInfo;
     }
 
     @Override
@@ -91,6 +104,14 @@ public class PortResult {
 
     public boolean isEcu() {
         return type == SerialPortType.Ecu || type == SerialPortType.EcuWithOpenblt;
+    }
+
+    public boolean isUnsupportedEcu() {
+        return type == SerialPortType.UnsupportedEcu;
+    }
+
+    public UnsupportedEcuInfo getUnsupportedEcuInfo() {
+        return unsupportedEcuInfo;
     }
 
     public Optional<String> getFirmwareHash() {

--- a/java_console/connectivity/src/main/java/com/rusefi/SerialPortScanner.java
+++ b/java_console/connectivity/src/main/java/com/rusefi/SerialPortScanner.java
@@ -2,7 +2,6 @@ package com.rusefi;
 
 import com.devexperts.logging.Logging;
 import com.rusefi.io.LinkManager;
-import com.rusefi.maintenance.CalibrationsInfo;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -46,7 +45,7 @@ public class SerialPortScanner implements PortScanner {
 
         Collection<String> listTcpPorts();
 
-        Optional<CalibrationsInfo> getEcuCalibrations(String tcpPort);
+        PortResult inspectTcpPort(String tcpPort);
 
         boolean isLiveEcuConnected();
 
@@ -264,14 +263,11 @@ public class SerialPortScanner implements PortScanner {
                 if (cachedPort.isPresent()) {
                     ports.add(cachedPort.get());
                 } else {
-                    final Optional<CalibrationsInfo> tcpCalibrations = probes.getEcuCalibrations(tcpPort);
-                    final PortResult tcpResult = tcpCalibrations
-                        .map(c -> new PortResult(tcpPort, SerialPortType.Ecu, c))
-                        .orElseGet(() -> new PortResult(tcpPort, SerialPortType.Unknown));
+                    final PortResult tcpResult = probes.inspectTcpPort(tcpPort);
                     ports.add(tcpResult);
 
-                    // cache port + calibrations
-                    if (tcpCalibrations.isPresent()) {
+                    // Preserve the previous policy: cache only a positively identified usable ECU.
+                    if (tcpResult.isEcu()) {
                         portCache.put(tcpResult);
                     }
                 }

--- a/java_console/connectivity/src/main/java/com/rusefi/SerialPortType.java
+++ b/java_console/connectivity/src/main/java/com/rusefi/SerialPortType.java
@@ -9,6 +9,7 @@ public enum SerialPortType {
     // synthetic PortResult (LinkManager.DFU) so a running console can offer DFU flashing in-session,
     // while DFU detection also stays exposed as AvailableHardware.isDfuFound() for back-compat.
     Dfu("DFU", 15),
+    UnsupportedEcu("Unsupported ECU", 25),
     CAN("CAN", 30),
     Unknown("Unknown", 100),
     ;

--- a/java_console/connectivity/src/test/java/com/rusefi/PortResultTest.java
+++ b/java_console/connectivity/src/test/java/com/rusefi/PortResultTest.java
@@ -1,11 +1,13 @@
 package com.rusefi;
 
+import com.rusefi.core.io.UnsupportedEcuInfo;
 import com.rusefi.updater.OpenbltDetectorStrategy.OpenbltInfo;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -45,7 +47,21 @@ public class PortResultTest {
         assertFalse(new PortResult("p", SerialPortType.OpenBlt).isEcu(), "a board in the bootloader is not a running ECU");
         assertFalse(new PortResult("p", SerialPortType.Dfu).isEcu());
         assertFalse(new PortResult("p", SerialPortType.CAN).isEcu());
+        assertFalse(new PortResult("p", SerialPortType.UnsupportedEcu).isEcu());
         assertFalse(new PortResult("p", SerialPortType.Unknown).isEcu());
+    }
+
+    @Test
+    public void unsupportedEcuCarriesDetectedIdentity() {
+        UnsupportedEcuInfo info = new UnsupportedEcuInfo("hellen121nissan", "universal");
+        PortResult unsupported = PortResult.unsupportedEcu("COM4", info);
+
+        assertEquals(SerialPortType.UnsupportedEcu, unsupported.type);
+        assertTrue(unsupported.isUnsupportedEcu());
+        assertSame(info, unsupported.getUnsupportedEcuInfo());
+        assertEquals(unsupported,
+            PortResult.unsupportedEcu("COM4", new UnsupportedEcuInfo("other", "universal")),
+            "port identity remains port and type, not the scan metadata");
     }
 
     @Test

--- a/java_console/connectivity/src/test/java/com/rusefi/SerialPortScannerTest.java
+++ b/java_console/connectivity/src/test/java/com/rusefi/SerialPortScannerTest.java
@@ -1,7 +1,6 @@
 package com.rusefi;
 
 import com.rusefi.io.LinkManager;
-import com.rusefi.maintenance.CalibrationsInfo;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -10,7 +9,6 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
 
@@ -32,7 +30,8 @@ public class SerialPortScannerTest {
         final Map<String, PortResult> inspectResults = new HashMap<>();
         final Map<String, Integer> inspectCalls = new HashMap<>();
         Collection<String> tcpPorts = new ArrayList<>();
-        int tcpCalibrationsCalls;
+        int tcpInspectionCalls;
+        PortResult tcpResult;
         boolean liveEcuConnected;
         boolean dfuConnected;
         int deviceProbeCalls;
@@ -55,9 +54,9 @@ public class SerialPortScannerTest {
         }
 
         @Override
-        public Optional<CalibrationsInfo> getEcuCalibrations(String tcpPort) {
-            tcpCalibrationsCalls++;
-            return Optional.empty();
+        public PortResult inspectTcpPort(String tcpPort) {
+            tcpInspectionCalls++;
+            return tcpResult != null ? tcpResult : new PortResult(tcpPort, SerialPortType.Unknown);
         }
 
         @Override
@@ -248,10 +247,21 @@ public class SerialPortScannerTest {
         scan(true);
         scan(true);
 
-        assertEquals(2, probes.tcpCalibrationsCalls, "a non-ECU TCP port must be re-checked, not cached");
+        assertEquals(2, probes.tcpInspectionCalls, "a non-ECU TCP port must be re-checked, not cached");
         List<PortResult> ports = knownPorts();
         assertEquals(1, ports.size());
         assertEquals(SerialPortType.Unknown, ports.get(0).type);
+    }
+
+    @Test
+    public void unsupportedTcpEcuKeepsItsClassification() {
+        probes.tcpPorts.add("29001");
+        probes.tcpResult = new PortResult("29001", SerialPortType.UnsupportedEcu);
+
+        scan(true);
+
+        assertEquals(1, probes.tcpInspectionCalls);
+        assertEquals(SerialPortType.UnsupportedEcu, knownPorts().get(0).type);
     }
 
     @Test

--- a/java_console/connectivity/src/test/java/com/rusefi/SerialPortTypeTest.java
+++ b/java_console/connectivity/src/test/java/com/rusefi/SerialPortTypeTest.java
@@ -16,7 +16,8 @@ public class SerialPortTypeTest {
     public void bootloadersSortFirstAndUnknownSortsLast() {
         assertTrue(SerialPortType.OpenBlt.sortOrder < SerialPortType.Dfu.sortOrder);
         assertTrue(SerialPortType.Dfu.sortOrder < SerialPortType.Ecu.sortOrder);
-        assertTrue(SerialPortType.Ecu.sortOrder < SerialPortType.CAN.sortOrder);
+        assertTrue(SerialPortType.Ecu.sortOrder < SerialPortType.UnsupportedEcu.sortOrder);
+        assertTrue(SerialPortType.UnsupportedEcu.sortOrder < SerialPortType.CAN.sortOrder);
         assertTrue(SerialPortType.CAN.sortOrder < SerialPortType.Unknown.sortOrder);
     }
 

--- a/java_console/io/src/main/java/com/rusefi/binaryprotocol/BinaryProtocol.java
+++ b/java_console/io/src/main/java/com/rusefi/binaryprotocol/BinaryProtocol.java
@@ -20,6 +20,7 @@ import com.rusefi.core.SignatureHelper;
 import com.rusefi.core.io.BoardCompatibility;
 import com.rusefi.core.io.BundleInfo;
 import com.rusefi.core.io.BundleUtil;
+import com.rusefi.core.io.UnsupportedEcuInfo;
 import com.rusefi.core.net.ConnectionAndMeta;
 import com.rusefi.io.*;
 import com.rusefi.io.commands.*;
@@ -221,6 +222,8 @@ public class BinaryProtocol {
         if (ecuSignature != null && bundleTarget != null && !"unknown".equalsIgnoreCase(bundleTarget)) {
             // exact target, _QC_ hack and board_compatibility (* / allowlist) all handled here [tag:QC_firmware]
             if (!com.rusefi.core.io.BoardCompatibility.isEcuCompatible(bundleTarget, ecuSignature.getBundleTarget())) {
+                linkManager.reportUnsupportedEcu(new UnsupportedEcuInfo(
+                    ecuSignature.getBundleTarget(), bundleTarget));
                 String errorMsg = String.format(
                     "Bundle/ECU mismatch detected!\n\n" +
                     "Connected ECU: %s\n" +

--- a/java_console/io/src/main/java/com/rusefi/io/LinkManager.java
+++ b/java_console/io/src/main/java/com/rusefi/io/LinkManager.java
@@ -6,6 +6,7 @@ import com.rusefi.Callable;
 import com.rusefi.binaryprotocol.BinaryProtocol;
 import com.rusefi.binaryprotocol.BinaryProtocolState;
 import com.rusefi.core.EngineState;
+import com.rusefi.core.io.UnsupportedEcuInfo;
 import com.rusefi.io.serial.BufferedSerialIoStream;
 import com.rusefi.io.serial.StreamConnector;
 import com.rusefi.io.can.PCanIoStream;
@@ -39,6 +40,13 @@ public class LinkManager implements Closeable {
     // never opened as a stream; used only to surface DFU in the ports list [tag:better_ux_for_flashing].
     public static final String DFU = "DFU";
 
+    @FunctionalInterface
+    public interface EcuCompatibilityListener {
+        EcuCompatibilityListener VOID = (port, info) -> { };
+
+        void onUnsupportedEcu(String port, UnsupportedEcuInfo info);
+    }
+
     @NotNull
     public static final LogLevel LOG_LEVEL = LogLevel.INFO;
 
@@ -63,6 +71,7 @@ public class LinkManager implements Closeable {
     public final MessagesListener messageListener = (source, message) -> log.info(source + ": " + message);
     private boolean isDisconnectedByUser;
     private boolean notifyGlobalStatusOnClose = true;
+    private volatile EcuCompatibilityListener ecuCompatibilityListener = EcuCompatibilityListener.VOID;
 
     // The board identity this link records at connect time. Defaults to a private instance (probe/tool
     // LinkManagers); production consoles share ConnectivityContext's instance so flashing decisions see
@@ -88,6 +97,15 @@ public class LinkManager implements Closeable {
     @NotNull
     public com.rusefi.core.io.ConnectedEcuTarget getConnectedEcuTarget() {
         return connectedEcuTarget;
+    }
+
+    public LinkManager setEcuCompatibilityListener(EcuCompatibilityListener listener) {
+        ecuCompatibilityListener = Objects.requireNonNull(listener);
+        return this;
+    }
+
+    public void reportUnsupportedEcu(UnsupportedEcuInfo info) {
+        ecuCompatibilityListener.onUnsupportedEcu(lastTriedPort, info);
     }
 
     @NotNull

--- a/java_console/io/src/test/java/com/rusefi/io/LinkManagerCompatibilityListenerTest.java
+++ b/java_console/io/src/test/java/com/rusefi/io/LinkManagerCompatibilityListenerTest.java
@@ -1,0 +1,29 @@
+package com.rusefi.io;
+
+import com.rusefi.core.io.UnsupportedEcuInfo;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+public class LinkManagerCompatibilityListenerTest {
+    @Test
+    public void unsupportedEventCarriesPortAndIdentity() {
+        AtomicReference<String> reportedPort = new AtomicReference<>();
+        AtomicReference<UnsupportedEcuInfo> reportedInfo = new AtomicReference<>();
+        UnsupportedEcuInfo info = new UnsupportedEcuInfo("board-a", "universal");
+
+        try (LinkManager linkManager = new LinkManager().setEcuCompatibilityListener((port, value) -> {
+            reportedPort.set(port);
+            reportedInfo.set(value);
+        })) {
+            linkManager.start(LinkManager.LOG_VIEWER, ConnectionStatusLogic.Listener.VOID);
+            linkManager.reportUnsupportedEcu(info);
+        }
+
+        assertEquals(LinkManager.LOG_VIEWER, reportedPort.get());
+        assertSame(info, reportedInfo.get());
+    }
+}

--- a/java_console/shared_io/src/main/java/com/rusefi/core/io/UnsupportedEcuInfo.java
+++ b/java_console/shared_io/src/main/java/com/rusefi/core/io/UnsupportedEcuInfo.java
@@ -1,0 +1,19 @@
+package com.rusefi.core.io;
+
+public final class UnsupportedEcuInfo {
+    private final String ecuTarget;
+    private final String bundleTarget;
+
+    public UnsupportedEcuInfo(String ecuTarget, String bundleTarget) {
+        this.ecuTarget = ecuTarget;
+        this.bundleTarget = bundleTarget;
+    }
+
+    public String getEcuTarget() {
+        return ecuTarget;
+    }
+
+    public String getBundleTarget() {
+        return bundleTarget;
+    }
+}

--- a/java_console/ui/src/main/java/com/rusefi/EcuHardwareProbes.java
+++ b/java_console/ui/src/main/java/com/rusefi/EcuHardwareProbes.java
@@ -14,11 +14,13 @@ import com.rusefi.maintenance.MaintenanceUtil;
 import com.rusefi.maintenance.StLinkFlasher;
 import com.rusefi.updater.OpenbltDetectorStrategy;
 import com.rusefi.updater.OpenbltDetectorStrategy.OpenbltInfo;
+import com.rusefi.core.io.UnsupportedEcuInfo;
 
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Production {@link SerialPortScanner.HardwareProbes}: real OS/hardware detection behind the
@@ -56,8 +58,9 @@ public class EcuHardwareProbes implements SerialPortScanner.HardwareProbes {
     }
 
     @Override
-    public Optional<CalibrationsInfo> getEcuCalibrations(String tcpPort) {
-        return EcuHardwareProbes.readEcuCalibrations(tcpPort);
+    public PortResult inspectTcpPort(String tcpPort) {
+        PortResult result = EcuHardwareProbes.inspectRunningEcu(tcpPort);
+        return result != null ? result : new PortResult(tcpPort, SerialPortType.Unknown);
     }
 
     @Override
@@ -96,7 +99,7 @@ public class EcuHardwareProbes implements SerialPortScanner.HardwareProbes {
         OpenbltInfo getOpenbltInfo(String port);
 
         /** @throws com.fazecast.jSerialComm.SerialPortInvalidPortException when the port vanishes mid-probe */
-        Optional<CalibrationsInfo> readEcuCalibrations(String port);
+        PortResult inspectRunningEcu(String port);
 
         boolean ecuHasOpenblt(String port);
 
@@ -111,8 +114,8 @@ public class EcuHardwareProbes implements SerialPortScanner.HardwareProbes {
         }
 
         @Override
-        public Optional<CalibrationsInfo> readEcuCalibrations(String port) {
-            return EcuHardwareProbes.readEcuCalibrations(port);
+        public PortResult inspectRunningEcu(String port) {
+            return EcuHardwareProbes.inspectRunningEcu(port);
         }
 
         @Override
@@ -152,23 +155,26 @@ public class EcuHardwareProbes implements SerialPortScanner.HardwareProbes {
         }
 
         for (int attempt = 1; attempt <= DETECT_MAX_ATTEMPTS; attempt++) {
-            final Optional<CalibrationsInfo> ecuCalibrations;
+            final PortResult ecuResult;
             try {
-                ecuCalibrations = probe.readEcuCalibrations(serialPort);
+                ecuResult = probe.inspectRunningEcu(serialPort);
             } catch (com.fazecast.jSerialComm.SerialPortInvalidPortException e) {
                 log.info("Port " + serialPort + " vanished during ECU detection: " + e.getMessage());
                 return null;
             }
-            final boolean isEcu = ecuCalibrations.isPresent();
+            final boolean isEcu = ecuResult != null;
             log.info("Port " + serialPort + " ECU detection attempt " + attempt + "/" + DETECT_MAX_ATTEMPTS
                 + ": " + (isEcu ? "found" : "not found"));
             if (isEcu) {
+                if (ecuResult.isUnsupportedEcu()) {
+                    return ecuResult;
+                }
                 final boolean hasOpenblt = probe.ecuHasOpenblt(serialPort);
                 log.info("ECU at " + serialPort + (hasOpenblt ? " has" : " does not have") + " an OpenBLT bootloader");
                 return new PortResult(
                     serialPort,
                     hasOpenblt ? SerialPortType.EcuWithOpenblt : SerialPortType.Ecu,
-                    ecuCalibrations.get()
+                    ecuResult.getCalibrations()
                 );
             }
             if (attempt < DETECT_MAX_ATTEMPTS) {
@@ -190,12 +196,20 @@ public class EcuHardwareProbes implements SerialPortScanner.HardwareProbes {
         return SerialPortScanner.inspectPorts(ports, null, EcuHardwareProbes::inspect);
     }
 
-    private static Optional<CalibrationsInfo> readEcuCalibrations(final String port) {
+    private static PortResult inspectRunningEcu(final String port) {
         log.info("getEcuCalibrations " + port);
-        return CalibrationsHelper.readCurrentCalibrationsWithoutSuspendingPortScanner(
+        AtomicReference<UnsupportedEcuInfo> unsupported = new AtomicReference<>();
+        Optional<CalibrationsInfo> calibrations =
+            CalibrationsHelper.readCurrentCalibrationsWithoutSuspendingPortScanner(
             port,
-            UpdateOperationCallbacks.LOGGER
+            UpdateOperationCallbacks.LOGGER,
+            (ignoredPort, info) -> unsupported.set(info)
         );
+        if (calibrations.isPresent()) {
+            return new PortResult(port, SerialPortType.Ecu, calibrations.get());
+        }
+        UnsupportedEcuInfo info = unsupported.get();
+        return info == null ? null : PortResult.unsupportedEcu(port, info);
     }
 
     private static boolean ecuHasOpenblt(String port) {

--- a/java_console/ui/src/main/java/com/rusefi/maintenance/BinaryProtocolExecutor.java
+++ b/java_console/ui/src/main/java/com/rusefi/maintenance/BinaryProtocolExecutor.java
@@ -34,8 +34,21 @@ public class BinaryProtocolExecutor {
         final BinaryProtocolAction<T> bpAction,
         final T failureResult,
         boolean isScanningForEcu, String msg) {
+        return execute(port, callbacks, bpAction, failureResult, isScanningForEcu, msg,
+            LinkManager.EcuCompatibilityListener.VOID);
+    }
+
+    public static <T> T execute(
+        final String port,
+        final UpdateOperationCallbacks callbacks,
+        final BinaryProtocolAction<T> bpAction,
+        final T failureResult,
+        boolean isScanningForEcu,
+        String msg,
+        LinkManager.EcuCompatibilityListener compatibilityListener) {
         final AtomicReference<T> executionResult = new AtomicReference<>(failureResult);
         try (LinkManager linkManager = new LinkManager()
+            .setEcuCompatibilityListener(compatibilityListener)
             .setNeedPullText(false)
             .setNeedPullLiveData(true)
             .setNotifyGlobalStatusOnClose(false)

--- a/java_console/ui/src/main/java/com/rusefi/maintenance/CalibrationsHelper.java
+++ b/java_console/ui/src/main/java/com/rusefi/maintenance/CalibrationsHelper.java
@@ -910,6 +910,15 @@ public class CalibrationsHelper {
         final String port,
         final UpdateOperationCallbacks callbacks
     ) {
+        return readCurrentCalibrationsWithoutSuspendingPortScanner(
+            port, callbacks, LinkManager.EcuCompatibilityListener.VOID);
+    }
+
+    public static Optional<CalibrationsInfo> readCurrentCalibrationsWithoutSuspendingPortScanner(
+        final String port,
+        final UpdateOperationCallbacks callbacks,
+        final LinkManager.EcuCompatibilityListener compatibilityListener
+    ) {
         return BinaryProtocolExecutor.execute(
             port,
             callbacks,
@@ -924,7 +933,8 @@ public class CalibrationsHelper {
             },
             Optional.empty(),
             true,
-            "readCalibrationsInfo");
+            "readCalibrationsInfo",
+            compatibilityListener);
     }
 
     public static Optional<CalibrationsInfo> readAndBackupCurrentCalibrationsWithSuspendedPortScanner(

--- a/java_console/ui/src/test/java/com/rusefi/EcuHardwareProbesInspectTest.java
+++ b/java_console/ui/src/test/java/com/rusefi/EcuHardwareProbesInspectTest.java
@@ -2,6 +2,7 @@ package com.rusefi;
 
 import com.fazecast.jSerialComm.SerialPortInvalidPortException;
 import com.opensr5.ConfigurationImageWithMeta;
+import com.rusefi.core.io.UnsupportedEcuInfo;
 import com.rusefi.maintenance.CalibrationsInfo;
 import com.rusefi.updater.OpenbltDetectorStrategy.OpenbltInfo;
 import org.junit.jupiter.api.AfterEach;
@@ -34,7 +35,7 @@ public class EcuHardwareProbesInspectTest {
         boolean openbltPortThrowsStaleNode;
         boolean ecuHasOpenblt;
         boolean interruptOnSleep;
-        /** one entry per readEcuCalibrations call: an Optional to return, or a RuntimeException to throw */
+        /** one entry per ECU inspection: Optional calibrations, an explicit PortResult, or an exception */
         final Deque<Object> ecuReadOutcomes = new ArrayDeque<>();
 
         int ecuReadCalls;
@@ -51,13 +52,18 @@ public class EcuHardwareProbesInspectTest {
 
         @SuppressWarnings("unchecked")
         @Override
-        public Optional<CalibrationsInfo> readEcuCalibrations(String port) {
+        public PortResult inspectRunningEcu(String port) {
             ecuReadCalls++;
             Object outcome = ecuReadOutcomes.removeFirst();
             if (outcome instanceof RuntimeException) {
                 throw (RuntimeException) outcome;
             }
-            return (Optional<CalibrationsInfo>) outcome;
+            if (outcome instanceof PortResult) {
+                return (PortResult) outcome;
+            }
+            return ((Optional<CalibrationsInfo>) outcome)
+                .map(c -> new PortResult(port, SerialPortType.Ecu, c))
+                .orElse(null);
         }
 
         @Override
@@ -155,6 +161,21 @@ public class EcuHardwareProbesInspectTest {
         assertEquals(SerialPortType.Ecu, result.type);
         assertEquals(3, probe.ecuReadCalls);
         assertEquals(2, probe.sleepCalls, "backoff runs between attempts only");
+    }
+
+    @Test
+    public void unsupportedEcuIsReturnedWithoutRetryOrBootloaderProbe() {
+        FakePortProbe probe = new FakePortProbe();
+        UnsupportedEcuInfo info = new UnsupportedEcuInfo("hellen121nissan", "universal");
+        probe.ecuReadOutcomes.add(PortResult.unsupportedEcu(PORT, info));
+
+        PortResult result = EcuHardwareProbes.inspect(PORT, probe);
+
+        assertEquals(SerialPortType.UnsupportedEcu, result.type);
+        assertSame(info, result.getUnsupportedEcuInfo());
+        assertEquals(1, probe.ecuReadCalls);
+        assertEquals(0, probe.sleepCalls);
+        assertEquals(0, probe.hasOpenbltCalls);
     }
 
     @Test

--- a/java_tools/version/src/main/java/com/rusefi/UiVersion.java
+++ b/java_tools/version/src/main/java/com/rusefi/UiVersion.java
@@ -5,5 +5,5 @@ public interface UiVersion {
      * *** BE CAREFUL WE HAVE SEPARATE AUTOUPDATE_VERSION also managed manually ***
      * @see com.rusefi.autoupdate.Autoupdate#AUTOUPDATE_VERSION
      */
-    int CONSOLE_VERSION = 20260729;
+    int CONSOLE_VERSION = 20260730;
 }


### PR DESCRIPTION
only visual change on the port wording:

<img width="392" height="268" alt="image" src="https://github.com/user-attachments/assets/ebea3d19-f2dd-42ba-8f71-37d998927fdd" />
