### PR TITLE
#10117 preparation: Add basic configuration module

### DIFF
--- a/firmware/controllers/algo/algo.mk
+++ b/firmware/controllers/algo/algo.mk
@@ -13,6 +13,7 @@ CONTROLLERS_ALGO_SRC_CPP = $(PROJECT_DIR)/controllers/algo/ignition/ignition_sta
 	$(PROJECT_DIR)/controllers/algo/antilag_system.cpp \
 	$(PROJECT_DIR)/controllers/algo/dynoview.cpp \
 	$(PROJECT_DIR)/controllers/algo/runtime_state.cpp \
+	$(PROJECT_DIR)/controllers/algo/basic_configuration.cpp \
 	$(PROJECT_DIR)/controllers/algo/engine_configuration.cpp \
 	$(PROJECT_DIR)/controllers/algo/engine_type_impl.cpp \
 	$(PROJECT_DIR)/controllers/algo/engine.cpp \

--- a/firmware/controllers/algo/basic_configuration.cpp
+++ b/firmware/controllers/algo/basic_configuration.cpp
@@ -1,0 +1,71 @@
+#include "pch.h"
+
+#include "basic_configuration.h"
+#include "board_overrides.h"
+#include "defaults.h"
+#include "tunerstudio.h"
+
+std::optional<board_basic_configuration_type> custom_board_applyBasicConfiguration;
+
+static void applyActuatorDefaults(bool useStepper, void (*applyEtbStepperPinDefaults)()) {
+	engineConfiguration->useStepperIdle = useStepper;
+	engineConfiguration->useHbridgesToDriveIdleStepper = useStepper;
+	engineConfiguration->useRawOutputToDriveIdleStepper = false;
+	engineConfiguration->stepper_dc_use_two_wires = false;
+	engineConfiguration->stepperDcInvertedPins = false;
+
+	engineConfiguration->etbFunctions[0] = useStepper ? DC_None : DC_Throttle1;
+	engineConfiguration->etbFunctions[1] = useStepper ? DC_None : DC_Throttle2;
+
+	applyEtbStepperPinDefaults();
+}
+
+bool applyBasicConfiguration(BasicConfigurationAction action,
+	void (*applyEtbStepperPinDefaults)(),
+	adc_channel_e tpsPrimary,
+	adc_channel_e tpsSecondary,
+	adc_channel_e ppsPrimary,
+	adc_channel_e ppsSecondary) {
+	switch (action) {
+	case BasicConfigurationAction::EtbToStepper:
+		applyActuatorDefaults(true, applyEtbStepperPinDefaults);
+		break;
+	case BasicConfigurationAction::StepperToEtb:
+		applyActuatorDefaults(false, applyEtbStepperPinDefaults);
+		break;
+	case BasicConfigurationAction::CableTps:
+		setTPS1Inputs(tpsPrimary, EFI_ADC_NONE);
+		setPPSInputs(EFI_ADC_NONE, EFI_ADC_NONE);
+		break;
+	case BasicConfigurationAction::PpsTps:
+		setTPS1Inputs(tpsPrimary, tpsSecondary);
+		setPPSInputs(ppsPrimary, ppsSecondary);
+		break;
+	default:
+		return false;
+	}
+
+	return true;
+}
+
+bool handleBasicConfigurationAction(uint16_t index) {
+	if (index > static_cast<uint16_t>(BasicConfigurationAction::PpsTps) ||
+		!custom_board_applyBasicConfiguration.has_value()) {
+		return false;
+	}
+
+	if (!engine->rpmCalculator.isStopped()) {
+		return true;
+	}
+
+	if (!get_board_override_result(custom_board_applyBasicConfiguration, false,
+		static_cast<BasicConfigurationAction>(index))) {
+		return false;
+	}
+
+#if EFI_TUNER_STUDIO
+	onApplyPreset();
+#endif
+
+	return true;
+}

--- a/firmware/controllers/algo/basic_configuration.h
+++ b/firmware/controllers/algo/basic_configuration.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "rusefi_types.h"
+
+enum class BasicConfigurationAction : uint16_t {
+	EtbToStepper = 0,
+	StepperToEtb = 1,
+	CableTps = 2,
+	PpsTps = 3,
+};
+
+bool applyBasicConfiguration(BasicConfigurationAction action,
+	void (*applyEtbStepperPinDefaults)(),
+	adc_channel_e tpsPrimary,
+	adc_channel_e tpsSecondary,
+	adc_channel_e ppsPrimary,
+	adc_channel_e ppsSecondary);
+// Returns false so non-Basic TS_BOARD_ACTION indices can use the legacy board handler.
+bool handleBasicConfigurationAction(uint16_t index);

