### PR TITLE
Autoupdate: report a broken bundle instead of exiting silently (#6564)

### DIFF
--- a/docs/report.md
+++ b/docs/report.md
@@ -435,3 +435,54 @@ Open follow-ups:
   applying/resetting learned trims, or introduce an explicit tuning session).
 - Decide how a future bank-2-aware VE Analyze correction should select/combine
   STFT banks; this change preserves the existing bank-1 behavior.
+
+## 2026-08-13 - Autoupdate: report a broken bundle instead of exiting silently (#6564)
+
+What: Launching the updater against a bundle it cannot identify produced no
+user-visible output at all. `Autoupdate#autoupdate` logged
+"unable to perform without bundleFullName" and called `System.exit(-1)`
+without a dialog; since the launcher is a GUI exe with no console attached,
+the user double-clicks it and simply sees nothing happen. Running the same
+code as `java -jar` showed the message on stderr, which is exactly the
+asymmetry #6564 reports.
+
+A second, related defect made the same situation worse: `BundleUtil#parse`
+did `line.split("=", 2)` and then read `pair[1]` unconditionally, so a blank,
+commented or truncated line in `release.txt` threw
+`ArrayIndexOutOfBoundsException`. That surfaced as a raw stack-trace dialog
+from the catch-all in `main` rather than as an explanation.
+
+| File | Change |
+|--------------------------------------------------------|------------------------------------------------|
+| java_console/autoupdate/.../Autoupdate.java | Show an error dialog naming release.txt and the working directory before exiting; bump AUTOUPDATE_VERSION |
+| java_console/shared_io/.../BundleUtil.java | Skip lines without '=' instead of throwing; widen BRANCH_REF_FILE to public so the message can name it |
+| java_console/shared_io/src/test/.../BundleUtilTest.java | 5 new cases: malformed lines, truncated content, missing release, empty content, nextRelease |
+
+Key decisions and why:
+- The dialog is guarded by `AutoupdateUtil.runHeadless`, matching the existing
+  pattern in `startConsoleAsANewProcess`, so CI and headless runs are unaffected.
+- `parse` skips unparseable lines rather than failing the whole file. The
+  existing "target == null || branchName == null" check already returns
+  `BundleInfo.UNKNOWN`, so a genuinely unusable file still reaches the new
+  dialog through one code path instead of two different failure modes.
+- The message names `release.txt` and prints `user.dir` because the file lives
+  in the bundle's `console` folder, which is not where users look first.
+- Note the repro in the issue has moved: bundle identity comes from
+  `console/release.txt` (see BundleUtil / BundleInfoStrategy), not from the
+  bundle's parent folder name, so renaming the parent folder no longer breaks
+  anything. The "no error message" defect the issue asks about is still real
+  and is what this change fixes.
+
+Validation:
+- New tests fail on the unfixed `BundleUtil` with
+  `ArrayIndexOutOfBoundsException` at both the malformed-line and the
+  truncated-content case, and pass after the fix.
+- `gradlew :shared_io:test :autoupdate:test :ui:shadowJar` green.
+- The dialog itself is Swing and is not unit tested; it was reviewed by
+  reading, not by running the exe.
+
+Open follow-ups:
+- `java_console/peak-can-basic` and `java_console/luaformatter` are submodules;
+  without `git submodule update --init` for both, `:ecu_io` fails on a missing
+  `peak.can.basic` package and `:ui` on a missing `neoe.formatter.lua`. Worth a
+  line in the Java build docs.

