### PR TITLE
Add emergency wipe support for OpenBLT

### DIFF
--- a/java_console/connectivity/src/main/java/com/rusefi/maintenance/jobs/OpenBltManualJob.java
+++ b/java_console/connectivity/src/main/java/com/rusefi/maintenance/jobs/OpenBltManualJob.java
@@ -28,7 +28,12 @@ public class OpenBltManualJob extends AsyncJobWithContext<SerialPortWithParentCo
 
     OpenBltManualJob(final PortResult port, final JComponent parent, final ConnectivityContext connectivityContext,
                      final FlashSteps steps) {
-        super("OpenBLT via Serial", new SerialPortWithParentComponentJobContext(port, parent));
+        this("OpenBLT via Serial", port, parent, connectivityContext, steps);
+    }
+
+    OpenBltManualJob(final String title, final PortResult port, final JComponent parent,
+                     final ConnectivityContext connectivityContext, final FlashSteps steps) {
+        super(title, new SerialPortWithParentComponentJobContext(port, parent));
         this.connectivityContext = connectivityContext;
         this.steps = steps;
     }
@@ -50,9 +55,18 @@ public class OpenBltManualJob extends AsyncJobWithContext<SerialPortWithParentCo
                 // auto path's bltUpdateFirmware. [tag:better_ux_for_flashing]
                 final PortScanner scanner = connectivityContext.getPortScanner();
                 try {
-                    scanner.suspend().await(30, TimeUnit.SECONDS);
+                    if (!scanner.suspend().await(30, TimeUnit.SECONDS)) {
+                        callbacks.logLine("Timed out waiting for the serial port scanner to stop.");
+                        scanner.resume();
+                        callbacks.error();
+                        return;
+                    }
                 } catch (InterruptedException e) {
                     Thread.currentThread().interrupt();
+                    callbacks.logLine("Interrupted while waiting for the serial port scanner to stop.");
+                    scanner.resume();
+                    callbacks.error();
+                    return;
                 }
                 final boolean flashed;
                 try {

--- a/java_console/connectivity/src/test/java/com/rusefi/maintenance/jobs/OpenBltManualJobTest.java
+++ b/java_console/connectivity/src/test/java/com/rusefi/maintenance/jobs/OpenBltManualJobTest.java
@@ -179,4 +179,21 @@ public class OpenBltManualJobTest {
         assertEquals(1, callbacks.errorCount);
         assertEquals(1, jobFinishedCount.get());
     }
+
+    @Test
+    public void interruptedScannerAcquisitionAbortsBeforeFlashingAndResumesScanner() {
+        Thread.currentThread().interrupt();
+        try {
+            newJob().doJob(callbacks, jobFinishedCount::incrementAndGet);
+            assertTrue(Thread.currentThread().isInterrupted());
+        } finally {
+            Thread.interrupted();
+        }
+
+        assertEquals(0, steps.flashCount);
+        assertEquals(1, scanner.resumeCount);
+        assertTrue(scanner.invalidatedPorts.isEmpty());
+        assertEquals(1, callbacks.errorCount);
+        assertEquals(1, jobFinishedCount.get());
+    }
 }

--- a/java_console/io/src/main/java/com/rusefi/libopenblt/XcpLoader.java
+++ b/java_console/io/src/main/java/com/rusefi/libopenblt/XcpLoader.java
@@ -6,6 +6,7 @@ import com.rusefi.libopenblt.transport.IXcpTransport;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
 import static com.devexperts.logging.Logging.getLogging;