--- a/firmware/hw_layer/board_overrides.h
+++ b/firmware/hw_layer/board_overrides.h
@@ -66,6 +66,11 @@ extern std::optional<custom_fix_configuration_type> custom_board_fix_configurati
 using setup_custom_board_ts_command_override_type = void (*)(uint16_t /*subsystem*/, uint16_t /*index*/);
 extern std::optional<setup_custom_board_ts_command_override_type> custom_board_ts_command;
 
+enum class BasicConfigurationAction : uint16_t;
+// Applies board pin/ADC changes for a supported Basic Configurations action.
+using board_basic_configuration_type = bool (*)(BasicConfigurationAction);
+extern std::optional<board_basic_configuration_type> custom_board_applyBasicConfiguration;
+
 // Board-specific TunerStudio binary command handler. Unlike custom_board_ts_command
 // (which rides on TS_EXECUTE and is fire-and-forget), this hook receives the channel and
 // the raw request payload so a board can implement a full binary request/response. It is invoked for opcodes the

--- a/firmware/integration/rusefi_config.txt
+++ b/firmware/integration/rusefi_config.txt
@@ -2850,6 +2850,7 @@ end_struct
 #define ts_show_gdi false
 #define ts_show_fuel_level_sensor true
 #define ts_show_popular_vehicles true
+#define ts_show_basic_configurations false
 #define ts_show_reset_calibrations true
 #define ts_show_air_conditioning true
 #define ts_show_oil_pressure_sensor true

--- a/unit_tests/tests/test_basic_configuration.cpp
+++ b/unit_tests/tests/test_basic_configuration.cpp
@@ -44,49 +44,6 @@ protected:
 	EngineTestHelper eth;
 };
 
