### PR TITLE
fix search path for rusefi_updater.sh

### DIFF
--- a/misc/console_launcher/rusefi_updater.sh
+++ b/misc/console_launcher/rusefi_updater.sh
@@ -4,4 +4,5 @@
 # Arguments are forwarded so that Autoupdate#startConsoleAsANewProcess can pass them on.
 
 cd "$(dirname "$0")/console" || exit 1
+export PATH=$PWD:$PATH # search path fix for spawned processes
 exec java -jar ./rusefi_console.jar "$@"


### PR DESCRIPTION
Search path under unix based systems can skip working directory