### PR TITLE
Coverage: findBaudIndex leaves the link at the last probed baud rate

### DIFF
--- a/firmware/console/binary/bluetooth.cpp
+++ b/firmware/console/binary/bluetooth.cpp
@@ -20,7 +20,7 @@
 #include <stdio.h>
 #include <ctype.h>
 
-#if EFI_BLUETOOTH_SETUP
+#if EFI_BLUETOOTH_SETUP || EFI_UNIT_TEST
 
 #ifndef EFI_BLUETOOTH_SETUP_DEBUG
 #define EFI_BLUETOOTH_SETUP_DEBUG TRUE
@@ -359,4 +359,4 @@ void bluetoothSoftwareDisconnectNotify(SerialTsChannelBase* tsChannel) {
 	}
 }
 
-#endif /* EFI_BLUETOOTH_SETUP */
+#endif /* EFI_BLUETOOTH_SETUP || EFI_UNIT_TEST */

--- a/unit_tests/chibios-mock/mock-threads.h
+++ b/unit_tests/chibios-mock/mock-threads.h
@@ -27,6 +27,15 @@ static inline systime_t chTimeAddX(systime_t systime,
   return systime + (systime_t)interval;
 }
 
+// There is no tick clock on the host, so an interval is just the millisecond count itself.
+#ifndef TIME_MS2I
+#define TIME_MS2I(ms) (ms)
+#endif
+
+// Nothing to sleep on: host tests drive time explicitly (setTimeNowUs/advanceTimeUs) rather than
+// waiting, so sleeping is a no-op.
+static inline void chThdSleepMilliseconds(uint32_t /*milliseconds*/) { }
+
 #define PAL_MODE_OUTPUT_PUSHPULL 0
 
 namespace chibios_rt {

--- a/unit_tests/tests/test_bluetooth.cpp
+++ b/unit_tests/tests/test_bluetooth.cpp
@@ -1,0 +1,84 @@
+/**
+ * @file test_bluetooth.cpp
+ *
+ * Coverage for the Bluetooth module auto-setup helper in console/binary/bluetooth.cpp.
+ */
+
+#include "pch.h"
+#include "bluetooth.h"
+
+// set by bluetoothStart(); findBaudIndex() branches on it. Default (0) is BLUETOOTH_HC_05, which
+// takes the plain "probe each baud with AT" path - no JDY-specific disconnect handshakes.
+extern bluetooth_module_e btModuleType;
+
+// getBluetoothChannel()/getTsSignature() are deliberately compiled out of the host unit-test build
+// (they need real serial ports / the prod signature). bluetooth.cpp's bluetoothStart() references
+// them, so provide host stubs to let the translation unit link. findBaudIndex(), the unit under
+// test here, does not call either.
+SerialTsChannelBase* getBluetoothChannel() {
+	return nullptr;
+}
+const char* getTsSignature() {
+	return "unit test signature";
+}
+
+namespace {
+
+// A SerialTsChannelBase that records the last baud it was (re)started at and never answers the
+// AT probe, so findBaudIndex() is forced down its "no module found" path.
+class RecordingSerialChannel : public SerialTsChannelBase {
+public:
+	RecordingSerialChannel() : SerialTsChannelBase("test") { }
+
+	void start(uint32_t baud) override {
+		lastStartedBaud = baud;
+		startCount++;
+	}
+
+	void stop() override {
+		stopCount++;
+	}
+
+	void write(const uint8_t*, size_t, bool) override { }
+
+	// always "time out" - report that zero of the requested bytes arrived
+	size_t readTimeout(uint8_t*, size_t, int) override {
+		return 0;
+	}
+
+	uint32_t lastStartedBaud = 0;
+	int startCount = 0;
+	int stopCount = 0;
+};
+
+} // namespace
+
+/**
+ * Coverage for findBaudIndex() when no Bluetooth module answers at any known baud rate.
+ *
+ * The function is supposed to put the serial link back to the configured console/TS speed before
+ * giving up - that recovery exists, but it sits INSIDE the probe loop guarded by
+ * `baudIdx == efi::size(baudRates)`, while the loop condition is `baudIdx < efi::size(baudRates)`.
+ * The branch is therefore unreachable and never runs, so the channel is left started at the last
+ * probed rate (57600) until the ECU is rebooted.
+ *
+ * This test documents CURRENT behavior. Once the recovery is reachable, expect the channel to be
+ * left at engineConfiguration->tunerStudioSerialSpeed instead.
+ */
+TEST(bluetooth, findBaudIndexLeavesChannelAtLastProbedRate) {
+	EngineTestHelper eth(engine_type_e::TEST_ENGINE);
+
+	btModuleType = BLUETOOTH_HC_05;
+
+	// a distinctive configured speed that is NOT one of the probed baudRates[]
+	engineConfiguration->tunerStudioSerialSpeed = 250000;
+
+	RecordingSerialChannel channel;
+
+	uint8_t result = findBaudIndex(&channel);
+
+	// no module answered
+	EXPECT_EQ(255, result);
+	// the configured speed was never restored - the link is stuck on the last entry of baudRates[]
+	EXPECT_EQ(57600u, channel.lastStartedBaud);
+}

--- a/unit_tests/tests/tests.mk
+++ b/unit_tests/tests/tests.mk
@@ -147,6 +147,7 @@ TESTS_SRC_CPP = \
 	tests/ignition_injection/test_fuel_wall_wetting.cpp \
 	tests/test_one_cylinder_logic.cpp \
 	tests/test_tunerstudio.cpp \
+	tests/test_bluetooth.cpp \
 	tests/test_pwm_generator.cpp \
 	tests/test_log_buffer.cpp \
 	tests/test_event_queue.cpp \


### PR DESCRIPTION
First of two, per [TDB](https://github.com/rusefi/rusefi/wiki/TDB-Test-Driven-Bugfixing). **Coverage only — green, asserting the bad behaviour.** No behavioural change to `findBaudIndex()` in this PR. The fix (and the adjustment of this expectation) follows in a second PR.

## What is asserted

`findBaudIndex()` probes each known baud rate looking for a Bluetooth module. When none answers it is supposed to put the serial link back to the configured console/TS speed before giving up. That recovery exists, but it sits **inside** the probe loop:

```cpp
for (uint8_t baudIdx = 0; baudIdx < efi::size(baudRates); baudIdx++) {
    ...
    if (baudIdx == efi::size(baudRates)) {     // never true inside this loop
        tsChannel->start(engineConfiguration->tunerStudioSerialSpeed);
        return 255;
    }
```

so it never runs. `findBaudIndexLeavesChannelAtLastProbedRate` drives the function with a mock `SerialTsChannelBase` that records the last baud it was started at and never answers the AT probe, and asserts what happens today: returns 255, and the channel is left at **57600** — the last entry of `baudRates[]` — while `tunerStudioSerialSpeed` is 250000.

## Test enablement (why bluetooth.cpp is touched)

`findBaudIndex` sits behind `EFI_BLUETOOTH_SETUP`, which is off in the host unit-test build, so `bluetooth.cpp` compiled empty there and the function had no coverage at all. This PR widens that guard to `EFI_BLUETOOTH_SETUP || EFI_UNIT_TEST` — the same pattern `serial_can.cpp` already uses in this subsystem — and adds two unit-test-only shims for the ChibiOS primitives the host build omits (`chThdSleepMilliseconds`, `TIME_MS2I`). `getBluetoothChannel()` / `getTsSignature()`, which need real serial ports, are stubbed in the test.

That is the only production-file change here, and it is compile-gating only — no logic is altered.

## Validation

```
cd unit_tests && make -j12 && ./build/rusefi_test.exe
  1169 tests pass (green on unfixed master, as coverage should be)
```