-TEST_F(BasicConfigurationTest, ActuatorPresetsDoNotChangeSensors) {
-	setTPS1Inputs(EFI_ADC_5, EFI_ADC_6);
-	setPPSInputs(EFI_ADC_7, EFI_ADC_8);
-	engineConfiguration->useRawOutputToDriveIdleStepper = true;
-	engineConfiguration->stepper_dc_use_two_wires = true;
-	engineConfiguration->stepperDcInvertedPins = true;
-	engine->engineTypeChangeTimer.init();
-
-	run(BasicConfigurationAction::EtbToStepper);
-
-	EXPECT_TRUE(engineConfiguration->useStepperIdle);
-	EXPECT_TRUE(engineConfiguration->useHbridgesToDriveIdleStepper);
-	EXPECT_FALSE(engineConfiguration->useRawOutputToDriveIdleStepper);
-	EXPECT_FALSE(engineConfiguration->stepper_dc_use_two_wires);
-	EXPECT_FALSE(engineConfiguration->stepperDcInvertedPins);
-	EXPECT_EQ(DC_None, engineConfiguration->etbFunctions[0]);
-	EXPECT_EQ(DC_None, engineConfiguration->etbFunctions[1]);
-	EXPECT_EQ(EFI_ADC_5, engineConfiguration->tps1_1AdcChannel);
-	EXPECT_EQ(EFI_ADC_6, engineConfiguration->tps1_2AdcChannel);
-	EXPECT_EQ(EFI_ADC_7, engineConfiguration->throttlePedalPositionAdcChannel);
-	EXPECT_EQ(EFI_ADC_8, engineConfiguration->throttlePedalPositionSecondAdcChannel);
-	EXPECT_EQ(1, pinDefaultsApplyCount);
-	EXPECT_TRUE(needToTriggerTsRefresh());
-	EXPECT_FALSE(isIdleHardwareRestartNeeded());
-
-	auto* etb = static_cast<EtbController*>(engine->etbControllers[0]);
-	const auto runningFunction = etb->getFunction();
-	activeConfiguration.etbFunctions[0] = DC_None;
-	activeConfiguration.etbFunctions[1] = DC_None;
-
-	run(BasicConfigurationAction::StepperToEtb);
-	onConfigurationChangeElectronicThrottleCallback(&activeConfiguration);
-
-	EXPECT_FALSE(engineConfiguration->useStepperIdle);
-	EXPECT_FALSE(engineConfiguration->useHbridgesToDriveIdleStepper);
-	EXPECT_FALSE(engineConfiguration->useRawOutputToDriveIdleStepper);
-	EXPECT_EQ(DC_Throttle1, engineConfiguration->etbFunctions[0]);
-	EXPECT_EQ(DC_Throttle2, engineConfiguration->etbFunctions[1]);
-	EXPECT_EQ(2, pinDefaultsApplyCount);
-	EXPECT_FALSE(isIdleHardwareRestartNeeded());
-	EXPECT_EQ(runningFunction, etb->getFunction());
-}
-
 TEST_F(BasicConfigurationTest, SensorPresetsPreserveCalibration) {
 	engineConfiguration->tpsMin = 101;
 	engineConfiguration->tpsMax = 202;

--- a/unit_tests/tests/test_basic_configuration.cpp
+++ b/unit_tests/tests/test_basic_configuration.cpp
@@ -1,0 +1,145 @@
+#include "pch.h"
+
+#include "basic_configuration.h"
+#include "board_overrides.h"
+#include "defaults.h"
+#include "electronic_throttle_impl.h"
+#include "engine_types.h"
+#include "idle_hardware.h"
+#include "tunerstudio.h"
+
+extern engine_configuration_s& activeConfiguration;
+
+static int pinDefaultsApplyCount;
+
+static void applyTestPinDefaults() {
+	pinDefaultsApplyCount++;
+}
+
+static bool applyTestBasicConfiguration(BasicConfigurationAction action) {
+	return applyBasicConfiguration(action,
+		applyTestPinDefaults,
+		EFI_ADC_1,
+		EFI_ADC_2,
+		EFI_ADC_3,
+		EFI_ADC_4);
+}
+
+class BasicConfigurationTest : public testing::Test {
+protected:
+	BasicConfigurationTest()
+		: eth(engine_type_e::TEST_ENGINE) {
+		pinDefaultsApplyCount = 0;
+		custom_board_applyBasicConfiguration = applyTestBasicConfiguration;
+	}
+
+	~BasicConfigurationTest() override {
+		custom_board_applyBasicConfiguration.reset();
+	}
+
+	void run(BasicConfigurationAction action) {
+		ASSERT_TRUE(handleBasicConfigurationAction(static_cast<uint16_t>(action)));
+	}
+
+	EngineTestHelper eth;
+};
+
+TEST_F(BasicConfigurationTest, ActuatorPresetsDoNotChangeSensors) {
+	setTPS1Inputs(EFI_ADC_5, EFI_ADC_6);
+	setPPSInputs(EFI_ADC_7, EFI_ADC_8);
+	engineConfiguration->useRawOutputToDriveIdleStepper = true;
+	engineConfiguration->stepper_dc_use_two_wires = true;
+	engineConfiguration->stepperDcInvertedPins = true;
+	engine->engineTypeChangeTimer.init();
+
+	run(BasicConfigurationAction::EtbToStepper);
+
+	EXPECT_TRUE(engineConfiguration->useStepperIdle);
+	EXPECT_TRUE(engineConfiguration->useHbridgesToDriveIdleStepper);
+	EXPECT_FALSE(engineConfiguration->useRawOutputToDriveIdleStepper);
+	EXPECT_FALSE(engineConfiguration->stepper_dc_use_two_wires);
+	EXPECT_FALSE(engineConfiguration->stepperDcInvertedPins);
+	EXPECT_EQ(DC_None, engineConfiguration->etbFunctions[0]);
+	EXPECT_EQ(DC_None, engineConfiguration->etbFunctions[1]);
+	EXPECT_EQ(EFI_ADC_5, engineConfiguration->tps1_1AdcChannel);
+	EXPECT_EQ(EFI_ADC_6, engineConfiguration->tps1_2AdcChannel);
+	EXPECT_EQ(EFI_ADC_7, engineConfiguration->throttlePedalPositionAdcChannel);
+	EXPECT_EQ(EFI_ADC_8, engineConfiguration->throttlePedalPositionSecondAdcChannel);
+	EXPECT_EQ(1, pinDefaultsApplyCount);
+	EXPECT_TRUE(needToTriggerTsRefresh());
+	EXPECT_FALSE(isIdleHardwareRestartNeeded());
+
+	auto* etb = static_cast<EtbController*>(engine->etbControllers[0]);
+	const auto runningFunction = etb->getFunction();
+	activeConfiguration.etbFunctions[0] = DC_None;
+	activeConfiguration.etbFunctions[1] = DC_None;
+
+	run(BasicConfigurationAction::StepperToEtb);
+	onConfigurationChangeElectronicThrottleCallback(&activeConfiguration);
+
+	EXPECT_FALSE(engineConfiguration->useStepperIdle);
+	EXPECT_FALSE(engineConfiguration->useHbridgesToDriveIdleStepper);
+	EXPECT_FALSE(engineConfiguration->useRawOutputToDriveIdleStepper);
+	EXPECT_EQ(DC_Throttle1, engineConfiguration->etbFunctions[0]);
+	EXPECT_EQ(DC_Throttle2, engineConfiguration->etbFunctions[1]);
+	EXPECT_EQ(2, pinDefaultsApplyCount);
+	EXPECT_FALSE(isIdleHardwareRestartNeeded());
+	EXPECT_EQ(runningFunction, etb->getFunction());
+}
+
+TEST_F(BasicConfigurationTest, SensorPresetsPreserveCalibration) {
+	engineConfiguration->tpsMin = 101;
+	engineConfiguration->tpsMax = 202;
+	engineConfiguration->tps1SecondaryMin = 303;
+	engineConfiguration->tps1SecondaryMax = 404;
+	engineConfiguration->throttlePedalUpVoltage = 0.5f;
+	engineConfiguration->throttlePedalWOTVoltage = 4.5f;
+	engineConfiguration->throttlePedalSecondaryUpVoltage = 4.4f;
+	engineConfiguration->throttlePedalSecondaryWOTVoltage = 0.6f;
+
+	run(BasicConfigurationAction::CableTps);
+
+	EXPECT_EQ(EFI_ADC_1, engineConfiguration->tps1_1AdcChannel);
+	EXPECT_EQ(EFI_ADC_NONE, engineConfiguration->tps1_2AdcChannel);
+	EXPECT_EQ(EFI_ADC_NONE, engineConfiguration->throttlePedalPositionAdcChannel);
+	EXPECT_EQ(EFI_ADC_NONE, engineConfiguration->throttlePedalPositionSecondAdcChannel);
+	EXPECT_EQ(0, pinDefaultsApplyCount);
+
+	run(BasicConfigurationAction::PpsTps);
+
+	EXPECT_EQ(EFI_ADC_1, engineConfiguration->tps1_1AdcChannel);
+	EXPECT_EQ(EFI_ADC_2, engineConfiguration->tps1_2AdcChannel);
+	EXPECT_EQ(EFI_ADC_3, engineConfiguration->throttlePedalPositionAdcChannel);
+	EXPECT_EQ(EFI_ADC_4, engineConfiguration->throttlePedalPositionSecondAdcChannel);
+	EXPECT_EQ(101, engineConfiguration->tpsMin);
+	EXPECT_EQ(202, engineConfiguration->tpsMax);
+	EXPECT_EQ(303, engineConfiguration->tps1SecondaryMin);
+	EXPECT_EQ(404, engineConfiguration->tps1SecondaryMax);
+	EXPECT_FLOAT_EQ(0.5f, engineConfiguration->throttlePedalUpVoltage);
+	EXPECT_FLOAT_EQ(4.5f, engineConfiguration->throttlePedalWOTVoltage);
+	EXPECT_FLOAT_EQ(4.4f, engineConfiguration->throttlePedalSecondaryUpVoltage);
+	EXPECT_FLOAT_EQ(0.6f, engineConfiguration->throttlePedalSecondaryWOTVoltage);
+	EXPECT_EQ(0, pinDefaultsApplyCount);
+}
+
+TEST_F(BasicConfigurationTest, RejectsRunningEngineAndUnknownAction) {
+	engineConfiguration->useStepperIdle = false;
+	engine->rpmCalculator.setRpmValue(1000);
+	engine->engineTypeChangeTimer.init();
+
+	run(BasicConfigurationAction::EtbToStepper);
+
+	EXPECT_FALSE(engineConfiguration->useStepperIdle);
+	EXPECT_EQ(0, pinDefaultsApplyCount);
+	EXPECT_FALSE(needToTriggerTsRefresh());
+
+	engine->rpmCalculator.setRpmValue(0);
+	EXPECT_FALSE(handleBasicConfigurationAction(0xffff));
+
+	EXPECT_FALSE(engineConfiguration->useStepperIdle);
+	EXPECT_EQ(0, pinDefaultsApplyCount);
+	EXPECT_FALSE(needToTriggerTsRefresh());
+
+	custom_board_applyBasicConfiguration.reset();
+	EXPECT_FALSE(handleBasicConfigurationAction(static_cast<uint16_t>(BasicConfigurationAction::EtbToStepper)));
+}

--- a/unit_tests/tests/tests.mk
+++ b/unit_tests/tests/tests.mk
@@ -128,6 +128,7 @@ TESTS_SRC_CPP = \
 	tests/lua/test_lua_vin.cpp \
 	tests/lua/test_lua_debounce.cpp \
 	tests/test_change_engine_type.cpp \
+	tests/test_basic_configuration.cpp \
 	tests/test_big_buffer.cpp \
 	tests/system/test_periodic_thread_controller.cpp \
 	tests/system/test_scheduler.cpp \


### PR DESCRIPTION
we have existing but confusing `applyActuatorDefaults`, let's expand it to a "basic configuration", so we can setup etb/tps modes from one place, with explicit actions, so the TS side is only a new button

not for now, but if we want an explicit action of "use on board WBO / use Analog WBO" or something that touches multiple configs, we can use this new module!

related #10117