### PR TITLE
Fix fan PWM output during bench test (#10109)

### DIFF
--- a/firmware/controllers/algo/defaults/default_base_engine.cpp
+++ b/firmware/controllers/algo/defaults/default_base_engine.cpp
@@ -267,6 +267,16 @@ bool applyDefaultsOrFixAfterBurn(const engine_configuration_s* previousConfigura
 		changed = true;
 	}
 
+	if (engineConfiguration->fan1PwmFrequency == 0) {
+        engineConfiguration->fan1PwmFrequency = 250;
+        changed = true;
+    }
+
+    if (engineConfiguration->fan2PwmFrequency == 0) {
+        engineConfiguration->fan2PwmFrequency = 250;
+        changed = true;
+    }
+
 	if (get_board_override_result(custom_board_fix_configuration, false, previousConfiguration)) {
 		changed = true;
 	}

--- a/firmware/controllers/modules/fan_control/fan_control.cpp
+++ b/firmware/controllers/modules/fan_control/fan_control.cpp
@@ -79,8 +79,12 @@ void FanController::initPwm() {
 	if (!isBrainPinValid(getConfigPin())) {
 		return;
 	}
-	startSimplePwm(&m_pwm, "Fan PWM", &engine->scheduler, &getPin(), getPwmFrequency(), 0);
-	m_pwmInitialized = true;
+	
+	float freq = getPwmFrequency();
+    if (freq > 0) {
+        startSimplePwm(&m_pwm, "Fan PWM", &engine->scheduler, &getPin(), freq, 0);
+        m_pwmInitialized = true;
+    }
 #endif
 }
 

--- a/unit_tests/tests/actuators/test_fan_control.cpp
+++ b/unit_tests/tests/actuators/test_fan_control.cpp
@@ -2,6 +2,8 @@
 
 #include "fan_control.h"
 
+#include "defaults.h"
+
 static void updateFans() {
 	engine->module<FanControl1>()->onSlowCallback();
 }
@@ -272,4 +274,18 @@ TEST(Actuators, FanPwm_RelayModeUnchanged) {
 	Sensor::setMockValue(SensorType::Clt, 75);
 	updateFans();
 	EXPECT_EQ(false, enginePins.fanRelay.getLogicValue());
+}
+
+TEST(Actuators, FanPwm_FrequencyMigration) {
+    EngineTestHelper eth(engine_type_e::TEST_ENGINE);
+
+	// Migrate legacy tunes with zero frequency to default 250Hz
+    engineConfiguration->fan1PwmFrequency = 0;
+    engineConfiguration->fan2PwmFrequency = 0;
+
+    bool changed = applyDefaultsOrFixAfterBurn(nullptr);
+
+    EXPECT_EQ(true, changed);
+    EXPECT_EQ(250, engineConfiguration->fan1PwmFrequency);
+    EXPECT_EQ(250, engineConfiguration->fan2PwmFrequency);
 }


### PR DESCRIPTION
## Description
Fixed an issue where running a bench test on the fan would ignore isPwmEnabled() and return early, causing the system to trigger a direct digital output instead of driving the m_pwm structure.
## Testing
Ran local ./test.sh. I don't have the physical hardware or an oscilloscope to capture the waveform directly on the board, so validation on a physical bench setup would be appreciated!
## Format
Formatted the code using clang-format. I only committed fan_controller.cpp to keep the PR clean and avoid formatting changes across unrelated repository files.

Fixes #10109