### PR TITLE
AfrLambdaTableMigrator: ensure unchanged lambda tables are not migrated

### DIFF
--- a/java_console/io/src/main/java/com/rusefi/maintenance/migration/migrators/AfrLambdaTableMigrator.java
+++ b/java_console/io/src/main/java/com/rusefi/maintenance/migration/migrators/AfrLambdaTableMigrator.java
@@ -41,23 +41,27 @@ public enum AfrLambdaTableMigrator implements TuneMigrator {
             ) {
                 final int updatedTableFieldCols = updatedTableField.getCols();
                 final Constant prevValue = context.getPrevTune().getConstantsAsMap().get(LAMBDA_TABLE_FIELD_NAME);
-                if (prevValue != null) {
+                final Constant updatedValue = context.getUpdatedTune().getConstantsAsMap().get(LAMBDA_TABLE_FIELD_NAME);
+                if (prevValue != null && updatedValue != null) {
                     final Optional<String[][]> migratedValues = AfrLambdaTableValuesConverter.INSTANCE.convertTableValues(
                         prevTableField.getValues(prevValue.getValue()),
                         context
                     );
                     if (migratedValues.isPresent()) {
-                        context.addMigration(
+                        final Constant migratedValue = new Constant(
                             LAMBDA_TABLE_FIELD_NAME,
-                            new Constant(
-                                LAMBDA_TABLE_FIELD_NAME,
-                                updatedTableField.getUnits(),
-                                updatedTableField.formatValue(migratedValues.get()),
-                                updatedTableField.getDigits(),
-                                Integer.toString(updatedTableField.getRows()),
-                                Integer.toString(updatedTableFieldCols)
-                            )
+                            updatedTableField.getUnits(),
+                            updatedTableField.formatValue(migratedValues.get()),
+                            updatedTableField.getDigits(),
+                            Integer.toString(updatedTableField.getRows()),
+                            Integer.toString(updatedTableFieldCols)
                         );
+                        final String formattedUpdatedValue = updatedTableField.formatValue(
+                            updatedTableField.getValues(updatedValue.getValue())
+                        );
+                        if (!Objects.equals(migratedValue.getValue(), formattedUpdatedValue)) {
+                            context.addMigration(LAMBDA_TABLE_FIELD_NAME, migratedValue);
+                        }
                     }
                 }
             }

--- a/java_console/ui/src/test/java/com/rusefi/maintenance/migration/afr_msq_import_migration/AfrLambdaTableNoOpMigrationTest.java
+++ b/java_console/ui/src/test/java/com/rusefi/maintenance/migration/afr_msq_import_migration/AfrLambdaTableNoOpMigrationTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test;
 
 import static com.rusefi.maintenance.migration.TestTuneMigrationContextFactory.createTestMigrationContext;
 import static com.rusefi.maintenance.migration.migrators.TableAddColumnsMigrator.LAMBDA_TABLE_FIELD_NAME;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 class AfrLambdaTableNoOpMigrationTest {
     private static final ArrayIniField LAMBDA_TABLE_FIELD = new ArrayIniField(
@@ -35,7 +35,7 @@ class AfrLambdaTableNoOpMigrationTest {
     );
 
     @Test
-    void unchangedLambdaTableIsMigrated() {
+    void unchangedLambdaTableIsNotMigrated() {
         final TestTuneMigrationContext context = createTestMigrationContext(
             LAMBDA_TABLE_VALUE,
             LAMBDA_TABLE_FIELD,
@@ -45,6 +45,6 @@ class AfrLambdaTableNoOpMigrationTest {
 
         AfrLambdaTableMigrator.INSTANCE.migrateTune(context);
 
-        assertTrue(context.getMigratedConstants().containsKey(LAMBDA_TABLE_FIELD_NAME));
+        assertFalse(context.getMigratedConstants().containsKey(LAMBDA_TABLE_FIELD_NAME));
     }
 }


### PR DESCRIPTION
resolves #9962 also resolves #10041