--- a/java_console/autoupdate/src/main/java/com/rusefi/autoupdate/Autoupdate.java
+++ b/java_console/autoupdate/src/main/java/com/rusefi/autoupdate/Autoupdate.java
@@ -129,7 +129,7 @@ import static com.rusefi.core.FindFileHelper.findFirmwareFile;
  */
 public class Autoupdate {
     private static final Logging log = getLogging(Autoupdate.class);
-    private static final int AUTOUPDATE_VERSION = 20260804; // separate from rusEFIVersion#CONSOLE_VERSION
+    private static final int AUTOUPDATE_VERSION = 20260813; // separate from rusEFIVersion#CONSOLE_VERSION
     private static final String userHomeSubDirectory = FileUtil.RUSEFI_SETTINGS_FOLDER + "updates" + File.separator;
 
     /**
@@ -244,6 +244,17 @@ public class Autoupdate {
         BundleInfo bundleInfo = BundleUtil.readBundleFullNameNotNull();
         if (BundleInfo.isUndefined(bundleInfo)) {
             log.error("ERROR: Autoupdate: unable to perform without bundleFullName");
+            // #6564 the launcher is a GUI exe with no console attached, so without a dialog the user
+            // double-clicks it and simply sees nothing happen
+            if (!AutoupdateUtil.runHeadless) {
+                ErrorMessageHelper.showErrorDialog(String.format(
+                    "Unable to update: `%s` is missing or does not describe this bundle.\n"
+                        + "It is expected next to rusefi_console.jar, in\n%s\n\n"
+                        + "Please re-extract the bundle without moving or renaming files inside it.",
+                    BundleUtil.BRANCH_REF_FILE,
+                    System.getProperty("user.dir")
+                ), "Autoupdate Error " + TITLE);
+            }
             System.exit(-1);
         }
 

--- a/java_console/shared_io/src/main/java/com/rusefi/core/io/BundleUtil.java
+++ b/java_console/shared_io/src/main/java/com/rusefi/core/io/BundleUtil.java
@@ -16,7 +16,7 @@ import static com.devexperts.logging.Logging.getLogging;
 public class BundleUtil {
     private static final Logging log = getLogging(BundleUtil.class);
 
-    private static final String BRANCH_REF_FILE = "release.txt";
+    public static final String BRANCH_REF_FILE = "release.txt";
 
     /**
      * @return null in case of error
@@ -51,6 +51,12 @@ public class BundleUtil {
         Map<String, String> keyValues = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
         for (String line : info) {
             String[] pair = line.split("=", 2);
+            if (pair.length < 2) {
+                // a blank, commented or truncated line must not take the whole updater down with
+                // an ArrayIndexOutOfBoundsException - see #6564
+                log.info(BRANCH_REF_FILE + " ignoring line without '=': " + line);
+                continue;
+            }
             keyValues.put(pair[0], pair[1]);
         }
         String target = keyValues.get("platform");

--- a/java_console/shared_io/src/test/java/com/rusefi/core/io/BundleUtilTest.java
+++ b/java_console/shared_io/src/test/java/com/rusefi/core/io/BundleUtilTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
+import java.util.Collections;
 
 public class BundleUtilTest {
     @Test
@@ -13,5 +14,48 @@ public class BundleUtilTest {
         Assertions.assertEquals("proteus_f7", info.getTarget());
         Assertions.assertEquals("development", info.getBranchName());
     }
-}
 
+    /**
+     * #6564: a truncated or hand-edited release.txt used to take the updater down with an
+     * ArrayIndexOutOfBoundsException before it could report anything useful.
+     */
+    @Test
+    public void testLineWithoutSeparatorIsIgnored() {
+        BundleInfo info = BundleUtil.parse(Arrays.asList(
+            "platform=proteus_f7",
+            "",
+            "# hand written comment",
+            "release=development"
+        ));
+
+        Assertions.assertEquals("proteus_f7", info.getTarget());
+        Assertions.assertEquals("development", info.getBranchName());
+    }
+
+    @Test
+    public void testTruncatedContentIsReportedAsUndefined() {
+        Assertions.assertTrue(BundleInfo.isUndefined(BundleUtil.parse(Collections.singletonList("platform"))));
+    }
+
+    @Test
+    public void testMissingReleaseIsReportedAsUndefined() {
+        Assertions.assertTrue(BundleInfo.isUndefined(BundleUtil.parse(Collections.singletonList("platform=proteus_f7"))));
+    }
+
+    @Test
+    public void testEmptyContentIsReportedAsUndefined() {
+        Assertions.assertTrue(BundleInfo.isUndefined(BundleUtil.parse(Collections.emptyList())));
+    }
+
+    @Test
+    public void testNextReleaseIsParsed() {
+        BundleInfo info = BundleUtil.parse(Arrays.asList(
+            "platform=proteus_f7",
+            "release=lts-25jersey",
+            "nextRelease=lts-26jersey"
+        ));
+
+        Assertions.assertEquals("lts-25jersey", info.getBranchName());
+        Assertions.assertEquals("lts-26jersey", info.getNextBranchName());
+    }
+}


