### PR TITLE
ignition: add dwell duty cycle mode for Ford TFI modules

### DIFF
--- a/.github/workflows/build-firmware.yaml
+++ b/.github/workflows/build-firmware.yaml
@@ -170,6 +170,9 @@ jobs:
       run: echo "BUNDLE_DATE=$(date +'%Y-%m-%d')">> $GITHUB_ENV
 
     - name: Set run condition variables 2
+      env:
+        # ref names may contain shell metacharacters - never interpolate them into scripts with ${{ }}
+        GH_REF: ${{ github.ref }}
       run: |
         if [ "${{github.event_name}}" = "schedule" ] && [ "${{github.repository}}" = "rusefi/rusefi" ]; then
           echo "Creating nightly build"
@@ -177,7 +180,7 @@ jobs:
           echo "upload=release" >> $GITHUB_ENV
           echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
         elif [ "${{github.event_name}}" = "push" ]\
-        && [ "${{github.ref}}" = "refs/heads/master" ]\
+        && [ "$GH_REF" = "refs/heads/master" ]\
         || [ "${{toJSON(inputs.lts)}}" = "true" ]; then
           echo "Server upload mode"
           echo "full=true" >> $GITHUB_ENV
@@ -201,10 +204,14 @@ jobs:
         sudo bash misc/actions/ubuntu-install-tools.sh
 
     - name: Set Build Env Variables
+      env:
+        # ref names may contain shell metacharacters - never interpolate them into scripts with ${{ }}
+        REF_NAME: ${{ github.ref_name }}
+        META_INFO: ${{ matrix.meta-info }}
       run: |
         echo AUTOMATION_LTS=${{toJSON(inputs.lts)}} >> $GITHUB_ENV
-        echo AUTOMATION_REF=${{github.ref_name}} >> $GITHUB_ENV
-        echo BOARD_META_PATH=${{matrix.meta-info}} >> $GITHUB_ENV
+        echo "AUTOMATION_REF=$REF_NAME" >> $GITHUB_ENV
+        echo "BOARD_META_PATH=$META_INFO" >> $GITHUB_ENV
         echo "WHITE_LABEL=rusefi" >> $GITHUB_ENV
 
     - name: Git Status

--- a/.github/workflows/build-unit-tests.yaml
+++ b/.github/workflows/build-unit-tests.yaml
@@ -77,8 +77,10 @@ jobs:
     - name: Set FTP variables
       env:
         ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
+        # ref names may contain shell metacharacters - never interpolate them into scripts with ${{ }}
+        GH_REF: ${{ github.ref }}
       run: |
-        if [ "${{github.ref}}" = "refs/heads/master" ]; then
+        if [ "$GH_REF" = "refs/heads/master" ]; then
           echo "RUSEFI_SSH_SERVER=${{secrets.RUSEFI_SSH_SERVER}}" >> $GITHUB_ENV
           echo "RUSEFI_SSH_USER=${{secrets.RUSEFI_SSH_USER}}" >> $GITHUB_ENV
           echo "RUSEFI_SSH_PASS=${{secrets.RUSEFI_SSH_PASS}}" >> $GITHUB_ENV

--- a/.github/workflows/custom-board-build/action.yaml
+++ b/.github/workflows/custom-board-build/action.yaml
@@ -157,6 +157,9 @@ runs:
     - name: Set Env Variables
       id: set-env-variables
       shell: bash
+      env:
+        # ref names may contain shell metacharacters - never interpolate them into scripts with ${{ }}
+        REF_NAME: ${{ github.ref_name }}
       run: |
         : Set Env Variables
         echo "WHITE_LABEL=${{steps.find-out-white-label.outputs.white_label}}" >> $GITHUB_ENV
@@ -167,7 +170,7 @@ runs:
         echo "AUTOMATION_LTS=${{toJSON(inputs.lts)}}" >> $GITHUB_ENV
         echo "BUNDLE_SIMULATOR=${{toJSON(inputs.bundle_simulator)}}" >> $GITHUB_ENV
         echo "RUN_SIMULATOR=${{toJSON(inputs.run_simulator)}}" >> $GITHUB_ENV
-        echo "AUTOMATION_REF=${{github.ref_name}}" >> $GITHUB_ENV
+        echo "AUTOMATION_REF=$REF_NAME" >> $GITHUB_ENV
         echo "${{ inputs.ADDITIONAL_ENV }}" >> $GITHUB_ENV
         shopt -s expand_aliases
         if which grealpath >/dev/null 2>&1; then alias realpath='grealpath'; fi
