### PR TITLE
TCU unit tests, and two members that were never initialized (#6380)

### DIFF
--- a/docs/report.md
+++ b/docs/report.md
@@ -435,3 +435,64 @@ Open follow-ups:
   applying/resetting learned trims, or introduce an explicit tuning session).
 - Decide how a future bank-2-aware VE Analyze correction should select/combine
   STFT banks; this change preserves the existing bank-1 behavior.
+
+## 2026-08-13 - TCU unit tests, and two members that were never initialized (#6380)
+
+What: `test_tcu.cpp` covered ButtonShift and the Generic gear controller only.
+Added coverage for the two pieces of TCU logic that had none - the automatic
+shift decisions in `AutomaticGearController` and the shift timing helpers on
+`TransmissionControllerBase`.
+
+Writing the tests immediately turned up two members declared without an
+initializer. Both are harmless in production only because every controller is
+a file-scope instance and therefore zero initialized; the moment one is
+constructed on the stack they are read as garbage:
+
+- `GearControllerBase::transmissionController` - `update()` NULL-checks it
+  before dereferencing, so a garbage value segfaults. Reproduced: the new test
+  passed in isolation and crashed the binary (exit 139) when run after the
+  existing tcu tests, which is the classic uninitialized-stack signature.
+- `TransmissionControllerBase::m_shiftTime` - read by `isShiftCompleted()`
+  before any `measureShiftTime()` call.
+
+| File | Change |
+|--------------------------------------------|--------------------------------------------------------|
+| firmware/controllers/tcu/gear_controller.h | Initialize `transmissionController` to nullptr |
+| firmware/controllers/tcu/tcu.h | Initialize `m_shiftTime` to false |
+| unit_tests/tests/test_tcu.cpp | 7 new tests |
+
+New coverage:
+- automatic controller leaves NEUTRAL on the first update
+- upshifts 1-2-3-4 as speed crosses each curve, and holds in top gear
+- downshifts 4-3-2-1, and holds in bottom gear
+- holds the current gear when VSS or TPS is invalid
+- shift not reported as completed before it starts
+- shift completes when DetectedGear reaches the target, and is reported once
+- shift falls back to `tcu_shiftTime` when ISS is not configured
+
+Key decisions and why:
+- Flat shift curves. `shift()` interpolates the curve against throttle, so a
+  flat curve keeps these tests about the gear state machine rather than about
+  `interpolate2d`, which has its own tests.
+- `measureShiftTime`/`isShiftCompleted` are protected, so the test declares a
+  small subclass with `using` declarations rather than making them public or
+  reaching in some other way.
+- The two initializers are in scope because the tests cannot construct these
+  classes on the stack without them - not opportunistic cleanup.
+
+Validation:
+- Full suite: 1166 tests pass, up from 1159. No regressions.
+- The segfault above is the direct before/after evidence for the
+  `transmissionController` initializer.
+- Host build only (MinGW GCC 16.1). No ARM firmware build was run locally, so
+  the board builds are covered by CI rather than by me.
+
+Open follow-ups:
+- `GearControllerMode::Automatic` is offered in the TunerStudio dropdown
+  (`gear_controller_e_enum` = "None", "Button Shift", "Automatic", "Generic")
+  but `initGearController()` handles only ButtonShift and Generic, so
+  selecting Automatic falls to `default` and leaves `engine->gearController`
+  NULL. `AutomaticGearController` is only reachable today as the base class of
+  `GenericGearController`. Either the mode should be wired up or it should be
+  removed from the dropdown - that is a maintainer call, so it is reported
+  rather than changed here.

--- a/firmware/controllers/tcu/gear_controller.h
+++ b/firmware/controllers/tcu/gear_controller.h
@@ -16,7 +16,9 @@ public:
 	virtual GearControllerMode getMode() const {
 		return GearControllerMode::ButtonShift;
 	}
-	TransmissionControllerBase *transmissionController;
+	// update() checks this against NULL before dereferencing it, which only worked because every
+	// production controller is a file-scope instance and therefore zero initialized
+	TransmissionControllerBase *transmissionController = nullptr;
 protected:
 	virtual gear_e setDesiredGear(gear_e);
 	void initTransmissionController();

