### PR TITLE
more generic TableAddColumnsMigrator

### DIFF
--- a/java_console/io/src/main/java/com/rusefi/maintenance/migration/migrators/BinsIniFieldMigratorStrategy.java
+++ b/java_console/io/src/main/java/com/rusefi/maintenance/migration/migrators/BinsIniFieldMigratorStrategy.java
@@ -2,12 +2,12 @@ package com.rusefi.maintenance.migration.migrators;
 
 import com.opensr5.ini.field.ArrayIniField;
 import com.opensr5.ini.field.IniField;
-import com.rusefi.CompatibilitySet;
 import com.rusefi.config.FieldType;
 import com.rusefi.io.UpdateOperationCallbacks;
-import com.rusefi.tune.xml.Msq;
 import org.jetbrains.annotations.NotNull;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
@@ -15,9 +15,6 @@ import java.util.stream.Collectors;
 
 class BinsIniFieldMigratorStrategy {
     private static final int BINS_INI_FIELD_COLS = 1;
-    private static final double BINS_INI_FIELD_MULTIPLIER = 1;
-    private static final String BINS_INI_FIELD_DIGITS = "0";
-    private static final FieldType BINS_INI_FIELD_TYPE = FieldType.UINT16;
 
     private final String iniFieldName;
     private final int prevCount;
@@ -38,56 +35,145 @@ class BinsIniFieldMigratorStrategy {
         Optional<String> result = Optional.empty();
         final Optional<ArrayIniField> prevValidatedBinsIniField = getValidatedBinsArrayIniField(
             prevField,
+            prevCount,
             callbacks
         );
         final Optional<ArrayIniField> newValidatedBinsIniField = getValidatedBinsArrayIniField(
             newField,
+            newCount,
             callbacks
         );
         if (prevValidatedBinsIniField.isPresent() && newValidatedBinsIniField.isPresent()) {
             final ArrayIniField prevBinsField = prevValidatedBinsIniField.get();
             final ArrayIniField newBinsField = newValidatedBinsIniField.get();
+            if (prevBinsField.getType() != newBinsField.getType()) {
+                callbacks.logLine(String.format(
+                    "WARNING! Type of `%s` ini-field is changed: `%s` -> `%s`",
+                    iniFieldName,
+                    prevBinsField.getType(),
+                    newBinsField.getType()
+                ));
+                return Optional.empty();
+            }
+            if (Double.compare(prevBinsField.getMultiplier(), newBinsField.getMultiplier()) != 0) {
+                callbacks.logLine(String.format(
+                    "WARNING! Multiplier of `%s` ini-field is changed: `%s` -> `%s`",
+                    iniFieldName,
+                    prevBinsField.getMultiplier(),
+                    newBinsField.getMultiplier()
+                ));
+                return Optional.empty();
+            }
+
             final int binsToAddCount = newBinsField.getRows() - prevBinsField.getRows();
             if (0 < binsToAddCount) {
                 final List<String> prevValues = Arrays.stream(prevBinsField.getValues(prevValue))
                     .map(e -> e[0])
                     .collect(Collectors.toList());
-                final List<Long> prevLongValues = prevValues.stream()
-                    .map(Double::parseDouble)
-                    .map(Math::round)
-                    .collect(Collectors.toList());
-                final long lastValue = prevLongValues.get(prevLongValues.size() - 1);
-                final String max = newBinsField.getMax();
-
-                Optional<Long> recommendedStep;
-                if (max != null) {
-                    final long maxPossibleStep = (long)(
-                        (Double.parseDouble(max) - lastValue) / binsToAddCount
-                    );
-                    if (1 <= maxPossibleStep) {
-                        recommendedStep = Optional.of(chooseStep(prevLongValues, maxPossibleStep));
+                try {
+                    final BigDecimal quantum = getQuantum(newBinsField);
+                    final List<Long> prevRawValues = prevValues.stream()
+                        .map(BigDecimal::new)
+                        .map(value -> value.divide(quantum, 0, RoundingMode.HALF_UP).longValueExact())
+                        .collect(Collectors.toList());
+                    final long lastValue = prevRawValues.get(prevRawValues.size() - 1);
+                    final String max = newBinsField.getMax();
+                    final Optional<Long> maximumValue = getMaximumValue(newBinsField, quantum);
+                    final long recommendedStep;
+                    if (maximumValue.isPresent()) {
+                        final long maxPossibleStep = (maximumValue.get() - lastValue) / binsToAddCount;
+                        if (1 <= maxPossibleStep) {
+                            recommendedStep = chooseStep(prevRawValues, maxPossibleStep);
+                        } else {
+                            callbacks.logLine(String.format(
+                                "WARNING! `%s` ini-field cannot be propagated with increasing values, because max value is %s",
+                                iniFieldName,
+                                max == null ? newBinsField.getType() + " storage limit" : max
+                            ));
+                            return Optional.empty();
+                        }
+                    } else if (prevRawValues.size() > 1) {
+                        recommendedStep = lastValue - prevRawValues.get(prevRawValues.size() - 2);
                     } else {
                         callbacks.logLine(String.format(
-                            "WARNING! `%s` ini-field cannot be propagated with increasing values, because max value is %s",
-                            iniFieldName,
-                            max
+                            "WARNING! `%s` ini-field cannot be propagated without a maximum or two previous values",
+                            iniFieldName
                         ));
                         return Optional.empty();
                     }
-                } else {
-                    final long valueBeforeLast = prevLongValues.get(prevLongValues.size() - 2);
-                    recommendedStep = Optional.of(lastValue - valueBeforeLast);
-                }
-                if (recommendedStep.isPresent()) {
-                    final String[][] newValues = expandValues(prevValues, lastValue, recommendedStep);
+
+                    if (recommendedStep <= 0) {
+                        callbacks.logLine(String.format(
+                            "WARNING! `%s` ini-field cannot be propagated with increasing values",
+                            iniFieldName
+                        ));
+                        return Optional.empty();
+                    }
+
+                    final String[][] newValues = expandValues(
+                        prevValues,
+                        lastValue,
+                        recommendedStep,
+                        quantum,
+                        Math.max(1, (int)IniField.parseDouble(newBinsField.getDigits()))
+                    );
                     result = Optional.of(newBinsField.formatValue(newValues));
+                } catch (ArithmeticException | NumberFormatException e) {
+                    callbacks.logLine(String.format(
+                        "WARNING! `%s` ini-field contains an invalid numeric value",
+                        iniFieldName
+                    ));
                 }
             }
         }
         return result;
     }
 
-    private String[] @NotNull [] expandValues(List<String> prevValues, long lastValue, Optional<Long> recommendedStep) {
+    private BigDecimal getQuantum(final ArrayIniField field) {
+        if (field.getType() == FieldType.FLOAT) {
+            return BigDecimal.ONE.scaleByPowerOfTen(-(int)IniField.parseDouble(field.getDigits()));
+        }
+
+        return BigDecimal.valueOf(Math.abs(field.getMultiplier()));
+    }
+
+    private Optional<Long> getMaximumValue(final ArrayIniField field, final BigDecimal quantum) {
+        final String max = field.getMax();
+        final Long storageMax = getStorageMax(field.getType());
+        if (max == null) {
+            return Optional.ofNullable(storageMax);
+        }
+
+        final long configuredMax = BigDecimal.valueOf(IniField.parseDouble(max))
+            .divide(quantum, 0, RoundingMode.FLOOR)
+            .longValueExact();
+        return Optional.of(storageMax == null ? configuredMax : Math.min(configuredMax, storageMax));
+    }
+
+    private Long getStorageMax(final FieldType type) {
+        switch (type) {
+            case UINT8:
+                return 0xFFL;
+            case UINT16:
+                return 0xFFFFL;
+            case INT8:
+                return (long)Byte.MAX_VALUE;
+            case INT16:
+                return (long)Short.MAX_VALUE;
+            case INT:
+                return (long)Integer.MAX_VALUE;
+            default:
+                return null;
+        }
+    }
+
+    private String[] @NotNull [] expandValues(
+        final List<String> prevValues,
+        final long lastValue,
+        final long recommendedStep,
+        final BigDecimal quantum,
+        final int digits
+    ) {
         final String[][] newValues = new String[newCount][1];
         // copy prev values:
         for (int i = 0; i < prevCount; i++) {
@@ -96,8 +182,10 @@ class BinsIniFieldMigratorStrategy {
         long lastBin = lastValue;
         // add missed bins with recommended step:
         for (int i = prevCount; i < newCount; i++) {
-            lastBin += recommendedStep.get();
-            newValues[i] = new String[] { String.format(Msq.TS_INTEGRATION_LOCALE, "%.1f", (double)lastBin) };
+            lastBin = Math.addExact(lastBin, recommendedStep);
+            newValues[i] = new String[] {
+                quantum.multiply(BigDecimal.valueOf(lastBin)).setScale(digits, RoundingMode.HALF_UP).toPlainString()
+            };
         }
         return newValues;
     }
@@ -105,6 +193,7 @@ class BinsIniFieldMigratorStrategy {
 
     private Optional<ArrayIniField> getValidatedBinsArrayIniField(
         final IniField field,
+        final int expectedRows,
         final UpdateOperationCallbacks callbacks
     ) {
         if (!(field instanceof ArrayIniField)) {
@@ -117,11 +206,10 @@ class BinsIniFieldMigratorStrategy {
         }
         final ArrayIniField arrayField = (ArrayIniField) field;
         final FieldType arrayFieldType = arrayField.getType();
-        if (arrayFieldType != BINS_INI_FIELD_TYPE) {
+        if (!arrayFieldType.isNumeric()) {
             callbacks.logLine(String.format(
-                "WARNING! Type of `%s` ini-field is expected to be `%s` instead of `%s`",
+                "WARNING! Type of `%s` ini-field is expected to be numeric instead of `%s`",
                 iniFieldName,
-                BINS_INI_FIELD_TYPE,
                 arrayFieldType
             ));
             return Optional.empty();
@@ -136,35 +224,14 @@ class BinsIniFieldMigratorStrategy {
             ));
             return Optional.empty();
         }
-        final double arrayFieldMultiplier = arrayField.getMultiplier();
-        if (arrayFieldMultiplier != BINS_INI_FIELD_MULTIPLIER) {
-            callbacks.logLine(String.format(
-                "WARNING! Multiplier of `%s` ini-field is expected to be %f instead of %f",
-                iniFieldName,
-                BINS_INI_FIELD_MULTIPLIER,
-                arrayFieldMultiplier
-            ));
-            return Optional.empty();
-        }
-        final String arrayFieldDigits = arrayField.getDigits();
-        if (!BINS_INI_FIELD_DIGITS.equals(arrayFieldDigits)) {
-            callbacks.logLine(String.format(
-                "WARNING! Digits of `%s` ini-field is expected to be `%s` instead of `%s`",
-                iniFieldName,
-                BINS_INI_FIELD_DIGITS,
-                arrayFieldDigits
-            ));
-            return Optional.empty();
-        }
         final int arrayFieldRows = arrayField.getRows();
-        if (CompatibilitySet.of(prevCount, newCount).contains(arrayFieldRows)) {
+        if (arrayFieldRows == expectedRows) {
             return Optional.of(arrayField);
         } else {
             callbacks.logLine(String.format(
-                "WARNING! `%s` ini-field is expected to contain %d or %d rows instead of %d",
+                "WARNING! `%s` ini-field is expected to contain %d rows instead of %d",
                 iniFieldName,
-                prevCount,
-                newCount,
+                expectedRows,
                 arrayFieldRows
             ));
             return Optional.empty();

--- a/java_console/io/src/main/java/com/rusefi/maintenance/migration/migrators/ComposedTuneMigrator.java
+++ b/java_console/io/src/main/java/com/rusefi/maintenance/migration/migrators/ComposedTuneMigrator.java
@@ -16,6 +16,7 @@ public enum ComposedTuneMigrator implements TuneMigrator {
         TableAddColumnsMigrator.IGNITION_TABLE_MIGRATOR,
         TableAddColumnsMigrator.INJECTION_PHASE_MIGRATOR,
         TableAddColumnsMigrator.MAP_SAMPLING_MIGRATOR,
+        TableAddColumnsMigrator.PEDAL_TO_TPS_MIGRATOR,
         // rest of migrators
         AfrLambdaTableMigrator.INSTANCE,
         ArrayFieldScaleMigrator.INSTANCE,

--- a/java_console/io/src/main/java/com/rusefi/maintenance/migration/migrators/TableAddColumnsMigrator.java
+++ b/java_console/io/src/main/java/com/rusefi/maintenance/migration/migrators/TableAddColumnsMigrator.java
@@ -7,10 +7,12 @@ import com.rusefi.io.UpdateOperationCallbacks;
 import com.rusefi.maintenance.migration.TuneMigrationContext;
 import com.rusefi.tune.xml.Constant;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.Optional;
 
 /**
- * TableAddColumnsMigrator handles resizing of 2D tables (e.g., VE, Ignition) when columns or rows are added.
+ * Handles non-shrinking resize of 2D tables and their axes.
  *
  * <h3>Testing and Coverage Examples:</h3>
  * This migrator is tested in {@code TableAddColumnsMigratorTest} in the {@code java_console/ui} module.
@@ -23,19 +25,27 @@ import java.util.Optional;
 public class TableAddColumnsMigrator implements TuneMigrator {
     public static final String VE_TABLE_FIELD_NAME = "veTable";
     public static final String VE_RPM_BINS_FIELD_NAME = "veRpmBins";
+    public static final String VE_LOAD_BINS_FIELD_NAME = "veLoadBins";
     public static final String LAMBDA_TABLE_FIELD_NAME = "lambdaTable";
     public static final String LAMBDA_RPM_BINS_FIELD_NAME = "lambdaRpmBins";
+    public static final String LAMBDA_LOAD_BINS_FIELD_NAME = "lambdaLoadBins";
     public static final String IGNITION_TABLE_FIELD_NAME = "ignitionTable";
     public static final String IGNITION_RPM_BINS_FIELD_NAME = "ignitionRpmBins";
+    public static final String IGNITION_LOAD_BINS_FIELD_NAME = "ignitionLoadBins";
     public static final String INJECTION_PHASE_FIELD_NAME = "injectionPhase";
     public static final String INJECTION_PHASE_RPM_BINS_FIELD_NAME = "injPhaseRpmBins";
+    public static final String INJECTION_PHASE_LOAD_BINS_FIELD_NAME = "injPhaseLoadBins";
     public static final String MAP_SAMPLING_FIELD_NAME = "map_samplingAngle";
     public static final String MAP_SAMPLING_RPM_BINS_NAME = "map_samplingAngleBins";
+    public static final String PEDAL_TO_TPS_TABLE_FIELD_NAME = "pedalToTpsTable";
+    public static final String PEDAL_TO_TPS_RPM_BINS_FIELD_NAME = "pedalToTpsRpmBins";
+    public static final String PEDAL_TO_TPS_PEDAL_BINS_FIELD_NAME = "pedalToTpsPedalBins";
 
     public static final TableAddColumnsMigrator VE_TABLE_MIGRATOR = new TableAddColumnsMigrator(
         VE_TABLE_FIELD_NAME,
         FieldType.UINT16,
         VE_RPM_BINS_FIELD_NAME,
+        VE_LOAD_BINS_FIELD_NAME,
         RetainTableValuesConverter.INSTANCE
     );
 
@@ -43,6 +53,7 @@ public class TableAddColumnsMigrator implements TuneMigrator {
         LAMBDA_TABLE_FIELD_NAME,
         FieldType.UINT8,
         LAMBDA_RPM_BINS_FIELD_NAME,
+        LAMBDA_LOAD_BINS_FIELD_NAME,
         AfrLambdaTableValuesConverter.INSTANCE
     );
 
@@ -50,6 +61,7 @@ public class TableAddColumnsMigrator implements TuneMigrator {
         IGNITION_TABLE_FIELD_NAME,
         FieldType.INT16,
         IGNITION_RPM_BINS_FIELD_NAME,
+        IGNITION_LOAD_BINS_FIELD_NAME,
         RetainTableValuesConverter.INSTANCE
     );
 
@@ -57,19 +69,30 @@ public class TableAddColumnsMigrator implements TuneMigrator {
         INJECTION_PHASE_FIELD_NAME ,
         FieldType.INT16,
         INJECTION_PHASE_RPM_BINS_FIELD_NAME,
+        INJECTION_PHASE_LOAD_BINS_FIELD_NAME,
         RetainTableValuesConverter.INSTANCE
     );
 
     public static final TableAddColumnsMigrator MAP_SAMPLING_MIGRATOR = new TableAddColumnsMigrator(
         MAP_SAMPLING_FIELD_NAME ,
         FieldType.FLOAT,
+        null,
         MAP_SAMPLING_RPM_BINS_NAME,
         MapSamplingValuesConverter.INSTANCE
+    );
+
+    public static final TableAddColumnsMigrator PEDAL_TO_TPS_MIGRATOR = new TableAddColumnsMigrator(
+        PEDAL_TO_TPS_TABLE_FIELD_NAME,
+        FieldType.UINT8,
+        PEDAL_TO_TPS_RPM_BINS_FIELD_NAME,
+        PEDAL_TO_TPS_PEDAL_BINS_FIELD_NAME,
+        RetainTableValuesConverter.INSTANCE
     );
 
     private final String tableFieldName;
     private final FieldType tableFieldType;
     private final String columnsBinFieldName;
+    private final String rowsBinFieldName;
     private final TableValuesConverter prevTableValueConverter;
 
     private static class RetainTableValuesConverter implements TableValuesConverter {
@@ -93,9 +116,20 @@ public class TableAddColumnsMigrator implements TuneMigrator {
         final String columnsIniBinFieldName,
         final TableValuesConverter tableValuesConverter
     ) {
+        this(tableIniFieldName, tableIniFieldType, columnsIniBinFieldName, null, tableValuesConverter);
+    }
+
+    private TableAddColumnsMigrator(
+        final String tableIniFieldName,
+        final FieldType tableIniFieldType,
+        final String columnsIniBinFieldName,
+        final String rowsIniBinFieldName,
+        final TableValuesConverter tableValuesConverter
+    ) {
         tableFieldName = tableIniFieldName;
         tableFieldType = tableIniFieldType;
         columnsBinFieldName = columnsIniBinFieldName;
+        rowsBinFieldName = rowsIniBinFieldName;
         prevTableValueConverter = tableValuesConverter;
     }
 
@@ -120,8 +154,47 @@ public class TableAddColumnsMigrator implements TuneMigrator {
         if (prevArrayIniField.isPresent() && updatedArrayIniField.isPresent()) {
             final ArrayIniField prevTableField = prevArrayIniField.get();
             final int prevTableFieldCols = prevTableField.getCols();
+            final int prevTableFieldRows = prevTableField.getRows();
             final ArrayIniField updatedTableField = updatedArrayIniField.get();
             final int updatedTableFieldCols = updatedTableField.getCols();
+            final int updatedTableFieldRows = updatedTableField.getRows();
+            final boolean columnsGrow = prevTableFieldCols < updatedTableFieldCols;
+            final boolean rowsGrow = prevTableFieldRows < updatedTableFieldRows;
+            if (!columnsGrow && !rowsGrow) {
+                if (updatedTableFieldCols < prevTableFieldCols || updatedTableFieldRows < prevTableFieldRows) {
+                    context.getCallbacks().logLine(String.format(
+                        "WARNING! `%s` ini-field cannot be migrated from %dx%d to smaller %dx%d dimensions",
+                        tableFieldName,
+                        prevTableFieldCols,
+                        prevTableFieldRows,
+                        updatedTableFieldCols,
+                        updatedTableFieldRows
+                    ));
+                }
+                return;
+            }
+            if (updatedTableFieldCols < prevTableFieldCols || updatedTableFieldRows < prevTableFieldRows) {
+                context.getCallbacks().logLine(String.format(
+                    "WARNING! `%s` ini-field cannot be migrated when one dimension shrinks",
+                    tableFieldName
+                ));
+                return;
+            }
+            if (rowsGrow && rowsBinFieldName == null) {
+                context.getCallbacks().logLine(String.format(
+                    "WARNING! `%s` ini-field cannot add rows without a row-axis field",
+                    tableFieldName
+                ));
+                return;
+            }
+            if (columnsGrow && columnsBinFieldName == null) {
+                context.getCallbacks().logLine(String.format(
+                    "WARNING! `%s` ini-field cannot add columns without a column-axis field",
+                    tableFieldName
+                ));
+                return;
+            }
+
             final Constant prevValue = context.getPrevTune().getConstantsAsMap().get(tableFieldName);
             if (prevValue != null) {
                 final Optional<String[][]> convertedPrevValues = prevTableValueConverter.convertTableValues(
@@ -136,7 +209,8 @@ public class TableAddColumnsMigrator implements TuneMigrator {
                         context.getCallbacks()
                     );
                     if (migratedValues.isPresent()) {
-                        context.addMigration(
+                        final Map<String, Constant> migrations = new LinkedHashMap<>();
+                        migrations.put(
                             tableFieldName,
                             new Constant(
                                 tableFieldName,
@@ -147,57 +221,91 @@ public class TableAddColumnsMigrator implements TuneMigrator {
                                 Integer.toString(updatedTableFieldCols)
                             )
                         );
+
+                        if (columnsGrow) {
+                            final Optional<Constant> columnsMigration = migrateBins(
+                                context,
+                                columnsBinFieldName,
+                                prevTableFieldCols,
+                                updatedTableFieldCols
+                            );
+                            if (!columnsMigration.isPresent()) {
+                                return;
+                            }
+                            migrations.put(columnsBinFieldName, columnsMigration.get());
+                        }
+                        if (rowsGrow) {
+                            final Optional<Constant> rowsMigration = migrateBins(
+                                context,
+                                rowsBinFieldName,
+                                prevTableFieldRows,
+                                updatedTableFieldRows
+                            );
+                            if (!rowsMigration.isPresent()) {
+                                return;
+                            }
+                            migrations.put(rowsBinFieldName, rowsMigration.get());
+                        }
+
+                        migrations.forEach(context::addMigration);
                     }
                 }
             }
-            migrateBins(context, prevTableFieldCols, updatedTableFieldCols);
         }
     }
 
-    private void migrateBins(final TuneMigrationContext context, final int prevBinsCount, final int updatedBinsCount) {
-        final Constant prevValue = context.getPrevTune().getConstantsAsMap().get(columnsBinFieldName);
+    private Optional<Constant> migrateBins(
+        final TuneMigrationContext context,
+        final String binsFieldName,
+        final int prevBinsCount,
+        final int updatedBinsCount
+    ) {
+        final Constant prevValue = context.getPrevTune().getConstantsAsMap().get(binsFieldName);
         if (prevValue != null) {
-            final Optional<IniField> prevField = context.getPrevIniFile().findIniField(columnsBinFieldName);
+            final Optional<IniField> prevField = context.getPrevIniFile().findIniField(binsFieldName);
             if (!prevField.isPresent()) {
                 context.getCallbacks().logLine(String.format(
                     "WARNING!!! Missed `%s` ini field in previous .ini file.",
-                    columnsBinFieldName
+                    binsFieldName
                 ));
-                return;
+                return Optional.empty();
             }
-            final Optional<IniField> updatedField = context.getUpdatedIniFile().findIniField(columnsBinFieldName);
+            final Optional<IniField> updatedField = context.getUpdatedIniFile().findIniField(binsFieldName);
             if (!updatedField.isPresent()) {
                 context.getCallbacks().logLine(String.format(
                     "WARNING!!! Missed `%s` ini field in updated .ini file.",
-                    columnsBinFieldName
+                    binsFieldName
                 ));
-                return;
+                return Optional.empty();
             }
-            final ArrayIniField updatedBinsField = (ArrayIniField) updatedField.get();
             final Optional<String> migratedValue = new BinsIniFieldMigratorStrategy(
-                columnsBinFieldName,
+                binsFieldName,
                 prevBinsCount,
                 updatedBinsCount
             ).tryMigrateBins(
                 prevField.get(),
-                updatedBinsField,
+                updatedField.get(),
                 prevValue.getValue(),
                 context.getCallbacks()
             );
             if (migratedValue.isPresent()) {
-                context.addMigration(
-                    columnsBinFieldName,
-                    new Constant(
-                        columnsBinFieldName,
-                        updatedBinsField.getUnits(),
-                        migratedValue.get(),
-                        updatedBinsField.getDigits(),
-                        Integer.toString(updatedBinsField.getRows()),
-                        Integer.toString(updatedBinsField.getCols())
-                    )
-                );
+                final ArrayIniField updatedBinsField = (ArrayIniField) updatedField.get();
+                return Optional.of(new Constant(
+                    binsFieldName,
+                    updatedBinsField.getUnits(),
+                    migratedValue.get(),
+                    updatedBinsField.getDigits(),
+                    Integer.toString(updatedBinsField.getRows()),
+                    Integer.toString(updatedBinsField.getCols())
+                ));
             }
+        } else {
+            context.getCallbacks().logLine(String.format(
+                "WARNING!!! Missed `%s` value in previous tune.",
+                binsFieldName
+            ));
         }
+        return Optional.empty();
     }
 
     private Optional<String[][]> tryMigrateTable(
@@ -206,33 +314,46 @@ public class TableAddColumnsMigrator implements TuneMigrator {
         final String[][] prevValues,
         final UpdateOperationCallbacks callbacks
     ) {
-        Optional<String[][]> result = Optional.empty();
-        final int tableFieldRows = prevField.getRows();
-        if (newField.getRows() == tableFieldRows) {
-            final int prevTableFieldCols = prevField.getCols();
-            final int newTableFieldCols = newField.getCols();
-            if (prevTableFieldCols < newTableFieldCols) {
-                final String[][] newValues = new String[tableFieldRows][newTableFieldCols];
-                for (int rowIdx = 0; rowIdx < tableFieldRows; rowIdx++) {
-                    // copy prev values:
-                    for (int colIdx = 0; colIdx < prevTableFieldCols; colIdx++) {
-                        newValues[rowIdx][colIdx] = prevValues[rowIdx][colIdx];
-                    }
-                    // propagate value from a last column to new columns:
-                    for (int colIdx = prevTableFieldCols; colIdx < newTableFieldCols; colIdx++) {
-                        newValues[rowIdx][colIdx] = prevValues[rowIdx][prevTableFieldCols - 1];
-                    }
-                }
-                result = Optional.of(newValues);
-            }
-        } else {
+        final int prevRows = prevField.getRows();
+        final int prevCols = prevField.getCols();
+        if (prevValues.length != prevRows) {
             callbacks.logLine(String.format(
-                "WARNING! New `%s` ini-field is expected to contain %d rows as prev ini-field does",
+                "WARNING! Previous `%s` value has %d rows instead of %d",
                 tableFieldName,
-                tableFieldRows
+                prevValues.length,
+                prevRows
             ));
+            return Optional.empty();
         }
-        return result;
+        for (final String[] row : prevValues) {
+            if (row.length != prevCols) {
+                callbacks.logLine(String.format(
+                    "WARNING! Previous `%s` value has a row with %d columns instead of %d",
+                    tableFieldName,
+                    row.length,
+                    prevCols
+                ));
+                return Optional.empty();
+            }
+        }
+
+        final int newRows = newField.getRows();
+        final int newCols = newField.getCols();
+        if (newRows < prevRows || newCols < prevCols) {
+            return Optional.empty();
+        }
+
+        final String[][] newValues = new String[newRows][newCols];
+        for (int rowIdx = 0; rowIdx < newRows; rowIdx++) {
+            for (int colIdx = 0; colIdx < newCols; colIdx++) {
+                newValues[rowIdx][colIdx] = prevValues[
+                    Math.min(rowIdx, prevRows - 1)
+                ][
+                    Math.min(colIdx, prevCols - 1)
+                ];
+            }
+        }
+        return Optional.of(newValues);
     }
 
     private Optional<ArrayIniField> getValidatedTableArrayIniField(

--- a/java_console/ui/src/test/java/com/rusefi/maintenance/migration/afr_msq_import_migration/AfrLambdaTableAddColumnsMigrationTest.java
+++ b/java_console/ui/src/test/java/com/rusefi/maintenance/migration/afr_msq_import_migration/AfrLambdaTableAddColumnsMigrationTest.java
@@ -23,7 +23,7 @@ public class AfrLambdaTableAddColumnsMigrationTest {
         ComposedTuneMigrator.INSTANCE.migrateTune(testContext);
 
         final Map<String, Constant> migratedConstants = testContext.getMigratedConstants();
-        assertEquals(1, migratedConstants.size());
+        assertEquals(2, migratedConstants.size());
         assertEquals("", testContext.getTestCallbacks().getContent());
     }
 
@@ -136,4 +136,3 @@ public class AfrLambdaTableAddColumnsMigrationTest {
         );
     }
 }
-

--- a/java_console/ui/src/test/java/com/rusefi/maintenance/migration/afr_msq_import_migration/test_data/SmallAfrToBigLambda/prev_calibrations.msq
+++ b/java_console/ui/src/test/java/com/rusefi/maintenance/migration/afr_msq_import_migration/test_data/SmallAfrToBigLambda/prev_calibrations.msq
@@ -20,6 +20,24 @@
          12.8 12.8 12.8 12.8 12.8 12.8 12.8 12.8 12.8 12.7 12.7 12.7 12.7 12.6 12.6 12.6
          12.8 12.8 12.8 12.8 12.8 12.8 12.8 12.8 12.8 12.7 12.7 12.7 12.7 12.6 12.6 12.6
       </constant>
-      <constant digits="1" name="stoichRatioPrimary" units=":1">14.7</constant>
+       <constant cols="1" digits="0" name="lambdaRpmBins" rows="16" units="RPM">
+         800.0
+         1000.0
+         1300.0
+         1600.0
+         1900.0
+         2300.0
+         2700.0
+         3100.0
+         3500.0
+         4000.0
+         4500.0
+         5000.0
+         5500.0
+         6000.0
+         7250.0
+         8500.0
+       </constant>
+       <constant digits="1" name="stoichRatioPrimary" units=":1">14.7</constant>
     </page>
 </msq>

--- a/java_console/ui/src/test/java/com/rusefi/maintenance/migration/default_migration/DefaultTuneMigratorTest.java
+++ b/java_console/ui/src/test/java/com/rusefi/maintenance/migration/default_migration/DefaultTuneMigratorTest.java
@@ -243,9 +243,7 @@ public class DefaultTuneMigratorTest {
     @Test
     public void testContent() {
         assertEquals(
-            "WARNING! Type of `map_samplingAngleBins` ini-field is expected to be `UINT16` instead of `FLOAT`\r\n" +
-                "WARNING! Type of `map_samplingAngleBins` ini-field is expected to be `UINT16` instead of `FLOAT`\r\n" +
-                "We aren't going to restore field `auxSerialRxPin`: it is missed in new .ini file\r\n" +
+            "We aren't going to restore field `auxSerialRxPin`: it is missed in new .ini file\r\n" +
                 "We aren't going to restore field `auxSerialSpeed`: it is missed in new .ini file\r\n" +
                 "We aren't going to restore field `auxSerialTxPin`: it is missed in new .ini file\r\n" +
                 "We aren't going to restore field `boardUse2stepPullDown`: it is missed in new .ini file\r\n" +

--- a/java_console/ui/src/test/java/com/rusefi/maintenance/migration/table_add_columns_migration/TableAddColumnsMigratorTest.java
+++ b/java_console/ui/src/test/java/com/rusefi/maintenance/migration/table_add_columns_migration/TableAddColumnsMigratorTest.java
@@ -26,7 +26,57 @@ public class TableAddColumnsMigratorTest {
         ComposedTuneMigrator.INSTANCE.migrateTune(testContext);
 
         final Map<String, Constant> migratedConstants = testContext.getMigratedConstants();
-        assertEquals(8, migratedConstants.size());
+        assertEquals(11, migratedConstants.size());
+    }
+
+    @Test
+    void checkTableRowsAndColumnsMigration() {
+        testContext.checkValueMigration(
+            PEDAL_TO_TPS_TABLE_FIELD_NAME,
+            new Constant(
+                PEDAL_TO_TPS_TABLE_FIELD_NAME,
+                null,
+                "\n" +
+                    "         1.0 2.0 3.0\n" +
+                    "         4.0 5.0 6.0\n",
+                "0",
+                "2",
+                "3"
+            ),
+            new Constant(
+                PEDAL_TO_TPS_TABLE_FIELD_NAME,
+                null,
+                "\n" +
+                    "         0.0 0.0 0.0 0.0 0.0\n" +
+                    "         0.0 0.0 0.0 0.0 0.0\n" +
+                    "         0.0 0.0 0.0 0.0 0.0\n" +
+                    "         0.0 0.0 0.0 0.0 0.0\n",
+                "0",
+                "4",
+                "5"
+            ),
+            new Constant(
+                PEDAL_TO_TPS_TABLE_FIELD_NAME,
+                "%",
+                "\n" +
+                    "         1.0 2.0 3.0 3.0 3.0\n" +
+                    "         4.0 5.0 6.0 6.0 6.0\n" +
+                    "         4.0 5.0 6.0 6.0 6.0\n" +
+                    "         4.0 5.0 6.0 6.0 6.0\n",
+                "0",
+                "4",
+                "5"
+            )
+        );
+
+        assertEquals(
+            "\n         1000.0\n         2000.0\n         3000.0\n         4000.0\n         5000.0\n",
+            testContext.getMigratedValue(PEDAL_TO_TPS_RPM_BINS_FIELD_NAME).getValue()
+        );
+        assertEquals(
+            "\n         0.0\n         100.0\n         110.0\n         120.0\n",
+            testContext.getMigratedValue(PEDAL_TO_TPS_PEDAL_BINS_FIELD_NAME).getValue()
+        );
     }
 
     @Test
@@ -938,4 +988,3 @@ public class TableAddColumnsMigratorTest {
         );
     }
 }
-

--- a/java_console/ui/src/test/java/com/rusefi/maintenance/migration/table_add_columns_migration/test_data/prev_calibrations.ini
+++ b/java_console/ui/src/test/java/com/rusefi/maintenance/migration/table_add_columns_migration/test_data/prev_calibrations.ini
@@ -14,6 +14,9 @@ ignitionTable   = array, S16, 31128, [16x16], "deg", 0.1, 0, -20, 90, 1
 ignitionRpmBins = array, U16, 31672, [16], "RPM", 1, 0, 0, 18000, 0
 injectionPhase  = array, S16, 31128, [16x16], "deg", 1.0, 0, -720, 720, 0
 injPhaseRpmBins = array, U16, 30268, [16], "RPM", 1, 0, 0, 18000, 0
+pedalToTpsTable = array, U08, 34000, [3x2], "%", 1, 0, 0, 100, 0
+pedalToTpsRpmBins = array, U08, 34006, [3], "RPM", 100, 0, 0, 25000, 0
+pedalToTpsPedalBins = array, U08, 34009, [2], "%", 1, 0, 0, 120, 0
 
 [OutputChannels]
 ochBlockSize    = 2008

--- a/java_console/ui/src/test/java/com/rusefi/maintenance/migration/table_add_columns_migration/test_data/prev_calibrations.msq
+++ b/java_console/ui/src/test/java/com/rusefi/maintenance/migration/table_add_columns_migration/test_data/prev_calibrations.msq
@@ -146,5 +146,18 @@
          6500.0
          7000.0
 </constant>
+        <constant cols="3" digits="0" name="pedalToTpsTable" rows="2">
+         1.0 2.0 3.0
+         4.0 5.0 6.0
+</constant>
+        <constant cols="1" digits="0" name="pedalToTpsRpmBins" rows="3" units="RPM">
+         1000.0
+         2000.0
+         3000.0
+</constant>
+        <constant cols="1" digits="0" name="pedalToTpsPedalBins" rows="2" units="%">
+         0.0
+         100.0
+</constant>
     </page>
 </msq>

--- a/java_console/ui/src/test/java/com/rusefi/maintenance/migration/table_add_columns_migration/test_data/updated_calibrations.ini
+++ b/java_console/ui/src/test/java/com/rusefi/maintenance/migration/table_add_columns_migration/test_data/updated_calibrations.ini
@@ -14,6 +14,9 @@ ignitionTable   = array, S16, 31880, [24x16], "deg", 0.1, 0, -20, 90, 1
 ignitionRpmBins = array, U16, 32680, [24], "RPM", 1, 0, 0, 18000, 0
 injectionPhase  = array, S16, 30204, [24x16], "deg", 1, 0, -720, 720, 0
 injPhaseRpmBins = array, U16, 31004, [24], "RPM", 1, 0, 0, 18000, 0
+pedalToTpsTable = array, U08, 35000, [5x4], "%", 1, 0, 0, 100, 0
+pedalToTpsRpmBins = array, U08, 35020, [5], "RPM", 100, 0, 0, {rpmLimit ? (metric ? 25000 : 24000) : 20000}, 0
+pedalToTpsPedalBins = array, U08, 35025, [4], "%", 1, 0, 0, 120, 0
 
 [OutputChannels]
 ochBlockSize    = 2064

--- a/java_console/ui/src/test/java/com/rusefi/maintenance/migration/table_add_columns_migration/test_data/updated_calibrations.msq
+++ b/java_console/ui/src/test/java/com/rusefi/maintenance/migration/table_add_columns_migration/test_data/updated_calibrations.msq
@@ -178,5 +178,24 @@
          9100.0
          9400.0
 </constant>
+        <constant cols="5" digits="0" name="pedalToTpsTable" rows="4">
+         0.0 0.0 0.0 0.0 0.0
+         0.0 0.0 0.0 0.0 0.0
+         0.0 0.0 0.0 0.0 0.0
+         0.0 0.0 0.0 0.0 0.0
+</constant>
+        <constant cols="1" digits="0" name="pedalToTpsRpmBins" rows="5" units="RPM">
+         0.0
+         1000.0
+         2000.0
+         3000.0
+         4000.0
+</constant>
+        <constant cols="1" digits="0" name="pedalToTpsPedalBins" rows="4" units="%">
+         0.0
+         30.0
+         60.0
+         100.0
+</constant>
     </page>
 </msq>


### PR DESCRIPTION
now it can handle rows/columns for all `TableAddColumnsMigrator` existing migrations

todo: rename it? since now we are doing more than columns

resolves #9986