### PR TITLE
GP PWM on-off: minimum time in state (#9386)

### DIFF
--- a/firmware/controllers/actuators/gppwm/gppwm_channel.cpp
+++ b/firmware/controllers/actuators/gppwm/gppwm_channel.cpp
@@ -25,10 +25,22 @@ float GppwmChannel::setOutput(float result) {
 					m_config->onAboveDuty);
 		}
 		// Apply hysteresis with provided values
+		bool desiredState = m_state;
 		if (m_state && result < m_config->offBelowDuty) {
-			m_state = false;
+			desiredState = false;
 		} else if (!m_state && result > m_config->onAboveDuty) {
-			m_state = true;
+			desiredState = true;
+		}
+
+		// #9386 the duty band alone does not help when the table value sits on a threshold and
+		// jitters across it - the relay still chatters. Hold each state for at least the
+		// configured time. 0 means no minimum, which is the historical behaviour.
+		if (desiredState != m_state) {
+			float minimumStateTime = m_config->minimumStateTime;
+			if (minimumStateTime <= 0 || m_stateChangeTimer.hasElapsedSec(minimumStateTime)) {
+				m_state = desiredState;
+				m_stateChangeTimer.reset();
+			}
 		}
 
 		m_output->setValue(m_state);

--- a/firmware/controllers/actuators/gppwm/gppwm_channel.h
+++ b/firmware/controllers/actuators/gppwm/gppwm_channel.h
@@ -3,6 +3,7 @@
 #include "gppwm.h"
 
 #include "rusefi_types.h"
+#include <rusefi/timer.h>
 
 struct gppwm_channel;
 class OutputPin;
@@ -27,6 +28,10 @@ public:
 private:
 	// Store the current state so we can apply hysteresis
 	bool m_state = false;
+
+	// #9386 - how long the output has been in its current state, for minimumStateTime.
+	// A default constructed Timer reads as "a very long time ago", so the first switch is free.
+	Timer m_stateChangeTimer;
 
 	// Configuration fields
 	const gppwm_channel* m_config = nullptr;

--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -491,6 +491,10 @@ struct gppwm_channel
 	int16_t[GPPWM_LOAD_COUNT] autoscale loadBins;;"", 0.5, 0, -1000, 10000, 1
 	int16_t[GPPWM_RPM_COUNT] rpmBins;;"", 1, 0, -30000, 30000, 0
 	uint8_t[GPPWM_LOAD_COUNT x GPPWM_RPM_COUNT] autoscale table;;"duty", 0.5, 0, 0, 100, 1
+
+	! #9386 - deliberately at the end of the struct so the offsets of every field above stay put.
+	! 0 keeps the historical behaviour (switch as soon as the duty hysteresis band is crossed).
+	uint8_t autoscale minimumStateTime;Hysteresis: in on-off mode, hold the output in its current state for at least this long before letting it switch again. Stops a relay chattering while the table value sits near the on/off thresholds. 0 disables.;"sec", 0.1, 0, 0, 25, 1
 end_struct
 
 custom air_pressure_sensor_type_e 1 bits, U08, @OFFSET@, [0:4], "Custom", "DENSO183", "MPX4250", "HONDA3BAR", "NEON_2003", "22012AA090", "GM 3 Bar", "MPX4100", "Toyota 89420-02010", "MPX4250A", "Bosch 2.5", "Mazda1Bar", "GM 2 Bar", "GM 1 Bar", "MPXH6400", "MPXH6300", "Bosch 3 Bar"

--- a/firmware/tunerstudio/tunerstudio.template.ini
+++ b/firmware/tunerstudio/tunerstudio.template.ini
@@ -5362,6 +5362,7 @@ dialog = tcuControls, "Transmission Settings"
 		field = ""
 		field = "On above duty", gppwm1_onAboveDuty, {gppwm1_pin != 0 && gppwm1_pwmFrequency == 0}
 		field = "Off below duty", gppwm1_offBelowDuty, {gppwm1_pin != 0 && gppwm1_pwmFrequency == 0}
+		field = "Minimum time in state", gppwm1_minimumStateTime, {gppwm1_pin != 0 && gppwm1_pwmFrequency == 0}
 		field = "Duty if error", gppwm1_dutyIfError, {gppwm1_pin != 0}
 		field = ""
 		field = "X Axis", gppwm1_rpmAxis, {gppwm1_pin != 0}
@@ -5386,6 +5387,7 @@ dialog = tcuControls, "Transmission Settings"
 		field = ""
 		field = "On above duty", gppwm2_onAboveDuty, {gppwm2_pin != 0 && gppwm2_pwmFrequency == 0}
 		field = "Off below duty", gppwm2_offBelowDuty, {gppwm2_pin != 0 && gppwm2_pwmFrequency == 0}
