### PR TITLE
Second VE table: its own load axis (#10023)

### DIFF
--- a/firmware/controllers/algo/airmass/airmass.cpp
+++ b/firmware/controllers/algo/airmass/airmass.cpp
@@ -121,6 +121,9 @@ float AirmassVeModelBase::getVe(float rpm, float load, bool postState) const {
 		engine->engineState.veTableIdleYAxis = idleVeLoad;
 #if EFI_PROD_CODE || EFI_UNIT_TEST
 		engine->engineState.isSecondVeTableActive = switchTableActive;
+		// #10023 the second table has its own load axis, so the primary's veTableYAxis does not
+		// say what this table was actually indexed with - publish it separately
+		engine->engineState.veTableSecondYAxis = secondVeLoad;
 #endif
 	}
 

--- a/firmware/controllers/algo/airmass/airmass.cpp
+++ b/firmware/controllers/algo/airmass/airmass.cpp
@@ -37,11 +37,17 @@ float AirmassVeModelBase::getVe(float rpm, float load, bool postState) const {
 	const bool pinActive = isBrainPinValid(secondTablesGetState()->secondVeTableInput) &&
 		efiReadPin(secondTablesGetState()->secondVeTableInput, secondTablesGetState()->secondVeTableInputMode);
 
+	// #10023 the second table may be indexed by a different load axis from the primary one - useful
+	// where MAP has no resolution at small throttle, or as a fallback for MAP failure, where a
+	// MAP-indexed second table would be no help. VE_None inherits the primary's already-overridden
+	// load, exactly like idleVeOverrideMode below, so existing tunes are unaffected.
+	float secondVeLoad = getVeLoadAxis(engineConfiguration->secondVeOverrideMode, load);
+
 	if (pinActive) {
 		// Hard switch: pin overrides everything, replace VE entirely
 		ve = interpolate3d(
 			secondTablesGetState()->secondVeTable,
-			secondTablesGetState()->secondVeLoadBins, load,
+			secondTablesGetState()->secondVeLoadBins, secondVeLoad,
 			secondTablesGetState()->secondVeRpmBins, rpm
 		);
 		switchTableActive = true;
@@ -50,7 +56,7 @@ float AirmassVeModelBase::getVe(float rpm, float load, bool postState) const {
 			secondTablesGetState()->secondVeBlendParameter,
 			secondTablesGetState()->secondVeBlendBins, secondTablesGetState()->secondVeBlendValues,
 			secondTablesGetState()->secondVeTable,
-			secondTablesGetState()->secondVeLoadBins, load,
+			secondTablesGetState()->secondVeLoadBins, secondVeLoad,
 			secondTablesGetState()->secondVeRpmBins, rpm
 		);
 		if (result.Bias > 0) {

--- a/firmware/controllers/algo/engine_state.txt
+++ b/firmware/controllers/algo/engine_state.txt
@@ -77,6 +77,7 @@ struct_no_prefix engine_state_s
 
 	uint16_t autoscale veTableYAxis;;"%",{1/100}, 0, 0, 0, 0
 	int16_t autoscale veTableIdleYAxis;;"", 0.1, 0, -1000, 1000, 1
+	uint16_t autoscale veTableSecondYAxis;VE: Second table load axis;"%",{1/100}, 0, 0, 0, 0
 	uint8_t overDwellCanceledCounter;"Ignition: overcharge canceled";"", 1, 0, 0, 255, 0
 	uint8_t overDwellNotScheduledCounter;"Ignition: overDwellNotScheduled";"", 1, 0, 0, 255, 0
 	uint8_t sparkOutOfOrderCounter;"Ignition: sparkOutOfOrder";"", 1, 0, 0, 255, 0

--- a/firmware/integration/config_page_4.txt
+++ b/firmware/integration/config_page_4.txt
@@ -6,7 +6,7 @@ custom gppwm_channel_e 1 bits, U08, @OFFSET@, [0:5], $gppwm_channel_e_enum
 struct_no_prefix page4_s
   ! note this is pretty similar to a blend table!
   uint16_t[VE_LOAD_COUNT x VE_RPM_COUNT] autoscale secondVeTable;;"%", 0.1, 0, 0, 999, 1
-  uint16_t[VE_LOAD_COUNT] secondVeLoadBins;;{bitStringValue(veLoadUnitLabels, veLoadUnitIdx)}, {!(secondVeOverrideMode == 1 || (secondVeOverrideMode == 0 && (veOverrideMode == 1 || (veOverrideMode == 0 && fuelAlgorithm == 0)))) || useMetricOnInterface ? 1 : @@UNITS_KPA_TO_PSI@@}, 0, 0, {secondVeOverrideMode == 1 || (secondVeOverrideMode == 0 && (veOverrideMode == 1 || (veOverrideMode == 0 && fuelAlgorithm == 0))) ? (useMetricOnInterface ? @@MAP_UPPER_LIMIT@@ : @@MAP_UPPER_LIMIT@@ * @@UNITS_KPA_TO_PSI@@) : @@MAP_UPPER_LIMIT@@}, 0
+  uint16_t[VE_LOAD_COUNT] secondVeLoadBins;;{bitStringValue(veLoadUnitLabels, secondVeLoadUnitIdx)}, {!(secondVeOverrideMode == 1 || (secondVeOverrideMode == 0 && (veOverrideMode == 1 || (veOverrideMode == 0 && fuelAlgorithm == 0)))) || useMetricOnInterface ? 1 : @@UNITS_KPA_TO_PSI@@}, 0, 0, {secondVeOverrideMode == 1 || (secondVeOverrideMode == 0 && (veOverrideMode == 1 || (veOverrideMode == 0 && fuelAlgorithm == 0))) ? (useMetricOnInterface ? @@MAP_UPPER_LIMIT@@ : @@MAP_UPPER_LIMIT@@ * @@UNITS_KPA_TO_PSI@@) : @@MAP_UPPER_LIMIT@@}, 0
   uint16_t[VE_RPM_COUNT] secondVeRpmBins;;"RPM",	   1, 0, 0, 18000, 0
 
   switch_input_pin_e secondVeTableInput;Pin that activates the second VE table (hard switch, overrides blend)

--- a/firmware/integration/config_page_4.txt
+++ b/firmware/integration/config_page_4.txt
@@ -6,7 +6,7 @@ custom gppwm_channel_e 1 bits, U08, @OFFSET@, [0:5], $gppwm_channel_e_enum
 struct_no_prefix page4_s
   ! note this is pretty similar to a blend table!
   uint16_t[VE_LOAD_COUNT x VE_RPM_COUNT] autoscale secondVeTable;;"%", 0.1, 0, 0, 999, 1
-  uint16_t[VE_LOAD_COUNT] secondVeLoadBins;;{bitStringValue(veLoadUnitLabels, veLoadUnitIdx)}, {!(veOverrideMode == 1 || (veOverrideMode == 0 && fuelAlgorithm == 0)) || useMetricOnInterface ? 1 : @@UNITS_KPA_TO_PSI@@}, 0, 0, {veOverrideMode == 1 || (veOverrideMode == 0 && fuelAlgorithm == 0) ? (useMetricOnInterface ? @@MAP_UPPER_LIMIT@@ : @@MAP_UPPER_LIMIT@@ * @@UNITS_KPA_TO_PSI@@) : @@MAP_UPPER_LIMIT@@}, 0
+  uint16_t[VE_LOAD_COUNT] secondVeLoadBins;;{bitStringValue(veLoadUnitLabels, veLoadUnitIdx)}, {!(secondVeOverrideMode == 1 || (secondVeOverrideMode == 0 && (veOverrideMode == 1 || (veOverrideMode == 0 && fuelAlgorithm == 0)))) || useMetricOnInterface ? 1 : @@UNITS_KPA_TO_PSI@@}, 0, 0, {secondVeOverrideMode == 1 || (secondVeOverrideMode == 0 && (veOverrideMode == 1 || (veOverrideMode == 0 && fuelAlgorithm == 0))) ? (useMetricOnInterface ? @@MAP_UPPER_LIMIT@@ : @@MAP_UPPER_LIMIT@@ * @@UNITS_KPA_TO_PSI@@) : @@MAP_UPPER_LIMIT@@}, 0
   uint16_t[VE_RPM_COUNT] secondVeRpmBins;;"RPM",	   1, 0, 0, 18000, 0
 
   switch_input_pin_e secondVeTableInput;Pin that activates the second VE table (hard switch, overrides blend)

--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -2038,6 +2038,13 @@ end_struct
 	bit dwellDutyModeEnabled,"enabled","disabled";Dwell Duty Mode: when enabled, ignores the RPM/voltage dwell tables and computes dwell as a fixed percentage of the time between consecutive ignition pulses. Required for Ford TFI modules that expect a 50% duty cycle square wave.
 	uint8_t dwellDutyPercent;Dwell Duty Mode: percentage of the inter-spark interval used as coil dwell time. 50 = half the interval between pulses (standard TFI target).;"%", 1, 0, 1, 90, 0
 
+
+	! #10023 - the second VE table can use a different load axis from the primary one, for example
+	! TPS on a cammed/ITB engine where MAP collapses into a narrow noisy band at small throttle,
+	! or as a MAP-failure fallback where a MAP-indexed second table would be no help at all.
+	! "None" inherits whatever the primary resolved to, which is what every existing tune gets.
+	ve_override_e secondVeOverrideMode;Load axis for the second VE table. "None" means use the same axis as the primary table.
+
 ! end of engine_configuration_s
 end_struct
 

--- a/firmware/tunerstudio/secondary_panels.ini
+++ b/firmware/tunerstudio/secondary_panels.ini
@@ -424,6 +424,8 @@
 		readout = veValueGauge
 
 	dialog = secondVeTableControls, "Second VE Table"
+		field = "Second VE table load axis", secondVeOverrideMode
+		field = "#('None' uses the same load axis as the primary VE table)"
 		field = "#--- ON/OFF mode: pin activates full table switch ---"
 		field = "Second VE table input pin", secondVeTableInput
 		field = "Second VE table input mode", secondVeTableInputMode

--- a/firmware/tunerstudio/tunerstudio.template.ini
+++ b/firmware/tunerstudio/tunerstudio.template.ini
@@ -372,10 +372,13 @@ include_file @@TUNING_SECTION_FILE@@
 
 	; effective load source: 0=MAP 1=TPS 2=Air Charge(MAF) 3=Lua (+ign/afr: 4=Acc Pedal 5=Cyl Filling)
 	veLoadSrc       = scalar, U08, "", 1, 0, 0, 5, 0, noMsqSave
+	; the second VE table resolves its own axis, falling back to the primary's when None
+	secondVeLoadSrc = scalar, U08, "", 1, 0, 0, 5, 0, noMsqSave
 	ignLoadSrc      = scalar, U08, "", 1, 0, 0, 5, 0, noMsqSave
 	afrLoadSrc      = scalar, U08, "", 1, 0, 0, 5, 0, noMsqSave
 	; unit label index: 0=psi, 1=kPa, 2=%, 3=Lua
 	veLoadUnitIdx   = scalar, U08, "", 1, 0, 0, 3, 0, noMsqSave
+	secondVeLoadUnitIdx = scalar, U08, "", 1, 0, 0, 3, 0, noMsqSave
 	ignLoadUnitIdx  = scalar, U08, "", 1, 0, 0, 3, 0, noMsqSave
 	afrLoadUnitIdx  = scalar, U08, "", 1, 0, 0, 3, 0, noMsqSave
 
@@ -448,15 +451,19 @@ include_file @@TUNING_SECTION_FILE@@
 
 	; source: 0=MAP 1=TPS 2=Air Charge 3=Lua 4=Acc Pedal 5=Cyl Filling ; unit: 0=psi 1=kPa 2=% 3=Lua
 	defaultValue = veLoadSrc, 0
+	defaultValue = secondVeLoadSrc, 0
 	defaultValue = ignLoadSrc, 0
 	defaultValue = afrLoadSrc, 0
 	defaultValue = veLoadUnitIdx, 1
+	defaultValue = secondVeLoadUnitIdx, 1
 	defaultValue = ignLoadUnitIdx, 1
 	defaultValue = afrLoadUnitIdx, 1
 	maintainConstantValue = veLoadSrc,  { veOverrideMode == 1 ? 0 : veOverrideMode == 2 ? 1 : (fuelAlgorithm == 0 ? 0 : fuelAlgorithm == 2 ? 1 : fuelAlgorithm == 1 ? 2 : 3) }
+	maintainConstantValue = secondVeLoadSrc,  { secondVeOverrideMode == 1 ? 0 : secondVeOverrideMode == 2 ? 1 : (veOverrideMode == 1 ? 0 : veOverrideMode == 2 ? 1 : (fuelAlgorithm == 0 ? 0 : fuelAlgorithm == 2 ? 1 : fuelAlgorithm == 1 ? 2 : 3)) }
 	maintainConstantValue = ignLoadSrc, { ignOverrideMode == 1 ? 0 : ignOverrideMode == 2 ? 1 : ignOverrideMode == 3 ? 4 : ignOverrideMode == 4 ? 5 : (fuelAlgorithm == 0 ? 0 : fuelAlgorithm == 2 ? 1 : fuelAlgorithm == 1 ? 2 : 3) }
 	maintainConstantValue = afrLoadSrc, { afrOverrideMode == 1 ? 0 : afrOverrideMode == 2 ? 1 : afrOverrideMode == 3 ? 4 : afrOverrideMode == 4 ? 5 : (fuelAlgorithm == 0 ? 0 : fuelAlgorithm == 2 ? 1 : fuelAlgorithm == 1 ? 2 : 3) }
 	maintainConstantValue = veLoadUnitIdx,  { (veOverrideMode == 1 || (veOverrideMode == 0 && fuelAlgorithm == 0)) ? useMetricOnInterface : ((veOverrideMode == 0 && fuelAlgorithm == 3) ? 3 : 2) }
+	maintainConstantValue = secondVeLoadUnitIdx,  { (secondVeOverrideMode == 1 || (secondVeOverrideMode == 0 && (veOverrideMode == 1 || (veOverrideMode == 0 && fuelAlgorithm == 0)))) ? useMetricOnInterface : ((secondVeOverrideMode == 0 && veOverrideMode == 0 && fuelAlgorithm == 3) ? 3 : 2) }
 	maintainConstantValue = ignLoadUnitIdx, { (ignOverrideMode == 1 || (ignOverrideMode == 0 && fuelAlgorithm == 0)) ? useMetricOnInterface : ((ignOverrideMode == 0 && fuelAlgorithm == 3) ? 3 : 2) }
 	maintainConstantValue = afrLoadUnitIdx, { (afrOverrideMode == 1 || (afrOverrideMode == 0 && fuelAlgorithm == 0)) ? useMetricOnInterface : ((afrOverrideMode == 0 && fuelAlgorithm == 3) ? 3 : 2) }
 
@@ -1458,9 +1465,9 @@ curve = rangeMatrix, "Range Switch Input Matrix"
 		upDownLabel = "(RICHER)", "(LEANER)"
 
 	table = secondVeTableTbl, secondVeTableMap, "Second VE Table", 1
-		xyLabels	= "RPM", {bitStringValue(veAxisLabels, veLoadSrc)}
+		xyLabels	= "RPM", {bitStringValue(veAxisLabels, secondVeLoadSrc)}
 		xBins		= secondVeRpmBins,  RPMValue
-		yBins		= secondVeLoadBins, veTableYAxis
+		yBins		= secondVeLoadBins, veTableSecondYAxis
 		zBins		= secondVeTable
 		gridOrient	= 250,	0, 340
 		upDownLabel	= "(RICHER)", "(LEANER)"

--- a/unit_tests/tests/ignition_injection/test_fuel_math.cpp
+++ b/unit_tests/tests/ignition_injection/test_fuel_math.cpp
@@ -684,3 +684,83 @@ TEST(AirmassModes, PredictiveMapBlendTowardRisingSensor) {
 	Sensor::setMockValue(SensorType::Map, 90.0f);
 	EXPECT_FLOAT_EQ(dut.getMap(1500, false), 90.0f);
 }
+
+// #10023: the second VE table can be indexed by its own load axis. Fill it so that the value it
+// returns is whatever load it was looked up with, which makes the axis directly observable.
+static void makeSecondVeTableReportItsLoadAxis() {
+	page4_s* state = secondTablesGetState();
+	setLinearCurve(state->secondVeLoadBins, 0, 100, 1);
+	setLinearCurve(state->secondVeRpmBins, 0, 8000, 1);
+	for (size_t loadIdx = 0; loadIdx < efi::size(state->secondVeTable); loadIdx++) {
+		for (size_t rpmIdx = 0; rpmIdx < efi::size(state->secondVeTable[0]); rpmIdx++) {
+			state->secondVeTable[loadIdx][rpmIdx] = state->secondVeLoadBins[loadIdx];
+		}
+	}
+	state->secondVeTableInput = Gpio::A0;
+	setMockState(Gpio::A0, true);
+}
+
+TEST(FuelMath, SecondVeTableLoadAxisInheritsPrimaryByDefault) {
+	EngineTestHelper eth(engine_type_e::TEST_ENGINE);
+	MockAirmass dut;
+	EXPECT_CALL(dut.veTable, getValue(_, _)).WillRepeatedly(Return(50));
+	makeSecondVeTableReportItsLoadAxis();
+
+	Sensor::setMockValue(SensorType::Tps1, 20);
+	Sensor::setMockValue(SensorType::Map, 35);
+
+	// nothing overridden anywhere: the second table sees the load it was passed
+	engineConfiguration->veOverrideMode = VE_None;
+	engineConfiguration->secondVeOverrideMode = VE_None;
+	EXPECT_NEAR(0.70f, dut.getVe(1000, 70, false), EPS4D);
+
+	// primary overridden to MAP, second left at None: it inherits MAP, exactly as before #10023
+	engineConfiguration->veOverrideMode = VE_MAP;
+	EXPECT_NEAR(0.35f, dut.getVe(1000, 70, false), EPS4D);
+
+	// same for TPS
+	engineConfiguration->veOverrideMode = VE_TPS;
+	EXPECT_NEAR(0.20f, dut.getVe(1000, 70, false), EPS4D);
+}
+
+TEST(FuelMath, SecondVeTableLoadAxisCanDifferFromPrimary) {
+	EngineTestHelper eth(engine_type_e::TEST_ENGINE);
+	MockAirmass dut;
+	EXPECT_CALL(dut.veTable, getValue(_, _)).WillRepeatedly(Return(50));
+	makeSecondVeTableReportItsLoadAxis();
+
+	Sensor::setMockValue(SensorType::Tps1, 20);
+	Sensor::setMockValue(SensorType::Map, 35);
+
+	// the motivating case: speed density on MAP, second table on TPS for the small-throttle
+	// region where MAP has no resolution
+	engineConfiguration->veOverrideMode = VE_MAP;
+	engineConfiguration->secondVeOverrideMode = VE_TPS;
+	EXPECT_NEAR(0.20f, dut.getVe(1000, 70, false), EPS4D);
+
+	// and the reverse
+	engineConfiguration->veOverrideMode = VE_TPS;
+	engineConfiguration->secondVeOverrideMode = VE_MAP;
+	EXPECT_NEAR(0.35f, dut.getVe(1000, 70, false), EPS4D);
+}
+
+TEST(FuelMath, SecondVeTableLoadAxisAppliesToBlendToo) {
+	EngineTestHelper eth(engine_type_e::TEST_ENGINE);
+	MockAirmass dut;
+	EXPECT_CALL(dut.veTable, getValue(_, _)).WillRepeatedly(Return(50));
+	makeSecondVeTableReportItsLoadAxis();
+
+	// blend rather than hard switch, fully blended onto the second table
+	page4_s* state = secondTablesGetState();
+	state->secondVeTableInput = Gpio::Unassigned;
+	state->secondVeBlendParameter = GPPWM_Tps;
+	setLinearCurve(state->secondVeBlendBins, 0, 100, 1);
+	setLinearCurve(state->secondVeBlendValues, 100, 100, 1);
+
+	Sensor::setMockValue(SensorType::Tps1, 20);
+	Sensor::setMockValue(SensorType::Map, 35);
+
+	engineConfiguration->veOverrideMode = VE_MAP;
+	engineConfiguration->secondVeOverrideMode = VE_TPS;
+	EXPECT_NEAR(0.20f, dut.getVe(1000, 70, false), EPS4D);
+}

--- a/unit_tests/tests/ignition_injection/test_fuel_math.cpp
+++ b/unit_tests/tests/ignition_injection/test_fuel_math.cpp
@@ -738,6 +738,12 @@ TEST(FuelMath, SecondVeTableLoadAxisCanDifferFromPrimary) {
 	engineConfiguration->secondVeOverrideMode = VE_TPS;
 	EXPECT_NEAR(0.20f, dut.getVe(1000, 70, false), EPS4D);
 
+	// the two axes are separately observable: the primary channel still reports the primary's
+	// load, and the second table's own load is published rather than inferred
+	dut.getVe(1000, 70, true);
+	EXPECT_FLOAT_EQ(engine->engineState.veTableYAxis, 35.0f);
+	EXPECT_FLOAT_EQ(engine->engineState.veTableSecondYAxis, 20.0f);
+
 	// and the reverse
 	engineConfiguration->veOverrideMode = VE_TPS;
 	engineConfiguration->secondVeOverrideMode = VE_MAP;


### PR DESCRIPTION
Part of #10023 - this covers the load-axis half of the issue. It does **not** change the air model: `fuelAlgorithm` still picks one globally, so in speed density the airmass is still computed from the measured MAP. Blending SD and Alpha-N air models is a separate change (see the discussion below), so the issue stays open.

## The constraint being removed

`AirmassVeModelBase::getVe()` resolves the load axis **once, globally**:

```cpp
load = getVeLoadAxis(engineConfiguration->veOverrideMode, load);
```

and then uses that same `load` for the primary table *and* the second table — hard switch and blend alike. So the second table can never be indexed by anything other than whatever the primary is using.

That blocks both cases in the issue: speed density on MAP with a second table on TPS for the small-throttle region where MAP collapses into a narrow noisy band on a cammed or ITB engine, and MAP-sensor limp-home, where a pin-switched fallback table indexed by MAP is no help at all.

## Why `VE_None` is the right default, not a new sentinel

My first instinct was that this needed a distinct "same as primary" enum value, because defaulting to `VE_None` would silently change behaviour for anyone already using `veOverrideMode`.

Tracing the function showed that's already solved. `idleVeOverrideMode`, twelve lines below, is passed the **already-overridden** `load`:

```cpp
idleVeLoad = getVeLoadAxis(engineConfiguration->idleVeOverrideMode, load);
```

so `VE_None` there means "inherit whatever the primary resolved to". Using the identical pattern gives `0` → inherit → **bit-identical behaviour for every existing tune**, no new enum, and no migration. It also keeps the second table consistent with how the idle table already behaves.

## Changes

| File | Change |
|---|---|
| `rusefi_config.txt` | `ve_override_e secondVeOverrideMode`, appended at the end of `engine_configuration_s` |
| `airmass.cpp` | Separate `secondVeLoad` used by both second-table lookups; `load` itself untouched, so the primary table, `veBlends`, the idle table and `veTableYAxis` are all unaffected |
| `config_page_4.txt` | `secondVeLoadBins` axis label/scale now follows the second table's own mode, falling back to the primary's when None |
| `secondary_panels.ini` | Field in the existing "Second VE Table" dialog |

The `.ini` axis change matters: without it the axis would keep claiming kPa while the table was indexed by TPS.

I put the scalar in `engine_configuration_s` rather than `page4_s` because page 4 requires custom types to be re-declared locally, and because the other two override modes already live there. Happy to move it if you'd rather it sat with the rest of the second-table config.

## Validation

3 new tests, using the existing `MockAirmass` harness. The second table is filled so the value it returns **is** the load it was indexed with, which makes the axis directly observable rather than inferred:

- inherit: None/None sees the passed load; primary→MAP then primary→TPS are both inherited by the second table (this is the regression guard for existing tunes)
- override: MAP primary + TPS second, and the reverse
- the same applies through the blend path, not just the hard switch

**Full suite: 1169 pass.**

Host build only (MinGW GCC 16.1); no ARM firmware build locally, and not tested on an engine. This is a fuel path, so the inherit-by-default behaviour is the part I'd most want a second pair of eyes on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

