### PR TITLE
Log the real build date instead of the 1969 epoch (#6836)

### DIFF
--- a/docs/report.md
+++ b/docs/report.md
@@ -435,3 +435,55 @@ Open follow-ups:
   applying/resetting learned trims, or introduce an explicit tuning session).
 - Decide how a future bank-2-aware VE Analyze correction should select/combine
   STFT banks; this change preserves the existing bank-1 behavior.
+
+## 2026-08-13 - Console logs the real build date instead of the 1969 epoch (#6836)
+
+What: The console and the updater logged
+"Compiled Wed Dec 31 19:00:00 EST 1969" instead of a build timestamp.
+
+Root cause: `rusEFIVersion#classBuildTimeMillis` handled the `jar:` protocol by
+chopping the "file:" prefix off the URL path with `path.substring(5, ...)`.
+That path is percent-encoded, so any installation directory containing a space
+produced a file name with a literal `%20`, a file which does not exist, and
+therefore `lastModified() == 0`. `new Date(0)` then rendered the epoch.
+
+Reproduced exactly, with the jar URL shape of a bundle installed under
+"Program Files":
+
+    current  -> C:\Program%20Files\Purple%20Updater\console\rusefi_console.jar
+    exists   -> false, lastModified=0
+    printed  -> Wed Dec 31 17:00:00 MST 1969
+    fixed    -> C:\Program Files\Purple Updater\console\rusefi_console.jar
+
+The same encoding bug also affected the "Source ..." line logged by
+`Autoupdate#main`, which is where it first showed up in the #10000 log.
+
+| File | Change |
+|-------------------------------------------------------|--------------------------------------------------|
+| java_console/shared_io/.../rusEFIVersion.java | New `jarFileOf` parses the jar URL as a URI; new `classBuildTimeString` renders "unknown" rather than the epoch |
+| java_console/ui/.../Launcher.java | Use `classBuildTimeString()` |
+| java_console/autoupdate/.../Autoupdate.java | Use `classBuildTimeString(Class)`; `toURI()` for the "Source" log line; bump AUTOUPDATE_VERSION |
+| java_tools/proxy_server/.../Monitoring.java | Use `classBuildTimeString()` |
+| java_console/shared_io/src/test/.../RusEfiVersionTest.java | 7 cases: encoded path, plain path, encoded file name, missing separator, malformed URL, relative URL, no-epoch contract |
+
+Key decisions and why:
+- Two separate defects, both fixed. Decoding the path makes the timestamp
+  correct for the overwhelming majority of installs; rendering "unknown"
+  covers the cases where the timestamp genuinely cannot be determined, so the
+  log never again claims a 1969 build.
+- `jarFileOf` is a package-visible pure function taking the URL path as a
+  string, so the tests cover both the encoded and the malformed cases without
+  building a jar or touching the class loader. No reflection.
+- `jarFileOf` returns null instead of throwing. `new File(URI)` rejects
+  relative and opaque URIs with `IllegalArgumentException`, and a logging
+  helper must never be the reason startup fails.
+- Removed the now-unused `java.util.Date` imports from the two call sites that
+  no longer construct a Date.
+
+Validation:
+- Old and new path resolution compared side by side on the "Program Files"
+  URL shape; the old one reproduces the issue's literal 1969 string.
+- `gradlew :shared_io:test :autoupdate:test :ui:shadowJar :proxy_server:compileTestJava`
+  green, 7 new tests among them.
+- Not exercised by launching an installed bundle from a spaced path - verified
+  at the unit level and by the side-by-side reproduction only.

