### PR TITLE
TS UART DMA: re-arm the receive on a UART error instead of wedging until power cycle

### DIFF
--- a/firmware/console/connector_uart_dma.cpp
+++ b/firmware/console/connector_uart_dma.cpp
@@ -42,6 +42,28 @@ static void tsRxIRQIdleHandler(UARTDriver *uartp) {
 	reinterpret_cast<UartDmaTsChannel*>(uartp->dmaAdapterInstance)->copyDataFromDMA();
 }
 
+/* Called from the UART error ISR (overrun/framing/noise). */
+static void tsRxIRQErrHandler(UARTDriver *uartp, uartflags_t e) {
+	UNUSED(e);
+	reinterpret_cast<UartDmaTsChannel*>(uartp->dmaAdapterInstance)->onRxError();
+}
+
+void UartDmaTsChannel::onRxError() {
+	// A UART RX error - typically an overrun while the ECU is busy transmitting a large response
+	// and not draining RX - can abort the circular DMA receive. With rxerr_cb previously NULL,
+	// nothing re-armed it, so the receive stayed stopped and the tuning link went permanently
+	// silent until the next start() (a physical power cycle). Re-arm the receive here so a single
+	// glitch cannot wedge the link. This runs on the error path only; normal reception is untouched.
+	chSysLockFromISR();
+	rxErrorCounter++;
+	// uartStopReceiveI is a no-op if the receive is not active; either way rxstate ends up != ACTIVE
+	// so uartStartReceiveI's precondition holds. The DMA restarts filling dmaBuffer from index 0.
+	uartStopReceiveI(m_driver);
+	uartStartReceiveI(m_driver, sizeof(dmaBuffer), dmaBuffer);
+	readPos = 0;
+	chSysUnlockFromISR();
+}
+
 UartDmaTsChannel::UartDmaTsChannel(UARTDriver& driver)
 	: UartTsChannel(driver)
 {
@@ -57,7 +79,7 @@ void UartDmaTsChannel::start(uint32_t baud) {
 		.txend2_cb		= NULL,
 		.rxend_cb		= NULL,
 		.rxchar_cb		= NULL,
-		.rxerr_cb		= NULL,
+		.rxerr_cb		= tsRxIRQErrHandler,
 		.timeout_cb		= tsRxIRQIdleHandler,
 		.speed			= baud,
 		.cr1			= 0,

--- a/firmware/console/connector_uart_dma.h
+++ b/firmware/console/connector_uart_dma.h
@@ -26,6 +26,12 @@ public:
 	size_t readTimeout(uint8_t* buffer, size_t size, int timeout) override;
 
 	void copyDataFromDMA();
+	// Called from the UART error ISR to re-arm the circular DMA receive after a UART error
+	// (overrun/framing/noise), which otherwise leaves reception stopped until the next start().
+	void onRxError();
+
+	// Count of UART RX errors recovered from since construction, for diagnostics.
+	volatile uint32_t rxErrorCounter = 0;
 
 private:
 	// RX FIFO implementation


### PR DESCRIPTION
## Problem

`UartDmaTsChannel` — the DMA-driven TTL serial channel used for TunerStudio on STM32F4/F7 boards (`EFI_USE_UART_DMA`, which is also the Bluetooth/secondary-TTL path) — arms **one** circular DMA receive in `start()` and never touches it again. Its `UARTConfig` sets `rxerr_cb = NULL`, so a UART receive error has **no handler**.

On a receive error — classically an **overrun** when the ECU is busy transmitting a large response and not draining RX — the ChibiOS UART driver takes the error path and the circular DMA receive can be left stopped. With no `rxerr_cb` to re-arm it, reception never resumes: `readTimeout()` keeps draining a FIFO that no longer fills, so the ECU goes **silent on that channel until the next `start()`** — which only happens on a physical power cycle. The stuck state is on the ECU's DMA, so it survives the host reconnecting, rebooting, or reflashing.

Observed while bench-testing **core2-vehicle-dash** (an M5Stack Core2 ESP32 dashboard I built that reads rusEFI telemetry over a JDY-33 SPP bridge): after a burst of traffic the TS link wedged and only an ECU power cycle recovered it. It's a firmware defect independent of any particular client — any use of the DMA TTL channel in an electrically noisy environment can hit an overrun and wedge.

## Change

Give the channel an `rxerr_cb` that re-arms the receive:

```cpp
void UartDmaTsChannel::onRxError() {
    chSysLockFromISR();
    rxErrorCounter++;
    uartStopReceiveI(m_driver);                                  // ACTIVE -> IDLE (no-op if not active)
    uartStartReceiveI(m_driver, sizeof(dmaBuffer), dmaBuffer);   // restart circular DMA
    readPos = 0;
    chSysUnlockFromISR();
}
```

This is the canonical ChibiOS *restart-RX-after-error* sequence. `uartStartReceiveI`'s only precondition (`rxstate != UART_RX_ACTIVE`) is guaranteed by the preceding `uartStopReceiveI`. It runs on the **error path only** — normal reception is byte-for-byte unchanged — so a single glitch can no longer take the tuning channel down until reboot. Adds a `rxErrorCounter` for diagnostics.

## Safety impact

None on engine control — diagnostic/comms channel only. No timing or scheduling change to any control path; the new code executes only inside the UART error ISR, which previously did nothing.

## Regression risk

Low. The error path was a no-op (NULL callback) before; it now recovers. Re-entrancy checked: `_uart_rx_error_isr_code` invokes `rxerr_cb` and then `_uart_wakeup_rx_error_isr`, and the latter only does `osalThreadResumeI` on the (here unused) blocking-receive thread reference — it does not touch `rxstate`, so it cannot undo the re-arm.

## Validation

This file compiles only against the ChibiOS UART HAL (`HAL_USE_UART && EFI_USE_UART_DMA`), which is not present in the host unit-test or simulator builds, so it **could not be built locally — left to CI**. Verified by inspection against `firmware/ChibiOS`: the `rxerr_cb` signature matches `uartecb_t`; `uartStopReceiveI`/`uartStartReceiveI` state transitions and preconditions were checked in `hal_uart.c`; and the wakeup macro does not disturb `rxstate`. On-hardware confirmation of the wedge and its recovery (reproduce the wedge, watch `rxErrorCounter` climb and the link stay alive) is the remaining step.