@@ -197,14 +200,18 @@ runs:
 
     - name: Set Build Env Variables
       shell: bash
+      env:
+        # ref names may contain shell metacharacters - never interpolate them into scripts with ${{ }}
+        REF_NAME: ${{ github.ref_name }}
+        GH_REF: ${{ github.ref }}
       run: |
         : Set Build Env Variables
-        if [[ ${{github.ref_name}} == "lts"* ]]; then
+        if [[ "$REF_NAME" == "lts"* ]]; then
           echo AUTOMATION_LTS=true >> $GITHUB_ENV
-          echo AUTOMATION_REF=${{github.ref_name}} >> $GITHUB_ENV
-          echo "On LTS branch [${{github.ref}}]"
+          echo "AUTOMATION_REF=$REF_NAME" >> $GITHUB_ENV
+          echo "On LTS branch [$GH_REF]"
         else
-          echo "Not LTS branch [${{github.ref}}]"
+          echo "Not LTS branch [$GH_REF]"
         fi
 
     - name: Install Arm GNU Toolchain (arm-none-eabi-gcc)
@@ -338,14 +345,18 @@ runs:
       if: ${{ contains(inputs.uploads, 'ftp_upload_bundles') }}
       working-directory: ${{inputs.rusefi_dir}}/artifacts
       shell: bash
+      env:
+        # ref names may contain shell metacharacters - never interpolate them into scripts with ${{ }}
+        REF_NAME: ${{ github.ref_name }}
+        GH_REF: ${{ github.ref }}
       run: |
         : Ftp Upload Both Bundles
-        if [ "${{github.ref}}" = "refs/heads/master" ] || [ "${{github.ref}}" = "refs/heads/main" ]; then
+        if [ "$GH_REF" = "refs/heads/master" ] || [ "$GH_REF" = "refs/heads/main" ]; then
           echo "On master branch"
-        elif [[ ${{github.ref_name}} == "lts"* ]]; then
-          echo "On LTS branch [${{github.ref}}]"
+        elif [[ "$REF_NAME" == "lts"* ]]; then
+          echo "On LTS branch [$GH_REF]"
         else
-          echo "Not uploading [${{github.ref}}]"
+          echo "Not uploading [$GH_REF]"
           exit 0
         fi
         bash ../firmware/bin/upload_bundle.sh "${{ env.RUSEFI_SSH_USER }}" "${{ env.RUSEFI_SSH_PASS }}" "${{ env.RUSEFI_SSH_SERVER }}" "${{ env.BUNDLE_NAME }}"

--- a/.github/workflows/gen-diffs.yaml
+++ b/.github/workflows/gen-diffs.yaml
@@ -35,8 +35,10 @@ jobs:
     - name: Set SSH variables
       env:
         ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
+        # ref names may contain shell metacharacters - never interpolate them into scripts with ${{ }}
+        GH_REF: ${{ github.ref }}
       run: |
-        if [ "${{github.event_name}}" = "push" ] && [ "${{github.ref}}" = "refs/heads/master" ]; then
+        if [ "${{github.event_name}}" = "push" ] && [ "$GH_REF" = "refs/heads/master" ]; then
           echo "RUSEFI_SSH_SERVER=${{secrets.RUSEFI_SSH_SERVER}}" >> $GITHUB_ENV
           echo "RUSEFI_SSH_USER=${{secrets.RUSEFI_SSH_USER}}" >> $GITHUB_ENV
           echo "RUSEFI_SSH_PASS=${{secrets.RUSEFI_SSH_PASS}}" >> $GITHUB_ENV

--- a/.github/workflows/gen-docs.yaml
+++ b/.github/workflows/gen-docs.yaml
@@ -19,8 +19,10 @@ jobs:
     - name: Set FTP variables
       env:
         ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
+        # ref names may contain shell metacharacters - never interpolate them into scripts with ${{ }}
+        GH_REF: ${{ github.ref }}
       run: |
-        if [ "${{github.ref}}" = "refs/heads/master" ]; then
+        if [ "$GH_REF" = "refs/heads/master" ]; then
           echo "RUSEFI_SSH_SERVER=${{secrets.RUSEFI_SSH_SERVER}}" >> $GITHUB_ENV
           echo "RUSEFI_SSH_USER=${{secrets.RUSEFI_SSH_USER}}" >> $GITHUB_ENV
           echo "RUSEFI_SSH_PASS=${{secrets.RUSEFI_SSH_PASS}}" >> $GITHUB_ENV

