### PR TITLE
Bluetooth: set up the module from TunerStudio, not just a console command

### DIFF
--- a/firmware/console/binary/bluetooth.cpp
+++ b/firmware/console/binary/bluetooth.cpp
@@ -334,6 +334,38 @@ void bluetoothStart(bluetooth_module_e moduleType, const char *baudRate, const c
 	btSetupIsRequested = true;
 }
 
+// Ascending, indexed by bluetooth_baud_e (the btBaudRate config field).
+static const uint32_t btBaudRateValues[] = { 2400, 4800, 9600, 19200, 38400, 57600, 115200 };
+
+void bluetoothStartFromConfiguration() {
+	uint8_t baudIndex = (uint8_t)engineConfiguration->btBaudRate;
+	if (baudIndex >= efi::size(btBaudRateValues)) {
+		efiPrintf("Invalid Bluetooth baud selection %d", baudIndex);
+		return;
+	}
+
+	char baudStr[8];
+	chsnprintf(baudStr, sizeof(baudStr), "%lu", (unsigned long)btBaudRateValues[baudIndex]);
+
+	// The config strings are fixed-width and are not guaranteed to be null-terminated when fully
+	// used, so copy into a local buffer with room for the terminator before handing them off.
+	char name[BT_NAME_SIZE + 1];
+	char pin[BT_PIN_SIZE + 1];
+	memcpy(name, engineConfiguration->btName, BT_NAME_SIZE);
+	name[BT_NAME_SIZE] = '\0';
+	memcpy(pin, engineConfiguration->btPinCode, BT_PIN_SIZE);
+	pin[BT_PIN_SIZE] = '\0';
+
+	bluetoothStart(engineConfiguration->btModuleType, baudStr, name, pin);
+}
+
+void bluetoothCancelSetup() {
+	if (btSetupIsRequested) {
+		btSetupIsRequested = false;
+		efiPrintf("Bluetooth setup cancelled");
+	}
+}
+
 // Called after 1S of silence on BT UART...
 void bluetoothSoftwareDisconnectNotify(SerialTsChannelBase* tsChannel) {
 	if (btSetupIsRequested) {

--- a/firmware/console/binary/bluetooth.h
+++ b/firmware/console/binary/bluetooth.h
@@ -17,18 +17,8 @@
 // Thus any bytes sent from the Console Software may interfere with the procedure.
 #define BLUETOOTH_SILENT_TIMEOUT TIME_MS2I(3000)
 
-// Supported Bluetooth module types
-typedef enum {
-	BLUETOOTH_HC_05,
-	BLUETOOTH_HC_06,
-	/**
-	 * See https://rusefi.com/forum/viewtopic.php?f=13&t=1999
-	 */
-	BLUETOOTH_BK3231,
-	// fun fact: those use BK3232 see above
-	BLUETOOTH_JDY_3x,
-  BLUETOOTH_JDY_31,
-} bluetooth_module_e;
+// bluetooth_module_e now lives in engine_types.h so it can double as a TunerStudio config field
+// type (btModuleType). It reaches here via global.h.
 
 /**
  * Start Bluetooth module initialization using UART connection:
@@ -38,6 +28,16 @@ typedef enum {
  * - restore connection to PC.
  */
 void bluetoothStart(bluetooth_module_e moduleType, const char *baudRate, const char *name, const char *pinCode);
+
+/**
+ * Arm the same setup procedure as bluetoothStart(), but taking the module type, baud rate, name and
+ * PIN from persistent configuration (btModuleType / btBaudRate / btName / btPinCode) instead of
+ * console-command arguments. This is what the TunerStudio "Apply Bluetooth Setup" button triggers.
+ */
+void bluetoothStartFromConfiguration();
+
+/** Cancel an armed Bluetooth setup procedure (TunerStudio "Cancel" button / bluetooth_cancel). */
+void bluetoothCancelSetup();
 
 /**
  * Called by runBinaryProtocolLoop() if a connection disconnect is detected.

--- a/firmware/controllers/algo/engine_types.h
+++ b/firmware/controllers/algo/engine_types.h
@@ -365,7 +365,36 @@ typedef enum {
 	TS_WIDEBAND_SET_SENS_BY_ID = 37,
 	TS_WIDEBAND_FLASH_BY_ID_FILE = 38,
 	TS_WIDEBAND_RESTART = 39,
+	// Bluetooth module setup from TunerStudio: index 0 = apply the configured settings,
+	// index 1 = cancel an armed setup. See executeTSCommand() and bluetooth.cpp.
+	TS_BLUETOOTH_SETUP = 40,
 } ts_command_e;
+
+// Supported serial Bluetooth module types. Lives here (not bluetooth.h) so it can be used as a
+// TunerStudio configuration field type (btModuleType); see rusefi_config.txt.
+typedef enum __attribute__ ((__packed__)) {
+	BLUETOOTH_HC_05 = 0,
+	BLUETOOTH_HC_06 = 1,
+	/**
+	 * See https://rusefi.com/forum/viewtopic.php?f=13&t=1999
+	 */
+	BLUETOOTH_BK3231 = 2,
+	// fun fact: those use BK3232 see above
+	BLUETOOTH_JDY_3x = 3,
+	BLUETOOTH_JDY_31 = 4,
+} bluetooth_module_e;
+
+// Baud rates the Bluetooth setup accepts, ascending. Index maps to btBaudRateValues[] in
+// bluetooth.cpp. Used as the btBaudRate TunerStudio config field type.
+typedef enum __attribute__ ((__packed__)) {
+	BT_BAUD_2400 = 0,
+	BT_BAUD_4800 = 1,
+	BT_BAUD_9600 = 2,
+	BT_BAUD_19200 = 3,
+	BT_BAUD_38400 = 4,
+	BT_BAUD_57600 = 5,
+	BT_BAUD_115200 = 6,
+} bluetooth_baud_e;
 
 typedef enum {
 	BENCH_MAIN_RELAY, // 0

--- a/firmware/controllers/algo/rusefi_types.h
+++ b/firmware/controllers/algo/rusefi_types.h
@@ -75,6 +75,10 @@ using warning_message_t = char[WARNING_BUFFER_SIZE];
 
 using vehicle_info_t = char[VEHICLE_INFO_SIZE];
 
+using bt_name_t = char[BT_NAME_SIZE];
+
+using bt_pin_t = char[BT_PIN_SIZE];
+
 using vin_number_t = char[VIN_NUMBER_SIZE];
 
 using gppwm_note_t = char[GPPWM_NOTE_SIZE];

--- a/firmware/controllers/bench_test.cpp
+++ b/firmware/controllers/bench_test.cpp
@@ -23,6 +23,7 @@
 #include "pch.h"
 #include "tunerstudio.h"
 #include "tunerstudio_calibration_channel.h"
+#include "bluetooth.h"
 #include "long_term_fuel_trim.h"
 #include "can_common.h"
 #include "can_rx.h"
@@ -867,6 +868,17 @@ void executeTSCommand(uint16_t subsystem, uint16_t index) {
 	case TS_STOP_ENGINE:
 		doScheduleStopEngine(StopRequestedReason::TsCommand);
 		break;
+
+#if EFI_BLUETOOTH_SETUP
+	case TS_BLUETOOTH_SETUP:
+		// index 0 = apply the configured Bluetooth settings, index 1 = cancel an armed setup
+		if (index == 0) {
+			bluetoothStartFromConfiguration();
+		} else {
+			bluetoothCancelSetup();
+		}
+		break;
+#endif // EFI_BLUETOOTH_SETUP
 
 	case JUMP_DFU_COMMAND:
 #if EFI_PROD_CODE && EFI_DFU_JUMP

--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -281,8 +281,11 @@ struct_no_prefix engine_configuration_s
 
 #define VEHICLE_INFO_SIZE 32
 
-#define BT_NAME_SIZE 20
-#define BT_PIN_SIZE 6
+! String sizes must be a multiple of 8: the config generator aligns a custom type on
+! (size % 8), and an alignment of 5..7 can demand a fill larger than it allows.
+! See VEHICLE_INFO_SIZE / GPPWM_NOTE_SIZE which follow the same rule.
+#define BT_NAME_SIZE 24
+#define BT_PIN_SIZE 8
 
 #define FUEL_RPM_COUNT 16
 #define FUEL_LOAD_COUNT 16
@@ -2051,7 +2054,7 @@ end_struct
 	custom bluetooth_baud_e 1 bits, U08, @OFFSET@, [0:2], "2400", "4800", "9600", "19200", "38400", "57600", "115200"
 	bluetooth_baud_e btBaudRate;Baud rate to set on the Bluetooth module. Must match the serial speed of the TTL port Bluetooth uses, or the link connects but no data flows.
 	custom bt_name_t @@BT_NAME_SIZE@@ string, ASCII, @OFFSET@, @@BT_NAME_SIZE@@
-	bt_name_t btName;Bluetooth device name to advertise (up to 19 characters).
+	bt_name_t btName;Bluetooth device name to advertise (up to 20 characters).
 	custom bt_pin_t @@BT_PIN_SIZE@@ string, ASCII, @OFFSET@, @@BT_PIN_SIZE@@
 	bt_pin_t btPinCode;Bluetooth pairing PIN (4 digits).
 

--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -281,6 +281,9 @@ struct_no_prefix engine_configuration_s
 
 #define VEHICLE_INFO_SIZE 32
 
+#define BT_NAME_SIZE 20
+#define BT_PIN_SIZE 6
+
 #define FUEL_RPM_COUNT 16
 #define FUEL_LOAD_COUNT 16
 
@@ -2037,6 +2040,20 @@ end_struct
 	! Cranking always uses ignitionDwellForCrankingMs regardless of this setting.
 	bit dwellDutyModeEnabled,"enabled","disabled";Dwell Duty Mode: when enabled, ignores the RPM/voltage dwell tables and computes dwell as a fixed percentage of the time between consecutive ignition pulses. Required for Ford TFI modules that expect a 50% duty cycle square wave.
 	uint8_t dwellDutyPercent;Dwell Duty Mode: percentage of the inter-spark interval used as coil dwell time. 50 = half the interval between pulses (standard TFI target).;"%", 1, 0, 1, 90, 0
+
+	! --- Bluetooth module setup from TunerStudio (see "Bluetooth Setup" dialog) ---
+	! These replace the console-only bluetooth_<module> command: set the fields, then use the
+	! "Apply Bluetooth Setup" button, which runs the same AT sequence. btBaudRate MUST match the
+	! serial speed of the TTL port Bluetooth uses (secondary if the board has one, else primary)
+	! or the module pairs but transfers nothing.
+	custom bluetooth_module_e 1 bits, U08, @OFFSET@, [0:2], "HC-05", "HC-06", "BK3231", "JDY-33", "JDY-31"
+	bluetooth_module_e btModuleType;Bluetooth module type to configure.
+	custom bluetooth_baud_e 1 bits, U08, @OFFSET@, [0:2], "2400", "4800", "9600", "19200", "38400", "57600", "115200"
+	bluetooth_baud_e btBaudRate;Baud rate to set on the Bluetooth module. Must match the serial speed of the TTL port Bluetooth uses, or the link connects but no data flows.
+	custom bt_name_t @@BT_NAME_SIZE@@ string, ASCII, @OFFSET@, @@BT_NAME_SIZE@@
+	bt_name_t btName;Bluetooth device name to advertise (up to 19 characters).
+	custom bt_pin_t @@BT_PIN_SIZE@@ string, ASCII, @OFFSET@, @@BT_PIN_SIZE@@
+	bt_pin_t btPinCode;Bluetooth pairing PIN (4 digits).
 
 ! end of engine_configuration_s
 end_struct

--- a/firmware/tunerstudio/tunerstudio.template.ini
+++ b/firmware/tunerstudio/tunerstudio.template.ini
@@ -2023,6 +2023,7 @@ include_file @@TOP_LEVEL_MENU_FILE@@
 
 		subMenu = sdCard,					"SD Card Logger" @@if_ts_show_sd_card
 		subMenu = connection,					"Connection"@@if_ts_show_aux_connections
+		subMenu = bluetoothSetup,			"Bluetooth Setup"@@if_ts_show_aux_connections
 		subMenu = std_separator
 
 		subMenu = tle8888Dialog,			"TLE8888"@@if_ts_show_tle8888
@@ -2201,6 +2202,10 @@ cmd_set_wideband_flash_by_id_file= "@@TS_IO_TEST_COMMAND_char@@@@ts_command_e_TS
 cmd_restart_widebands = "@@TS_IO_TEST_COMMAND_char@@@@ts_command_e_TS_WIDEBAND_RESTART_16_hex@@\$canReWidebandHwIndex\x00"
 
 cmd_stop_engine				= "@@TS_IO_TEST_COMMAND_char@@@@ts_command_e_TS_STOP_ENGINE_16_hex@@\x00\x00"
+
+; Bluetooth module setup: index 0 = apply configured settings, index 1 = cancel an armed setup
+cmd_bluetooth_apply			= "@@TS_IO_TEST_COMMAND_char@@@@ts_command_e_TS_BLUETOOTH_SETUP_16_hex@@\x00\x00"
+cmd_bluetooth_cancel		= "@@TS_IO_TEST_COMMAND_char@@@@ts_command_e_TS_BLUETOOTH_SETUP_16_hex@@\x00\x01"
 
 ; reboot ECU
 cmd_reset_controller			= "@@TS_IO_TEST_COMMAND_char@@\x00\xbb\x00\x00"
@@ -4282,6 +4287,19 @@ include_file @@SECONDARY_PANELS_FILE@@
 		panel = tsPort							@@if_ts_show_tunerstudio_port
 		field = "uartConsoleSerialSpeed",				uartConsoleSerialSpeed
 		field = enableKline, enableKline
+
+	dialog = bluetoothSetup, "Bluetooth Setup", yAxis
+		field = "!Configures a serial Bluetooth module (HC-05/06, BK, JDY) over the ECU's TTL UART."
+		field = "!Baud rate MUST match the serial speed of the port Bluetooth uses (secondary TTL if"
+		field = "!the board has one, else primary) or the module pairs but no data flows."
+		field = "Bluetooth module type",				btModuleType
+		field = "Baud rate",							btBaudRate
+		field = "Device name",							btName
+		field = "Pairing PIN (4 digits)",				btPinCode
+		field = "!Set the fields above, then click Apply and disconnect TunerStudio: the setup runs"
+		field = "!while the link is quiet. Keep the board powered; some modules need a power cycle after."
+		commandButton = "Apply Bluetooth Setup",		cmd_bluetooth_apply
+		commandButton = "Cancel armed setup",			cmd_bluetooth_cancel
 
 	dialog = monitoringSettings, "rusEFI Console Settings"
 		topicHelp = "monitoringSettingsHelp"


### PR DESCRIPTION
## Problem

Configuring a serial Bluetooth module (HC-05/06, BK, JDY-33/31) required the **rusEFI Console** command `bluetooth_<module> <baud> <name> <pin>`. TunerStudio — where every other setting lives — had no interface for it, and nothing indicated the capability existed. The project's own wiki states: *"There is currently no TunerStudio interface for setting up the module — it is initialised from the rusEFI Console."*

## Change

A **"Bluetooth Setup"** dialog (under Settings, next to Connection) with module-type, baud, name and PIN fields, plus an **"Apply Bluetooth Setup"** button and a **Cancel** button. Apply runs the exact same AT sequence the console command does.

Reuses existing machinery end-to-end:
- New persisted config fields `btModuleType` / `btBaudRate` / `btName` / `btPinCode`, **appended at the end of `engine_configuration_s`** so no existing field offset moves (tune migration is by field name; `TOTAL_CONFIG_SIZE` 15804 → 15832, append-only).
- The button sends the standard `TS_IO_TEST_COMMAND` with a new subsystem `TS_BLUETOOTH_SETUP` (index 0 = apply, 1 = cancel) — the same button mechanism the spark/injector/wideband test buttons use. Generated: `cmd_bluetooth_apply = "Z\x00\x28\x00\x00"`.
- `executeTSCommand()` dispatches it to a new `bluetoothStartFromConfiguration()`, which reads the config fields and calls the existing `bluetoothStart()`. **The console commands are untouched and still work.**

`bluetooth_module_e` moved from `bluetooth.h` to `engine_types.h` so it can serve as the `btModuleType` field type; a new `bluetooth_baud_e` maps the dropdown to `btBaudRateValues[]`. Both `__packed__` to stay one byte (U08).

## Design notes

- The firmware only ever **configures** the module (name/PIN/baud/SPP mode) — it has no live enable/disable — so this is deliberately a *set-fields-then-Apply* flow, not an on/off switch.
- As with the console command, the AT sequence runs once the UART goes quiet (TS disconnected). The dialog and the `btBaudRate` description both warn the baud **must match the serial speed of the port Bluetooth uses** (secondary TTL if the board has one, else primary) — the single most common setup mistake.
- Applying with empty/invalid name or PIN is rejected by the existing `bluetoothStart()` validation, so unconfigured defaults are safe.

## Safety impact

None on engine control. This is the diagnostic/comms setup path; no timing or scheduling change, and the on-hardware AT sequence is byte-identical to the existing console path.

## Validation

- Unit build regenerates the config cleanly: the two enum dropdowns, the two string fields, the dialog/menu entry, and the `TS_BLUETOOTH_SETUP` command constant (40 = 0x28) all generate as intended.
- Full unit suite: **1168 tests pass** (config-layout change did not disturb persistent-config tests).
- The `EFI_BLUETOOTH_SETUP`-gated additions (`bluetoothStartFromConfiguration`, `bluetoothCancelSetup`, the `executeTSCommand` case) were compile-checked with the flag forced on — clean, no warnings. A full firmware/board build is left to CI (no ARM/32-bit MinGW toolchain locally).

## Regression risk

Low. Existing console commands and the AT sequence are unchanged; the new path is additive and gated by `EFI_BLUETOOTH_SETUP` exactly like the console commands. The config change is append-only.