### PR TITLE
StackUsageReport: fix for boards with a disabled engine module

### DIFF
--- a/java_tools/gcc_map_reader/src/main/java/com/rusefi/tools/stack/StackUsageReport.java
+++ b/java_tools/gcc_map_reader/src/main/java/com/rusefi/tools/stack/StackUsageReport.java
@@ -541,6 +541,16 @@ public class StackUsageReport {
         return matches.get(0);
     }
 
+    private static boolean hasSymbol(Map<String, Node> nodes, String function) {
+        for (Node node : nodes.values()) {
+            if (function.equals(node.function)
+                || (!function.contains("(") && node.function.startsWith(function + "("))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     static List<Set<String>> findComponents(Map<String, Node> nodes) {
         Tarjan tarjan = new Tarjan(nodes);
         List<String> symbols = new ArrayList<>(nodes.keySet());
@@ -606,6 +616,11 @@ public class StackUsageReport {
                 BigInteger budget = budgetFor(root, graph.stackSizes);
                 if (root.function == null) {
                     rows.add("| " + graph.image + " | " + root.name + " | " + budget + " | - | - | - | - | NOT REVIEWED |");
+                    continue;
+                }
+                if (!hasSymbol(graph.nodes, root.function)) {
+                    rows.add("| " + graph.image + " | " + root.name + " | " + budget
+                        + " | - | - | - | - | NOT ANALYZED: entry absent from post-LTO callgraph |");
                     continue;
                 }
 

--- a/java_tools/gcc_map_reader/src/test/java/com/rusefi/tools/stack/StackUsageReportTest.java
+++ b/java_tools/gcc_map_reader/src/test/java/com/rusefi/tools/stack/StackUsageReportTest.java
@@ -116,6 +116,18 @@ public class StackUsageReportTest {
     }
 
     @Test
+    void rootAbsentFromCallgraphIsReported() {
+        StackUsageReport.Root root = new StackUsageReport.Root("firmware", "inactive", "missing", 100, null);
+        StackUsageReport.Graph graph = new StackUsageReport.Graph("firmware",
+            Collections.<String, StackUsageReport.Node>emptyMap(), Collections.singletonList(root),
+            Collections.<String, Integer>emptyMap());
+
+        String report = StackUsageReport.render("test", Collections.singletonList(graph));
+
+        assertTrue(report.contains("NOT ANALYZED: entry absent from post-LTO callgraph"));
+    }
+
+    @Test
     void linkedStackRootMetadataAndExternalProfile() throws Exception {
         Path map = write("roots.map",
             "Discarded input sections\n"


### PR DESCRIPTION
some boards can have missing symbols reported (for an engine module disable) we don't have to fail in these cases