--- a/.github/workflows/gen-ibom.yaml
+++ b/.github/workflows/gen-ibom.yaml
@@ -25,8 +25,10 @@ jobs:
     - name: Set SSH variables
       env:
         ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
+        # ref names may contain shell metacharacters - never interpolate them into scripts with ${{ }}
+        GH_REF: ${{ github.ref }}
       run: |
-        if [ "${{github.ref}}" = "refs/heads/master" ]; then
+        if [ "$GH_REF" = "refs/heads/master" ]; then
           echo "RUSEFI_SSH_SERVER=${{secrets.RUSEFI_SSH_SERVER}}" >> $GITHUB_ENV
           echo "RUSEFI_SSH_USER=${{secrets.RUSEFI_SSH_USER}}" >> $GITHUB_ENV
           echo "RUSEFI_SSH_PASS=${{secrets.RUSEFI_SSH_PASS}}" >> $GITHUB_ENV

--- a/firmware/controllers/algo/defaults/default_ignition.cpp
+++ b/firmware/controllers/algo/defaults/default_ignition.cpp
@@ -114,6 +114,10 @@ void setDefaultIgnition() {
 	setLinearCurve(config->dwellVoltageCorrVoltBins, 8, 15, 0.1);
 	setLinearCurve(config->dwellVoltageCorrValues, 1, 1, 1);
 
+	// Dwell Duty Mode - disabled by default; 50% is the standard TFI module target.
+	engineConfiguration->dwellDutyModeEnabled = false;
+	engineConfiguration->dwellDutyPercent = 50;
+
 	// Multispark
 	setDefaultMultisparkParameters();
 

--- a/firmware/controllers/algo/ignition/ignition_state.cpp
+++ b/firmware/controllers/algo/ignition/ignition_state.cpp
@@ -23,6 +23,8 @@
 #include "idle_thread.h"
 #include "launch_control.h"
 #include "gppwm_channel.h"
+#include "spark_logic.h"
+#include "engine_math.h"
 
 #if EFI_ENGINE_CONTROL
 
@@ -346,6 +348,15 @@ floatms_t IgnitionState::getSparkDwell(float rpm, bool isCranking) {
 	float dwellMs;
 	if (isCranking) {
 		dwellMs = engineConfiguration->ignitionDwellForCrankingMs;
+	} else if (engineConfiguration->dwellDutyModeEnabled) {
+		efiAssert(ObdCode::CUSTOM_ERR_ASSERT, !std::isnan(rpm), "invalid rpm", NAN);
+		// Duty mode: dwell = duty% × (engine cycle duration / sparks per cycle).
+		// Exact inverse of getCoilDutyCycle() — gives the dwell that produces the
+		// requested duty on the coil output pin (e.g. 50% for Ford TFI modules).
+		float intervalMs = getEngineCycleDuration(rpm) / getNumberOfSparks(getCurrentIgnitionMode());
+		baseDwell = engineConfiguration->dwellDutyPercent / 100.0f * intervalMs;
+		dwellVoltageCorrection = 1.0f;
+		dwellMs = baseDwell;
 	} else {
 		efiAssert(ObdCode::CUSTOM_ERR_ASSERT, !std::isnan(rpm), "invalid rpm", NAN);
 

--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -107,7 +107,7 @@
 ! This is the version of the data stored in flash configuration
 ! Any time an incompatible change is made to the configuration format stored in flash,
 ! update this string to the current date!
-#define FLASH_DATA_VERSION 260714
+#define FLASH_DATA_VERSION 260805
 
 ! Remove next line when Java toolset gets adjusted to load those from json config into VariablesRegistry
 ! Also remove file integration/generated/rusefi_config_generated_enums.txt
@@ -2028,6 +2028,16 @@ end_struct
 	include_file controllers/can/can_sniffer.txt
 
 	SDLoggerMode sdLoggerMode;'Trigger' mode will write a high speed log of trigger events (warning: uses lots of space!). 'Full MLG' mode will write a standard MLG of sensors, engine function, etc. similar to the one captured in TunerStudio. 'DTC Freeze Frame' will write one frame MLG log and short CSV trigger log on every DTC
+
+	! --- Dwell Duty Mode ---
+	! Instead of the RPM/voltage dwell tables, compute dwell as a fixed percentage of the
+	! time between consecutive ignition pulses on the same output. This matches what Ford
+	! TFI (Thick Film Ignition) modules expect: a 50% duty cycle square wave where the ECU
+	! controls timing by advancing or retarding the pulse edge, not the absolute dwell time.
+	! Cranking always uses ignitionDwellForCrankingMs regardless of this setting.
+	bit dwellDutyModeEnabled,"enabled","disabled";Dwell Duty Mode: when enabled, ignores the RPM/voltage dwell tables and computes dwell as a fixed percentage of the time between consecutive ignition pulses. Required for Ford TFI modules that expect a 50% duty cycle square wave.
+	uint8_t dwellDutyPercent;Dwell Duty Mode: percentage of the inter-spark interval used as coil dwell time. 50 = half the interval between pulses (standard TFI target).;"%", 1, 0, 1, 90, 0
+
 ! end of engine_configuration_s
 end_struct
 

--- a/firmware/tunerstudio/tunerstudio.template.ini
+++ b/firmware/tunerstudio/tunerstudio.template.ini
@@ -2839,8 +2839,10 @@ cmd_set_engine_type_default					= "@@TS_IO_TEST_COMMAND_char@@@@ts_command_e_TS_
 		panel = targetAfrBlend2Bias, { targetAfrBlends2_blendParameter }
 
 	dialog = dwellSettings, "", yAxis
-		panel = dwellCorrection
-		panel = dwellVoltageCorrection
+		field = "Dwell Duty Mode",  dwellDutyModeEnabled
+		field = "Duty %",           dwellDutyPercent,       {dwellDutyModeEnabled}
+		panel = dwellCorrection,        {!dwellDutyModeEnabled}
+		panel = dwellVoltageCorrection, {!dwellDutyModeEnabled}
 
 	dialog = auxTempSensor1_thermistor,	"aux1 Thermistor Settings"
 		field = "Input channel",			auxTempSensor1_adcChannel

--- a/unit_tests/tests/ignition_injection/test_ignition_state.cpp
+++ b/unit_tests/tests/ignition_injection/test_ignition_state.cpp
@@ -322,4 +322,20 @@ TEST(ignition_state, getSparkDwellTableAndVoltageCorrection) {
   setArrayValues(config->dwellVoltageCorrValues, 0);
   engine->ignitionState.updateDwell(3000, false);
   EXPECT_NEAR(5, engine->ignitionState.getDwell(), EPS2D);
+
+  // Duty mode (for Ford TFI modules) bypasses the table/voltage-correction
+  // calculation above entirely, computing dwell as a fixed percentage of the
+  // inter-spark interval instead.
+  engineConfiguration->ignitionMode = IM_WASTED_SPARK;
+  engineConfiguration->dwellDutyModeEnabled = true;
+  engineConfiguration->dwellDutyPercent = 50;
+
+  // engine cycle @3000rpm = 40ms, 2 sparks per cycle (wasted spark) -> 20ms interval, 50% = 10ms
+  engine->ignitionState.updateDwell(3000, false);
+  EXPECT_NEAR(10, engine->ignitionState.getDwell(), EPS2D);
+
+  // duty mode ignores battery voltage correction entirely
+  Sensor::setMockValue(SensorType::BatteryVoltage, 8);
+  engine->ignitionState.updateDwell(3000, false);
+  EXPECT_NEAR(10, engine->ignitionState.getDwell(), EPS2D);
 }


### PR DESCRIPTION
Adds a switch that replaces the RPM/voltage dwell tables with a fixed percentage of the inter-spark interval. Ford TFI (Thick Film Ignition) modules used on Windsor engines expect a 50% duty cycle square wave rather than an absolute dwell time.

When enabled, dwell = (dutyPercent/100) * engineCycleDuration / numSparks, which is the exact inverse of the existing getCoilDutyCycle() function. Cranking still uses ignitionDwellForCrankingMs regardless of this setting.

Unlike the original AlphaX-branch version, this lives directly in the main engine_configuration_s (rusefi_config.txt) rather than the AlphaX page-5 layout, since master doesn't carry that infrastructure - following the same pattern already used by misfire detection. FLASH_DATA_VERSION bumped for the config layout change.

Extends the spark dwell characterization test (merged separately as same rpm and table configuration used to characterize the existing table/voltage-correction calculation, duty mode replaces it with a fixed percentage of the inter-spark interval and ignores battery- voltage correction entirely.