### PR TITLE
OpenBLT wipe: better confirmation text

### DIFF
--- a/java_console/ui/src/main/java/com/rusefi/maintenance/OpenBltWipeArtifact.java
+++ b/java_console/ui/src/main/java/com/rusefi/maintenance/OpenBltWipeArtifact.java
@@ -190,12 +190,11 @@ public class OpenBltWipeArtifact {
     }
 
     public String confirmationMessage() {
-        return "Target: " + bundleTarget + " (OpenBLT " + bootloaderTarget + ")\n"
-            + "MCU: " + mcuFamily + ", internal flash: " + getFlashSizeKiB() + " KiB\n\n"
-            + "This will erase application firmware and all internal MCU configuration after OpenBLT.\n"
-            + "OpenBLT itself will be preserved, but the ECU will not run application firmware afterward.\n"
-            + "Run a normal Manual OpenBLT Update next; the previous tune will not be restored automatically.\n"
-            + "External SPI/QSPI flash and SD card storage will not be erased.";
+        return "ECU: " + bundleTarget + "\n\n"
+            + "This will permanently erase the ECU firmware and all internal settings, including the current tune.\n\n"
+            + "The ECU will remain in recovery mode and cannot run the engine until firmware is installed again.\n"
+            + "Next, run Manual OpenBLT Update. The previous tune will not be restored automatically.\n\n"
+            + "SD card and external storage will not be erased.";
     }
 
     private static class Profile {

--- a/java_console/ui/src/test/java/com/rusefi/maintenance/OpenBltEmergencyWipeTest.java
+++ b/java_console/ui/src/test/java/com/rusefi/maintenance/OpenBltEmergencyWipeTest.java
@@ -136,9 +136,12 @@ class OpenBltEmergencyWipeTest {
     @Test
     void confirmationStatesDestructiveAndExternalStoragePolicy() throws IOException {
         String message = OpenBltWipeArtifact.loadAndValidate(signedPort(TARGET)).confirmationMessage();
-        assertTrue(message.contains("OpenBLT itself will be preserved"));
+        assertTrue(message.contains("permanently erase the ECU firmware and all internal settings"));
+        assertTrue(message.contains("remain in recovery mode"));
         assertTrue(message.contains("previous tune will not be restored"));
-        assertTrue(message.contains("External SPI/QSPI flash and SD card storage will not be erased"));
+        assertTrue(message.contains("SD card and external storage will not be erased"));
+        assertFalse(message.contains("MCU:"));
+        assertFalse(message.contains("KiB"));
     }
 
     @Test

--- a/java_tools/version/src/main/java/com/rusefi/UiVersion.java
+++ b/java_tools/version/src/main/java/com/rusefi/UiVersion.java
@@ -5,5 +5,5 @@ public interface UiVersion {
      * *** BE CAREFUL WE HAVE SEPARATE AUTOUPDATE_VERSION also managed manually ***
      * @see com.rusefi.autoupdate.Autoupdate#AUTOUPDATE_VERSION
      */
-    int CONSOLE_VERSION = 20260817;
+    int CONSOLE_VERSION = 20260818;
 }


### PR DESCRIPTION
resolves #9848

<img width="793" height="504" alt="image" src="https://github.com/user-attachments/assets/b4315840-76c6-4eda-b6b0-f9d54c79287a" />
