### PR TITLE
Fix: bound the ISO-TP single-frame length (out-of-bounds read)

### DIFF
--- a/firmware/controllers/can/isotp/isotp.cpp
+++ b/firmware/controllers/can/isotp/isotp.cpp
@@ -104,11 +104,18 @@ int CanStreamerState::receiveFrame(const CANRxFrame &rxmsg, uint8_t *destination
 	int numBytesAvailable, frameIdx;
 	const uint8_t *srcBuf;
 	switch (frameType) {
-	case ISO_TP_FRAME_SINGLE:
-		numBytesAvailable = rxmsg.data8[isoHeaderByteIndex] & 0xf;
+	case ISO_TP_FRAME_SINGLE: {
+		// The low nibble is the single-frame data length and can encode up to 15, but the frame
+		// only carries DLC bytes - and DLC is itself a 4-bit field, so a malformed frame can claim
+		// more than data8[] is wide. Bound the length by both before copying, the same way the
+		// FIRST and CONSECUTIVE branches below bound their own reads. Well-formed single frames
+		// always satisfy SF_DL <= DLC - 1, so they are unaffected.
+		int payloadBytes = minI(rxmsg.DLC, (int)sizeof(rxmsg.data8)) - 1 - (int)isoHeaderByteIndex;
+		numBytesAvailable = minI(rxmsg.data8[isoHeaderByteIndex] & 0xf, payloadBytes);
 		this->waitingForNumBytes = numBytesAvailable;
 		srcBuf = rxmsg.data8 + 1 + isoHeaderByteIndex;
 		break;
+	}
 	case ISO_TP_FRAME_FIRST:
 		this->waitingForNumBytes = ((rxmsg.data8[isoHeaderByteIndex] & 0xf) << 8) | rxmsg.data8[isoHeaderByteIndex + 1];
 		this->waitingForFrameIndex = 1;

--- a/unit_tests/tests/controllers/can/test_can_serial.cpp
+++ b/unit_tests/tests/controllers/can/test_can_serial.cpp
@@ -230,12 +230,9 @@ TEST(testCanSerial, test64_7Message) {
  *
  * A single frame carries its payload length in the low nibble of the PCI byte, so it can encode up
  * to 15 - but a classic-CAN frame only delivers DLC bytes and CANRxFrame::data8 is 8 bytes wide.
- * receiveFrame() takes that nibble at face value and copies that many bytes from data8 + 1, so a
- * malformed frame makes it read past the end of the payload. DLC itself is only a 4-bit field, so
- * a frame can also claim DLC > 8, which is equally unchecked.
- *
- * These tests document CURRENT behavior: the claimed length is used verbatim. Once the length is
- * bounded by what the frame actually holds, expect 7 (DLC - 1) in both cases.
+ * receiveFrame() used to take that nibble at face value and copy that many bytes from data8 + 1,
+ * reading past the end of the payload. DLC itself is only a 4-bit field, so a frame can also claim
+ * DLC > 8, which was equally unchecked. The length is now bounded by both.
  *
  * The frame is embedded in a padded wrapper so that the over-read this deliberately provokes lands
  * inside memory the test owns - otherwise it is a stack-buffer-overflow and AddressSanitizer (on by
@@ -256,7 +253,7 @@ void assertOverreadStaysInsidePaddedFrame(const PaddedRxFrame& padded) {
 }
 } // namespace
 
-TEST(testCanSerial, singleFrameLengthIsNotBoundedByDlc) {
+TEST(testCanSerial, singleFrameLengthIsBoundedByDlc) {
 	EngineTestHelper eth(engine_type_e::TEST_ENGINE);
 
 	TestCanStreamerState state;
@@ -273,11 +270,11 @@ TEST(testCanSerial, singleFrameLengthIsNotBoundedByDlc) {
 	assertOverreadStaysInsidePaddedFrame(padded);
 	int copied = state.receiveFrame(padded.frame, rxbuf, sizeof(rxbuf), 0);
 
-	// the claimed 15 bytes are copied even though only 7 payload bytes exist
-	EXPECT_EQ(15, copied);
+	// clamped to the 7 payload bytes the frame actually carries
+	EXPECT_EQ(7, copied);
 }
 
-TEST(testCanSerial, singleFrameLengthIsNotBoundedByPayloadSize) {
+TEST(testCanSerial, singleFrameLengthIsBoundedByPayloadSize) {
 	EngineTestHelper eth(engine_type_e::TEST_ENGINE);
 
 	TestCanStreamerState state;
@@ -294,8 +291,8 @@ TEST(testCanSerial, singleFrameLengthIsNotBoundedByPayloadSize) {
 	assertOverreadStaysInsidePaddedFrame(padded);
 	int copied = state.receiveFrame(padded.frame, rxbuf, sizeof(rxbuf), 0);
 
-	// nothing bounds the copy to sizeof(data8) either
-	EXPECT_EQ(15, copied);
+	// clamped to sizeof(data8) - 1 even though DLC claims more
+	EXPECT_EQ(7, copied);
 }
 
 TEST(testCanSerial, test3_64_4Message) {


### PR DESCRIPTION
Second of two, per [TDB](https://github.com/rusefi/rusefi/wiki/TDB-Test-Driven-Bugfixing). **Merge #10101 (coverage) first** — this PR is stacked on it and currently carries its commit too; once #10101 lands I will rebase so this is the fix alone.

## The fix

Bound the single-frame data length by what the frame actually carries, using the same `minI()` that the FIRST and CONSECUTIVE branches already apply to their own reads:

```cpp
int payloadBytes = minI(rxmsg.DLC, (int)sizeof(rxmsg.data8)) - 1 - (int)isoHeaderByteIndex;
numBytesAvailable = minI(rxmsg.data8[isoHeaderByteIndex] & 0xf, payloadBytes);
```

**Both bounds are needed:**
- `DLC` alone is not enough — it is a 4-bit field, so a malformed frame can claim up to 15 while `data8[]` is 8 bytes wide (the second coverage case).
- `sizeof(data8)` alone is not enough — a short frame carries fewer bytes than the array is wide.

Taking the minimum of the two, minus the PCI byte and any vendor header byte, is the number of payload bytes that really exist. `payloadBytes` cannot go negative: `receiveFrame()` already returns early unless `DLC >= 1 + isoHeaderByteIndex`.

## Coverage adjustment (the proof)

| coverage test | #10101 asserts | after this fix |
|---|---|---|
| `singleFrameLength...ByDlc` | 15 copied | **7** copied |
| `singleFrameLength...ByPayloadSize` | 15 copied | **7** copied |

Renamed `IsNotBoundedBy...` → `IsBoundedBy...` accordingly.

## Safety / regression

No engine-control path — this is the diagnostic/TS transport. The clamp only ever *reduces* the copied length, and only for frames that were already malformed: well-formed single frames always satisfy `SF_DL <= DLC - 1`. The six pre-existing `testCanSerial` round-trip tests (`test1Frame`, `test2Frames`, `testIrregularSplits`, `testLongMessage`, `test64_7Message`, `test3_64_4Message`) pass unchanged, which is the evidence for that.

The FIRST branch (offset `2 + header`, capped at `6 - header`) and CONSECUTIVE branch (offset `1 + header`, capped at `7 - header`) stay within the array by construction and are untouched.

## Validation

```
cd unit_tests && make -j12 && ./build/rusefi_test.exe    1170 tests pass
```
Firmware/simulator builds left to CI (no 32-bit MinGW/ARM toolchain locally).