+		field = "Minimum time in state", gppwm2_minimumStateTime, {gppwm2_pin != 0 && gppwm2_pwmFrequency == 0}
 		field = "Duty if error", gppwm2_dutyIfError, {gppwm2_pin != 0}
 		field = ""
 		field = "X Axis", gppwm2_rpmAxis, {gppwm2_pin != 0}
@@ -5410,6 +5412,7 @@ dialog = tcuControls, "Transmission Settings"
 		field = ""
 		field = "On above duty", gppwm3_onAboveDuty, {gppwm3_pin != 0 && gppwm3_pwmFrequency == 0}
 		field = "Off below duty", gppwm3_offBelowDuty, {gppwm3_pin != 0 && gppwm3_pwmFrequency == 0}
+		field = "Minimum time in state", gppwm3_minimumStateTime, {gppwm3_pin != 0 && gppwm3_pwmFrequency == 0}
 		field = "Duty if error", gppwm3_dutyIfError, {gppwm3_pin != 0}@@if_ts_show_gppwm3_error_value
 		field = ""
 		field = "X Axis", gppwm3_rpmAxis, {gppwm3_pin != 0}
@@ -5434,6 +5437,7 @@ dialog = tcuControls, "Transmission Settings"
 		field = ""
 		field = "On above duty", gppwm4_onAboveDuty, {gppwm4_pin != 0 && gppwm4_pwmFrequency == 0}
 		field = "Off below duty", gppwm4_offBelowDuty, {gppwm4_pin != 0 && gppwm4_pwmFrequency == 0}
+		field = "Minimum time in state", gppwm4_minimumStateTime, {gppwm4_pin != 0 && gppwm4_pwmFrequency == 0}
 		field = "Duty if error", gppwm4_dutyIfError, {gppwm4_pin != 0}
 		field = ""
 		field = "X Axis", gppwm4_rpmAxis, {gppwm4_pin != 0}