--- a/java_console/autoupdate/src/main/java/com/rusefi/autoupdate/Autoupdate.java
+++ b/java_console/autoupdate/src/main/java/com/rusefi/autoupdate/Autoupdate.java
@@ -129,7 +129,7 @@ import static com.rusefi.core.FindFileHelper.findFirmwareFile;
  */
 public class Autoupdate {
     private static final Logging log = getLogging(Autoupdate.class);
-    private static final int AUTOUPDATE_VERSION = 20260804; // separate from rusEFIVersion#CONSOLE_VERSION
+    private static final int AUTOUPDATE_VERSION = 20260813; // separate from rusEFIVersion#CONSOLE_VERSION
     private static final String userHomeSubDirectory = FileUtil.RUSEFI_SETTINGS_FOLDER + "updates" + File.separator;
 
     /**
@@ -193,12 +193,14 @@ public class Autoupdate {
         try {
             FileLogger.init();
             log.info("Version " + AUTOUPDATE_VERSION);
-            log.info("Compiled " + new Date(rusEFIVersion.classBuildTimeMillis(Autoupdate.class)));
+            log.info("Compiled " + rusEFIVersion.classBuildTimeString(Autoupdate.class));
             log.info("Current folder " + new File(".").getCanonicalPath());
+            // toURI() rather than getPath(): the location is percent-encoded, so an installation
+            // under "Program Files" used to be logged as `C:\Program%20Files\...` - see #6836
             log.info("Source " + new File(Autoupdate.class.getProtectionDomain()
                 .getCodeSource()
                 .getLocation()
-                .getPath())
+                .toURI())
                 .getCanonicalPath());
             autoupdate(args);
         } catch (Throwable e) {

--- a/java_console/shared_io/src/main/java/com/rusefi/core/rusEFIVersion.java
+++ b/java_console/shared_io/src/main/java/com/rusefi/core/rusEFIVersion.java
@@ -3,16 +3,35 @@ package com.rusefi.core;
 import com.rusefi.UiVersion;
 
 import java.io.File;
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.util.Date;
 import java.util.concurrent.atomic.AtomicReference;
 
 public interface rusEFIVersion extends UiVersion {
     AtomicReference<String> firmwareVersion = new AtomicReference<>("N/A");
 
+    String UNKNOWN_BUILD_TIME = "unknown";
+
     static long classBuildTimeMillis() {
         Class<?> clazz = rusEFIVersion.class;
         return classBuildTimeMillis(clazz);
+    }
+
+    /**
+     * Human readable build timestamp for logs.
+     * <p>
+     * Never renders {@code new Date(0)} - printing "Wed Dec 31 19:00:00 EST 1969" told the reader
+     * that the build time is unknown in the least obvious way possible. See #6836.
+     */
+    static String classBuildTimeString(Class<?> clazz) {
+        long millis = classBuildTimeMillis(clazz);
+        return millis == 0 ? UNKNOWN_BUILD_TIME : new Date(millis).toString();
+    }
+
+    static String classBuildTimeString() {
+        return classBuildTimeString(rusEFIVersion.class);
     }
 
     static long classBuildTimeMillis(Class<?> clazz) {
@@ -29,12 +48,35 @@ public interface rusEFIVersion extends UiVersion {
                 return 0;
             }
         } else if (resource.getProtocol().equals("jar")) {
-            String path = resource.getPath();
-            return new File(path.substring(5, path.indexOf("!"))).lastModified();
+            File jarFile = jarFileOf(resource.getPath());
+            return jarFile == null ? 0 : jarFile.lastModified();
         } else {
             throw new IllegalArgumentException("Unhandled url protocol: " +
                     resource.getProtocol() + " for class: " +
                     clazz.getName() + " resource: " + resource);
+        }
+    }
+
+    /**
+     * Extracts the jar file out of the path of a {@code jar:} URL, for example
+     * {@code file:/C:/Program%20Files/rusefi/console/rusefi_console.jar!/com/rusefi/core/rusEFIVersion.class}.
+     * <p>
+     * That path is percent-encoded, so it has to be parsed as a URI rather than by chopping the
+     * "file:" prefix off with a substring: a bundle installed under "Program Files" used to yield a
+     * literal {@code %20} in the file name, a file which does not exist, and therefore
+     * {@code lastModified() == 0}. See #6836.
+     *
+     * @return the jar file, or null when the path cannot be understood
+     */
+    static File jarFileOf(String jarUrlPath) {
+        int separator = jarUrlPath.indexOf('!');
+        if (separator < 0) {
+            return null;
+        }
+        try {
+            return new File(new URI(jarUrlPath.substring(0, separator)));
+        } catch (URISyntaxException | IllegalArgumentException e) {
+            return null;
         }
     }
 }

