### PR TITLE
CurveWidget: enable multi-cell selection and improve editing logic

### DIFF
--- a/java_console/ui/src/main/java/com/rusefi/ui/widgets/tune/CurveWidget.java
+++ b/java_console/ui/src/main/java/com/rusefi/ui/widgets/tune/CurveWidget.java
@@ -16,9 +16,11 @@ import javax.swing.table.DefaultTableCellRenderer;
 import java.awt.*;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
+import java.awt.event.KeyEvent;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.EventObject;
 
 /**
  * curve panel consists of two parts
@@ -53,6 +55,28 @@ public class CurveWidget {
     public CurveWidget(CurveModel curveModel, IniFileModel iniFileModel, ConfigurationImage ci) {
         table.getTableHeader().setReorderingAllowed(false);
         table.setDefaultRenderer(Object.class, new GradientRenderer());
+        table.setDefaultEditor(Object.class, new DefaultCellEditor(new JTextField()) {
+            private boolean keyboardEditing;
+
+            @Override
+            public boolean isCellEditable(EventObject event) {
+                keyboardEditing = event instanceof KeyEvent;
+                return super.isCellEditable(event);
+            }
+
+            @Override
+            public Component getTableCellEditorComponent(JTable table, Object value, boolean isSelected, int row, int column) {
+                JTextField editor = (JTextField) super.getTableCellEditorComponent(table, value, isSelected, row, column);
+                if (keyboardEditing) {
+                    editor.setText("");
+                }
+                return editor;
+            }
+        });
+        table.setCellSelectionEnabled(true);
+        table.setSelectionMode(ListSelectionModel.MULTIPLE_INTERVAL_SELECTION);
+        table.getSelectionModel().addListSelectionListener(e -> canvas.repaint());
+        table.getColumnModel().getSelectionModel().addListSelectionListener(e -> canvas.repaint());
         // JTable defaults to a 450x400 preferredScrollableViewportSize; left unchanged the table would
         // claim ~450px of fixed preferred width and starve the canvas (which only receives the GridBag
         // remainder) on narrow windows. Size the table to its actual content so the 0.8/0.2 weights hold.
@@ -337,6 +361,12 @@ public class CurveWidget {
                 Point p = worldToCanvas(x[i], y[i]);
                 g2.fillOval(p.x - 4, p.y - 4, 8, 8);
             }
+
+            g2.setColor(Color.MAGENTA);
+            for (int row : table.getSelectedRows()) {
+                Point p = worldToCanvas(x[row], y[row]);
+                g2.fillOval(p.x - 5, p.y - 5, 10, 10);
+            }
         }
 
         private Point worldToCanvas(double wx, double wy) {
@@ -418,19 +448,27 @@ public class CurveWidget {
         public void setValueAt(Object aValue, int rowIndex, int columnIndex) {
             try {
                 double val = Double.parseDouble(aValue.toString());
-                if (columnIndex == 0) {
-                    // Check order
-                    double min = (rowIndex == 0) ? curveModel.getxAxis().getMin() : xValues[rowIndex - 1];
-                    double max = (rowIndex == xValues.length - 1) ? curveModel.getxAxis().getMax() : xValues[rowIndex + 1];
-                    xValues[rowIndex] = Math.max(min, Math.min(max, val));
-                } else {
-                    yValues[rowIndex] = Math.max(curveModel.getyAxis().getMin(), Math.min(curveModel.getyAxis().getMax(), val));
+                for (int row : table.getSelectedRows()) {
+                    for (int column : table.getSelectedColumns()) {
+                        setValue(row, column, val);
+                    }
                 }
-                fireTableCellUpdated(rowIndex, columnIndex);
+                fireTableDataChanged();
                 canvas.repaint();
                 writeBackToImage();
                 if (onEdit != null) onEdit.run();
             } catch (NumberFormatException ignored) {}
+        }
+
+        private void setValue(int row, int column, double value) {
+            if (column == 0) {
+                // Keep adjacent X values in their required order.
+                double min = (row == 0) ? curveModel.getxAxis().getMin() : xValues[row - 1];
+                double max = (row == xValues.length - 1) ? curveModel.getxAxis().getMax() : xValues[row + 1];
+                xValues[row] = Math.max(min, Math.min(max, value));
+            } else {
+                yValues[row] = Math.max(curveModel.getyAxis().getMin(), Math.min(curveModel.getyAxis().getMax(), value));
+            }
         }
     }
 

--- a/java_console/ui/src/test/java/com/rusefi/ui/widgets/MainMenuTreeWidgetTest.java
+++ b/java_console/ui/src/test/java/com/rusefi/ui/widgets/MainMenuTreeWidgetTest.java
@@ -24,6 +24,7 @@ import javax.swing.tree.TreeModel;
 import javax.swing.tree.TreePath;
 import java.awt.*;
 import java.awt.event.MouseEvent;
+import java.awt.event.KeyEvent;
 import java.awt.image.BufferedImage;
 import java.awt.image.BufferedImageOp;
 import java.awt.image.ImageObserver;
@@ -517,6 +518,23 @@ todo: spllit into smaller tests?
         assertNotNull(table);
         assertEquals(16, table.getRowCount());
         assertEquals(2, table.getColumnCount());
+        assertTrue(table.getCellSelectionEnabled());
+
+        table.setRowSelectionInterval(0, 1);
+        table.setColumnSelectionInterval(1, 1);
+        table.setValueAt("42", 0, 1);
+        assertEquals(42, Double.parseDouble(table.getValueAt(0, 1).toString()));
+        assertEquals(42, Double.parseDouble(table.getValueAt(1, 1).toString()));
+
+        assertTrue(table.editCellAt(0, 1, new MouseEvent(table, MouseEvent.MOUSE_PRESSED,
+            System.currentTimeMillis(), 0, 0, 0, 2, false)));
+        assertEquals(42, Double.parseDouble(((JTextField) table.getEditorComponent()).getText()));
+        table.getCellEditor().cancelCellEditing();
+
+        assertTrue(table.editCellAt(0, 1, new KeyEvent(table, KeyEvent.KEY_PRESSED,
+            System.currentTimeMillis(), 0, KeyEvent.VK_5, '5')));
+        assertEquals("", ((JTextField) table.getEditorComponent()).getText());
+        table.getCellEditor().cancelCellEditing();
     }
 
     @Test


### PR DESCRIPTION
fixed the select, also the curve goes purple if we select points:

<img width="1280" height="353" alt="image" src="https://github.com/user-attachments/assets/a3c7c52f-50e4-493b-834d-7623150991ea" />

input number only with the keyboard, selecting multiple rows:
<img width="410" height="286" alt="image" src="https://github.com/user-attachments/assets/6e1929ce-f4fb-4cc4-afeb-efe5926dd150" />

after enter, all goes over the new value:
<img width="1280" height="349" alt="image" src="https://github.com/user-attachments/assets/f2b1f091-2ff1-472b-b04b-19402cb6424e" />


resolves #10026 , also resolves #10027