--- a/unit_tests/tests/actuators/test_gppwm.cpp
+++ b/unit_tests/tests/actuators/test_gppwm.cpp
@@ -11,7 +11,7 @@ using ::testing::StrictMock;
 TEST(GpPwm, OutputWithPwm) {
 	GppwmChannel ch;
 
-	gppwm_channel cfg;
+	gppwm_channel cfg{};
 
 	StrictMock<MockPwm> pwm;
 
@@ -40,7 +40,7 @@ TEST(GpPwm, OutputWithPwm) {
 TEST(GpPwm, OutputOnOff) {
 	GppwmChannel ch;
 
-	gppwm_channel cfg;
+	gppwm_channel cfg{};
 	cfg.onAboveDuty = 50;
 	cfg.offBelowDuty = 40;
 
@@ -77,7 +77,7 @@ TEST(GpPwm, TestGetOutput) {
 	EngineTestHelper eth(engine_type_e::TEST_ENGINE);
 	GppwmChannel ch;
 
-	gppwm_channel cfg;
+	gppwm_channel cfg{};
 	cfg.loadAxis = GPPWM_Tps;
 	cfg.rpmAxis = GPPWM_Rpm;
 	cfg.dutyIfError = 21.0f;
@@ -100,4 +100,89 @@ TEST(GpPwm, TestGetOutput) {
 	Sensor::setMockValue(SensorType::Tps1, 35.0f);
 	Sensor::setMockValue(SensorType::Rpm, 1200);
 	EXPECT_FLOAT_EQ(35.0f, ch.getOutput(-1).Result);
+}
+
+// ---------------------------------------------------------------------------
+// #9386: the duty band stops chatter caused by noise, but not by a table value
+// which drifts slowly back and forth across a threshold. minimumStateTime holds
+// each state for a while so a relay is not switched repeatedly.
+// ---------------------------------------------------------------------------
+
+TEST(GpPwm, OnOffMinimumStateTimeHoldsState) {
+	EngineTestHelper eth(engine_type_e::TEST_ENGINE);
+
+	gppwm_channel cfg{};
+	cfg.onAboveDuty = 50;
+	cfg.offBelowDuty = 40;
+	// scaled_channel<uint8_t, 10> - assign seconds directly, it stores tenths
+	cfg.minimumStateTime = 2;
+
+	MockOutputPin pin;
+	EXPECT_CALL(pin, setValue(::testing::_, false)).Times(::testing::AnyNumber());
+
+	GppwmChannel ch;
+	ch.init(false, nullptr, &pin, nullptr, &cfg);
+
+	// the very first switch is not held back - nothing has happened yet
+	EXPECT_FLOAT_EQ(100, ch.setOutput(60));
+
+	// wants to turn off immediately, but the minimum has not elapsed
+	EXPECT_FLOAT_EQ(100, ch.setOutput(30));
+	eth.moveTimeForwardAndInvokeEventsUs(1'000'000);
+	EXPECT_FLOAT_EQ(100, ch.setOutput(30));
+
+	// past two seconds it is allowed through
+	eth.moveTimeForwardAndInvokeEventsUs(1'100'000);
+	EXPECT_FLOAT_EQ(0, ch.setOutput(30));
+
+	// and the hold applies to the next switch as well
+	EXPECT_FLOAT_EQ(0, ch.setOutput(60));
+	eth.moveTimeForwardAndInvokeEventsUs(2'100'000);
+	EXPECT_FLOAT_EQ(100, ch.setOutput(60));
+}
+
+TEST(GpPwm, OnOffZeroMinimumStateTimeKeepsOldBehaviour) {
+	EngineTestHelper eth(engine_type_e::TEST_ENGINE);
+
+	gppwm_channel cfg{};
+	cfg.onAboveDuty = 50;
+	cfg.offBelowDuty = 40;
+	cfg.minimumStateTime = 0;
+
+	MockOutputPin pin;
+	EXPECT_CALL(pin, setValue(::testing::_, false)).Times(::testing::AnyNumber());
+
+	GppwmChannel ch;
+	ch.init(false, nullptr, &pin, nullptr, &cfg);
+
+	// no time passes between any of these - every crossing switches straight away
+	EXPECT_FLOAT_EQ(100, ch.setOutput(60));
+	EXPECT_FLOAT_EQ(0, ch.setOutput(30));
+	EXPECT_FLOAT_EQ(100, ch.setOutput(60));
+	EXPECT_FLOAT_EQ(0, ch.setOutput(30));
+}
+
+TEST(GpPwm, OnOffMinimumStateTimeDoesNotBlockStayingPut) {
+	EngineTestHelper eth(engine_type_e::TEST_ENGINE);
+
+	gppwm_channel cfg{};
+	cfg.onAboveDuty = 50;
+	cfg.offBelowDuty = 40;
+	cfg.minimumStateTime = 2;
+
+	MockOutputPin pin;
+	EXPECT_CALL(pin, setValue(::testing::_, false)).Times(::testing::AnyNumber());
+
+	GppwmChannel ch;
+	ch.init(false, nullptr, &pin, nullptr, &cfg);
+
+	EXPECT_FLOAT_EQ(100, ch.setOutput(60));
+
+	// inside the duty band: no switch is being asked for, so the timer is irrelevant
+	EXPECT_FLOAT_EQ(100, ch.setOutput(45));
+	EXPECT_FLOAT_EQ(100, ch.setOutput(45));
+
+	// still on, and once the value drops below the band the hold has long expired
+	eth.moveTimeForwardAndInvokeEventsUs(3'000'000);
+	EXPECT_FLOAT_EQ(0, ch.setOutput(30));
 }


### PR DESCRIPTION
Fixes #9386.

## What's already there, and why it isn't enough

On-off mode does have hysteresis — `onAboveDuty` / `offBelowDuty` form a proper Schmitt trigger in `GppwmChannel::setOutput`. That handles a **noisy** signal.

It does not help when the table value **drifts slowly** back and forth across a threshold: each crossing is a legitimate transition, so the output switches on every update. The reporter is driving relays (Toyota low/high fuel pump, water pump) off these outputs, so that's audible and hard on the hardware.

Hence a time-based minimum rather than a wider band.

## The change

`gppwm_channel.minimumStateTime` — once the output switches, it holds for at least this long before another switch is allowed.

**0 means no minimum, which is exactly the historical behaviour.** So no tune migration is needed, and nothing changes for anyone who doesn't set it. That's the "design 0 to be safe/neutral" case from `docs/calibration-compatibility.md` rather than the `applyDefaultsOrFixAfterBurn` case.

The field is at the **end of the struct on purpose**, so the offsets of every existing gppwm field stay put. Only the struct size grows. Say the word if you'd rather have it next to the other two hysteresis fields for readability and accept the intra-struct churn.

`Timer` default-constructs to `INT64_MIN / 8`, so the very first transition is never held back.

## One thing I had to fix on the way

The three `gppwm_channel cfg;` in `test_gppwm.cpp` are stack POD with only two fields assigned — everything else was whatever happened to be on the stack. That was already latent; adding a field that *changes behaviour* is what would have made it bite. They're now `gppwm_channel cfg{}`.

Same species as the uninitialized members in #10085, for what it's worth.

## Validation

- 3 new tests: the hold blocks an early switch and permits a late one in both directions; `0` reproduces the old switch-immediately behaviour; and a value sitting inside the band is unaffected, since no transition is being requested.
- **Full suite: 1169 pass.**
- Host build only (MinGW GCC 16.1). No ARM firmware build locally, and not tested on hardware — the claim that this stops the relay chatter is the reporter's, not mine.

No `docs/report.md` entry, per your note on #10082.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