--- a/java_console/shared_io/src/test/java/com/rusefi/core/RusEfiVersionTest.java
+++ b/java_console/shared_io/src/test/java/com/rusefi/core/RusEfiVersionTest.java
@@ -1,0 +1,77 @@
+package com.rusefi.core;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * #6836: an installation path containing a space made the console log
+ * "Compiled Wed Dec 31 19:00:00 EST 1969" - the percent-encoded jar URL was turned into a file
+ * name that does not exist, so lastModified() returned 0.
+ */
+class RusEfiVersionTest {
+    private static final String CLASS_SUFFIX = "!/com/rusefi/core/rusEFIVersion.class";
+
+    @Test
+    void percentEncodedPathIsDecoded() {
+        File jar = rusEFIVersion.jarFileOf(
+            "file:/C:/Program%20Files/Purple%20Updater/console/rusefi_console.jar" + CLASS_SUFFIX
+        );
+
+        assertNotNull(jar);
+        assertTrue(jar.getPath().contains("Program Files"), jar.getPath());
+        assertTrue(jar.getPath().contains("Purple Updater"), jar.getPath());
+        assertEquals("rusefi_console.jar", jar.getName());
+    }
+
+    @Test
+    void plainPathIsUnchanged() {
+        File jar = rusEFIVersion.jarFileOf("file:/opt/rusefi/console/rusefi_console.jar" + CLASS_SUFFIX);
+
+        assertNotNull(jar);
+        assertEquals("rusefi_console.jar", jar.getName());
+        assertTrue(jar.getPath().contains("rusefi"), jar.getPath());
+    }
+
+    @Test
+    void nameIsNeverLeftPercentEncoded() {
+        File jar = rusEFIVersion.jarFileOf("file:/tmp/my%20bundle/rusefi%20console.jar" + CLASS_SUFFIX);
+
+        assertNotNull(jar);
+        assertEquals("rusefi console.jar", jar.getName());
+    }
+
+    @Test
+    void pathWithoutSeparatorIsRejected() {
+        assertNull(rusEFIVersion.jarFileOf("file:/opt/rusefi/console/rusefi_console.jar"));
+    }
+
+    @Test
+    void malformedUrlIsRejected() {
+        assertNull(rusEFIVersion.jarFileOf("not a url" + CLASS_SUFFIX));
+    }
+
+    @Test
+    void relativeUrlIsRejectedRatherThanThrowing() {
+        // new File(URI) demands an absolute file: URI - anything else must come back as null
+        assertNull(rusEFIVersion.jarFileOf("console/rusefi_console.jar" + CLASS_SUFFIX));
+    }
+
+    @Test
+    void unknownBuildTimeIsNotRenderedAsTheEpoch() {
+        // the class under test is loaded from a directory or a jar that really exists, so this only
+        // pins the contract that we never print a 1970-ish date
+        String buildTime = rusEFIVersion.classBuildTimeString();
+
+        assertNotNull(buildTime);
+        assertTrue(
+            !buildTime.contains("1969") && !buildTime.contains("1970"),
+            "unexpected epoch build time: " + buildTime
+        );
+    }
+}

--- a/java_console/ui/src/main/java/com/rusefi/Launcher.java
+++ b/java_console/ui/src/main/java/com/rusefi/Launcher.java
@@ -10,7 +10,6 @@ import com.rusefi.core.preferences.storage.PersistentConfiguration;
 
 import javax.swing.*;
 import java.util.Arrays;
-import java.util.Date;
 import java.util.concurrent.CompletableFuture;
 
 import static com.devexperts.logging.Logging.getLogging;
@@ -46,7 +45,7 @@ public class Launcher implements rusEFIVersion {
         }
         FileLogger.init();
         log.info("rusEFI UI console " + UiVersion.CONSOLE_VERSION);
-        log.info("Compiled " + new Date(rusEFIVersion.classBuildTimeMillis()));
+        log.info("Compiled " + rusEFIVersion.classBuildTimeString());
         log.info("\n\n");
         PersistentConfiguration.registerShutdownHook();
         com.rusefi.maintenance.ManualIniFilePicker.register();

