### PR TITLE
TS UI: better names for CAN buses on custom boards

### DIFF
--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -393,7 +393,7 @@ custom SentEtbType 1 bits, S08, @OFFSET@, [0:1], @@SentEtbType_enum@@
 #define SentFuelHighPressureType_enum "None", "GM type", "Custom"
 custom SentFuelHighPressureType 1 bits, U08, @OFFSET@, [0:1], @@SentFuelHighPressureType_enum@@
 
-#define can_bus_channel_e_enum "None", "CAN1", "CAN2", "CAN3"
+#define can_bus_channel_e_enum "None", "@#PRIMARY_CAN_NAME#@", "@#SECONDARY_CAN_NAME#@", "@#TERTIARY_CAN_NAME#@"
 custom can_bus_channel_e 1 bits, U08, @OFFSET@, [0:1], @@can_bus_channel_e_enum@@
 
 #define SentInput_enum "None", "SENT input 1",  "SENT input 2",  "SENT input 3",  "SENT input 4",  "SENT input 5",  "SENT input 6",  "SENT input 7"
@@ -1100,7 +1100,7 @@ custom script_setting_t 4 scalar, F32, @OFFSET@, 		"",	   1,	   0, 0, 18000,	  2
 	custom vehicle_info_t @@VEHICLE_INFO_SIZE@@ string, ASCII, @OFFSET@, @@VEHICLE_INFO_SIZE@@
 	custom gppwm_note_t @@GPPWM_NOTE_SIZE@@ string, ASCII, @OFFSET@, @@GPPWM_NOTE_SIZE@@
 
-#define can_broadcast_channel_e_enum "first", "second", "3rd"
+#define can_broadcast_channel_e_enum "@#PRIMARY_CAN_NAME#@", "@#SECONDARY_CAN_NAME#@", "@#TERTIARY_CAN_NAME#@"
 custom can_broadcast_channel_e 1 bits, U08, @OFFSET@, [0:1], @@can_broadcast_channel_e_enum@@
 can_broadcast_channel_e canBroadcastUseChannel;
 

--- a/firmware/tunerstudio/tunerstudio.template.ini
+++ b/firmware/tunerstudio/tunerstudio.template.ini
@@ -4179,12 +4179,15 @@ include_file @@SECONDARY_PANELS_FILE@@
 		field = "Include frames we send",					canSniffer3_listenOurs
 		field = "ECU should handle what sniffer say",	canSniffer3_handleInjected, { 0 }
 
+	dialog = canBusSnifferTx, "Transmit Frames"
+		field = "Sniffer Tx CAN bus",					canSnifferTxBus
+
 	dialog = canBusSniffer, "CAN Bus sniffer"
 		topicHelp = "canBusSnifferHelp"
 		panel = canBusSniffer1
 		panel = canBusSniffer2
 		panel = canBusSniffer3
-		field = "Sniffer Tx CAN bus",					canSnifferTxBus
+		panel = canBusSnifferTx
 
 	dialog = sdCardHW, "SD Card Interface"
 		field = "SD Card Logging",						isSdCardEnabled


### PR DESCRIPTION
it would be better to have correct names in case of multi-CAN boards

<img width="554" height="246" alt="image" src="https://github.com/user-attachments/assets/95da4970-7e29-4bdb-8ba1-f8331e262aa8" />