### PR DESCRIPTION
Fixes #6564.

## Problem

The issue asks for one thing: the exe and the jar should both show a Java error dialog when the bundle is broken, instead of the exe silently doing nothing.

That is still exactly what happens. `Autoupdate#autoupdate` starts with:

```java
BundleInfo bundleInfo = BundleUtil.readBundleFullNameNotNull();
if (BundleInfo.isUndefined(bundleInfo)) {
    log.error("ERROR: Autoupdate: unable to perform without bundleFullName");
    System.exit(-1);
}
```

The launcher is a GUI exe with no console attached, so the log line goes nowhere the user can see and the process just disappears. Run the same code as `java -jar` and you get the message on stderr — the precise asymmetry described in the issue.

A related defect made the situation worse. `BundleUtil#parse` did:

```java
String[] pair = line.split("=", 2);
keyValues.put(pair[0], pair[1]);
```

Any blank, commented or truncated line in `release.txt` throws `ArrayIndexOutOfBoundsException`, which surfaced as a raw stack-trace dialog from the catch-all in `main()` rather than as an explanation.

So a broken bundle had two different bad outcomes: silence, or a stack trace. Now it has one dialog naming `release.txt` and the working directory.

## ⚠️ The repro in the issue has moved

Worth flagging for whoever reviews. The issue's steps say to rename the bundle's parent folder from `rusefi.snapshot.f407-discovery` to `haba`. That no longer breaks anything — bundle identity now comes from `console/release.txt` (`BundleUtil`, `BundleInfoStrategy`), not the parent folder name.

The underlying "no error message" defect the issue is actually about is still real, still reachable (missing, truncated or hand-edited `release.txt`), and is what this PR fixes. If you'd rather the issue be closed as obsolete instead, say so and I'll drop the PR.

## Changes

| File | Change |
|---|---|
| `Autoupdate.java` | Error dialog naming `release.txt` and the working directory before exiting; bump `AUTOUPDATE_VERSION` |
| `BundleUtil.java` | Skip lines without `=` instead of throwing; widen `BRANCH_REF_FILE` to public so the message can name it |
| `BundleUtilTest.java` | 5 new cases: malformed lines, truncated content, missing release, empty content, `nextRelease` |

The dialog is guarded by `AutoupdateUtil.runHeadless`, matching the existing pattern in `startConsoleAsANewProcess`, so headless and CI runs are unaffected.

`parse` skips unparseable lines rather than failing the file outright. The existing `target == null || branchName == null` check already returns `BundleInfo.UNKNOWN`, so a genuinely unusable file still reaches the new dialog through one code path instead of two different failure modes.

## Validation

- The new tests **fail on the unfixed `BundleUtil`** with `ArrayIndexOutOfBoundsException` at both the malformed-line and truncated-content cases, and pass after the fix. Verified by reverting the source and re-running.
- `gradlew :shared_io:test :autoupdate:test :ui:shadowJar` green.
- The dialog itself is Swing and is not unit tested — reviewed by reading, not by running the exe.

## Unrelated note that cost me time

`java_console/peak-can-basic` and `java_console/luaformatter` are submodules. Without `git submodule update --init` for both, `:ecu_io` fails on a missing `peak.can.basic` package and `:ui` on a missing `neoe.formatter.lua`, with nothing pointing at submodules as the cause. Might be worth a line in the Java build docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