--- a/java_tools/proxy_server/src/test/java/com/rusefi/server/Monitoring.java
+++ b/java_tools/proxy_server/src/test/java/com/rusefi/server/Monitoring.java
@@ -13,7 +13,6 @@ import javax.json.JsonObjectBuilder;
 import java.io.IOException;
 import java.lang.management.ManagementFactory;
 import java.lang.management.OperatingSystemMXBean;
-import java.util.Date;
 
 import static com.rusefi.Timeouts.SECOND;
 import static com.rusefi.binaryprotocol.BinaryProtocol.sleep;
@@ -73,7 +72,7 @@ public class Monitoring {
         builder.add("controllersCount", backend.getControllersCount());
         builder.add("backend version", ProxyClient.BACKEND_VERSION);
         builder.add("framework version", UiVersion.CONSOLE_VERSION);
-        builder.add("compiled", new Date(rusEFIVersion.classBuildTimeMillis()).toString());
+        builder.add("compiled", rusEFIVersion.classBuildTimeString());
         builder.add("now", System.currentTimeMillis());
         builder.add(SessionDetails.AGE, birthday.getDuration());
 


### PR DESCRIPTION
Fixes #6836.

## Root cause

`rusEFIVersion#classBuildTimeMillis` handled the `jar:` protocol like this:

```java
String path = resource.getPath();
return new File(path.substring(5, path.indexOf("!"))).lastModified();
```

That path is **percent-encoded**. Any installation directory containing a space produces a file name with a literal `%20`, which is a file that does not exist, so `lastModified()` returns `0` — and `new Date(0)` renders the epoch.

Reproduced with the jar URL shape of a bundle installed under "Program Files":

```
current  -> C:\Program%20Files\Purple%20Updater\console\rusefi_console.jar
exists   -> false, lastModified=0
printed  -> Wed Dec 31 17:00:00 MST 1969      <- the reported symptom
fixed    -> C:\Program Files\Purple Updater\console\rusefi_console.jar
```

That is not a hypothetical path either — the log in #10000 shows exactly this installation, and its "Source" line reads `C:\Program%20Files\Purple%20Updater\console\rusefi_console.jar`. Same encoding bug, so that line is fixed here too.

## Two defects, both fixed

1. **`jarFileOf()`** parses the jar URL as a URI, so the timestamp is now correct for real installations.
2. **`classBuildTimeString()`** renders `unknown` rather than a `Date(0)` when the build time genuinely cannot be determined. Even if some other path yields 0, the log never claims a 1969 build again.

`jarFileOf()` returns `null` instead of throwing: `new File(URI)` rejects relative and opaque URIs with `IllegalArgumentException`, and a logging helper must never be the reason startup fails.

## Changes

| File | Change |
|---|---|
| `rusEFIVersion.java` | New `jarFileOf` (URI-based) and `classBuildTimeString` (no epoch) |
| `Launcher.java` | Use `classBuildTimeString()` |
| `Autoupdate.java` | Use `classBuildTimeString(Class)`; `toURI()` for the "Source" log line; bump `AUTOUPDATE_VERSION` |
| `Monitoring.java` | Use `classBuildTimeString()` |
| `RusEfiVersionTest.java` | 7 new cases |

Test coverage: encoded path, plain path, encoded file *name*, missing `!` separator, malformed URL, relative URL, and the no-epoch contract. `jarFileOf` takes the URL path as a plain string, so all of that is covered without building a jar or touching the class loader, and without reflection.

Also dropped the two `java.util.Date` imports left unused by the call-site changes.

## Validation

- Old and new resolution compared side by side on the "Program Files" URL shape; the old one reproduces the issue's literal 1969 string, as shown above.
- `gradlew :shared_io:test :autoupdate:test :ui:shadowJar :proxy_server:compileTestJava` green.
- **Not** exercised by launching an installed bundle from a spaced path — verified at the unit level and by the side-by-side reproduction only.

## Note on overlap

This is my third updater-area PR (#10081, #10082). All three are independent branches off `master`; the only overlap is `AUTOUPDATE_VERSION`, which each bumps to `20260813` — a trivial conflict for whichever lands last. Happy to rebase whenever you like.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
