### PR TITLE
Coverage: ISO-TP single-frame length is not bounded by the frame

### DIFF
--- a/unit_tests/tests/controllers/can/test_can_serial.cpp
+++ b/unit_tests/tests/controllers/can/test_can_serial.cpp
@@ -225,6 +225,79 @@ TEST(testCanSerial, test64_7Message) {
 	}, 71, { 64 + 7 });
 }
 
+/**
+ * Coverage for the ISO-TP single-frame length field.
+ *
+ * A single frame carries its payload length in the low nibble of the PCI byte, so it can encode up
+ * to 15 - but a classic-CAN frame only delivers DLC bytes and CANRxFrame::data8 is 8 bytes wide.
+ * receiveFrame() takes that nibble at face value and copies that many bytes from data8 + 1, so a
+ * malformed frame makes it read past the end of the payload. DLC itself is only a 4-bit field, so
+ * a frame can also claim DLC > 8, which is equally unchecked.
+ *
+ * These tests document CURRENT behavior: the claimed length is used verbatim. Once the length is
+ * bounded by what the frame actually holds, expect 7 (DLC - 1) in both cases.
+ *
+ * The frame is embedded in a padded wrapper so that the over-read this deliberately provokes lands
+ * inside memory the test owns - otherwise it is a stack-buffer-overflow and AddressSanitizer (on by
+ * default for these tests) aborts the run.
+ */
+namespace {
+struct PaddedRxFrame {
+	CANRxFrame frame;
+	// room for the largest over-read the unclamped code can perform: SF_DL 15 starting at data8[1]
+	uint8_t overreadGuard[16];
+};
+
+// Fails the test rather than corrupting the stack if the guard above is ever too small for the
+// over-read these tests provoke (last byte read is data8[15], so data8 + 16 must stay inside).
+void assertOverreadStaysInsidePaddedFrame(const PaddedRxFrame& padded) {
+	const uint8_t* objectEnd = reinterpret_cast<const uint8_t*>(&padded) + sizeof(padded);
+	ASSERT_LE(padded.frame.data8 + 16, objectEnd) << "overreadGuard too small";
+}
+} // namespace
+
+TEST(testCanSerial, singleFrameLengthIsNotBoundedByDlc) {
+	EngineTestHelper eth(engine_type_e::TEST_ENGINE);
+
+	TestCanStreamerState state;
+
+	PaddedRxFrame padded;
+	memset(&padded, 0, sizeof(padded));
+	padded.frame.DLC = 8;
+	// frame type 0 (SINGLE), SF_DL nibble = 15 - more than the 8-byte frame can possibly hold
+	padded.frame.data8[0] = 0x0F;
+
+	uint8_t rxbuf[64];
+	memset(rxbuf, 0xCC, sizeof(rxbuf));
+
+	assertOverreadStaysInsidePaddedFrame(padded);
+	int copied = state.receiveFrame(padded.frame, rxbuf, sizeof(rxbuf), 0);
+
+	// the claimed 15 bytes are copied even though only 7 payload bytes exist
+	EXPECT_EQ(15, copied);
+}
+
+TEST(testCanSerial, singleFrameLengthIsNotBoundedByPayloadSize) {
+	EngineTestHelper eth(engine_type_e::TEST_ENGINE);
+
+	TestCanStreamerState state;
+
+	PaddedRxFrame padded;
+	memset(&padded, 0, sizeof(padded));
+	// DLC is a 4-bit field, so a malformed frame can claim more than data8[] can hold
+	padded.frame.DLC = 15;
+	padded.frame.data8[0] = 0x0F;
+
+	uint8_t rxbuf[64];
+	memset(rxbuf, 0xCC, sizeof(rxbuf));
+
+	assertOverreadStaysInsidePaddedFrame(padded);
+	int copied = state.receiveFrame(padded.frame, rxbuf, sizeof(rxbuf), 0);
+
+	// nothing bounds the copy to sizeof(data8) either
+	EXPECT_EQ(15, copied);
+}
+
 TEST(testCanSerial, test3_64_4Message) {
 	std::array<char, 64> buffer64;
 


### PR DESCRIPTION
First of two, per [TDB](https://github.com/rusefi/rusefi/wiki/TDB-Test-Driven-Bugfixing). **Coverage only — green, asserting the bad behaviour.** No production change in this PR. The fix (and the adjustment of these expectations) follows in a second PR.

## What is not bounded

`CanStreamerState::receiveFrame()` reads a single frame's payload length from the low nibble of the PCI byte and copies that many bytes from `data8 + 1 + isoHeaderByteIndex`:

```cpp
case ISO_TP_FRAME_SINGLE:
    numBytesAvailable = rxmsg.data8[isoHeaderByteIndex] & 0xf;   // 0..15
```

Nothing checks that against what the frame actually carries. There are **two** independent ways to exceed it, so there are two tests:

| test | frame | asserts (today) |
|---|---|---|
| `singleFrameLengthIsNotBoundedByDlc` | DLC 8, SF_DL 15 | 15 bytes copied — 8 past the payload |
| `singleFrameLengthIsNotBoundedByPayloadSize` | DLC 15, SF_DL 15 | 15 bytes copied |

The second case exists because `DLC` is a **4-bit field**, so a malformed frame can claim more than the 8-byte `data8[]` is wide — bounding by DLC alone would not be enough.

This path is reachable from outside the ECU: it is the RX side of TS-over-CAN tunnelling (`serial_can.cpp` / `CanTsListener`), so a single malformed CAN frame on the configured serial CAN ID reaches it.

## ASan note

These tests deliberately provoke the over-read, so the frame is embedded in a padded wrapper and the read lands in memory the test owns — otherwise it is a stack-buffer-overflow and AddressSanitizer (enabled by default for these tests on non-Windows, with `-fno-sanitize-recover=all`) would abort the run. `assertOverreadStaysInsidePaddedFrame()` checks the padding really does cover the largest over-read the unclamped code can perform, so the test fails loudly rather than corrupting the stack if that ever stops holding.

ASan itself could not be exercised locally — the MinGW toolchain here has no libasan — hence the in-test bounds assertion instead of relying on it.

## Validation

```
cd unit_tests && make -j12 && ./build/rusefi_test.exe
  1170 tests pass (green on unfixed master, as coverage should be)
```
The six pre-existing `testCanSerial` round-trip tests are untouched and still pass.