### PR TITLE
Initialize two members that are only zero by accident of static storage

### DIFF
--- a/firmware/controllers/long_term_fuel_trim.h
+++ b/firmware/controllers/long_term_fuel_trim.h
@@ -41,7 +41,9 @@ public:
 	void fillRandom();
 
 private:
-	LtftState *m_state;
+	// only init() ever writes this, and store() null-checks it - that guard is only meaningful
+	// if the pointer starts null rather than relying on the instance living at file scope
+	LtftState *m_state = nullptr;
 	// TODO: move to livedata and kill isVeUpdated() ?
 	bool veNeedRefresh = false;
 	bool showUpdateToUser = false;

--- a/firmware/controllers/modules/tachometer/tachometer.h
+++ b/firmware/controllers/modules/tachometer/tachometer.h
@@ -13,5 +13,7 @@ public:
     void init();
     void onFastCallback() override;
 private:
-    bool tachHasInit;
+    // onFastCallback() gates everything on this flag while only init() writes it, so it has to
+    // start false rather than depend on the instance being zero initialized at file scope
+    bool tachHasInit = false;
 };

--- a/unit_tests/tests/test_uninitialized_members.cpp
+++ b/unit_tests/tests/test_uninitialized_members.cpp
@@ -1,0 +1,49 @@
+/**
+ * @file test_uninitialized_members.cpp
+ *
+ * Engine modules live inside the global Engine, so the compiler zero initializes their members
+ * whether or not they carry an initializer. Several classes lean on that: they null-check or
+ * flag-check a member which is only ever written by init().
+ *
+ * That holds right up until someone constructs one somewhere other than file scope - which is
+ * exactly what a unit test does. GearControllerBase::transmissionController was the same shape and
+ * segfaulted the test binary (see the #6380 work); these pin the contract so the next one does not.
+ */
+
+#include "pch.h"
+
+#include "long_term_fuel_trim.h"
+#include "tachometer.h"
+
+
+
+/**
+ * TachometerModule::onFastCallback() gates all of its behaviour on tachHasInit, which only init()
+ * writes. A stack instance must therefore do nothing at all rather than act on a garbage flag.
+ */
+TEST(UninitializedMembers, tachometerIsInertBeforeInit) {
+	EngineTestHelper eth(engine_type_e::TEST_ENGINE);
+
+	TachometerModule dut;
+
+	// no init() call - the module must treat itself as disabled
+	dut.onFastCallback();
+	dut.onFastCallback();
+
+	SUCCEED() << "onFastCallback() before init() must be a no-op, not a read of an indeterminate flag";
+}
+
+/**
+ * LongTermFuelTrim::store() null-checks m_state, which only init() writes. The guard is only
+ * meaningful if the pointer starts null.
+ */
+TEST(UninitializedMembers, ltftStoreIsSafeBeforeInit) {
+	EngineTestHelper eth(engine_type_e::TEST_ENGINE);
+
+	LongTermFuelTrim dut;
+
+	// no init() call - store() must take its null branch rather than dereference garbage
+	dut.store();
+
+	SUCCEED() << "store() before init() must hit its null guard";
+}

--- a/unit_tests/tests/tests.mk
+++ b/unit_tests/tests/tests.mk
@@ -157,6 +157,7 @@ TESTS_SRC_CPP = \
 	tests/test_sd_log_trigger.cpp \
 	tests/test_gpiochip.cpp \
 	tests/test_deadband.cpp \
+	tests/test_uninitialized_members.cpp \
 	tests/test_sticky_pps.cpp \
 	tests/test_knock.cpp \
 	tests/test_misfire_detection.cpp \


### PR DESCRIPTION
Found by scanning for the pattern behind the `GearControllerBase::transmissionController` segfault in #6380 — a member that gets null-checked or flag-checked but has no initializer.

**Read the caveat before the findings: I could not reproduce a failure for either of these.**

## The two

**`LongTermFuelTrim::m_state`** (`long_term_fuel_trim.h:44`) — written only by `init()`, and `store()` guards on it:

```cpp
if (m_state) {
    m_state->save();
}
```

That guard is only meaningful if the pointer starts null. It does — but only because `LongTermFuelTrim` is an engine module (`engine.h:199`) living inside the global `Engine`.

**`TachometerModule::tachHasInit`** (`tachometer.h:16`) — `onFastCallback()` gates *all* behaviour on it:

```cpp
if (!tachHasInit) { return; }
```

Same story: written only by `init()`, zero only by static storage.

## The caveat, stated plainly

I wrote the tests first, ran them against unfixed code, and **they passed** — isolated and in the full suite. I then deliberately poisoned the stack with `0xA5` before construction to try to make the read observable. **They still passed.**

So this is defensive correctness, not a reproduced defect. The justification is that reading an uninitialized member is UB regardless of what it happens to return, and that this exact shape *did* manifest as a segfault in #6380 — that one passed in isolation and crashed once earlier tests had dirtied the stack. In production both members already read as zero, so behaviour is unchanged either way.

If you think that is too thin a reason to touch working code, that is a fair call and I will close it.

## What the tests are for

They construct each module on the stack and assert the pre-init contract holds. The value is not catching today's bug — it is that whoever writes real coverage for these modules does not walk into what #6380 walked into.

**Full suite: 1170 pass.**

## Separate observation, deliberately not changed

`m_state` is dereferenced **unguarded** by `load()`, `learn()`, `getTrims()`, `reset()`, `applyTrimsToVe()` and `fillRandom()`. Only `store()` checks it.

`storage.cpp` reaches both sides — `store()` at :103 and `load()` at :128 — from the message-driven storage loop, while `initLtft()` runs from `engine_controller.cpp:501`. If that lone guard was added because someone actually hit a null on the write path, the read path may want the same treatment.

I have **not** traced whether the storage thread can process a read before `initLtft()` returns, and I have not added guards — doing so could mask an ordering bug rather than fix it. Flagging it for someone who knows the intended sequence.

Host build only (MinGW GCC 16.1); no ARM build locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
