### PR TITLE
Fix VE Analyze correction scale coupling

### DIFF
--- a/docs/report.md
+++ b/docs/report.md
@@ -390,3 +390,48 @@ Open follow-ups:
   wedge never reaches the new recovery path (lib_scsi is in ChibiOS-Contrib).
 - The loss-of-cdc.pcapng pre-capture wedge could not be attributed (stale
   firmware vs blkRead wedge); confirm the flashed build via sdinfo counters.
+
+## 2026-08-01 - Decouple VE Analyze from the STFT display scale
+
+What: Restored zero-based STFT presentation without changing the 100-based
+correction contract required by TunerStudio VE Analyze. PR #9657 changed the
+STFT translation from -1.0 to -100; under TunerStudio's `(raw + translate) *
+scale` conversion, a neutral raw multiplier of 1.0 became -9900 percent. The
+derived `100 + stftCorrection1` channel then supplied -9800 instead of 100 to
+VE Analyze, causing it to remove fuel.
+
+| File | Change |
+|----------------------------------------------------|----------------------------------------|
+| firmware/controllers/algo/engine_state.txt | Restore STFT display metadata to scale 100, translation -1.0, so raw 0.9/1.0/1.1 displays as -10/0/+10 percent |
+| firmware/tunerstudio/tunerstudio.template.ini | Feed `egoCorrectionForVeAnalyze` directly from `Gego`, the existing 100-neutral STFT output channel |
+| java_tools/configuration_definition/src/test/java/com/rusefi/test/VeAnalyzeCorrectionTest.java | Regression coverage for zero-neutral display and independence of the VE Analyze channel |
+| java_tools/version/src/main/java/com/rusefi/UiVersion.java | Bump console version to 20260801 as required for Java changes |
+
+Key decisions and why:
+- Reused `Gego` instead of adding another live-data field. `status_loop.cpp`
+  already publishes it as `100 * stftCorrection[0]`, so this avoids output
+  layout churn and keeps the machine-facing 100-neutral contract explicit.
+- Kept the user-facing `stftCorrection` channels zero-neutral and independent
+  from AutoTune. Gauge scale or translation changes can no longer alter the
+  correction consumed by VE Analyze.
+- No persistent calibration field or generated file is part of the change, so
+  existing tunes require no migration.
+- LTFT behavior is intentionally unchanged in this unit of work. Stored LTFT
+  correction still affects delivered fuel without being represented in the VE
+  Analyze correction channel; that requires a separate policy change and test.
+
+Validation:
+- Regression test first failed on the old code: raw 0.9 displayed as -9910
+  instead of -10, and VE Analyze still referenced the visual STFT channel.
+- The same test passes after the fix.
+- `gradlew.bat :config_definition:test` passes.
+- Clean uaefi `make -B -j12 ini` generation passes. The generated INI contains
+  `stftCorrection1/2` with `100.0, -1.0`, keeps `Gego` at scale 0.01, and emits
+  `egoCorrectionForVeAnalyze = { Gego }`; both VE Analyze and WUE Analyze use
+  that alias.
+
+Open follow-ups:
+- Define and test the LTFT policy during AutoTune (disable application, require
+  applying/resetting learned trims, or introduce an explicit tuning session).
+- Decide how a future bank-2-aware VE Analyze correction should select/combine
+  STFT banks; this change preserves the existing bank-1 behavior.

--- a/firmware/controllers/algo/engine_state.txt
+++ b/firmware/controllers/algo/engine_state.txt
@@ -85,7 +85,7 @@ struct_no_prefix engine_state_s
 	float dwellActualRatio;"Ignition: Dwell deviation";"%", 100, -1.0, 80, 120, 1
 
 	! todo: extract to injection.txt?
-	float[FT_BANK_COUNT iterate] stftCorrection;STFT: Bank; "%", 100, -100, -50, 50, 1
+	float[FT_BANK_COUNT iterate] stftCorrection;STFT: Bank; "%", 100, -1.0, -50, 50, 1
 
 ! engine_state_s
 end_struct

--- a/firmware/tunerstudio/tunerstudio.template.ini
+++ b/firmware/tunerstudio/tunerstudio.template.ini
@@ -291,8 +291,9 @@ include_file @@TUNING_SECTION_FILE@@
 
 	time				= { timeNow }
 
-	; TODO: add stftCorrection2?
-	egoCorrectionForVeAnalyze = { 100 + stftCorrection1 }
+	; VE Analyze requires a 100-based correction while the user-facing STFT channel is 0-based.
+	; TODO: add bank 2 correction?
+	egoCorrectionForVeAnalyze = { Gego }
 
 
 	wb1hasFault = { enableAemXSeries && ((wb1stateCode >= 3 && wb1stateCode <= 5) || !wb1isValid) }

--- a/java_tools/configuration_definition/src/test/java/com/rusefi/test/VeAnalyzeCorrectionTest.java
+++ b/java_tools/configuration_definition/src/test/java/com/rusefi/test/VeAnalyzeCorrectionTest.java
@@ -1,0 +1,50 @@
+package com.rusefi.test;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class VeAnalyzeCorrectionTest {
+    private static final double EPSILON = 0.0001;
+    private static final Pattern STFT_FIELD = Pattern.compile(
+            "(?m)^\\s*float\\[FT_BANK_COUNT iterate]\\s+stftCorrection;[^\\r\\n]*?\"%\",\\s*" +
+                    "([-+]?\\d+(?:\\.\\d+)?),\\s*([-+]?\\d+(?:\\.\\d+)?)");
+    private static final Pattern VE_ANALYZE_CORRECTION = Pattern.compile(
+            "(?m)^\\s*egoCorrectionForVeAnalyze\\s*=\\s*\\{\\s*Gego\\s*}\\s*$");
+
+    @Test
+    void stftDisplayUsesZeroAsNeutral() throws IOException {
+        String engineState = Files.readString(Path.of(
+                ConfigDefinitionTest.FIRMWARE, "controllers", "algo", "engine_state.txt"));
+        Matcher matcher = STFT_FIELD.matcher(engineState);
+
+        assertTrue(matcher.find(), "Missing stftCorrection live-data field");
+
+        double scale = Double.parseDouble(matcher.group(1));
+        double translate = Double.parseDouble(matcher.group(2));
+
+        assertEquals(-10.0, toTunerStudioValue(0.9, scale, translate), EPSILON);
+        assertEquals(0.0, toTunerStudioValue(1.0, scale, translate), EPSILON);
+        assertEquals(10.0, toTunerStudioValue(1.1, scale, translate), EPSILON);
+    }
+
+    @Test
+    void veAnalyzeUsesHundredBasedChannelDirectly() throws IOException {
+        String template = Files.readString(Path.of(
+                ConfigDefinitionTest.FIRMWARE, "tunerstudio", "tunerstudio.template.ini"));
+
+        assertTrue(VE_ANALYZE_CORRECTION.matcher(template).find(),
+                "VE Analyze must use the 100-based Gego channel, independently of the STFT display scale");
+    }
+
+    private static double toTunerStudioValue(double rawValue, double scale, double translate) {
+        return (rawValue + translate) * scale;
+    }
+}

--- a/java_tools/version/src/main/java/com/rusefi/UiVersion.java
+++ b/java_tools/version/src/main/java/com/rusefi/UiVersion.java
@@ -5,5 +5,5 @@ public interface UiVersion {
      * *** BE CAREFUL WE HAVE SEPARATE AUTOUPDATE_VERSION also managed manually ***
      * @see com.rusefi.autoupdate.Autoupdate#AUTOUPDATE_VERSION
      */
-    int CONSOLE_VERSION = 20260720;
+    int CONSOLE_VERSION = 20260801;
 }


### PR DESCRIPTION
User report:
<img width="1876" height="173" alt="image" src="https://github.com/user-attachments/assets/372171bf-57f5-419c-80d3-c02b7b17ea40" />


## What changed

- Restore the user-facing STFT scale to zero-neutral: raw multipliers 0.9, 1.0, and 1.1 display as -10%, 0%, and +10%.
- Feed TunerStudio VE Analyze from the existing 100-neutral `Gego` output channel.
- Add regression tests that keep the visual STFT scale independent from the correction channel used by AutoTune.
- Document the decision and validation in `docs/report.md`.

## Root cause

PR #9657 changed the STFT translation from `-1.0` to `-100`. TunerStudio applies scalar conversion as `(raw + translate) * scale`, so a neutral raw multiplier of `1.0` became `-9900%`.

The VE Analyze channel was derived as `100 + stftCorrection1`, which then produced `-9800` instead of the required neutral value of `100`. This caused VE Analyze/AutoTune to remove fuel and drive the tune lean.

## Impact

The dashboard continues to show correction relative to zero, while VE Analyze keeps its required 100-based machine contract. No persistent calibration field or output-channel layout changes are introduced, so existing tunes need no migration.


