### PR TITLE
Check Engine phase one: pending bits

### DIFF
--- a/firmware/controllers/algo/misfire_detection.cpp
+++ b/firmware/controllers/algo/misfire_detection.cpp
@@ -52,6 +52,12 @@ void MisfireController::onEngineStop() {
 	resetDetectionState();
 }
 
+void MisfireController::onSlowCallback() {
+	if (misfireLatched) {
+		addError(ObdCode::OBD_Random_Misfire);
+	}
+}
+
 void MisfireController::recordFiring(bool flagged) {
 	m_window[m_windowHead] = flagged;
 	m_windowHead = (m_windowHead + 1) % MISFIRE_WINDOW_MAX;
@@ -271,6 +277,7 @@ void MisfireController::onEnginePhase(float /*rpm*/, efitick_t edgeTimestamp,
 
 void MisfireController::onEnginePhase(float, efitick_t, angle_t, angle_t) {}
 void MisfireController::onEngineStop() {}
+void MisfireController::onSlowCallback() {}
 void MisfireController::evaluateSegment(float) {}
 void MisfireController::registerMisfire() {}
 void MisfireController::resetDetectionState() {}

--- a/firmware/controllers/algo/misfire_detection.h
+++ b/firmware/controllers/algo/misfire_detection.h
@@ -34,6 +34,7 @@ public:
 	// Engine stopped: discard transient detection state (baselines/streaks/timers).
 	// Cumulative counters and the MIL latch persist until power cycle ("since key-on").
 	void onEngineStop() override;
+	void onSlowCallback() override;
 
 	// Upper bound on the sliding rate-test window (config field misfireWindowFirings is
 	// clamped to this). Sized for two cycles of the largest supported engine.

--- a/firmware/controllers/modules/malfunction_indicator/malfunction_indicator.cpp
+++ b/firmware/controllers/modules/malfunction_indicator/malfunction_indicator.cpp
@@ -6,6 +6,8 @@
  * @date Dec 20, 2013
  * @author Konstantin Nikonenko
  * @author Andrey Belomutskiy, (c) 2012-2020
+ * first we start on OFF state, then ON when we have ignition voltage, then OFF after we have rpm,
+ * then if we have any error:
  * we show 4 digit error code - 1,5sec * (4xxx+1) digit + 0,4sec * (x3xxx+1) + ....
  * ATTENTION!!! 0 = 1 blink, 1 = 2 blinks, ...., 9 = 10 blinks
  * sequence is the constant!!!
@@ -34,6 +36,10 @@
 static constexpr float ShortPulseMs = 400;
 static constexpr float LongPulseMs = 1500;
 static constexpr float PulseGapMs = 400;
+
+void MILController::onIgnitionStateChanged(bool ignitionOn) {
+	m_ignitionOn = ignitionOn;
+}
 
 void MILController::startPulse() {
 	enginePins.checkEnginePin.setValue("MIL", true);
@@ -106,10 +112,17 @@ void MILController::onSlowCallback() {
 		m_activeCode = ObdCode::None;
 	}
 
-	if (!hasErrorCodes()) {
+	if (!m_ignitionOn) {
 		m_phase = Phase::Idle;
 		m_activeCode = ObdCode::None;
 		enginePins.checkEnginePin.setValue("MIL", false);
+		return;
+	}
+
+	if (!hasErrorCodes()) {
+		m_phase = Phase::Idle;
+		m_activeCode = ObdCode::None;
+		enginePins.checkEnginePin.setValue("MIL", engine->rpmCalculator.isStopped());
 		return;
 	}
 

--- a/firmware/controllers/modules/malfunction_indicator/malfunction_indicator.h
+++ b/firmware/controllers/modules/malfunction_indicator/malfunction_indicator.h
@@ -17,6 +17,7 @@
 class MILController : public EngineModule {
 public:
 	void onSlowCallback() override;
+	void onIgnitionStateChanged(bool ignitionOn) override;
 
 private:
 	enum class Phase : uint8_t {
@@ -38,4 +39,5 @@ private:
 	int m_digitPlace = 0;
 	int m_pulsesRemaining = 0;
 	bool m_wasBenchActive = false;
+	bool m_ignitionOn = false;
 };

--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -881,7 +881,7 @@ engineSyncCam_e engineSyncCam;Select which cam is used for engine sync. Other ca
 	pin_output_mode_e fuelPumpPinMode;
 	int8_t gapVvtTrackingLengthOverride;How many consecutive VVT gap rations have to match expected ranges for sync to happen;"count", 1, 0, 1, @@VVT_TRACKING_LENGTH@@, 0
 
-	output_pin_e malfunctionIndicatorPin;Check engine light, also malfunction indicator light. Always blinks once on boot.
+	output_pin_e malfunctionIndicatorPin;Check engine light, also malfunction indicator light. Solid while ignition is on and the engine is stopped, blinks active error codes.
 	pin_output_mode_e malfunctionIndicatorPinMode;
 
 switch_input_pin_e clutchDownPin;Some cars have a switch to indicate that clutch pedal is all the way down

--- a/firmware/tunerstudio/tunerstudio.template.ini
+++ b/firmware/tunerstudio/tunerstudio.template.ini
@@ -3743,13 +3743,16 @@ include_file @@SECONDARY_PANELS_FILE@@
 		commandButton = "Test Starter Relay", cmd_test_starter_relay
 
 ;			Engine->MIL Settings
+	indicatorPanel = celActiveIndicators, 1
+		indicator = { checkEngine }, "No active error codes", "Check Engine active", white, black, red, black
+
 	indicatorPanel = celRangeIndicators, 2
 		indicator = { cel_battery_min_v < cel_battery_max_v && (VBatt < cel_battery_min_v || VBatt > cel_battery_max_v) }, "Battery voltage in range", "Battery voltage out of range", white, black, red, black
 		indicator = { cel_map_min_v < cel_map_max_v && (rawMap < cel_map_min_v || rawMap > cel_map_max_v) }, "MAP voltage in range", "MAP voltage out of range", white, black, red, black
 		indicator = { cel_iat_min_v < cel_iat_max_v && (rawIat < cel_iat_min_v || rawIat > cel_iat_max_v) }, "IAT voltage in range", "IAT voltage out of range", white, black, red, black
 		indicator = { cel_tps_min_v < cel_tps_max_v && (rawTps1Primary < cel_tps_min_v || rawTps1Primary > cel_tps_max_v) }, "TPS voltage in range", "TPS voltage out of range", white, black, red, black
 
-	dialog = malfunctionDialog,	"Check Engine Settings"
+	dialog = celSettings, "Settings"
 		field = "Output",						malfunctionIndicatorPin
 		field = "Output mode",				malfunctionIndicatorPinMode
 		field = "Minimum battery voltage",	cel_battery_min_v
@@ -3760,9 +3763,19 @@ include_file @@SECONDARY_PANELS_FILE@@
 		field = "Maximum IAT voltage",		cel_iat_max_v
 		field = "Minimum TPS voltage",		cel_tps_min_v
 		field = "Maximum TPS voltage",		cel_tps_max_v
-		field = "Transient warning display period",	warningPeriod
+		panel = celActiveIndicators
 		panel = celRangeIndicators
 		commandButton = "Test Check Engine", cmd_test_check_engine_light
+
+	readoutPanel = celReadouts, 1
+		readout = VBatt, "Battery", "V", 0, 25, 0, 0, 25, 25, 2, 0
+		readout = rawMap, "Raw MAP", "V", 0, 5, 0, 0, 5, 5, 3, 0
+		readout = rawIat, "Raw IAT", "V", 0, 5, 0, 0, 5, 5, 3, 0
+		readout = rawTps1Primary, "Raw TPS", "V", 0, 5, 0, 0, 5, 5, 3, 0
+
+	dialog = malfunctionDialog,	"Check Engine Settings", border
+		panel = celSettings, West
+		panel = celReadouts, East
 
 	dialog = tachSettings, "Tachometer output"
 		field = "Output",									tachOutputPin

--- a/unit_tests/tests/test_check_engine_light.cpp
+++ b/unit_tests/tests/test_check_engine_light.cpp
@@ -34,6 +34,9 @@ protected:
 		advanceTimeUs(6'000'000);
 		sensorChecker->onSlowCallback();
 		ASSERT_TRUE(sensorChecker->analogSensorsShouldWork());
+#ifdef MODULE_MIL
+		engine->module<MILController>()->onIgnitionStateChanged(true);
+#endif
 	}
 
 	void registerSensor(FunctionalSensor& sensor, float value) {
@@ -114,7 +117,7 @@ TEST_F(CheckEngineLightTest, configuredVoltageFaults) {
 	evaluateAfterDebounce();
 	EXPECT_FALSE(hasErrorCodes());
 #ifdef MODULE_MIL
-	EXPECT_FALSE(enginePins.checkEnginePin.getLogicValue());
+	EXPECT_TRUE(enginePins.checkEnginePin.getLogicValue());
 #endif
 
 	tps.postRawValue(0.1f, getTimeNowNt());
@@ -147,6 +150,9 @@ TEST_F(CheckEngineLightTest, disabledRangesAndIgnitionGate) {
 
 	auto& sensorChecker = engine->module<SensorChecker>();
 	sensorChecker->onIgnitionStateChanged(false);
+#ifdef MODULE_MIL
+	engine->module<MILController>()->onIgnitionStateChanged(false);
+#endif
 	sensorChecker->onSlowCallback();
 	engine->module<CheckEngineLight>()->onSlowCallback();
 #ifdef MODULE_MIL
@@ -206,8 +212,13 @@ TEST(checkEngineLight, sensorWithoutRawVoltageIsIgnored) {
 TEST(checkEngineLight, milControllerBlinksDiagnosticCode) {
 	EngineTestHelper eth(engine_type_e::TEST_ENGINE);
 	auto& mil = engine->module<MILController>();
+	addError(ObdCode::OBD_Map_Low);
+	mil->onSlowCallback();
+	EXPECT_FALSE(enginePins.checkEnginePin.getLogicValue());
 
-	addError(ObdCode::OBD_Map_Low); // 107: two short pulses, one long pulse, eight short pulses
+	mil->onIgnitionStateChanged(true);
+
+	// 107: two short pulses, one long pulse, eight short pulses
 	mil->onSlowCallback();
 
 	auto expectPulse = [&](int durationMs) {
@@ -234,12 +245,21 @@ TEST(checkEngineLight, milControllerBlinksDiagnosticCode) {
 
 	clearWarnings();
 	mil->onSlowCallback();
+	EXPECT_TRUE(enginePins.checkEnginePin.getLogicValue());
+
+	engine->rpmCalculator.setRpmValue(100);
+	mil->onSlowCallback();
 	EXPECT_FALSE(enginePins.checkEnginePin.getLogicValue());
+
+	engine->rpmCalculator.setStopSpinning();
+	mil->onSlowCallback();
+	EXPECT_TRUE(enginePins.checkEnginePin.getLogicValue());
 }
 
 TEST(checkEngineLight, milRestartsAfterBenchTest) {
 	EngineTestHelper eth(engine_type_e::TEST_ENGINE);
 	auto& mil = engine->module<MILController>();
+	mil->onIgnitionStateChanged(true);
 
 	addError(ObdCode::OBD_Map_Low);
 	mil->onSlowCallback();

--- a/unit_tests/tests/test_misfire_detection.cpp
+++ b/unit_tests/tests/test_misfire_detection.cpp
@@ -1,6 +1,7 @@
 #include "pch.h"
 #include "misfire_detection.h"
 #include "idle_thread.h"
+#include "malfunction_central.h"
 
 // Drives synthetic primary-trigger teeth into MisfireController::onEnginePhase, optionally
 // inflating the expansion-stroke segment of one cylinder to simulate a misfire.
@@ -140,6 +141,16 @@ TEST(MisfireDetection, repeatedMisfireLatchesMil) {
 
 	EXPECT_GE(getMc().misfireTotalCount, engineConfiguration->misfireCountThreshold);
 	EXPECT_TRUE(getMc().misfireLatched);
+
+	getMc().onSlowCallback();
+	error_codes_set_s errors;
+	getErrorCodes(&errors);
+	ASSERT_EQ(1, errors.count);
+	EXPECT_EQ(ObdCode::OBD_Random_Misfire, errors.error_codes[0]);
+
+	clearWarnings();
+	getMc().onSlowCallback();
+	EXPECT_TRUE(hasErrorCodes());
 }
 
 // ---- threshold == 0: monitor-only, never latches ----


### PR DESCRIPTION
* nicer UI:
<img width="427" height="588" alt="image" src="https://github.com/user-attachments/assets/56088b58-0d54-4694-9093-865697720907" />
<img width="1280" height="551" alt="image" src="https://github.com/user-attachments/assets/c03d834d-2146-4899-ae48-8c50394fbc75" />

* resolved:

> Is on when engine off, off when engine on. Usually used to show ECU is alive without having to look at it directly

cc @ElDominio resolves #7332

* we light the MIL in case of misfire errors

also resolves #7382 , resolves #9073