--- a/firmware/controllers/tcu/tcu.h
+++ b/firmware/controllers/tcu/tcu.h
@@ -18,7 +18,9 @@
 class TransmissionControllerBase: public tcu_controller_s {
 private:
 	Timer m_shiftTimer;
-	bool m_shiftTime;
+	// no initializer meant the flag was only reliably false for the file-scope controller
+	// instances which get zero initialized; anything on the stack (a unit test) read garbage
+	bool m_shiftTime = false;
 	gear_e m_shiftTimeGear;
 public:
 	virtual void update(gear_e);

--- a/unit_tests/tests/test_tcu.cpp
+++ b/unit_tests/tests/test_tcu.cpp
@@ -114,3 +114,182 @@ TEST(tcu, testGenericGC) {
 	engine->gearController->update();
 	ASSERT_EQ(GEAR_2, engine->gearController->getDesiredGear());
 }
+
+// ---------------------------------------------------------------------------
+// #6380: coverage for the parts of the TCU which had none - the automatic
+// shift decisions and the shift timing helpers of the transmission controller.
+// ---------------------------------------------------------------------------
+
+static void setTcuCurve(uint8_t (&curve)[TCU_TABLE_WIDTH], uint8_t speed) {
+	for (size_t i = 0; i < efi::size(curve); i++) {
+		curve[i] = speed;
+	}
+}
+
+// Flat curves: the shift point does not depend on throttle, which keeps these tests about
+// the gear state machine rather than about interpolation.
+static void setupAutomaticShiftCurves() {
+	for (size_t i = 0; i < efi::size(config->tcu_shiftTpsBins); i++) {
+		config->tcu_shiftTpsBins[i] = i * 10;
+	}
+	setTcuCurve(config->tcu_shiftSpeed12, 20);
+	setTcuCurve(config->tcu_shiftSpeed23, 40);
+	setTcuCurve(config->tcu_shiftSpeed34, 60);
+	setTcuCurve(config->tcu_shiftSpeed43, 50);
+	setTcuCurve(config->tcu_shiftSpeed32, 30);
+	setTcuCurve(config->tcu_shiftSpeed21, 10);
+}
+
+TEST(tcu, automaticGearControllerLeavesNeutralOnFirstUpdate) {
+	EngineTestHelper eth(engine_type_e::TCU_4R70W);
+	setupAutomaticShiftCurves();
+
+	AutomaticGearController gc;
+	ASSERT_EQ(NEUTRAL, gc.getDesiredGear());
+
+	// no valid speed or throttle yet, but neutral is still left behind
+	gc.update();
+	ASSERT_EQ(GEAR_1, gc.getDesiredGear());
+}
+
+TEST(tcu, automaticGearControllerUpshiftsThroughTheGears) {
+	EngineTestHelper eth(engine_type_e::TCU_4R70W);
+	setupAutomaticShiftCurves();
+
+	AutomaticGearController gc;
+	Sensor::setMockValue(SensorType::DriverThrottleIntent, 25);
+
+	Sensor::setMockValue(SensorType::VehicleSpeed, 5);
+	gc.update();
+	ASSERT_EQ(GEAR_1, gc.getDesiredGear());
+
+	// still below the 1-2 shift speed
+	gc.update();
+	ASSERT_EQ(GEAR_1, gc.getDesiredGear());
+
+	Sensor::setMockValue(SensorType::VehicleSpeed, 25);
+	gc.update();
+	ASSERT_EQ(GEAR_2, gc.getDesiredGear());
+
+	// between the 2-1 and the 2-3 shift speeds, so it holds
+	gc.update();
+	ASSERT_EQ(GEAR_2, gc.getDesiredGear());
+
+	Sensor::setMockValue(SensorType::VehicleSpeed, 45);
+	gc.update();
+	ASSERT_EQ(GEAR_3, gc.getDesiredGear());
+
+	Sensor::setMockValue(SensorType::VehicleSpeed, 65);
+	gc.update();
+	ASSERT_EQ(GEAR_4, gc.getDesiredGear());
+
+	// top gear, nothing above it
+	gc.update();
+	ASSERT_EQ(GEAR_4, gc.getDesiredGear());
+}
+
+TEST(tcu, automaticGearControllerDownshiftsThroughTheGears) {
+	EngineTestHelper eth(engine_type_e::TCU_4R70W);
+	setupAutomaticShiftCurves();
+
+	AutomaticGearController gc;
+	Sensor::setMockValue(SensorType::DriverThrottleIntent, 25);
+
+	// climb to top gear first
+	Sensor::setMockValue(SensorType::VehicleSpeed, 65);
+	for (int i = 0; i < 4; i++) {
+		gc.update();
+	}
+	ASSERT_EQ(GEAR_4, gc.getDesiredGear());
+
+	Sensor::setMockValue(SensorType::VehicleSpeed, 45);
+	gc.update();
+	ASSERT_EQ(GEAR_3, gc.getDesiredGear());
+
+	Sensor::setMockValue(SensorType::VehicleSpeed, 25);
+	gc.update();
+	ASSERT_EQ(GEAR_2, gc.getDesiredGear());
+
+	Sensor::setMockValue(SensorType::VehicleSpeed, 5);
+	gc.update();
+	ASSERT_EQ(GEAR_1, gc.getDesiredGear());
+
+	// bottom gear, nothing below it
+	gc.update();
+	ASSERT_EQ(GEAR_1, gc.getDesiredGear());
+}
+
+TEST(tcu, automaticGearControllerHoldsGearWithoutValidSensors) {
+	EngineTestHelper eth(engine_type_e::TCU_4R70W);
+	setupAutomaticShiftCurves();
+
+	AutomaticGearController gc;
+	Sensor::setMockValue(SensorType::DriverThrottleIntent, 25);
+	Sensor::setMockValue(SensorType::VehicleSpeed, 25);
+	gc.update();
+	ASSERT_EQ(GEAR_2, gc.getDesiredGear());
+
+	// speed way above the 2-3 shift point, but the sensor is no longer trustworthy
+	Sensor::resetMockValue(SensorType::VehicleSpeed);
+	gc.update();
+	ASSERT_EQ(GEAR_2, gc.getDesiredGear());
+
+	Sensor::setMockValue(SensorType::VehicleSpeed, 100);
+	Sensor::resetMockValue(SensorType::DriverThrottleIntent);
+	gc.update();
+	ASSERT_EQ(GEAR_2, gc.getDesiredGear());
+}
+
+// measureShiftTime()/isShiftCompleted() are protected; expose them rather than reaching
+// into the class from the test.
+class TestTransmissionController : public TransmissionControllerBase {
+public:
+	using TransmissionControllerBase::isShiftCompleted;
+	using TransmissionControllerBase::measureShiftTime;
+};
+
+TEST(tcu, shiftIsNotCompletedBeforeItStarts) {
+	EngineTestHelper eth(engine_type_e::TCU_4R70W);
+
+	TestTransmissionController tc;
+	ASSERT_FLOAT_EQ(0, tc.isShiftCompleted());
+}
+
+TEST(tcu, shiftCompletesWhenTheTargetGearIsDetected) {
+	EngineTestHelper eth(engine_type_e::TCU_4R70W);
+
+	TestTransmissionController tc;
+	Sensor::setMockValue(SensorType::InputShaftSpeed, 1500);
+	Sensor::setMockValue(SensorType::DetectedGear, GEAR_1);
+
+	tc.measureShiftTime(GEAR_2);
+	ASSERT_FLOAT_EQ(0, tc.isShiftCompleted());
+
+	eth.moveTimeForwardAndInvokeEventsUs(300000);
+	// still in the old gear
+	ASSERT_FLOAT_EQ(0, tc.isShiftCompleted());
+
+	Sensor::setMockValue(SensorType::DetectedGear, GEAR_2);
+	ASSERT_NEAR(0.3, tc.isShiftCompleted(), 0.01);
+
+	// the shift is only reported once
+	ASSERT_FLOAT_EQ(0, tc.isShiftCompleted());
+}
+
+TEST(tcu, shiftFallsBackToConfiguredTimeWithoutInputShaftSpeed) {
+	EngineTestHelper eth(engine_type_e::TCU_4R70W);
+
+	TestTransmissionController tc;
+	Sensor::resetMockValue(SensorType::InputShaftSpeed);
+	Sensor::resetMockValue(SensorType::DetectedGear);
+	config->tcu_shiftTime = 500;
+
+	tc.measureShiftTime(GEAR_2);
+	eth.moveTimeForwardAndInvokeEventsUs(400000);
+	ASSERT_FLOAT_EQ(0, tc.isShiftCompleted());
+
+	eth.moveTimeForwardAndInvokeEventsUs(200000);
+	ASSERT_FLOAT_EQ(0.5, tc.isShiftCompleted());
+
+	ASSERT_FLOAT_EQ(0, tc.isShiftCompleted());
+}


### PR DESCRIPTION
Addresses #6380 — "We shall like our transmissions same as we like our engines."

`test_tcu.cpp` covered ButtonShift and the Generic gear controller. This adds coverage for the two pieces of TCU logic that had none: the automatic shift decisions in `AutomaticGearController`, and the shift-timing helpers on `TransmissionControllerBase`.

## Two uninitialized members, found by writing the tests

Both are harmless in production **only** because every controller is a file-scope instance and therefore zero-initialized. The moment one is constructed on the stack, they are read as garbage:

- **`GearControllerBase::transmissionController`** — `update()` NULL-checks it before dereferencing, so a garbage value segfaults. This is not theoretical: my new test passed in isolation and **crashed the binary (exit 139) when run after the existing `tcu` tests** — the classic uninitialized-stack signature. Initializing it to `nullptr` fixes it.
- **`TransmissionControllerBase::m_shiftTime`** — read by `isShiftCompleted()` before any `measureShiftTime()` call.

Both initializers are in scope because the tests cannot construct these classes on the stack without them — not opportunistic cleanup.

## New coverage

| Test | What it pins |
|---|---|
| `automaticGearControllerLeavesNeutralOnFirstUpdate` | NEUTRAL → GEAR_1 even without valid sensors |
| `automaticGearControllerUpshiftsThroughTheGears` | 1→2→3→4 as speed crosses each curve; holds in top gear |
| `automaticGearControllerDownshiftsThroughTheGears` | 4→3→2→1; holds in bottom gear |
| `automaticGearControllerHoldsGearWithoutValidSensors` | No shift when VSS or TPS is invalid |
| `shiftIsNotCompletedBeforeItStarts` | Returns 0 before `measureShiftTime` |
| `shiftCompletesWhenTheTargetGearIsDetected` | Completes on `DetectedGear`, reported exactly once |
| `shiftFallsBackToConfiguredTimeWithoutInputShaftSpeed` | Falls back to `tcu_shiftTime` when ISS is absent |

Two notes on approach:

- Shift curves are **flat on purpose**. `shift()` interpolates the curve against throttle, so a flat curve keeps these tests about the gear state machine rather than about `interpolate2d`, which has its own tests.
- `measureShiftTime`/`isShiftCompleted` are protected, so the test declares a small subclass with `using` declarations rather than widening the production API.

## Validation

- **Full suite: 1166 tests pass, up from 1159.** No regressions.
- The segfault above is direct before/after evidence for the `transmissionController` initializer.
- Host build only (MinGW GCC 16.1). **No ARM firmware build was run locally**, so board builds are on CI rather than me. These are header-only member initializers, so I'd expect no surprises, but flagging it rather than implying I checked.

## Separate finding, reported not fixed

`GearControllerMode::Automatic` is offered in the TunerStudio dropdown:

```
#define gear_controller_e_enum "None", "Button Shift", "Automatic", "Generic"
```

but `initGearController()` handles only `ButtonShift` and `Generic`. Selecting **Automatic** falls to `default` and leaves `engine->gearController` NULL — the mode silently does nothing. `AutomaticGearController` is reachable today only as the base class of `GenericGearController`.

Either the mode should be wired up or removed from the dropdown. That is a maintainer call about intended behavior, so I've reported it rather than guessing. Happy to implement whichever you prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
