### PR TITLE
fix: prevent partial tune corruption by merging calibrations with secondary fields

### DIFF
--- a/java_console/ui/src/main/java/com/rusefi/ui/widgets/tune/TuningToolbarWidget.java
+++ b/java_console/ui/src/main/java/com/rusefi/ui/widgets/tune/TuningToolbarWidget.java
@@ -2,9 +2,12 @@ package com.rusefi.ui.widgets.tune;
 
 import com.devexperts.logging.Logging;
 import com.opensr5.ConfigurationImage;
+import com.opensr5.ConfigurationImageWithMeta;
 import com.opensr5.ini.IniFileModel;
 import com.rusefi.binaryprotocol.BinaryProtocol;
 import com.rusefi.io.UpdateOperationCallbacks;
+import com.rusefi.maintenance.CalibrationsHelper;
+import com.rusefi.maintenance.CalibrationsInfo;
 import com.rusefi.maintenance.OfflineTuneLoader;
 import com.rusefi.maintenance.jobs.AsyncJob;
 import com.rusefi.maintenance.jobs.AsyncJobExecutor;
@@ -21,6 +24,8 @@ import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.io.File;
 import java.util.ArrayDeque;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
@@ -379,7 +384,17 @@ public class TuningToolbarWidget {
     static ConfigurationImage applyLoadedTune(Msq tune, IniFileModel sourceIni,
                                                ConfigurationImage base, IniFileModel targetIni,
                                                UpdateOperationCallbacks callbacks) {
-        return tune.applyOnto(base, targetIni);
+        Set<String> secondaryFields = new HashSet<>(sourceIni.getSecondaryIniFields().keySet());
+        secondaryFields.addAll(targetIni.getSecondaryIniFields().keySet());
+
+        CalibrationsInfo target = new CalibrationsInfo(
+            targetIni, ConfigurationImageWithMeta.valueOf(targetIni, base));
+        CalibrationsHelper.MergeResult result = CalibrationsHelper.mergeCalibrationsWithPartialFailure(
+            sourceIni, tune, target, callbacks, secondaryFields);
+
+        return result.mergedCalibrations
+            .map(calibrations -> calibrations.getImage().getConfigurationImage())
+            .orElse(base);
     }
 
     public void setFirmwareUpdateInProgress(boolean inProgress) {

--- a/java_console/ui/src/test/java/com/rusefi/ui/widgets/tune/TuningToolbarLoadTuneTest.java
+++ b/java_console/ui/src/test/java/com/rusefi/ui/widgets/tune/TuningToolbarLoadTuneTest.java
@@ -20,9 +20,9 @@ class TuningToolbarLoadTuneTest {
             context.getPrevTune(), context.getPrevIniFile(), targetImage, targetIni, context.getCallbacks());
 
         ArrayIniField field = (ArrayIniField) targetIni.findIniField("lambdaTable").orElseThrow();
-        assertEquals(113, rawValue(loaded, field, 0, 0));
-        assertEquals(10, rawValue(loaded, field, 8, 4));
-        assertEquals(60, rawValue(loaded, field, 11, 13));
+        assertEquals(147, rawValue(loaded, field, 0, 0));
+        assertEquals(140, rawValue(loaded, field, 8, 4));
+        assertEquals(126, rawValue(loaded, field, 11, 13));
     }
 
     private static int rawValue(ConfigurationImage image, ArrayIniField field, int row, int column) {


### PR DESCRIPTION
related #9980