### PR TITLE
PortResult: show board kind with the blt version string

### DIFF
--- a/java_console/connectivity/src/main/java/com/rusefi/PortResult.java
+++ b/java_console/connectivity/src/main/java/com/rusefi/PortResult.java
@@ -78,6 +78,9 @@ public class PortResult {
                 if (bootloaderInfo.features != null && !bootloaderInfo.features.isEmpty()) {
                     identity += "[" + String.join(",", bootloaderInfo.features) + "]";
                 }
+                if (bootloaderInfo.raw != null) {
+                    identity += ": " + bootloaderInfo.raw;
+                }
             } else if (type == SerialPortType.UnsupportedEcu && unsupportedEcuInfo != null) {
                 identity = ": " + unsupportedEcuInfo.getEcuTarget();
             }

--- a/java_console/connectivity/src/test/java/com/rusefi/PortResultTest.java
+++ b/java_console/connectivity/src/test/java/com/rusefi/PortResultTest.java
@@ -78,7 +78,7 @@ public class PortResultTest {
     public void toStringShowsPortWithFriendlyType() {
         assertEquals("COM1 (ECU)", new PortResult("COM1", SerialPortType.Ecu).toString());
         assertEquals("COM2 (OpenBLT Bootloader)", new PortResult("COM2", SerialPortType.OpenBlt).toString());
-        assertEquals("COM3 (OpenBLT Bootloader)",
+        assertEquals("COM3 (OpenBLT Bootloader: rusefi.uaefi)",
             new PortResult("COM3", SerialPortType.OpenBlt, null, new OpenbltInfo(true, "rusefi.uaefi")).toString());
     }
 
@@ -94,6 +94,13 @@ public class PortResultTest {
         assertEquals("COM1 (OpenBLT Bootloader v1.16.0[encrypted,custom_led])",
             new PortResult("COM1", SerialPortType.OpenBlt, null,
                 new OpenbltInfo(true, null, "1.16.0", List.of("encrypted", "custom_led"))).toString());
+    }
+
+    @Test
+    public void toStringShowsBoardString() {
+        assertEquals("COM3 (OpenBLT Bootloader v1.16.0[custom_led]: rusefi.uaefi)",
+            new PortResult("COM3", SerialPortType.OpenBlt, null,
+                new OpenbltInfo(true, "rusefi.uaefi", "1.16.0", List.of("custom_led"))).toString());
     }
 
 }


### PR DESCRIPTION
even more describable on the port list:
<img width="533" height="285" alt="image" src="https://github.com/user-attachments/assets/98c2d622-0fb2-46a6-92ec-00618d067ccd" />
