### PR TITLE
Fix: findBaudIndex restores the configured console speed

### DIFF
--- a/firmware/console/binary/bluetooth.cpp
+++ b/firmware/console/binary/bluetooth.cpp
@@ -236,12 +236,6 @@ uint8_t findBaudIndex(SerialTsChannelBase* tsChannel) {
 		tsChannel->stop();
 		chThdSleepMilliseconds(10);	// safety
 
-		if (baudIdx == efi::size(baudRates)) {
-			efiPrintf("Failed to find current BT module baudrate");
-			tsChannel->start(engineConfiguration->tunerStudioSerialSpeed);
-			return 255;//failed
-		}
-
 		efiPrintf("Restarting at %lu", baudRates[baudIdx].rate);
 		tsChannel->start(baudRates[baudIdx].rate);
 		chThdSleepMilliseconds(10);	// safety
@@ -269,6 +263,16 @@ uint8_t findBaudIndex(SerialTsChannelBase* tsChannel) {
 		}
 		/* try next baudrate */
 	}
+
+	// None of the known baud rates responded. The channel is currently running at the last probe
+	// rate, so restore the configured console/TS speed before giving up - otherwise a failed setup
+	// attempt leaves the serial link at the wrong baud until reboot. This recovery used to sit
+	// inside the loop above, guarded by baudIdx == efi::size(baudRates), which the loop condition
+	// makes unreachable.
+	efiPrintf("Failed to find current BT module baudrate");
+	tsChannel->stop();
+	chThdSleepMilliseconds(10);	// safety
+	tsChannel->start(engineConfiguration->tunerStudioSerialSpeed);
 	return 255;//failed
 }
 

--- a/unit_tests/tests/test_bluetooth.cpp
+++ b/unit_tests/tests/test_bluetooth.cpp
@@ -56,16 +56,12 @@ public:
 /**
  * Coverage for findBaudIndex() when no Bluetooth module answers at any known baud rate.
  *
- * The function is supposed to put the serial link back to the configured console/TS speed before
- * giving up - that recovery exists, but it sits INSIDE the probe loop guarded by
- * `baudIdx == efi::size(baudRates)`, while the loop condition is `baudIdx < efi::size(baudRates)`.
- * The branch is therefore unreachable and never runs, so the channel is left started at the last
- * probed rate (57600) until the ECU is rebooted.
- *
- * This test documents CURRENT behavior. Once the recovery is reachable, expect the channel to be
- * left at engineConfiguration->tunerStudioSerialSpeed instead.
+ * The recovery that puts the serial link back to the configured console/TS speed used to sit
+ * INSIDE the probe loop guarded by `baudIdx == efi::size(baudRates)`, while the loop condition is
+ * `baudIdx < efi::size(baudRates)` - unreachable, so it never ran and the channel was left started
+ * at the last probed rate (57600) until the ECU was rebooted. It now runs after the loop.
  */
-TEST(bluetooth, findBaudIndexLeavesChannelAtLastProbedRate) {
+TEST(bluetooth, findBaudIndexRestoresConsoleSpeedWhenNoModuleResponds) {
 	EngineTestHelper eth(engine_type_e::TEST_ENGINE);
 
 	btModuleType = BLUETOOTH_HC_05;
@@ -79,6 +75,6 @@ TEST(bluetooth, findBaudIndexLeavesChannelAtLastProbedRate) {
 
 	// no module answered
 	EXPECT_EQ(255, result);
-	// the configured speed was never restored - the link is stuck on the last entry of baudRates[]
-	EXPECT_EQ(57600u, channel.lastStartedBaud);
+	// and the link is restored to the configured speed, not left on the last entry of baudRates[]
+	EXPECT_EQ(250000u, channel.lastStartedBaud);
 }


### PR DESCRIPTION
Second of two, per [TDB](https://github.com/rusefi/rusefi/wiki/TDB-Test-Driven-Bugfixing). **Merge #10102 (coverage) first** — this PR is stacked on it and currently carries its commit too; once #10102 lands I will rebase so this is the fix alone.

## The fix

The recovery that restores the configured console/TS speed is unreachable: it sits inside `for (baudIdx = 0; baudIdx < efi::size(baudRates); baudIdx++)` guarded by `baudIdx == efi::size(baudRates)`, which is never true inside the loop body. On a total probe failure the function fell through to a bare `return 255` with the channel still started at the last probe rate (57600).

Moved to after the loop, where it is reached: stop the channel and restart it at `engineConfiguration->tunerStudioSerialSpeed` before returning 255.

## Impact

A failed `bluetooth_<module>` setup attempt (wrong module, module not answering AT, already-configured module in a silent mode) left the serial console/TS link at 57600 instead of the configured speed, until the ECU was rebooted.

## Coverage adjustment (the proof)

`findBaudIndexLeavesChannelAtLastProbedRate` (asserts 57600 in #10102) becomes `findBaudIndexRestoresConsoleSpeedWhenNoModuleResponds` (asserts 250000, the configured speed).

## Safety / regression

No engine-control path. The success paths are unchanged — when a baud rate answers, the channel is still left at the found rate for the caller, exactly as before. The only behavioural change is on the total-failure branch of a manually-invoked setup command, and it restores the documented intent.

## Validation

```
cd unit_tests && make -j12 && ./build/rusefi_test.exe    1169 tests pass
```
Firmware builds left to CI (no ARM toolchain locally).