@@ -25,6 +26,7 @@ public class XcpLoader {
     private static final byte XCPLOADER_CMD_PROGRAM = (byte)0xD0;    // XCP program command code
     private static final byte XCPLOADER_CMD_PROGRAM_RESET = (byte)0xCF;    // XCP program reset command code
     private static final byte XCPLOADER_CMD_PROGRAM_MAX = (byte)0xC9;    // XCP program max command code
+    private static final byte XCPLOADER_CMD_GET_SIGNATURE = (byte)0xBF;
 
     private static final byte XCPLOADER_CMD_PID_RES = (byte)0xFF;   // positive response
     private static final byte XCPLOADER_CMD_PID_ERR = (byte)0xFE;   // negative response
@@ -52,22 +54,62 @@ public class XcpLoader {
     }
 
     private TargetInfo mTargetInfo;
+    private String mExpectedStationId;
+    private boolean mVerifyStationId;
 
     public XcpLoader(IXcpTransport transport, XcpSettings settings) {
         mTransport = transport;
         mSettings = settings;
     }
 
+    public void requireStationIdCheck(String expectedStationId) {
+        mExpectedStationId = expectedStationId;
+        mVerifyStationId = true;
+    }
+
     public void start() throws IOException {
-        mTransport.connect();
-        connect();
+        boolean connected = false;
+        try {
+            mTransport.connect();
+            connected = true;
+            connect();
+        } catch (IOException | RuntimeException | Error e) {
+            if (connected) {
+                disconnectAfterFailure(e);
+            }
+            throw e;
+        }
     }
 
     public void stop() throws IOException {
-        // Send a null program to conclude the programming session
-        sendCmdProgram(new byte[0]);
-        sendCmdProgramReset();
-        mTransport.disconnect();
+        Throwable failure = null;
+        try {
+            // Send a null program to conclude the programming session
+            sendCmdProgram(new byte[0]);
+            sendCmdProgramReset();
+        } catch (IOException | RuntimeException | Error e) {
+            failure = e;
+            throw e;
+        } finally {
+            try {
+                mTransport.disconnect();
+                mTargetInfo = null;
+            } catch (IOException | RuntimeException e) {
+                if (failure != null) {
+                    failure.addSuppressed(e);
+                } else {
+                    throw e;
+                }
+            }
+        }
+    }
+
+    private void disconnectAfterFailure(Throwable failure) {
+        try {
+            mTransport.disconnect();
+        } catch (IOException | RuntimeException e) {
+            failure.addSuppressed(e);
+        }
     }
 
     private void connect() throws IOException {
@@ -107,10 +149,26 @@ public class XcpLoader {
             throw new IllegalStateException("Controller returned invalid max DTO configuration: " + ti.maxDto);
         }
 
+        if (mVerifyStationId) {
+            verifyStationId();
+        }
+
         // Place the target in programming mode
         ti.maxProgCto = programStart();
 
         mTargetInfo = ti;
+    }
+
+    private void verifyStationId() throws IOException {
+        byte[] response = mTransport.sendPacket(new byte[]{XCPLOADER_CMD_GET_SIGNATURE},
+            mSettings.timeoutT1, mExpectedStationId == null ? 1 : mExpectedStationId.length() + 1);
+        String actual = response.length > 1 && response[0] == XCPLOADER_CMD_PID_RES
+            ? new String(response, 1, response.length - 1, StandardCharsets.US_ASCII)
+            : null;
+        if (mExpectedStationId == null ? actual != null : !mExpectedStationId.equals(actual)) {
+            throw new IOException("OpenBLT target changed before programming: expected "
+                + mExpectedStationId + ", received " + actual);
+        }
     }
 
     // Place the target in programming mode, and return the maximum programming CTO

--- a/java_console/io/src/test/java/com/rusefi/libopenblt/XcpLoaderStationIdTest.java
+++ b/java_console/io/src/test/java/com/rusefi/libopenblt/XcpLoaderStationIdTest.java
@@ -1,0 +1,80 @@
+package com.rusefi.libopenblt;
+
+import com.rusefi.libopenblt.transport.IXcpTransport;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class XcpLoaderStationIdTest {
+    @Test
+    void legacyClassificationRejectsLiveSignedTargetBeforeProgramStart() {
+        StationTransport transport = new StationTransport();
+        XcpLoader loader = new XcpLoader(transport, new XcpSettings());
+        loader.requireStationIdCheck(null);
+
+        assertThrows(IOException.class, loader::start);
+
+        assertEquals(1, transport.signatureQueries);
+        assertEquals(0, transport.programStarts);
+        assertEquals(1, transport.disconnects);
+    }
+
+    @Test
+    void legacyClassificationAcceptsLiveLegacyTarget() throws IOException {
+        StationTransport transport = new StationTransport();
+        transport.liveSigned = false;
+        XcpLoader loader = new XcpLoader(transport, new XcpSettings());
+        loader.requireStationIdCheck(null);
+
+        loader.start();
+        loader.stop();
+
+        assertEquals(1, transport.signatureQueries);
+        assertEquals(1, transport.programStarts);
+        assertEquals(1, transport.disconnects);
+    }
+
+    private static class StationTransport implements IXcpTransport {
+        int signatureQueries;
+        int programStarts;
+        int disconnects;
+        boolean liveSigned = true;
+
+        @Override
+        public void connect() {
+        }
+
+        @Override
+        public void disconnect() {
+            disconnects++;
+        }
+
+        @Override
+        public byte[] sendPacket(byte[] request, int timeoutMs, int expectResponseBytes) {
+            int command = request[0] & 0xFF;
+            if (command == 0xFF) {
+                return new byte[]{(byte) 0xFF, 0, 0, (byte) 240, (byte) 240, 0, 0, 0};
+            }
+            if (command == 0xBF) {
+                signatureQueries++;
+                if (!liveSigned) {
+                    return new byte[]{(byte) 0xFE, 0x20};
+                }
+                byte[] station = "rusEFI.stm32f429_nucleo".getBytes(StandardCharsets.US_ASCII);
+                byte[] response = new byte[station.length + 1];
+                response[0] = (byte) 0xFF;
+                System.arraycopy(station, 0, response, 1, station.length);
+                return response;
+            }
+            if (command == 0xD2) {
+                programStarts++;
+                return new byte[]{(byte) 0xFF, 0, 0, (byte) 240, 0, 0, 0};
+            }
+            return new byte[]{(byte) 0xFF};
+        }
+    }
+}

--- a/java_console/ui/src/main/java/com/rusefi/DevicePane.java
+++ b/java_console/ui/src/main/java/com/rusefi/DevicePane.java
@@ -49,7 +49,7 @@ public class DevicePane {
     public DevicePane(final UIContext uiContext, final ConnectivityContext connectivityContext,
                       final DeviceSessionManager sessionManager, final JTabbedPane tabbedPane,
                       final SingleAsyncJobExecutor jobExecutor, final StatusPanelWithProgressBar statusPanel,
-                      final Consumer<JComponent> showRollbackPicker, final Runnable closeRollbackPicker) {
+                      final Consumer<JComponent> showFullScreenPanel, final Runnable closeFullScreenPanel) {
         this.connectivityContext = connectivityContext;
         this.sessionManager = sessionManager;
         this.tabbedPane = tabbedPane;
@@ -61,7 +61,8 @@ public class DevicePane {
         // well as the DFU/OpenBLT bootloader states), so no separate job-executor listeners are needed.
         sessionManager.setJobExecutor(jobExecutor);
 
-        this.selector = new ProgramSelector(connectivityContext, comboPorts);
+        this.selector = new ProgramSelector(
+            connectivityContext, comboPorts, showFullScreenPanel, closeFullScreenPanel);
         selector.setJobExecutor(jobExecutor);
         selector.setLinkManager(uiContext.getLinkManager());
         rollbackController = new FirmwareRollbackController(
@@ -71,8 +72,8 @@ public class DevicePane {
             () -> Optional.ofNullable((PortResult) comboPorts.getSelectedItem()),
             () -> sessionManager.getState() == SessionState.CONNECTED,
             this::refreshFirmwareControls,
-            showRollbackPicker,
-            closeRollbackPicker);
+            showFullScreenPanel,
+            closeFullScreenPanel);
         rollbackController.setLinkManager(uiContext.getLinkManager());
         selector.setFirmwareUpdateInterceptor(rollbackController::startLatestUpdate);
         selector.setExternalBusySupplier(rollbackController::isBusy);

--- a/java_console/ui/src/main/java/com/rusefi/StartupFrame.java
+++ b/java_console/ui/src/main/java/com/rusefi/StartupFrame.java
@@ -331,7 +331,8 @@ public class StartupFrame {
         dfuErrorTimer.setRepeats(false);
         dfuErrorTimer.start();
 
-        selector = new ProgramSelector(connectivityContext, portsComboBox.getComboPorts());
+        selector = new ProgramSelector(connectivityContext, portsComboBox.getComboPorts(),
+            this::showFullScreenPanel, this::closeFullScreenPanel);
         selector.setJobExecutor(asyncJobExecutor);
 
         realHardwarePanel.add(new HorizontalLine(), "right, wrap");
@@ -444,12 +445,7 @@ public class StartupFrame {
         BinaryProtocol.iniFileProvider.setStatusConsumer(firmwareStatusPanel);
         startupUpdateActions = new StartupUpdateActions(connectivityContext, firmwareStatusPanel,
             asyncJobExecutor, ecuPortToUse, softwareUpdateOutcome,
-            picker -> {
-                rollbackPicker.removeAll();
-                rollbackPicker.add(picker, BorderLayout.CENTER);
-                showCard(CARD_ROLLBACK);
-            },
-            () -> showCard(CARD_STARTUP));
+            this::showFullScreenPanel, this::closeFullScreenPanel);
         startupUpdateActions.configureFirmwareSelector(selector);
 
         JPanel firmwareTopPanel = new JPanel(new BorderLayout(0, 0));
@@ -598,6 +594,16 @@ public class StartupFrame {
         unsupportedEcuHost.setNormalContent(root);
         // Frame stays fixed-maximized (#9715) — relayout in place instead of pack()/resize.
         AutoupdateUtil.trueLayoutAndRepaint(frame);
+    }
+
+    private void showFullScreenPanel(JComponent panel) {
+        rollbackPicker.removeAll();
+        rollbackPicker.add(panel, BorderLayout.CENTER);
+        showCard(CARD_ROLLBACK);
+    }
+
+    private void closeFullScreenPanel() {
+        showCard(CARD_STARTUP);
     }
 
     private void updateConnectButtonState() {

--- a/java_console/ui/src/main/java/com/rusefi/maintenance/OpenBltFlasher.java
+++ b/java_console/ui/src/main/java/com/rusefi/maintenance/OpenBltFlasher.java
@@ -27,7 +27,7 @@ public class OpenBltFlasher {
     private List<SrecParser.SRecord> mSegments;
     private int mTotalFileSize;
 
-    private OpenBltFlasher(IXcpTransport transport, XcpSettings settings, OpenbltJni.OpenbltCallbacks callbacks) {
+    OpenBltFlasher(IXcpTransport transport, XcpSettings settings, OpenbltJni.OpenbltCallbacks callbacks) {
         mLoader = new XcpLoader(transport, settings);
         mCallbacks = callbacks;
     }
@@ -48,22 +48,52 @@ public class OpenBltFlasher {
         f.flash(fileName);
     }
 
+    public static void eraseSerial(OpenBltWipeArtifact artifact, String port,
+                                   OpenbltJni.OpenbltCallbacks callbacks) throws IOException {
+        OpenBltFlasher f = OpenBltFlasher.makeSerial(port, new XcpSettings(), callbacks);
+        f.erase(artifact);
+    }
+
     public void flash(String filename) throws IOException {
         loadFile(filename);
+        execute(true);
+    }
 
+    void erase(OpenBltWipeArtifact artifact) throws IOException {
+        mCallbacks.setPhase("Load emergency wipe image", false);
+        setSegments(artifact.getSegments(), "Emergency wipe image");
+        mLoader.requireStationIdCheck(artifact.getReportedStationId());
+        execute(false);
+    }
+
+    private void execute(boolean writeData) throws IOException {
         mCallbacks.setPhase("Connect to target", false);
-        // Prepare loader
-        mLoader.start();
-
-        // Erase memory
-        erase();
-
-        // Write new data
-        write();
-
-        mCallbacks.setPhase("Cleanup", false);
-        // Done, stop the session!
-        mLoader.stop();
+        boolean started = false;
+        Throwable failure = null;
+        try {
+            mLoader.start();
+            started = true;
+            erase();
+            if (writeData) {
+                write();
+            }
+            mCallbacks.setPhase("Cleanup", false);
+        } catch (IOException | RuntimeException | Error e) {
+            failure = e;
+            throw e;
+        } finally {
+            if (started) {
+                try {
+                    mLoader.stop();
+                } catch (IOException | RuntimeException e) {
+                    if (failure != null) {
+                        failure.addSuppressed(e);
+                    } else {
+                        throw e;
+                    }
+                }
+            }
+        }
     }
 
     private void loadFile(String filename) throws IOException {
@@ -72,14 +102,21 @@ public class OpenBltFlasher {
 
         SrecParser file = new SrecParser();
         file.parse(new File(filename));
+        setSegments(file.getSegments(), "Firmware file");
+    }
 
-        mSegments = file.getSegments();
+    private void setSegments(List<SrecParser.SRecord> segments, String description) throws IOException {
+        if (segments.isEmpty()) {
+            throw new IOException(description + " contains no data records");
+        }
+
+        mSegments = segments;
 
         mTotalFileSize = mSegments.stream()
             .map(s -> s.data.length).reduce(0, Integer::sum);
 
-        mCallbacks.log("Firmware file parsed:");
-        mCallbacks.log("\tfirst address: 0x" + Integer.toString(mSegments.get(0).address, 16));
+        mCallbacks.log(description + " parsed:");
+        mCallbacks.log(String.format("\tfirst address: 0x%08X", mSegments.get(0).address));
         mCallbacks.log("\ttotal size: " + mTotalFileSize);
     }
 

--- a/java_console/ui/src/main/java/com/rusefi/maintenance/OpenBltWipeArtifact.java
+++ b/java_console/ui/src/main/java/com/rusefi/maintenance/OpenBltWipeArtifact.java
@@ -1,0 +1,221 @@
+package com.rusefi.maintenance;
+
+import com.rusefi.PortResult;
+import com.rusefi.SerialPortType;
+import com.rusefi.core.FindFileHelper;
+import com.rusefi.core.io.BundleUtil;
+import com.rusefi.libopenblt.file.SrecParser;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.List;
+import java.util.Properties;
+
+public class OpenBltWipeArtifact {
+    private static final long APPLICATION_START = 0x08008000L;
+    private static final long FLASH_1MB_END_EXCLUSIVE = 0x08100000L;
+    private static final long FLASH_2MB_END_EXCLUSIVE = 0x08200000L;
+
+    private final String bundleTarget;
+    private final String bootloaderTarget;
+    private final String mcuFamily;
+    private final long endAddressExclusive;
+    private final List<SrecParser.SRecord> segments;
+    private final String reportedStationId;
+
+    private OpenBltWipeArtifact(String bundleTarget, String bootloaderTarget, String mcuFamily,
+                                long endAddressExclusive, List<SrecParser.SRecord> segments,
+                                String reportedStationId) {
+        this.bundleTarget = bundleTarget;
+        this.bootloaderTarget = bootloaderTarget;
+        this.mcuFamily = mcuFamily;
+        this.endAddressExclusive = endAddressExclusive;
+        this.segments = segments;
+        this.reportedStationId = reportedStationId;
+    }
+
+    public static OpenBltWipeArtifact loadAndValidate(PortResult port) throws IOException {
+        Profile profile = loadProfileFor(port);
+
+        SrecParser parser = new SrecParser();
+        parser.parse(new File(profile.srecName));
+        if (parser.hasEmptyDataRecords()) {
+            throw new IOException("Emergency wipe SREC contains an empty data record");
+        }
+        List<SrecParser.SRecord> segments = parser.getSegments();
+        validateSegments(segments, profile.startAddress, profile.endAddressExclusive);
+
+        return new OpenBltWipeArtifact(profile.bundleTarget, profile.bootloaderTarget, profile.mcuFamily,
+            profile.endAddressExclusive, segments, profile.reportedStationId);
+    }
+
+    public static boolean isAvailableFor(PortResult port) {
+        if (!FindFileHelper.hasOpenBltWipeArtifact()) {
+            return false;
+        }
+        try {
+            loadProfileFor(port);
+            return true;
+        } catch (IOException e) {
+            return false;
+        }
+    }
+
+    private static Profile loadProfileFor(PortResult port) throws IOException {
+        if (port == null || port.type != SerialPortType.OpenBlt) {
+            throw new IOException("Emergency wipe requires a positively detected OpenBLT port");
+        }
+
+        String manifestName = FindFileHelper.findOpenBltWipeManifest();
+        if (manifestName == null) {
+            throw new IOException("This bundle does not contain an emergency wipe profile");
+        }
+
+        Properties profile = new Properties();
+        try (FileReader reader = new FileReader(manifestName)) {
+            profile.load(reader);
+        }
+
+        if (!"1".equals(required(profile, "format"))) {
+            throw new IOException("Unsupported emergency wipe profile format");
+        }
+        String bundleTarget = required(profile, "bundleTarget");
+        String bootloaderTarget = required(profile, "bootloaderTarget");
+        String mcuFamily = required(profile, "mcuFamily");
+        if (!"ARCH_STM32F4".equals(mcuFamily) && !"ARCH_STM32F7".equals(mcuFamily)) {
+            throw new IOException("Emergency wipe is not enabled for " + mcuFamily);
+        }
+
+        long startAddress = parseAddress(required(profile, "startAddress"));
+        long endAddressExclusive = parseAddress(required(profile, "endAddressExclusive"));
+        if (!isSupportedProfile(bundleTarget, bootloaderTarget, mcuFamily, startAddress, endAddressExclusive)) {
+            throw new IOException(String.format("Unsupported emergency wipe range 0x%08X-0x%08X",
+                startAddress, endAddressExclusive));
+        }
+
+        String reportedTarget = port.bootloaderInfo == null ? null : port.bootloaderInfo.board;
+        if (reportedTarget != null) {
+            if (!reportedTarget.equalsIgnoreCase(bootloaderTarget)) {
+                throw new IOException("OpenBLT target " + reportedTarget
+                    + " does not match wipe target " + bootloaderTarget);
+            }
+        } else {
+            String localBundleTarget = BundleUtil.getBundleTarget();
+            if (localBundleTarget == null || !localBundleTarget.equalsIgnoreCase(bundleTarget)) {
+                throw new IOException("Legacy OpenBLT wipe requires the matching " + bundleTarget + " bundle");
+            }
+        }
+
+        String srecName = FindFileHelper.findOpenBltWipeSrec(required(profile, "srec"));
+        String reportedStationId = reportedTarget == null ? null : port.bootloaderInfo.raw;
+        return new Profile(bundleTarget, bootloaderTarget, mcuFamily, startAddress, endAddressExclusive,
+            srecName, reportedStationId);
+    }
+
+    private static boolean isSupportedProfile(String bundleTarget, String bootloaderTarget, String mcuFamily,
+                                              long startAddress, long endAddressExclusive) {
+        return startAddress == APPLICATION_START
+            && ((endAddressExclusive == FLASH_1MB_END_EXCLUSIVE
+                    && "uaefi".equals(bundleTarget)
+                    && "uaefi".equals(bootloaderTarget)
+                    && "ARCH_STM32F4".equals(mcuFamily))
+                || (endAddressExclusive == FLASH_2MB_END_EXCLUSIVE
+                    && "stm32f429_nucleo".equals(bundleTarget)
+                    && "stm32f429_nucleo".equals(bootloaderTarget)
+                    && "ARCH_STM32F4".equals(mcuFamily))
+                || (endAddressExclusive == FLASH_2MB_END_EXCLUSIVE
+                    && "stm32f767_nucleo".equals(bundleTarget)
+                    && "stm32f767_nucleo".equals(bootloaderTarget)
+                    && "ARCH_STM32F7".equals(mcuFamily)));
+    }
+
+    private static String required(Properties profile, String name) throws IOException {
+        String value = profile.getProperty(name);
+        if (value == null || value.trim().isEmpty()) {
+            throw new IOException("Emergency wipe profile is missing " + name);
+        }
+        return value.trim();
+    }
+
+    private static long parseAddress(String value) throws IOException {
+        try {
+            String digits = value.startsWith("0x") || value.startsWith("0X") ? value.substring(2) : value;
+            return Long.parseUnsignedLong(digits, 16);
+        } catch (NumberFormatException e) {
+            throw new IOException("Invalid emergency wipe address: " + value, e);
+        }
+    }
+
+    private static void validateSegments(List<SrecParser.SRecord> segments, long startAddress,
+                                         long endAddressExclusive) throws IOException {
+        if (segments.size() != 1) {
+            throw new IOException("Emergency wipe SREC must contain one contiguous data range");
+        }
+
+        SrecParser.SRecord segment = segments.get(0);
+        if (Integer.toUnsignedLong(segment.address) != startAddress || segment.endAddress() != endAddressExclusive) {
+            throw new IOException(String.format("Emergency wipe SREC range is 0x%08X-0x%08X, expected 0x%08X-0x%08X",
+                Integer.toUnsignedLong(segment.address), segment.endAddress(), startAddress, endAddressExclusive));
+        }
+        for (byte value : segment.data) {
+            if (value != (byte) 0xFF) {
+                throw new IOException("Emergency wipe SREC contains data other than 0xFF");
+            }
+        }
+    }
+
+    List<SrecParser.SRecord> getSegments() {
+        return segments;
+    }
+
+    String getReportedStationId() {
+        return reportedStationId;
+    }
+
+    public String getBundleTarget() {
+        return bundleTarget;
+    }
+
+    public String getBootloaderTarget() {
+        return bootloaderTarget;
+    }
+
+    public String getMcuFamily() {
+        return mcuFamily;
+    }
+
+    public int getFlashSizeKiB() {
+        return (int) ((endAddressExclusive - 0x08000000L) / 1024);
+    }
+
+    public String confirmationMessage() {
+        return "Target: " + bundleTarget + " (OpenBLT " + bootloaderTarget + ")\n"
+            + "MCU: " + mcuFamily + ", internal flash: " + getFlashSizeKiB() + " KiB\n\n"
+            + "This will erase application firmware and all internal MCU configuration after OpenBLT.\n"
+            + "OpenBLT itself will be preserved, but the ECU will not run application firmware afterward.\n"
+            + "Run a normal Manual OpenBLT Update next; the previous tune will not be restored automatically.\n"
+            + "External SPI/QSPI flash and SD card storage will not be erased.";
+    }
+
+    private static class Profile {
+        final String bundleTarget;
+        final String bootloaderTarget;
+        final String mcuFamily;
+        final long startAddress;
+        final long endAddressExclusive;
+        final String srecName;
+        final String reportedStationId;
+
+        Profile(String bundleTarget, String bootloaderTarget, String mcuFamily, long startAddress,
+                long endAddressExclusive, String srecName, String reportedStationId) {
+            this.bundleTarget = bundleTarget;
+            this.bootloaderTarget = bootloaderTarget;
+            this.mcuFamily = mcuFamily;
+            this.startAddress = startAddress;
+            this.endAddressExclusive = endAddressExclusive;
+            this.srecName = srecName;
+            this.reportedStationId = reportedStationId;
+        }
+    }
+}

--- a/java_console/ui/src/main/java/com/rusefi/maintenance/ProgramSelector.java
+++ b/java_console/ui/src/main/java/com/rusefi/maintenance/ProgramSelector.java
@@ -18,6 +18,7 @@ import com.rusefi.maintenance.jobs.*;
 import com.rusefi.ui.basic.SingleAsyncJobExecutor;
 import com.rusefi.ui.util.URLLabel;
 import com.rusefi.ui.widgets.JSplitButton;
+import com.rusefi.ui.wizard.EmergencyWipePanel;
 import com.rusefi.updater.OpenbltDetectorStrategy;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -27,12 +28,14 @@ import javax.swing.filechooser.FileNameExtensionFilter;
 import java.awt.*;
 import java.awt.event.ItemEvent;
 import java.io.File;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.io.EOFException;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BooleanSupplier;
+import java.util.function.Consumer;
 import java.util.function.Function;
 
 import static com.devexperts.logging.Logging.getLogging;
@@ -51,6 +54,8 @@ public class ProgramSelector {
     private final List<JComponent> additionalFirmwareControls = new ArrayList<>();
     private final ConnectivityContext connectivityContext;
     private final JComboBox<PortResult> comboPorts;
+    private final Consumer<JComponent> showFullScreenPanel;
+    private final Runnable closeFullScreenPanel;
     @Nullable
     private SingleAsyncJobExecutor jobExecutor;
     @Nullable
@@ -58,9 +63,12 @@ public class ProgramSelector {
     private Function<JComponent, Boolean> firmwareUpdateInterceptor = source -> false;
     private BooleanSupplier externalBusy = () -> false;
 
-    public ProgramSelector(ConnectivityContext connectivityContext, JComboBox<PortResult> comboPorts) {
+    public ProgramSelector(ConnectivityContext connectivityContext, JComboBox<PortResult> comboPorts,
+                           Consumer<JComponent> showFullScreenPanel, Runnable closeFullScreenPanel) {
         this.connectivityContext = connectivityContext;
         this.comboPorts = comboPorts;
+        this.showFullScreenPanel = Objects.requireNonNull(showFullScreenPanel);
+        this.closeFullScreenPanel = Objects.requireNonNull(closeFullScreenPanel);
         noHardware.setBorder(BorderFactory.createEmptyBorder(5, 8, 5, 8));
         noHardware.setFont(noHardware.getFont().deriveFont(noHardware.getFont().getSize2D() + 2));
         content.add(updateModeAndButton, BorderLayout.NORTH);
@@ -218,6 +226,9 @@ public class ProgramSelector {
             case OPENBLT_AUTO:
                 job = new OpenBltAutoJob(selectedPort, parent, connectivityContext, linkManager);
                 break;
+            case OPENBLT_EMERGENCY_WIPE:
+                showEmergencyWipeConfirmation(parent, selectedPort);
+                return;
             case DFU_ERASE:
                 job = new DfuEraseJob();
                 break;
@@ -226,6 +237,24 @@ public class ProgramSelector {
         }
 
         runJob(job, parent);
+    }
+
+    private void showEmergencyWipeConfirmation(JComponent parent, PortResult selectedPort) {
+        final OpenBltWipeArtifact artifact;
+        try {
+            artifact = OpenBltWipeArtifact.loadAndValidate(selectedPort);
+        } catch (IOException e) {
+            log.error("Emergency wipe validation failed", e);
+            JOptionPane.showMessageDialog(parent, e.getMessage(), "Emergency wipe unavailable",
+                JOptionPane.ERROR_MESSAGE);
+            return;
+        }
+
+        showFullScreenPanel.accept(new EmergencyWipePanel(artifact.confirmationMessage(), () -> {
+            closeFullScreenPanel.run();
+            runJob(OpenBltManualJobFactory.createEmergencyWipe(
+                selectedPort, parent, connectivityContext, artifact), parent);
+        }, closeFullScreenPanel));
     }
 
     private void runJob(AsyncJob job, JComponent parent) {
@@ -543,6 +572,25 @@ public class ProgramSelector {
         }
     }
 
+    public static boolean wipeOpenbltSerial(String port, UpdateOperationCallbacks callbacks,
+                                            OpenBltWipeArtifact artifact) {
+        OpenbltJni.OpenbltCallbacks cb = makeOpenbltCallbacks(callbacks);
+
+        // Once a wipe is confirmed, fail safe: never let a later manual flash restore the suspect tune,
+        // even if this erase is interrupted after invalidating the application vector.
+        CalibrationsHelper.discardLastEcuCalibrations();
+        callbacks.logLine("Previous session tune discarded; the next manual update will keep firmware defaults.");
+        try {
+            OpenBltFlasher.eraseSerial(artifact, port, cb);
+            callbacks.logLine("Emergency wipe completed. The ECU remains in OpenBLT.");
+            return true;
+        } catch (Throwable e) {
+            callbacks.logLine("Emergency OpenBLT wipe error: " + e);
+            log.error("wipeOpenbltSerial " + e, e);
+            return false;
+        }
+    }
+
     @NotNull
     public static JComponent createHelpButton() {
         return new URLLabel("HOWTO Update Firmware", UiProperties.getUpdateHelpUrl());
@@ -610,6 +658,10 @@ public class ProgramSelector {
         if (hasSerialPorts) {
             addMenuItem(popupMenu, OPENBLT_SWITCH);
             addMenuItem(popupMenu, OPENBLT_MANUAL);
+            PortResult selected = resolveFlashPort();
+            if (isEmergencyWipeAvailable(selected)) {
+                addMenuItem(popupMenu, OPENBLT_EMERGENCY_WIPE);
+            }
         }
 
         int menuItemCount = popupMenu.getComponentCount();
@@ -629,6 +681,10 @@ public class ProgramSelector {
 
     static boolean hasRealSerialPort(List<PortResult> ports) {
         return ports.stream().anyMatch(port -> port.type != SerialPortType.Dfu && !isUnflashableEcu(port));
+    }
+
+    static boolean isEmergencyWipeAvailable(@Nullable PortResult port) {
+        return OpenBltWipeArtifact.isAvailableFor(port);
     }
 
     static boolean shouldEnableMainButton(
@@ -668,7 +724,9 @@ public class ProgramSelector {
     private void addMenuItem(JPopupMenu menu, UpdateMode mode) {
         JMenuItem item = new JMenuItem(mode.displayText);
         item.addActionListener(e -> {
-            PortResult selected = (PortResult) comboPorts.getSelectedItem();
+            PortResult selected = mode == OPENBLT_EMERGENCY_WIPE
+                ? resolveFlashPort()
+                : (PortResult) comboPorts.getSelectedItem();
             if (isUnflashableEcu(selected)) {
                 return;
             }

--- a/java_console/ui/src/main/java/com/rusefi/maintenance/UpdateMode.java
+++ b/java_console/ui/src/main/java/com/rusefi/maintenance/UpdateMode.java
@@ -12,6 +12,7 @@ public enum UpdateMode {
     OPENBLT_CAN("OpenBLT via CAN"),
     OPENBLT_MANUAL("Manual OpenBLT Update"),
     OPENBLT_AUTO("Auto OpenBLT Update"),
+    OPENBLT_EMERGENCY_WIPE("EMERGENCY WIPE INTERNAL FLASH"),
     DFU_ERASE("Full DFU Erase");
 
     /***

--- a/java_console/ui/src/main/java/com/rusefi/maintenance/jobs/OpenBltManualJobFactory.java
+++ b/java_console/ui/src/main/java/com/rusefi/maintenance/jobs/OpenBltManualJobFactory.java
@@ -2,11 +2,19 @@ package com.rusefi.maintenance.jobs;
 
 import com.rusefi.ConnectivityContext;
 import com.rusefi.PortResult;
+import com.rusefi.maintenance.OpenBltWipeArtifact;
 
 import javax.swing.*;
 
 public class OpenBltManualJobFactory {
     public static OpenBltManualJob createProduction(PortResult port, final JComponent parent, final ConnectivityContext connectivityContext) {
         return new OpenBltManualJob(port, parent, connectivityContext, ProductionFlashSteps.PRODUCTION_STEPS);
+    }
+
+    public static OpenBltManualJob createEmergencyWipe(PortResult port, final JComponent parent,
+                                                        final ConnectivityContext connectivityContext,
+                                                        final OpenBltWipeArtifact artifact) {
+        return new OpenBltManualJob("Emergency OpenBLT wipe", port, parent, connectivityContext,
+            ProductionFlashSteps.emergencyWipe(artifact));
     }
 }

--- a/java_console/ui/src/main/java/com/rusefi/maintenance/jobs/ProductionFlashSteps.java
+++ b/java_console/ui/src/main/java/com/rusefi/maintenance/jobs/ProductionFlashSteps.java
@@ -5,6 +5,7 @@ import com.rusefi.core.io.ConnectedEcuTarget;
 import com.rusefi.io.UpdateOperationCallbacks;
 import com.rusefi.maintenance.CalibrationsHelper;
 import com.rusefi.maintenance.MaintenanceUtil;
+import com.rusefi.maintenance.OpenBltWipeArtifact;
 import com.rusefi.maintenance.ProgramSelector;
 
 import javax.swing.*;
@@ -28,4 +29,25 @@ public class ProductionFlashSteps {
             CalibrationsHelper.restorePreviousCalibrationsAfterManualFlash(callbacks, connectivityContext);
         }
     };
+
+    public static OpenBltManualJob.FlashSteps emergencyWipe(final OpenBltWipeArtifact artifact) {
+        return new OpenBltManualJob.FlashSteps() {
+            @Override
+            public boolean ensureFirmware(final UpdateOperationCallbacks callbacks, final ConnectedEcuTarget target) {
+                return true;
+            }
+
+            @Override
+            public boolean flash(final JComponent parent, final String port,
+                                 final UpdateOperationCallbacks callbacks, final ConnectedEcuTarget target) {
+                return ProgramSelector.wipeOpenbltSerial(port, callbacks, artifact);
+            }
+
+            @Override
+            public void restoreCalibrations(final UpdateOperationCallbacks callbacks,
+                                            final ConnectivityContext connectivityContext) {
+                // Emergency wipe intentionally leaves the ECU in OpenBLT with no tune restoration.
+            }
+        };
+    }
 }

--- a/java_console/ui/src/main/java/com/rusefi/ui/wizard/EmergencyWipePanel.java
+++ b/java_console/ui/src/main/java/com/rusefi/ui/wizard/EmergencyWipePanel.java
@@ -1,0 +1,77 @@
+package com.rusefi.ui.wizard;
+
+import javax.swing.*;
+import java.awt.*;
+
+public final class EmergencyWipePanel extends JPanel {
+    private static final int CARD_WIDTH = 760;
+    private final JButton cancelButton = new JButton("Cancel");
+    private final JButton eraseButton = new JButton("Erase Internal Flash");
+
+    public EmergencyWipePanel(String message, Runnable erase, Runnable cancel) {
+        super(new BorderLayout());
+        setBorder(BorderFactory.createEmptyBorder(
+            WizardStyle.LARGE_GAP, WizardStyle.LARGE_GAP, WizardStyle.LARGE_GAP, WizardStyle.LARGE_GAP));
+
+        JLabel heading = new JLabel("Emergency Internal Flash Wipe");
+        AbstractWizardStep.styleTitle(heading);
+        add(heading, BorderLayout.NORTH);
+
+        JPanel card = new JPanel();
+        card.setLayout(new BoxLayout(card, BoxLayout.Y_AXIS));
+        card.setBorder(BorderFactory.createCompoundBorder(
+            BorderFactory.createLineBorder(WizardStyle.border()),
+            BorderFactory.createEmptyBorder(26, 30, 26, 30)));
+        card.setPreferredSize(new Dimension(CARD_WIDTH, 460));
+        card.setMaximumSize(new Dimension(CARD_WIDTH, 460));
+
+        JLabel warning = new JLabel("This action cannot be undone", UIManager.getIcon("OptionPane.warningIcon"),
+            SwingConstants.LEFT);
+        warning.setFont(warning.getFont().deriveFont(Font.BOLD, warning.getFont().getSize() * 1.3f));
+        warning.setAlignmentX(Component.LEFT_ALIGNMENT);
+        card.add(warning);
+        card.add(Box.createVerticalStrut(WizardStyle.LARGE_GAP));
+
+        JTextArea details = new JTextArea(message);
+        details.setEditable(false);
+        details.setOpaque(false);
+        details.setLineWrap(true);
+        details.setWrapStyleWord(true);
+        details.setFont(UIManager.getFont("Label.font").deriveFont(UIManager.getFont("Label.font").getSize() * 1.1f));
+        details.setAlignmentX(Component.LEFT_ALIGNMENT);
+        card.add(details);
+        card.add(Box.createVerticalGlue());
+        card.add(Box.createVerticalStrut(WizardStyle.LARGE_GAP));
+
+        AbstractWizardStep.styleButton(cancelButton);
+        cancelButton.addActionListener(e -> cancel.run());
+        AbstractWizardStep.stylePrimaryAction(eraseButton);
+        eraseButton.addActionListener(e -> {
+            eraseButton.setEnabled(false);
+            erase.run();
+        });
+
+        JPanel actions = new JPanel(new BorderLayout(WizardStyle.GAP, 0));
+        actions.setAlignmentX(Component.LEFT_ALIGNMENT);
+        actions.setMaximumSize(new Dimension(Integer.MAX_VALUE, eraseButton.getPreferredSize().height));
+        actions.add(cancelButton, BorderLayout.WEST);
+        actions.add(eraseButton, BorderLayout.EAST);
+        card.add(actions);
+
+        JPanel center = new JPanel(new GridBagLayout());
+        center.add(card);
+        add(center, BorderLayout.CENTER);
+
+        registerKeyboardAction(e -> cancel.run(), KeyStroke.getKeyStroke("ESCAPE"),
+            JComponent.WHEN_IN_FOCUSED_WINDOW);
+        SwingUtilities.invokeLater(cancelButton::requestFocusInWindow);
+    }
+
+    JButton cancelButtonForTests() {
+        return cancelButton;
+    }
+
+    JButton eraseButtonForTests() {
+        return eraseButton;
+    }
+}

--- a/java_console/ui/src/test/java/com/rusefi/maintenance/OpenBltEmergencyWipeTest.java
+++ b/java_console/ui/src/test/java/com/rusefi/maintenance/OpenBltEmergencyWipeTest.java
@@ -1,0 +1,292 @@
+package com.rusefi.maintenance;
+
+import com.rusefi.PortResult;
+import com.rusefi.SerialPortType;
+import com.rusefi.core.FindFileHelper;
+import com.rusefi.libopenblt.XcpSettings;
+import com.rusefi.libopenblt.transport.IXcpTransport;
+import com.rusefi.updater.OpenbltDetectorStrategy.OpenbltInfo;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class OpenBltEmergencyWipeTest {
+    private static final String TARGET = "stm32f429_nucleo";
+    private static final String UAEFI_TARGET = "uaefi";
+    private static final long START = 0x08008000L;
+    private static final long UAEFI_END = 0x08100000L;
+    private static final long END = 0x08200000L;
+    private static final int RECORD_DATA_SIZE = 240;
+
+    @TempDir
+    Path tempDir;
+
+    private String previousInputFilesPath;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        previousInputFilesPath = FindFileHelper.INPUT_FILES_PATH;
+        FindFileHelper.INPUT_FILES_PATH = tempDir.toString();
+        writeArtifact();
+    }
+
+    @AfterEach
+    void tearDown() {
+        FindFileHelper.INPUT_FILES_PATH = previousInputFilesPath;
+    }
+
+    @Test
+    void erasesEveryChunkWithoutProgrammingData() throws IOException {
+        OpenBltWipeArtifact artifact = OpenBltWipeArtifact.loadAndValidate(signedPort(TARGET));
+        RecordingTransport transport = new RecordingTransport();
+        OpenBltFlasher flasher = new OpenBltFlasher(transport, new XcpSettings(), callbacks());
+
+        flasher.erase(artifact);
+
+        assertEquals(1, transport.connectCount);
+        assertEquals(1, transport.disconnectCount);
+        assertEquals(504, transport.commandCount(0xD1));
+        assertEquals(1, transport.commandCount(0xD0));
+        assertEquals(0, transport.commandCount(0xC9));
+        assertEquals(1, transport.commandCount(0xCF));
+
+        List<byte[]> setMtaRequests = transport.commands(0xF6);
+        List<byte[]> clearRequests = transport.commands(0xD1);
+        for (int i = 0; i < clearRequests.size(); i++) {
+            assertEquals(START + i * 4096L, Integer.toUnsignedLong(ByteBuffer.wrap(setMtaRequests.get(i))
+                .order(ByteOrder.LITTLE_ENDIAN).getInt(4)));
+            assertEquals(4096, ByteBuffer.wrap(clearRequests.get(i)).order(ByteOrder.LITTLE_ENDIAN).getInt(4));
+        }
+        assertEquals(END, START + clearRequests.size() * 4096L);
+
+        byte[] finalProgram = transport.first(0xD0);
+        assertEquals(2, finalProgram.length);
+        assertEquals(0, finalProgram[1]);
+        assertEquals(0xCF, transport.requests.get(transport.requests.size() - 1)[0] & 0xFF);
+    }
+
+    @Test
+    void eraseFailureStillDisconnectsAndNeverProgramsPayload() throws IOException {
+        OpenBltWipeArtifact artifact = OpenBltWipeArtifact.loadAndValidate(signedPort(TARGET));
+        RecordingTransport transport = new RecordingTransport();
+        transport.failFirstClear = true;
+        OpenBltFlasher flasher = new OpenBltFlasher(transport, new XcpSettings(), callbacks());
+
+        assertThrows(IOException.class, () -> flasher.erase(artifact));
+
+        assertEquals(1, transport.disconnectCount);
+        assertEquals(0, transport.commandCount(0xC9));
+        assertTrue(transport.requests.stream()
+            .filter(request -> (request[0] & 0xFF) == 0xD0)
+            .allMatch(request -> request.length == 2 && request[1] == 0));
+    }
+
+    @Test
+    void signedTargetMismatchFailsBeforeAnyTransportExists() {
+        IOException error = assertThrows(IOException.class,
+            () -> OpenBltWipeArtifact.loadAndValidate(signedPort("different_board")));
+        assertTrue(error.getMessage().contains("does not match"));
+        assertFalse(OpenBltWipeArtifact.isAvailableFor(signedPort("different_board")));
+        assertTrue(OpenBltWipeArtifact.isAvailableFor(signedPort(TARGET)));
+    }
+
+    @Test
+    void uaefiProfileUsesOneMiBGeometry() throws IOException {
+        Files.delete(tempDir.resolve("bin/wipe/rusefi_development_test_" + TARGET + "_wipe.srec"));
+        writeArtifact(UAEFI_TARGET, UAEFI_END, false);
+
+        OpenBltWipeArtifact artifact = OpenBltWipeArtifact.loadAndValidate(signedPort(UAEFI_TARGET));
+
+        assertEquals(1024, artifact.getFlashSizeKiB());
+        assertTrue(OpenBltWipeArtifact.isAvailableFor(signedPort(UAEFI_TARGET)));
+    }
+
+    @Test
+    void liveTargetChangeDisconnectsBeforeProgrammingStarts() throws IOException {
+        OpenBltWipeArtifact artifact = OpenBltWipeArtifact.loadAndValidate(signedPort(TARGET));
+        RecordingTransport transport = new RecordingTransport();
+        transport.stationId = "rusEFI.different_board";
+        OpenBltFlasher flasher = new OpenBltFlasher(transport, new XcpSettings(), callbacks());
+
+        IOException error = assertThrows(IOException.class, () -> flasher.erase(artifact));
+
+        assertTrue(error.getMessage().contains("target changed"));
+        assertEquals(1, transport.disconnectCount);
+        assertEquals(0, transport.commandCount(0xD2));
+        assertEquals(0, transport.commandCount(0xD1));
+    }
+
+    @Test
+    void confirmationStatesDestructiveAndExternalStoragePolicy() throws IOException {
+        String message = OpenBltWipeArtifact.loadAndValidate(signedPort(TARGET)).confirmationMessage();
+        assertTrue(message.contains("OpenBLT itself will be preserved"));
+        assertTrue(message.contains("previous tune will not be restored"));
+        assertTrue(message.contains("External SPI/QSPI flash and SD card storage will not be erased"));
+    }
+
+    @Test
+    void emptyDataRecordIsRejectedForWipeUse() throws IOException {
+        writeArtifact(true);
+        IOException error = assertThrows(IOException.class,
+            () -> OpenBltWipeArtifact.loadAndValidate(signedPort(TARGET)));
+        assertTrue(error.getMessage().contains("empty data record"));
+    }
+
+    private static PortResult signedPort(String target) {
+        return new PortResult("COM_TEST", SerialPortType.OpenBlt, null,
+            new OpenbltInfo(true, "rusEFI." + target, Collections.emptyList()));
+    }
+
+    private void writeArtifact() throws IOException {
+        writeArtifact(false);
+    }
+
+    private void writeArtifact(boolean includeEmptyRecord) throws IOException {
+        writeArtifact(TARGET, END, includeEmptyRecord);
+    }
+
+    private void writeArtifact(String target, long end, boolean includeEmptyRecord) throws IOException {
+        Path wipeDir = tempDir.resolve("bin/wipe");
+        Files.createDirectories(wipeDir);
+        String srecName = "rusefi_development_test_" + target + "_wipe.srec";
+        Files.write(wipeDir.resolve("openblt_wipe.properties"), (
+            "format=1\n"
+                + "bundleTarget=" + target + "\n"
+                + "bootloaderTarget=" + target + "\n"
+                + "mcuFamily=ARCH_STM32F4\n"
+                + "startAddress=0x08008000\n"
+                + String.format("endAddressExclusive=0x%08X\n", end)
+                + "srec=" + srecName + "\n").getBytes(StandardCharsets.US_ASCII));
+
+        try (BufferedWriter writer = Files.newBufferedWriter(wipeDir.resolve(srecName), StandardCharsets.US_ASCII)) {
+            writer.write(record('0', 0, 2, "wipe".getBytes(StandardCharsets.US_ASCII)));
+            if (includeEmptyRecord) {
+                writer.write(record('3', START, 4, new byte[0]));
+            }
+            int recordCount = 0;
+            for (long address = START; address < end; address += RECORD_DATA_SIZE) {
+                int size = (int) Math.min(RECORD_DATA_SIZE, end - address);
+                byte[] data = new byte[size];
+                java.util.Arrays.fill(data, (byte) 0xFF);
+                writer.write(record('3', address, 4, data));
+                recordCount++;
+            }
+            writer.write(record('5', recordCount, 2, new byte[0]));
+            writer.write(record('7', START, 4, new byte[0]));
+        }
+    }
+
+    private static String record(char type, long address, int addressSize, byte[] data) {
+        byte[] body = new byte[addressSize + data.length];
+        for (int i = 0; i < addressSize; i++) {
+            body[i] = (byte) (address >> (8 * (addressSize - i - 1)));
+        }
+        System.arraycopy(data, 0, body, addressSize, data.length);
+        int count = body.length + 1;
+        int sum = count;
+        StringBuilder result = new StringBuilder(String.format("S%c%02X", type, count));
+        for (byte value : body) {
+            sum += value & 0xFF;
+            result.append(String.format("%02X", value & 0xFF));
+        }
+        return result.append(String.format("%02X%n", (~sum) & 0xFF)).toString();
+    }
+
+    private static OpenbltJni.OpenbltCallbacks callbacks() {
+        return new OpenbltJni.OpenbltCallbacks() {
+            @Override
+            public void log(String line) {
+            }
+
+            @Override
+            public void updateProgress(int percent) {
+            }
+
+            @Override
+            public void error(String line) {
+                throw new AssertionError(line);
+            }
+
+            @Override
+            public void setPhase(String title, boolean hasProgress) {
+            }
+        };
+    }
+
+    private static class RecordingTransport implements IXcpTransport {
+        final List<byte[]> requests = new ArrayList<>();
+        int connectCount;
+        int disconnectCount;
+        boolean failFirstClear;
+        String stationId = "rusEFI." + TARGET;
+
+        @Override
+        public void connect() {
+            connectCount++;
+        }
+
+        @Override
+        public void disconnect() {
+            disconnectCount++;
+        }
+
+        @Override
+        public byte[] sendPacket(byte[] request, int timeoutMs, int expectResponseBytes) throws IOException {
+            requests.add(request.clone());
+            int command = request[0] & 0xFF;
+            if (command == 0xFF) {
+                return new byte[]{(byte) 0xFF, 0, 0, (byte) 240, (byte) 240, 0, 0, 0};
+            }
+            if (command == 0xD2) {
+                return new byte[]{(byte) 0xFF, 0, 0, (byte) 240, 0, 0, 0};
+            }
+            if (command == 0xBF) {
+                byte[] station = stationId.getBytes(StandardCharsets.US_ASCII);
+                byte[] response = new byte[station.length + 1];
+                response[0] = (byte) 0xFF;
+                System.arraycopy(station, 0, response, 1, station.length);
+                return response;
+            }
+            if (command == 0xD1 && failFirstClear) {
+                failFirstClear = false;
+                throw new IOException("erase failed");
+            }
+            return new byte[]{(byte) 0xFF};
+        }
+
+        int commandCount(int command) {
+            return (int) requests.stream().filter(request -> (request[0] & 0xFF) == command).count();
+        }
+
+        byte[] first(int command) {
+            return requests.stream().filter(request -> (request[0] & 0xFF) == command).findFirst().orElseThrow();
+        }
+
+        List<byte[]> commands(int command) {
+            List<byte[]> result = new ArrayList<>();
+            for (byte[] request : requests) {
+                if ((request[0] & 0xFF) == command) {
+                    result.add(request);
+                }
+            }
+            return result;
+        }
+    }
+}

--- a/java_console/ui/src/test/java/com/rusefi/maintenance/ProgramSelectorTest.java
+++ b/java_console/ui/src/test/java/com/rusefi/maintenance/ProgramSelectorTest.java
@@ -170,4 +170,5 @@ public class ProgramSelectorTest {
         assertTrue(ProgramSelector.shouldEnableMainButton(true, false, false, OPENBLT_MANUAL, false));
         assertFalse(ProgramSelector.shouldEnableMainButton(true, false, true, OPENBLT_MANUAL, true));
     }
+
 }

--- a/java_console/ui/src/test/java/com/rusefi/ui/wizard/EmergencyWipePanelTest.java
+++ b/java_console/ui/src/test/java/com/rusefi/ui/wizard/EmergencyWipePanelTest.java
@@ -1,0 +1,49 @@
+package com.rusefi.ui.wizard;
+
+import org.junit.jupiter.api.Test;
+
+import javax.swing.*;
+import java.awt.event.ActionEvent;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class EmergencyWipePanelTest {
+    @Test
+    void requiresExplicitEraseAndCannotSubmitTwice() throws Exception {
+        AtomicInteger eraseCount = new AtomicInteger();
+        AtomicInteger cancelCount = new AtomicInteger();
+        EmergencyWipePanel[] panel = new EmergencyWipePanel[1];
+        SwingUtilities.invokeAndWait(() -> panel[0] = new EmergencyWipePanel(
+            "Target details", eraseCount::incrementAndGet, cancelCount::incrementAndGet));
+
+        SwingUtilities.invokeAndWait(panel[0].cancelButtonForTests()::doClick);
+        assertEquals(0, eraseCount.get());
+        assertEquals(1, cancelCount.get());
+
+        SwingUtilities.invokeAndWait(() -> {
+            panel[0].eraseButtonForTests().doClick();
+            panel[0].eraseButtonForTests().doClick();
+        });
+        assertEquals(1, eraseCount.get());
+    }
+
+    @Test
+    void escapeCancels() throws Exception {
+        AtomicInteger cancelCount = new AtomicInteger();
+        EmergencyWipePanel[] panel = new EmergencyWipePanel[1];
+        SwingUtilities.invokeAndWait(() -> panel[0] = new EmergencyWipePanel(
+            "Target details", () -> { }, cancelCount::incrementAndGet));
+
+        SwingUtilities.invokeAndWait(() -> {
+            KeyStroke escape = KeyStroke.getKeyStroke("ESCAPE");
+            Object actionKey = panel[0].getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).get(escape);
+            assertNotNull(actionKey);
+            panel[0].getActionMap().get(actionKey).actionPerformed(
+                new ActionEvent(panel[0], ActionEvent.ACTION_PERFORMED, "escape"));
+        });
+
+        assertEquals(1, cancelCount.get());
+    }
+}


### PR DESCRIPTION
- Implement OpenBLT emergency wipe handling, including artifact loading, validation, and execution.
- Extend UI with emergency wipe confirmation dialogs and full-screen panel handling.
- Refactor XcpLoader to improve robustness and integrate emergency wipe logic.
- Add tests for emergency wipe validation and behavior.

new action:
<img width="585" height="401" alt="image" src="https://github.com/user-attachments/assets/e2b06c5b-d19c-43ce-a89b-a041a4e8b249" />

new confirmation modal: (i will put a more clear wording on next pr)

<img width="799" height="525" alt="image" src="https://github.com/user-attachments/assets/2bdf29c8-e42d-4036-8406-f2b9034a9282" />

job finish:

<img width="589" height="357" alt="image" src="https://github.com/user-attachments/assets/5e88bd84-66d4-4216-9bad-8259ff43161b" />


related #9848