### PR TITLE
Remove the FileLog OS helpers, leaving one implementation

### DIFF
--- a/java_console/autotest/src/main/java/com/rusefi/IoUtil.java
+++ b/java_console/autotest/src/main/java/com/rusefi/IoUtil.java
@@ -1,5 +1,7 @@
 package com.rusefi;
 
+import com.rusefi.core.OsUtil;
+
 import com.devexperts.logging.Logging;
 import com.rusefi.config.generated.Integration;
 import com.rusefi.core.*;
@@ -119,7 +121,7 @@ public class IoUtil {
 
     public static void connectToSimulator(LinkManager linkManager, boolean startProcess) throws InterruptedException {
         if (startProcess) {
-            if (FileLog.isWindows()) {
+            if (OsUtil.isWindows()) {
                 // this check seems not to work on Linux
                 if (!TcpConnector.getAvailablePorts().isEmpty())
                     throw new IllegalStateException("Port already binded on startup?");

--- a/java_console/autotest/src/main/java/com/rusefi/SimulatorExecHelper.java
+++ b/java_console/autotest/src/main/java/com/rusefi/SimulatorExecHelper.java
@@ -1,5 +1,7 @@
 package com.rusefi;
 
+import com.rusefi.core.OsUtil;
+
 import com.devexperts.logging.Logging;
 
 import java.io.BufferedReader;
@@ -29,7 +31,7 @@ public class SimulatorExecHelper {
     private static Process simulatorProcess;
 
     private static String getSimulatorBinary() {
-        return FileLog.isWindows() ? SIMULATOR_BUILD_RUSEFI_SIMULATOR + ".exe" : SIMULATOR_BUILD_RUSEFI_SIMULATOR;
+        return OsUtil.isWindows() ? SIMULATOR_BUILD_RUSEFI_SIMULATOR + ".exe" : SIMULATOR_BUILD_RUSEFI_SIMULATOR;
     }
 
     /**

--- a/java_console/connectivity/src/main/java/com/rusefi/SerialPortScanner.java
+++ b/java_console/connectivity/src/main/java/com/rusefi/SerialPortScanner.java
@@ -1,5 +1,7 @@
 package com.rusefi;
 
+import com.rusefi.core.OsUtil;
+
 import com.devexperts.logging.Logging;
 import com.rusefi.io.LinkManager;
 import org.jetbrains.annotations.NotNull;
@@ -28,7 +30,7 @@ import java.util.stream.Collectors;
 public class SerialPortScanner implements PortScanner {
     private final static Logging log = Logging.getLogging(SerialPortScanner.class);
 
-    private static final boolean SHOW_SOCKETCAN = FileLog.isLinux();
+    private static final boolean SHOW_SOCKETCAN = OsUtil.isLinux();
     private static final long DETECTED_ECU_CACHE_MS = 3000;
 
     /**

--- a/java_console/io/src/main/java/com/rusefi/FileLog.java
+++ b/java_console/io/src/main/java/com/rusefi/FileLog.java
@@ -12,19 +12,8 @@ public class FileLog {
     FileLog() {
     }
 
-    public static boolean isLinux() {
-        return getOsName().equalsIgnoreCase("Linux");
-    }
-
-    public static String getOsName() {
-        return System.getProperty("os.name");
-    }
-
     public static boolean is32bitJava() {
         return System.getProperty("os.arch").contains("86");
     }
 
-    public static boolean isWindows() {
-        return getOsName().contains("Windows");
-    }
 }

--- a/java_console/shared_io/src/main/java/com/rusefi/core/OsUtil.java
+++ b/java_console/shared_io/src/main/java/com/rusefi/core/OsUtil.java
@@ -1,0 +1,26 @@
+package com.rusefi.core;
+
+/**
+ * Host OS checks, in the lowest module that needs them.
+ * <p>
+ * {@code com.rusefi.FileLog} in :ecu_io has had these for years, but :autoupdate and :core_ui sit
+ * below :ecu_io in the dependency graph and cannot reach it, so this is where the single
+ * implementation lives now and FileLog delegates here.
+ */
+public class OsUtil {
+    public static String getOsName() {
+        return System.getProperty("os.name", "");
+    }
+
+    /**
+     * Note the deliberate "Windows" rather than a shorter "win" - the latter also matches
+     * "Darwin", which would tag macOS as Windows.
+     */
+    public static boolean isWindows() {
+        return getOsName().contains("Windows");
+    }
+
+    public static boolean isLinux() {
+        return getOsName().equalsIgnoreCase("Linux");
+    }
+}

--- a/java_console/shared_io/src/test/java/com/rusefi/core/OsUtilTest.java
+++ b/java_console/shared_io/src/test/java/com/rusefi/core/OsUtilTest.java
@@ -1,0 +1,32 @@
+package com.rusefi.core;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class OsUtilTest {
+    /**
+     * "Darwin" contains "win". Matching on the short form would tag macOS as Windows, which is
+     * how the first version of this got it wrong.
+     */
+    @Test
+    void darwinIsNotWindows() {
+        assertFalse("Darwin".contains("Windows"));
+        assertFalse("Mac OS X".contains("Windows"));
+        assertTrue("Windows 11".contains("Windows"));
+        assertTrue("Windows Server 2022".contains("Windows"));
+    }
+
+    @Test
+    void currentHostIsExactlyOneOfThem() {
+        // whatever we are running on, isWindows and isLinux must not both be true
+        assertFalse(OsUtil.isWindows() && OsUtil.isLinux());
+    }
+
+    @Test
+    void osNameIsNeverNull() {
+        // System.getProperty with a default, so callers can chain .contains() safely
+        assertFalse(OsUtil.getOsName() == null);
+    }
+}

--- a/java_console/ui/src/main/java/com/rusefi/DevicePane.java
+++ b/java_console/ui/src/main/java/com/rusefi/DevicePane.java
@@ -1,5 +1,7 @@
 package com.rusefi;
 
+import com.rusefi.core.OsUtil;
+
 import com.rusefi.core.preferences.storage.PersistentConfiguration;
 import com.rusefi.maintenance.DfuFlasher;
 import com.rusefi.maintenance.ProgramSelector;
@@ -182,7 +184,7 @@ public class DevicePane {
 
     static String bootloaderGuidance(final SessionState state) {
         if (state == SessionState.DEVICE_IN_DFU) {
-            if (FileLog.isLinux()) {
+            if (OsUtil.isLinux()) {
                 return "Board is in the DFU bootloader - click Update Firmware to flash with dfu-util.";
             }
             return DfuFlasher.isDfuProgrammingSupported()

--- a/java_console/ui/src/main/java/com/rusefi/PortsComboBox.java
+++ b/java_console/ui/src/main/java/com/rusefi/PortsComboBox.java
@@ -1,5 +1,7 @@
 package com.rusefi;
 
+import com.rusefi.core.OsUtil;
+
 import javax.swing.*;
 
 import static com.rusefi.ui.util.UiUtils.setToolTip;
@@ -8,7 +10,7 @@ public class PortsComboBox {
     private final JComboBox<PortResult> comboPorts = new JComboBox<>();
 
     public PortsComboBox() {
-        if (FileLog.isWindows()) {
+        if (OsUtil.isWindows()) {
             setToolTip(comboPorts, "Use 'Device Manager' icon above to launch Device Manager",
                 "In 'Ports' section look for ",
                 "'STMicroelectronics Virtual COM Port' for USB port",

--- a/java_console/ui/src/main/java/com/rusefi/StartupFrame.java
+++ b/java_console/ui/src/main/java/com/rusefi/StartupFrame.java
@@ -1,5 +1,7 @@
 package com.rusefi;
 
+import com.rusefi.core.OsUtil;
+
 import com.devexperts.logging.Logging;
 import com.opensr5.ConfigurationImage;
 import com.opensr5.ini.IniFileModel;
@@ -300,7 +302,7 @@ public class StartupFrame {
             leftPanel.add(miscPanel);
         }
 
-        if (FileLog.isWindows()) {
+        if (OsUtil.isWindows()) {
             JPanel topButtons = new JPanel(new FlowLayout(FlowLayout.CENTER, 5, 0));
             topButtons.add(ToolButtons.createShowDeviceManagerButton());
             if (DriverInstall.isFolderExist())

--- a/java_console/ui/src/main/java/com/rusefi/maintenance/DfuFlasher.java
+++ b/java_console/ui/src/main/java/com/rusefi/maintenance/DfuFlasher.java
@@ -1,5 +1,7 @@
 package com.rusefi.maintenance;
 
+import com.rusefi.core.OsUtil;
+
 import com.rusefi.*;
 import com.rusefi.autodetect.PortDetector;
 import com.rusefi.autodetect.SerialAutoChecker;
@@ -49,7 +51,7 @@ public class DfuFlasher {
     }
 
     public static boolean isDfuProgrammingSupported() {
-        return FileLog.isWindows() || FileLog.isLinux();
+        return OsUtil.isWindows() || OsUtil.isLinux();
     }
 
     public static boolean doAutoDfu(
@@ -105,12 +107,12 @@ public class DfuFlasher {
         }
 
         if (!isDfuProgrammingSupported()) {
-            callbacks.logLine("DFU programming is not supported on " + FileLog.getOsName());
+            callbacks.logLine("DFU programming is not supported on " + OsUtil.getOsName());
             return false;
         }
 
         // Do not reboot a working ECU into DFU if the external Linux programmer is unavailable.
-        if (FileLog.isLinux() && !executeDfuUtilCommand(getDfuUtilVersionCommand(), callbacks)) {
+        if (OsUtil.isLinux() && !executeDfuUtilCommand(getDfuUtilVersionCommand(), callbacks)) {
             return false;
         }
 
@@ -200,15 +202,15 @@ public class DfuFlasher {
     }
 
     private static void runDfuErase(UpdateOperationCallbacks callbacks) {
-        if (FileLog.isLinux()) {
+        if (OsUtil.isLinux()) {
             if (!executeDfuUtilCommand(getDfuUtilEraseCommand(), callbacks)) {
                 callbacks.error();
             }
             return;
         }
 
-        if (!FileLog.isWindows()) {
-            callbacks.logLine("DFU erase is not supported on " + FileLog.getOsName());
+        if (!OsUtil.isWindows()) {
+            callbacks.logLine("DFU erase is not supported on " + OsUtil.getOsName());
             callbacks.error();
             return;
         }
@@ -268,7 +270,7 @@ public class DfuFlasher {
     private static boolean executeDFU(UpdateOperationCallbacks callbacks, String firmwareBinFile,
                                        ConnectedEcuTarget connectedEcuTarget) {
         if (!isDfuProgrammingSupported()) {
-            callbacks.logLine("DFU programming is not supported on " + FileLog.getOsName());
+            callbacks.logLine("DFU programming is not supported on " + OsUtil.getOsName());
             return false;
         }
 
@@ -279,7 +281,7 @@ public class DfuFlasher {
         }
         boolean driverIsHappy = detectSTM32BootloaderDriverState(callbacks, connectedEcuTarget);
         if (!driverIsHappy) {
-            if (FileLog.isLinux()) {
+            if (OsUtil.isLinux()) {
                 callbacks.logLine("STM32 DFU device 0483:df11 was not detected. Check the USB connection and lsusb access.");
             } else {
                 callbacks.logLine("*** DRIVER ERROR? *** Did you have a chance to try 'Install Drivers' button on top of rusEFI console start screen?");
@@ -287,7 +289,7 @@ public class DfuFlasher {
             return false;
         }
 
-        if (FileLog.isLinux()) {
+        if (OsUtil.isLinux()) {
             if (!executeDfuUtilCommand(getDfuUtilWriteCommand(firmwareBinFile), callbacks)) {
                 return false;
             }
@@ -329,11 +331,11 @@ public class DfuFlasher {
 
     public static boolean detectSTM32BootloaderDriverState(UpdateOperationCallbacks callbacks,
                                                            ConnectedEcuTarget connectedEcuTarget) {
-        if (!FileLog.isWindows()) {
+        if (!OsUtil.isWindows()) {
             // The WMIC/driver check below is Windows-only. On Linux the STM32 system bootloader is
             // visible directly over USB as 0483:df11 ("STM Device in DFU Mode"), so probe lsusb so the
             // console reflects the DFU state before the Linux dfu-util flasher runs.
-            return FileLog.isLinux() && detectStm32DfuViaLsusb(callbacks);
+            return OsUtil.isLinux() && detectStm32DfuViaLsusb(callbacks);
         }
         // #9714: a universal bundle's is_h7 property can't cover every board, so trust the connected
         // ECU's target first (e.g. "uaefi_pro_h7"), falling back to the bundled is_h7 property.

--- a/java_console/ui/src/main/java/com/rusefi/maintenance/DriverInstall.java
+++ b/java_console/ui/src/main/java/com/rusefi/maintenance/DriverInstall.java
@@ -1,5 +1,7 @@
 package com.rusefi.maintenance;
 
+import com.rusefi.core.OsUtil;
+
 import com.devexperts.logging.Logging;
 import com.rusefi.FileLog;
 import com.rusefi.io.UpdateOperationCallbacks;
@@ -49,7 +51,7 @@ public class DriverInstall {
     }
 
     private static void installDrivers(UpdateOperationCallbacks wnd) {
-        log.info("IsWindows=" + FileLog.isWindows());
+        log.info("IsWindows=" + OsUtil.isWindows());
         if (!new File(FOLDER).exists()) {
             String message = FOLDER + " not found";
             wnd.logLine(message);

--- a/java_console/ui/src/main/java/com/rusefi/maintenance/MaintenanceUtil.java
+++ b/java_console/ui/src/main/java/com/rusefi/maintenance/MaintenanceUtil.java
@@ -1,7 +1,8 @@
 package com.rusefi.maintenance;
 
+import com.rusefi.core.OsUtil;
+
 import com.devexperts.logging.Logging;
-import com.rusefi.FileLog;
 import com.rusefi.autoupdate.Autoupdate;
 import com.rusefi.core.FindFileHelper;
 import com.rusefi.core.io.BoardCompatibility;
@@ -20,7 +21,7 @@ public class MaintenanceUtil {
     private static final String WMIC_PCAN_QUERY_COMMAND = "powershell -NoProfile -Command \"Get-CimInstance Win32_PnPEntity -Filter \\\"Caption like '%PCAN-USB%'\\\" | Select-Object Caption, ConfigManagerErrorCode | Format-List\"";
 
     static boolean detectDevice(UpdateOperationCallbacks callbacks, String queryCommand, String pattern) throws ErrorExecutingCommand {
-        if (!FileLog.isWindows()) {
+        if (!OsUtil.isWindows()) {
             return false;
         }
         long now = System.currentTimeMillis();

--- a/java_console/ui/src/main/java/com/rusefi/maintenance/ProgramSelector.java
+++ b/java_console/ui/src/main/java/com/rusefi/maintenance/ProgramSelector.java
@@ -1,5 +1,7 @@
 package com.rusefi.maintenance;
 
+import com.rusefi.core.OsUtil;
+
 import com.devexperts.logging.Logging;
 import com.fazecast.jSerialComm.SerialPort;
 import com.rusefi.*;
@@ -589,7 +591,7 @@ public class ProgramSelector {
             }
         }
 
-        if (FileLog.isWindows()) {
+        if (OsUtil.isWindows()) {
             if (!requireBlt && currentHardware.isStLinkConnected()) {
                 addMenuItem(popupMenu, ST_LINK);
             }

--- a/java_console/ui/src/main/java/com/rusefi/tools/ConsoleTools.java
+++ b/java_console/ui/src/main/java/com/rusefi/tools/ConsoleTools.java
@@ -1,5 +1,7 @@
 package com.rusefi.tools;
 
+import com.rusefi.core.OsUtil;
+
 import com.devexperts.logging.Logging;
 import com.opensr5.ConfigurationImage;
 import com.opensr5.io.ConfigurationImageFile;
@@ -70,7 +72,7 @@ public class ConsoleTools {
             PCanIoStream stream = PCanIoStream.createStream();
             CANConnectorStartup.start(stream, statusListener);
         }, "Connect your rusEFI ECU using PCAN CAN-bus adapter");
-        if (!FileLog.isWindows()) {
+        if (!OsUtil.isWindows()) {
             registerTool("socketcan_connector", strings -> CANConnectorStartup.start(SocketCANIoStream.create(), statusListener), "Connect your rusEFI ECU using SocketCAN CAN-bus adapter");
         }
         registerTool("print_auth_token", args -> printAuthToken(), "Print current rusEFI Online authentication token.");

--- a/java_console/ui/src/main/java/com/rusefi/tools/TunerStudioHelper.java
+++ b/java_console/ui/src/main/java/com/rusefi/tools/TunerStudioHelper.java
@@ -1,7 +1,8 @@
 package com.rusefi.tools;
 
+import com.rusefi.core.OsUtil;
+
 import com.devexperts.logging.Logging;
-import com.rusefi.FileLog;
 import com.rusefi.NamedThreadFactory;
 
 import com.rusefi.StartupFrame;
@@ -107,7 +108,7 @@ public class TunerStudioHelper {
 
         JFileChooser chooser = new JFileChooser();
         chooser.setDialogTitle("Locate TunerStudio executable");
-        if (FileLog.isWindows()) {
+        if (OsUtil.isWindows()) {
             chooser.setFileFilter(new FileNameExtensionFilter("Executables (*.exe)", "exe"));
             File pf = new File(System.getenv().getOrDefault("ProgramFiles", "C:\\Program Files"));
             if (pf.isDirectory()) chooser.setCurrentDirectory(pf);
@@ -121,7 +122,7 @@ public class TunerStudioHelper {
 
     private static List<String> defaultTsCandidatePaths() {
         String home = System.getProperty("user.home");
-        if (FileLog.isWindows()) {
+        if (OsUtil.isWindows()) {
             String pf = System.getenv().getOrDefault("ProgramFiles", "C:\\Program Files");
             String pf86 = System.getenv().getOrDefault("ProgramFiles(x86)", "C:\\Program Files (x86)");
             return Arrays.asList(
@@ -131,7 +132,7 @@ public class TunerStudioHelper {
                 pf86 + "\\TunerStudioMS\\TunerStudio.exe"
             );
         }
-        if (FileLog.isLinux()) {
+        if (OsUtil.isLinux()) {
             return Arrays.asList(
                 home + "/TunerStudioMS/TunerStudio.sh",
                 home + "/.TunerStudioMS/TunerStudio.sh",
@@ -148,7 +149,7 @@ public class TunerStudioHelper {
     }
 
     public static boolean isTsRunning() {
-        if (!FileLog.isWindows())
+        if (!OsUtil.isWindows())
             return false;
         try {
             Process powerShellProcess = Runtime.getRuntime().exec("powershell \"" + FIND_TS_PROCESS + "\"");

--- a/java_console/ui/src/main/java/com/rusefi/ui/basic/UiHelper.java
+++ b/java_console/ui/src/main/java/com/rusefi/ui/basic/UiHelper.java
@@ -1,5 +1,7 @@
 package com.rusefi.ui.basic;
 
+import com.rusefi.core.OsUtil;
+
 import com.devexperts.logging.Logging;
 import com.formdev.flatlaf.FlatDarkLaf;
 import com.formdev.flatlaf.FlatLightLaf;
@@ -16,7 +18,7 @@ public class UiHelper {
     private static final Logging log = getLogging(UiHelper.class);
 
     public static void commonUiStartup() {
-        log.info("OS name: " + FileLog.getOsName());
+        log.info("OS name: " + OsUtil.getOsName());
         log.info("OS version: " + System.getProperty(FileLog.OS_VERSION));
 
         try {

--- a/java_console/ui/src/main/java/com/rusefi/ui/widgets/StatusPanel.java
+++ b/java_console/ui/src/main/java/com/rusefi/ui/widgets/StatusPanel.java
@@ -1,7 +1,8 @@
 package com.rusefi.ui.widgets;
 
+import com.rusefi.core.OsUtil;
+
 import com.devexperts.logging.Logging;
-import com.rusefi.FileLog;
 import com.rusefi.UiVersion;
 import com.rusefi.core.io.BundleUtil;
 import com.rusefi.io.UpdateOperationCallbacks;
@@ -82,7 +83,7 @@ public class StatusPanel extends JPanel implements UpdateOperationCallbacks {
         logTextArea.setText("");
         logTextArea.setBackground(Color.WHITE);
         logLine("Console version " + UiVersion.CONSOLE_VERSION);
-        log.info(FileLog.getOsName() + " " + System.getProperty("os.version"));
+        log.info(OsUtil.getOsName() + " " + System.getProperty("os.version"));
         logLine("Bundle " + BundleUtil.readBundleFullNameNotNull());
     }
 

--- a/java_console/ui/src/test/java/com/rusefi/DevicePaneTest.java
+++ b/java_console/ui/src/test/java/com/rusefi/DevicePaneTest.java
@@ -1,5 +1,7 @@
 package com.rusefi;
 
+import com.rusefi.core.OsUtil;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -27,10 +29,10 @@ public class DevicePaneTest {
     public void dfuGuidanceMentionsDfuAndReflectsPlatformSupport() {
         String guidance = DevicePane.bootloaderGuidance(SessionState.DEVICE_IN_DFU);
         assertTrue(guidance.contains("DFU"), guidance);
-        if (FileLog.isLinux()) {
+        if (OsUtil.isLinux()) {
             assertTrue(guidance.contains("dfu-util"), guidance);
             assertTrue(guidance.contains("Update Firmware"), guidance);
-        } else if (FileLog.isWindows()) {
+        } else if (OsUtil.isWindows()) {
             assertTrue(guidance.contains("Update Firmware"), guidance);
         } else {
             assertTrue(guidance.contains("not supported"), guidance);


### PR DESCRIPTION
Split out of #10081 at @FDSoftware's request — that PR should stay a Linux launcher fix.

> last commits should be on a separate pr, but seem ok the rest

**Depends on #10081**, which introduces `com.rusefi.core.OsUtil` in `:shared_io`. Happy to rebase once that lands, or to fold this in if you would rather take them together.

## What this does

#10081 added `OsUtil` and left `FileLog#isWindows`/`isLinux`/`getOsName` delegating to it, so existing callers were untouched. @FDSoftware's point was that a delegating wrapper is still two entry points:

> since "moved" from `ecu_io` to `shared_io` i will expect to be removed the now old copy so we have only one implementation of this

So this deletes those three methods and moves all 15 call sites onto `OsUtil` directly:

| Module | Files |
|---|---|
| `:ui` | `DfuFlasher`, `DriverInstall`, `MaintenanceUtil`, `ProgramSelector`, `PortsComboBox`, `StartupFrame`, `ConsoleTools`, `TunerStudioHelper`, `UiHelper`, `StatusPanel`, `DevicePane`, `DevicePaneTest` |
| `:autotest` | `IoUtil`, `SimulatorExecHelper` |
| `:connectivity` | `SerialPortScanner` |

Verified nothing references the old ones:

```
$ grep -rn 'FileLog\.\(isWindows\|isLinux\|getOsName\)' --include=*.java java_console java_tools
(no matches)
```

`:ui:shadowJar`, `:autotest`, `:connectivity`, `:autoupdate`, `:core_ui` and `:shared_io` all build and test clean.

## What I deliberately left alone

`FileLog` keeps `is32bitJava()` and `OS_VERSION`. Those read `os.arch` and `os.version` rather than `os.name`, so they were never duplicated and moving them is a separate decision. That does leave `FileLog` as a two-member class whose own comment has been asking *"what the hell is this anyway? rename this utility class?"* since 2013 — say the word and I will finish the job in another PR rather than deciding that for you here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
