### PR TITLE
TS: answer a CRC-framed 'Q' (query) instead of silently rejecting it

### DIFF
--- a/firmware/console/binary/tunerstudio.cpp
+++ b/firmware/console/binary/tunerstudio.cpp
@@ -603,7 +603,7 @@ void TunerStudio::handleBurnCommand(TsChannelBase* tsChannel, uint16_t page) {
 #if (EFI_PROD_CODE || EFI_SIMULATOR)
 
 static bool isKnownCommand(char command) {
-	return command == TS_HELLO_COMMAND || command == TS_READ_COMMAND || command == TS_READ32_COMMAND || command == TS_OUTPUT_COMMAND
+	return command == TS_HELLO_COMMAND || command == TS_QUERY_COMMAND || command == TS_READ_COMMAND || command == TS_READ32_COMMAND || command == TS_OUTPUT_COMMAND
 			|| command == TS_BURN_COMMAND
 			|| command == TS_CHUNK_WRITE_COMMAND || command == TS_EXECUTE
 			|| command == TS_IO_TEST_COMMAND
@@ -988,6 +988,11 @@ int TunerStudio::handleCrcCommand(TsChannelBase* tsChannel, char *data, int inco
 #endif // EFI_TS_SCATTER
 		break;
 	case TS_HELLO_COMMAND:
+	// TunerStudio scans serial ports with a bare unframed 'Q' (handled in handlePlainCommand), but a
+	// client that CRC-frames everything else may also frame 'Q'. Answer a framed query exactly like
+	// the framed hello ('S') instead of silently rejecting it - the reject is invisible when the
+	// channel is not yet in sync, which is the state right after a fresh (e.g. Bluetooth) connect.
+	case TS_QUERY_COMMAND:
 		handleQueryCommand(tsChannel, TS_CRC);
 		break;
 	case TS_GET_FIRMWARE_VERSION:


### PR DESCRIPTION
## Problem

`isKnownCommand()` and the `handleCrcCommand()` switch both list the framed hello `'S'` (`TS_HELLO_COMMAND`) but **not** the framed query `'Q'` (`TS_QUERY_COMMAND`). A CRC-framed `'Q'` falls through `isKnownCommand()` and is dropped — and when the channel is not yet in sync (the state right after a fresh connect, e.g. over Bluetooth) the drop is **completely silent**, no error code.

TunerStudio itself probes serial ports with a bare, unframed `'Q'`, which `handlePlainCommand()` already answers — so signature discovery works for stock TS. But a third-party client that CRC-frames all its other commands has no framed way to read the signature and gets nothing back, with no indication why. This was hit in practice by a Bluetooth dashboard client (JDY-33 field report).

## Change

Add `TS_QUERY_COMMAND` to `isKnownCommand()`, and give it a `case` alongside `TS_HELLO_COMMAND` in `handleCrcCommand()`, so a framed `'Q'` returns the signature exactly like a framed `'S'`. Two lines, mirroring the adjacent hello handling.

The bare unframed `'Q'` path (`handlePlainCommand`) is **untouched**, so TunerStudio's port scan is unaffected.

## Safety impact

None on engine control — diagnostic/handshake path only. No timing or scheduling change.

## Regression risk

Low. `'Q'` framed was previously rejected; now it returns the signature (same handler `'S'` already uses). No other command byte changes behaviour.

## Validation

Not unit-tested: `isKnownCommand()`/`handleCrcCommand()` live in the `EFI_PROD_CODE || EFI_SIMULATOR` block, excluded from the host unit-test build (the whole receive/dispatch path pulls in prod-only headers when enabled for unit tests). The change is a two-line addition mirroring the adjacent `TS_HELLO_COMMAND` handling; full firmware build left to CI, and a bare-`'Q'` port-scan regression should be confirmed on hardware.