### PR TITLE
fix "RE console: some gauges do not have units under them"

### DIFF
--- a/java_console/io/src/main/java/com/rusefi/core/SensorCentral.java
+++ b/java_console/io/src/main/java/com/rusefi/core/SensorCentral.java
@@ -151,7 +151,9 @@ public class SensorCentral implements ISensorCentral {
 
     @Override
     public void onGaugeLabelsResolved(Map<String, ResolvedGaugeLabels> labels) {
-        this.resolvedGaugeLabels = labels;
+        Map<String, ResolvedGaugeLabels> normalizedLabels = new LowercaseHashMap<>();
+        normalizedLabels.putAll(labels);
+        this.resolvedGaugeLabels = normalizedLabels;
     }
 
     /**

--- a/java_console/io/src/test/java/com/rusefi/core/SensorCentralTest.java
+++ b/java_console/io/src/test/java/com/rusefi/core/SensorCentralTest.java
@@ -268,10 +268,10 @@ public class SensorCentralTest {
     @Test
     void onGaugeLabelsResolvedStoresLabels() {
         Map<String, ISensorHolder.ResolvedGaugeLabels> labels = Collections.singletonMap(
-                "somegauge", new ISensorHolder.ResolvedGaugeLabels("Title", "Units"));
+                "someGauge", new ISensorHolder.ResolvedGaugeLabels("Title", "Units"));
         sensorCentral.onGaugeLabelsResolved(labels);
 
-        assertSame(labels, sensorCentral.getResolvedGaugeLabels());
+        assertEquals(1, sensorCentral.getResolvedGaugeLabels().size());
         ISensorHolder.ResolvedGaugeLabels resolved = sensorCentral.getResolvedLabels("someGauge");
         assertNotNull(resolved);
         assertEquals("Title", resolved.getTitle());


### PR DESCRIPTION
resolves #9989
<img width="1280" height="150" alt="image" src="https://github.com/user-attachments/assets/8bfd98f7-569f-4ee9-9efb-23d0ea18d332" />
