### PR TITLE
Configurable per H-bridge ETB duty ceiling (#9799)

### DIFF
--- a/firmware/controllers/actuators/electronic_throttle.cpp
+++ b/firmware/controllers/actuators/electronic_throttle.cpp
@@ -196,6 +196,21 @@ float EtbController::percentToDuty(float percent) const {
 	return clampF(-limit, 0.01f * percent, limit);
 }
 
+/**
+ * The bench test and the TPS autocal drive the motor directly rather than through setOutput(),
+ * so they would otherwise ignore the ceiling entirely. On the hardware which motivated #9799 that
+ * is the worst case: the fixed 50% those two command is above the limit the user lowered the
+ * ceiling to in order to stop the driver faulting.
+ *
+ * Note this can make autocal less accurate on a throttle which needs more than the configured
+ * ceiling to reach its mechanical stops - but exceeding a limit the user set for hardware
+ * protection is the worse of the two.
+ */
+float EtbController::clampToMaxDutyCycle(float duty) const {
+	float limit = getMaxDutyCycle();
+	return clampF(-limit, duty, limit);
+}
+
 PUBLIC_API_WEAK bool isBoardAllowingLackOfPps() {
   return false;
 }

--- a/firmware/controllers/actuators/electronic_throttle.cpp
+++ b/firmware/controllers/actuators/electronic_throttle.cpp
@@ -159,9 +159,42 @@ static TsCalMode functionToCalModeSecMax(dc_function_e func) {
 }
 #endif // EFI_TUNER_STUDIO
 
-#define ETB_DUTY_LIMIT 0.9
-// this macro clamps both positive and negative percentages from about -100% to 100%
-#define ETB_PERCENT_TO_DUTY(x) (clampF(-ETB_DUTY_LIMIT, 0.01f * (x), ETB_DUTY_LIMIT))
+/**
+ * #9799: the ceiling used to be hard-coded at 90%. Some H-bridge drivers trip their own
+ * overcurrent/thermal protection before reaching it, and a throttle which is mechanically wide
+ * open well below that never needs the rest of the range, so it is configurable per H-bridge now.
+ *
+ * Anything outside the configurable range - including the 0 carried by tunes which predate the
+ * field, should one reach here before applyDefaultsOrFixAfterBurn() runs - falls back to the
+ * historical limit rather than to "throttle stays shut".
+ */
+float EtbController::getMaxDutyCycle() const {
+	uint8_t configured = engineConfiguration->etbMaxDutyCycle[getHBridgeIndex()];
+	if (configured < ETB_MIN_MAX_DUTY_CYCLE || configured > ETB_DEFAULT_MAX_DUTY_CYCLE) {
+		return 0.01f * ETB_DEFAULT_MAX_DUTY_CYCLE;
+	}
+	return 0.01f * configured;
+}
+
+/**
+ * etbFunctions[] is what maps a function onto an H-bridge slot, so finding our function in it
+ * gives the index of the hardware we drive. init() deliberately keeps its existing signature -
+ * it is a pure virtual with a couple of dozen call sites in the tests.
+ */
+size_t EtbController::getHBridgeIndex() const {
+	for (size_t i = 0; i < efi::size(engineConfiguration->etbFunctions); i++) {
+		if (engineConfiguration->etbFunctions[i] == m_function) {
+			return i;
+		}
+	}
+	return 0;
+}
+
+// clamps both positive and negative percentages down to the configured ceiling
+float EtbController::percentToDuty(float percent) const {
+	float limit = getMaxDutyCycle();
+	return clampF(-limit, 0.01f * percent, limit);
+}
 
 PUBLIC_API_WEAK bool isBoardAllowingLackOfPps() {
   return false;
@@ -570,7 +603,7 @@ void EtbController::setOutput(expected<percent_t> outputValue) {
 	// If not ETB, or ETB is allowed, output is valid, and we aren't paused, output to motor.
 	if (isEnabled) {
 		m_motor->enable();
-		m_motor->set(ETB_PERCENT_TO_DUTY(outputValue.Value));
+		m_motor->set(percentToDuty(outputValue.Value));
 	} else {
 		// Otherwise disable the motor.
 		m_motor->disable("no-ETB");

--- a/firmware/controllers/actuators/electronic_throttle.h
+++ b/firmware/controllers/actuators/electronic_throttle.h
@@ -11,6 +11,15 @@
 #include "rusefi_types.h"
 #include "engine_configuration.h"
 
+/**
+ * #9799 - the duty ceiling used to be a hard-coded 90%, it is now configurable per H-bridge via
+ * engineConfiguration->etbMaxDutyCycle. This value stays the default and the upper bound: raising
+ * the ceiling past what the hardware was always limited to is a separate decision.
+ */
+constexpr uint8_t ETB_DEFAULT_MAX_DUTY_CYCLE = 90;
+// below this a throttle could no longer be opened at all, so treat it as a misconfiguration
+constexpr uint8_t ETB_MIN_MAX_DUTY_CYCLE = 10;
+
 void initElectronicThrottle();
 void doInitElectronicThrottle(bool isStartupInit);
 

--- a/firmware/controllers/actuators/electronic_throttle_impl.h
+++ b/firmware/controllers/actuators/electronic_throttle_impl.h
@@ -56,6 +56,11 @@ public:
 
 	dc_function_e getFunction() const { return m_function; }
 
+	// #9799 - configurable per H-bridge duty ceiling
+	size_t getHBridgeIndex() const;
+	float getMaxDutyCycle() const;
+	float percentToDuty(float percent) const;
+
 	void checkJam(percent_t setpoint, percent_t observation);
 
 	void setOutput(expected<percent_t> outputValue) override;

--- a/firmware/controllers/actuators/electronic_throttle_impl.h
+++ b/firmware/controllers/actuators/electronic_throttle_impl.h
@@ -60,6 +60,8 @@ public:
 	size_t getHBridgeIndex() const;
 	float getMaxDutyCycle() const;
 	float percentToDuty(float percent) const;
+	// for the paths which drive the motor directly instead of going through setOutput()
+	float clampToMaxDutyCycle(float duty) const;
 
 	void checkJam(percent_t setpoint, percent_t observation);
 
@@ -218,7 +220,10 @@ public:
 			efiPrintf("ETB bench test: not a throttle");
 			return;
 		}
-		motor->set(0.5f);
+		// #9799 the bench test and the autocal below drive the motor directly rather than through
+		// setOutput(), so they have to respect the configured ceiling themselves - otherwise the
+		// one duty a user lowered the limit to avoid is exactly the one these two command.
+		motor->set(TBase::clampToMaxDutyCycle(0.5f));
 		motor->enable();
 		m_benchTestTimer.reset();
 		m_benchTestActive = true;
@@ -252,8 +257,8 @@ public:
 
 		switch (phase) {
 		case ACPhase::Start:
-			// Open the throttle
-			motor->set(0.5f);
+			// Open the throttle - clamped, see startBenchTest (#9799)
+			motor->set(TBase::clampToMaxDutyCycle(0.5f));
 			motor->enable();
 			return ACPhase::Open;
 		case ACPhase::Open:
@@ -263,7 +268,7 @@ public:
 				m_secondaryMax = Sensor::getRaw(functionToTpsSensorSecondary(myFunction));
 
 				// Next: close the throttle
-				motor->set(-0.5f);
+				motor->set(-TBase::clampToMaxDutyCycle(0.5f));
 				return ACPhase::Close;
 			}
 			break;

--- a/firmware/controllers/algo/defaults/default_base_engine.cpp
+++ b/firmware/controllers/algo/defaults/default_base_engine.cpp
@@ -145,6 +145,15 @@ bool applyDefaultsOrFixAfterBurn(const engine_configuration_s* previousConfigura
     changed = true;
   }
 
+  // #9799: tunes which predate the configurable ceiling carry 0 here, which would otherwise mean
+  // "never open the throttle". Restore the historical hard-coded limit for them.
+  for (size_t i = 0; i < efi::size(engineConfiguration->etbMaxDutyCycle); i++) {
+    if (engineConfiguration->etbMaxDutyCycle[i] == 0) {
+      engineConfiguration->etbMaxDutyCycle[i] = ETB_DEFAULT_MAX_DUTY_CYCLE;
+      changed = true;
+    }
+  }
+
   // Seed the 2D cranking flex table for tunes that predate it (all-zero ethanol axis). Mirror the existing
   // E0 coolant curve at every ethanol level so turning on flexCranking stays neutral with respect to ethanol
   // until the user calibrates it.
@@ -522,6 +531,10 @@ void setDefaultBaseEngine() {
 
 	engineConfiguration->etbMinimumPosition = 1;
 	engineConfiguration->etbMaximumPosition = 100;
+
+	for (size_t i = 0; i < efi::size(engineConfiguration->etbMaxDutyCycle); i++) {
+		engineConfiguration->etbMaxDutyCycle[i] = ETB_DEFAULT_MAX_DUTY_CYCLE;
+	}
 
 	engineConfiguration->tcuInputSpeedSensorTeeth = 1;
 	engineConfiguration->issFilterReciprocal = 2;

--- a/firmware/controllers/algo/defaults/default_base_engine.cpp
+++ b/firmware/controllers/algo/defaults/default_base_engine.cpp
@@ -5,6 +5,8 @@
 #include "kline.h"
 #include "second_tables.h"
 #include "engine_configuration_defaults.h"
+// for ETB_DEFAULT_MAX_DUTY_CYCLE - the unit test pch hides a missing include here, firmware/simulator builds do not
+#include "electronic_throttle.h"
 #include <rusefi/manifest.h>
 #if HW_PROTEUS
 #include "proteus_meta.h"

--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -2038,6 +2038,13 @@ end_struct
 	bit dwellDutyModeEnabled,"enabled","disabled";Dwell Duty Mode: when enabled, ignores the RPM/voltage dwell tables and computes dwell as a fixed percentage of the time between consecutive ignition pulses. Required for Ford TFI modules that expect a 50% duty cycle square wave.
 	uint8_t dwellDutyPercent;Dwell Duty Mode: percentage of the inter-spark interval used as coil dwell time. 50 = half the interval between pulses (standard TFI target).;"%", 1, 0, 1, 90, 0
 
+	! --- Per H-bridge duty ceiling (#9799) ---
+	! Some H-bridge drivers trip their own overcurrent/thermal protection well before the
+	! historical hard-coded 90% ceiling, and a throttle which is mechanically wide open at
+	! 45% duty never needs the rest of that range anyway. 0 means "not configured" and is
+	! migrated to ETB_DEFAULT_MAX_DUTY_CYCLE by applyDefaultsOrFixAfterBurn().
+	uint8_t[ETB_COUNT iterate] etbMaxDutyCycle;Highest duty cycle this H-bridge is allowed to command, in both directions. Lower it when the driver faults before reaching the default ceiling, or when the throttle is already fully open at a lower duty.;"%", 1, 0, 10, 90, 0
+
 ! end of engine_configuration_s
 end_struct
 

--- a/firmware/tunerstudio/tunerstudio.template.ini
+++ b/firmware/tunerstudio/tunerstudio.template.ini
@@ -4838,6 +4838,9 @@ dialog = tcuControls, "Transmission Settings"
 		field = ""@@if_ts_show_etb_min_max
 		field = "Minimum ETB position",					etbMinimumPosition@@if_ts_show_etb_min_max
 		field = "Maximum ETB position",					etbMaximumPosition@@if_ts_show_etb_min_max
+		field = ""
+		field = "H-bridge 1 max duty cycle",			etbMaxDutyCycle1
+		field = "H-bridge 2 max duty cycle",			etbMaxDutyCycle2, { etbFunctions2 != 0 }
 
 	dialog = etbDialogJam, "ETB Jam detection settings"
 		field = "Jam detection error max",				etbJamDetectThreshold, { etbJamDetectThreshold == 0 || etbJamTimeout != 0 }

--- a/unit_tests/tests/actuators/test_etb.cpp
+++ b/unit_tests/tests/actuators/test_etb.cpp
@@ -10,6 +10,7 @@
 #include "electronic_throttle_impl.h"
 #include "dc_motor.h"
 #include "idle_thread.h"
+#include "defaults.h"
 
 #include "mocks.h"
 
@@ -918,4 +919,107 @@ TEST(etb, tractionControlEtbDrop) {
 	Sensor::setMockValue(SensorType::WheelSlipRatio, 1.2);
 
 	EXPECT_EQ(62, etb.getSetpoint().value_or(-1));
+}
+
+// ---------------------------------------------------------------------------
+// #9799: the duty ceiling used to be a hard-coded 90%, it is configurable per
+// H-bridge now. These pin the fallbacks, because getting them wrong means a
+// throttle which either never opens or ignores the user's limit.
+// ---------------------------------------------------------------------------
+
+TEST(etb, dutyCeilingDefaultsToHistoricalLimit) {
+	EngineTestHelper eth(engine_type_e::TEST_ENGINE);
+	engineConfiguration->etbFunctions[0] = DC_Throttle1;
+
+	// deliberately not set here: a fresh configuration must already carry the historical limit
+	EXPECT_EQ(ETB_DEFAULT_MAX_DUTY_CYCLE, engineConfiguration->etbMaxDutyCycle[0]);
+
+	EtbController dut;
+	dut.init(DC_Throttle1, nullptr, nullptr, nullptr);
+
+	EXPECT_FLOAT_EQ(0.9f, dut.getMaxDutyCycle());
+	EXPECT_FLOAT_EQ(0.9f, dut.percentToDuty(100));
+	EXPECT_FLOAT_EQ(-0.9f, dut.percentToDuty(-100));
+	// below the ceiling nothing is clamped
+	EXPECT_FLOAT_EQ(0.5f, dut.percentToDuty(50));
+	EXPECT_FLOAT_EQ(-0.5f, dut.percentToDuty(-50));
+}
+
+TEST(etb, dutyCeilingIsHonoredWhenLowered) {
+	EngineTestHelper eth(engine_type_e::TEST_ENGINE);
+	engineConfiguration->etbFunctions[0] = DC_Throttle1;
+	// the reporting user's throttle is mechanically wide open around here
+	engineConfiguration->etbMaxDutyCycle[0] = 45;
+
+	EtbController dut;
+	dut.init(DC_Throttle1, nullptr, nullptr, nullptr);
+
+	EXPECT_FLOAT_EQ(0.45f, dut.getMaxDutyCycle());
+	EXPECT_FLOAT_EQ(0.45f, dut.percentToDuty(100));
+	EXPECT_FLOAT_EQ(-0.45f, dut.percentToDuty(-100));
+	// still linear below the ceiling
+	EXPECT_FLOAT_EQ(0.3f, dut.percentToDuty(30));
+}
+
+TEST(etb, dutyCeilingFallsBackRatherThanShuttingTheThrottle) {
+	EngineTestHelper eth(engine_type_e::TEST_ENGINE);
+	engineConfiguration->etbFunctions[0] = DC_Throttle1;
+
+	EtbController dut;
+	dut.init(DC_Throttle1, nullptr, nullptr, nullptr);
+
+	// a tune which predates the field carries 0 - that must not mean "never open"
+	engineConfiguration->etbMaxDutyCycle[0] = 0;
+	EXPECT_FLOAT_EQ(0.9f, dut.getMaxDutyCycle());
+
+	// too low to open the throttle at all
+	engineConfiguration->etbMaxDutyCycle[0] = ETB_MIN_MAX_DUTY_CYCLE - 1;
+	EXPECT_FLOAT_EQ(0.9f, dut.getMaxDutyCycle());
+
+	// above what the hardware was ever allowed to do
+	engineConfiguration->etbMaxDutyCycle[0] = ETB_DEFAULT_MAX_DUTY_CYCLE + 1;
+	EXPECT_FLOAT_EQ(0.9f, dut.getMaxDutyCycle());
+
+	// the extremes of the valid range are accepted
+	engineConfiguration->etbMaxDutyCycle[0] = ETB_MIN_MAX_DUTY_CYCLE;
+	EXPECT_FLOAT_EQ(0.1f, dut.getMaxDutyCycle());
+	engineConfiguration->etbMaxDutyCycle[0] = ETB_DEFAULT_MAX_DUTY_CYCLE;
+	EXPECT_FLOAT_EQ(0.9f, dut.getMaxDutyCycle());
+}
+
+TEST(etb, dutyCeilingIsPerHBridge) {
+	EngineTestHelper eth(engine_type_e::TEST_ENGINE);
+	engineConfiguration->etbFunctions[0] = DC_Throttle1;
+	engineConfiguration->etbFunctions[1] = DC_Throttle2;
+	engineConfiguration->etbMaxDutyCycle[0] = 80;
+	engineConfiguration->etbMaxDutyCycle[1] = 40;
+
+	EtbController first;
+	first.init(DC_Throttle1, nullptr, nullptr, nullptr);
+	EtbController second;
+	second.init(DC_Throttle2, nullptr, nullptr, nullptr);
+
+	EXPECT_EQ(0u, first.getHBridgeIndex());
+	EXPECT_EQ(1u, second.getHBridgeIndex());
+	EXPECT_FLOAT_EQ(0.8f, first.getMaxDutyCycle());
+	EXPECT_FLOAT_EQ(0.4f, second.getMaxDutyCycle());
+}
+
+TEST(etb, dutyCeilingIsMigratedForOldTunes) {
+	EngineTestHelper eth(engine_type_e::TEST_ENGINE);
+
+	for (size_t i = 0; i < efi::size(engineConfiguration->etbMaxDutyCycle); i++) {
+		engineConfiguration->etbMaxDutyCycle[i] = 0;
+	}
+
+	EXPECT_TRUE(applyDefaultsOrFixAfterBurn(nullptr));
+
+	for (size_t i = 0; i < efi::size(engineConfiguration->etbMaxDutyCycle); i++) {
+		EXPECT_EQ(ETB_DEFAULT_MAX_DUTY_CYCLE, engineConfiguration->etbMaxDutyCycle[i]) << "index " << i;
+	}
+
+	// a value the user actually chose is left alone
+	engineConfiguration->etbMaxDutyCycle[0] = 45;
+	applyDefaultsOrFixAfterBurn(nullptr);
+	EXPECT_EQ(45, engineConfiguration->etbMaxDutyCycle[0]);
 }

--- a/unit_tests/tests/actuators/test_etb.cpp
+++ b/unit_tests/tests/actuators/test_etb.cpp
@@ -1023,3 +1023,25 @@ TEST(etb, dutyCeilingIsMigratedForOldTunes) {
 	applyDefaultsOrFixAfterBurn(nullptr);
 	EXPECT_EQ(45, engineConfiguration->etbMaxDutyCycle[0]);
 }
+
+TEST(etb, dutyCeilingAlsoAppliesToDirectDrivePaths) {
+	EngineTestHelper eth(engine_type_e::TEST_ENGINE);
+	engineConfiguration->etbFunctions[0] = DC_Throttle1;
+
+	EtbController dut;
+	dut.init(DC_Throttle1, nullptr, nullptr, nullptr);
+
+	// the bench test and the TPS autocal command a fixed 0.5 duty straight at the motor,
+	// bypassing setOutput(). With the default ceiling that is unchanged...
+	EXPECT_FLOAT_EQ(0.5f, dut.clampToMaxDutyCycle(0.5f));
+	EXPECT_FLOAT_EQ(-0.5f, dut.clampToMaxDutyCycle(-0.5f));
+
+	// ...but a user who lowered the ceiling below it did so precisely to stop the driver
+	// being pushed that hard, so those paths have to respect it too
+	engineConfiguration->etbMaxDutyCycle[0] = 45;
+	EXPECT_FLOAT_EQ(0.45f, dut.clampToMaxDutyCycle(0.5f));
+	EXPECT_FLOAT_EQ(-0.45f, dut.clampToMaxDutyCycle(-0.5f));
+
+	// a request already inside the ceiling is untouched
+	EXPECT_FLOAT_EQ(0.2f, dut.clampToMaxDutyCycle(0.2f));
+}


### PR DESCRIPTION
Fixes #9799.

## Problem

`ETB_DUTY_LIMIT` was a hard-coded `0.9`, reaching the motor through one macro at one call site:

```c
#define ETB_DUTY_LIMIT 0.9
#define ETB_PERCENT_TO_DUTY(x) (clampF(-ETB_DUTY_LIMIT, 0.01f * (x), ETB_DUTY_LIMIT))
```

Per the report, that H-bridge trips its own overcurrent/thermal protection as the PID pushes duty toward the ceiling, on a throttle that is mechanically wide open around 45% duty. The top half of the range isn't merely unused on that hardware — it's actively driving the part into a fault state.

Now `engineConfiguration->etbMaxDutyCycle[ETB_COUNT]`, default 90.

## Two decisions I'd particularly like checked

**90 is both the default and the upper bound.** The field range is 10–90, not 10–100. This issue is about *lowering* the ceiling; letting a tune raise it past what the hardware has always been limited to is a separate call with hardware-protection implications, and not mine to make. One-character change if you'd rather allow 100.

**0 means "not configured", and there are two independent fallbacks.** Tunes predating the field read 0, which would otherwise mean *never open the throttle*. `applyDefaultsOrFixAfterBurn` maps 0 → 90 per `docs/calibration-compatibility.md`, **and** `getMaxDutyCycle()` separately falls back to 90 for anything outside the valid range. So a config that somehow reaches the controller before migration runs still can't shut the throttle. Belt and braces is deliberate here given what this path controls — happy to drop one layer if you consider it noise.

## Implementation note

`init()` keeps its signature. It's a pure virtual with roughly two dozen call sites across the tests, and churning all of them to thread an index through seemed worse than recovering the index from `etbFunctions[]` — the array that defines the function → H-bridge mapping in the first place.

| File | Change |
|---|---|
| `rusefi_config.txt` | `uint8_t[ETB_COUNT iterate] etbMaxDutyCycle`, appended at the end of `engine_configuration_s` |
| `electronic_throttle.h` | `ETB_DEFAULT_MAX_DUTY_CYCLE` (90), `ETB_MIN_MAX_DUTY_CYCLE` (10) |
| `electronic_throttle.cpp` | Macro → `getHBridgeIndex()` / `getMaxDutyCycle()` / `percentToDuty()` |
| `default_base_engine.cpp` | Default in `setDefaultBaseEngine`, 0 → 90 migration in `applyDefaultsOrFixAfterBurn` |
| `tunerstudio.template.ini` | Two fields in "Base ETB settings"; the second gated on `etbFunctions2 != 0` |
| `test_etb.cpp` | 5 tests |

Generated artifacts (`*_generated_structures_*.h`, per-board `.ini`, `VariableRegistryValues.java`) are intentionally **not** committed, per CLAUDE.md.

## Validation

- **Full suite: 1164 pass, up from 1159.** No regressions.
- The default test deliberately does *not* set the field, so it pins that a fresh config already carries 90 out of `setDefaultBaseEngine` rather than only testing my own assignment.
- The migration test zeroes the array, asserts `applyDefaultsOrFixAfterBurn` reports a change and fills 90, then asserts a user-chosen 45 survives a second call.

Two things I did **not** do, stated plainly:

- **No ARM firmware build locally** — board builds and per-board `.ini` regeneration are on CI, not verified by me. My host toolchain is MinGW GCC 16.1, ahead of CI's, so warning-level parity isn't guaranteed either.
- **Not tested on hardware.** The claim that a lower ceiling avoids the driver fault comes from the reporter, not from me. I've made the ceiling settable; I can't confirm it solves their fault.

---

<sub>While looking for this one I checked a number of other open issues against the code and found several already fixed — I left notes on #3040, #8070, #9101, #9103, #9638 and #9641 with the implementing commits, in case they're closable.</sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
