### PR TITLE
Can sniffer GUI improvements

### DIFF
--- a/java_console/io/src/main/java/com/rusefi/io/can/slcan/SlcanClient.java
+++ b/java_console/io/src/main/java/com/rusefi/io/can/slcan/SlcanClient.java
@@ -81,7 +81,11 @@ public class SlcanClient implements Closeable {
                 stream.getDataBuffer().dropPending();
 
                 String version = command(stream, "V");
-                if (version == null || version.isEmpty() || version.charAt(0) != 'V') {
+                if (version == null || version.isEmpty()) {
+                    logger.accept(port + ": no response to SLCAN V command, skipping");
+                    continue;
+                }
+                if (version.charAt(0) != 'V' && Frame.parse(version) == null) {
                     logger.accept(port + ": not SLCAN (V response: " + printable(version) + ")");
                     continue;
                 }
@@ -104,6 +108,14 @@ public class SlcanClient implements Closeable {
     private void openChannel() throws IOException {
         // close first in case a previous session left the terminal open; error ack is fine here
         command(stream, "C");
+        try {
+            Thread.sleep(100);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IOException(e);
+        }
+        stream.getDataBuffer().dropPending();
+
         expectOk("S6");
         expectOk("O");
         log.info(port + ": SLCAN channel open");

--- a/java_console/io/src/test/java/com/rusefi/io/can/slcan/SlcanClientTest.java
+++ b/java_console/io/src/test/java/com/rusefi/io/can/slcan/SlcanClientTest.java
@@ -1,0 +1,26 @@
+package com.rusefi.io.can.slcan;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class SlcanClientTest {
+    @Test
+    public void testParseFrame() {
+        assertNotNull(SlcanClient.Frame.parse("t1230"));
+        assertNotNull(SlcanClient.Frame.parse("T123456780"));
+        assertNotNull(SlcanClient.Frame.parse("r1230"));
+        assertNotNull(SlcanClient.Frame.parse("R123456780"));
+
+        // Valid frame with data
+        SlcanClient.Frame f = SlcanClient.Frame.parse("t1232AABB");
+        assertNotNull(f);
+        assertEquals(0x123, f.id);
+        assertEquals(2, f.dlc);
+        assertArrayEquals(new byte[]{(byte)0xAA, (byte)0xBB}, f.data);
+
+        // Invalid frames
+        assertNull(SlcanClient.Frame.parse("V123"));
+        assertNull(SlcanClient.Frame.parse(""));
+        assertNull(SlcanClient.Frame.parse("x1230"));
+    }
+}

--- a/java_console/ui/src/main/java/com/rusefi/ConsoleUI.java
+++ b/java_console/ui/src/main/java/com/rusefi/ConsoleUI.java
@@ -460,7 +460,7 @@ console live data tab is broken #8402
                 tabbedPane.addTab("SLCAN Sniffer", new InitOnFirstPaintPanel() {
                     @Override
                     protected JPanel createContent() {
-                        return new SlcanTab(mainFrame::showMessageOverlay).getContent();
+                        return new SlcanTab(uiContext, mainFrame::showMessageOverlay).getContent();
                     }
                 }.getContent());
             }

--- a/java_console/ui/src/main/java/com/rusefi/ui/SlcanTab.java
+++ b/java_console/ui/src/main/java/com/rusefi/ui/SlcanTab.java
@@ -3,6 +3,13 @@ package com.rusefi.ui;
 import com.devexperts.logging.Logging;
 import com.rusefi.io.can.HexUtil;
 import com.rusefi.io.can.slcan.SlcanClient;
+import com.opensr5.ini.DialogModel;
+import com.opensr5.ini.IniFileModel;
+import com.rusefi.binaryprotocol.BinaryProtocol;
+import com.opensr5.ConfigurationImage;
+import com.opensr5.ini.field.EnumIniField;
+import com.opensr5.ini.field.IniField;
+import com.opensr5.ini.field.ScalarIniField;
 
 import javax.swing.*;
 import javax.swing.Timer;
@@ -63,12 +70,14 @@ public class SlcanTab {
     private final JButton recordButton = new JButton("Record");
     private final JButton stopButton = new JButton("Stop");
     private final Consumer<String> messageHandler;
+    private final UIContext uiContext;
 
-    public SlcanTab() {
-        this(null);
+    public SlcanTab(UIContext uiContext) {
+        this(uiContext, null);
     }
 
-    public SlcanTab(Consumer<String> messageHandler) {
+    public SlcanTab(UIContext uiContext, Consumer<String> messageHandler) {
+        this.uiContext = uiContext;
         this.messageHandler = messageHandler != null
             ? messageHandler
             : message -> JOptionPane.showMessageDialog(content, message, "SLCAN", JOptionPane.INFORMATION_MESSAGE);
@@ -89,6 +98,11 @@ public class SlcanTab {
         top.add(buttons, BorderLayout.WEST);
         top.add(statusLabel, BorderLayout.CENTER);
         top.add(indicatorWrapper, BorderLayout.EAST);
+
+        JPanel busPanel = createBusPanel();
+        if (busPanel != null) {
+            top.add(busPanel, BorderLayout.SOUTH);
+        }
 
         framesArea.setEditable(false);
         framesArea.setFont(new Font(Font.MONOSPACED, Font.PLAIN, 13));
@@ -210,6 +224,101 @@ public class SlcanTab {
         if (!newText.equals(framesArea.getText())) {
             framesArea.setText(newText);
             framesArea.setCaretPosition(0);
+        }
+    }
+
+    private JPanel createBusPanel() {
+        if (uiContext == null) {
+            return null;
+        }
+        IniFileModel ini = uiContext.iniFileState.getIniFileModel();
+        if (ini == null) {
+            return null;
+        }
+
+        JPanel busPanel = new JPanel(new FlowLayout(FlowLayout.LEFT));
+        busPanel.add(new JLabel("Listen:"));
+
+        for (int i = 1; i <= 3; i++) {
+            String dialogKey = "canHw" + i;
+            DialogModel dialog = ini.getDialogs().get(dialogKey);
+            if (dialog == null) {
+                continue;
+            }
+
+            String busName = dialog.getUiName();
+            String fieldName1 = "canSniffer" + i + "_listenOurs";
+            String fieldName2 = "canSniffer" + i + "_read";
+
+            // Verify the fields exist
+            try {
+                ini.getIniField(fieldName1);
+                ini.getIniField(fieldName2);
+            } catch (Exception e) {
+                // Skip if not found
+                continue;
+            }
+
+            JCheckBox cb = new JCheckBox(busName);
+
+            uiContext.addConfigImageListener(image -> {
+                updateCheckbox(cb, fieldName1, fieldName2, ini, image);
+            });
+
+            // Initial state
+            BinaryProtocol bp = uiContext.getBinaryProtocol();
+            if (bp != null) {
+                ConfigurationImage image = bp.getBinaryProtocolState().getConfigurationImage();
+                if (image != null) {
+                    updateCheckbox(cb, fieldName1, fieldName2, ini, image);
+                }
+            }
+
+            cb.addActionListener(e -> {
+                BinaryProtocol bp2 = uiContext.getBinaryProtocol();
+                if (bp2 == null) return;
+                ConfigurationImage image = bp2.getBinaryProtocolState().getConfigurationImage();
+                if (image == null) return;
+
+                int newValue = cb.isSelected() ? 1 : 0;
+                applyValue(image, ini.getIniField(fieldName1), newValue);
+                applyValue(image, ini.getIniField(fieldName2), newValue);
+
+                ConfigurationImage snapshot = image.clone();
+                uiContext.getLinkManager().submit(() -> bp2.uploadChangesWithoutBurn(snapshot));
+                uiContext.fireConfigImageChanged(image);
+            });
+
+            busPanel.add(cb);
+        }
+
+        return busPanel;
+    }
+
+    private void updateCheckbox(JCheckBox cb, String field1, String field2, IniFileModel ini, ConfigurationImage image) {
+        Double v1 = image.readNumericValue(ini.getIniField(field1));
+        Double v2 = image.readNumericValue(ini.getIniField(field2));
+        if (v1 == null || v2 == null) return;
+
+        boolean b1 = v1 != 0;
+        boolean b2 = v2 != 0;
+
+        if (b1 == b2) {
+            cb.setSelected(b1);
+            cb.setBackground(null);
+        } else {
+            cb.setSelected(true); // show as checked but grayed
+            cb.setBackground(java.awt.Color.LIGHT_GRAY);
+        }
+    }
+
+    private void applyValue(ConfigurationImage image, IniField field, int newValue) {
+        if (field instanceof EnumIniField) {
+            image.setBitValue((EnumIniField) field, newValue);
+        } else if (field instanceof ScalarIniField) {
+            ScalarIniField sf = (ScalarIniField) field;
+            java.nio.ByteBuffer bb = image.getByteBuffer(sf.getOffset(), sf.getSize());
+            sf.getType().writeRawValue(bb, newValue);
         }
     }
 

--- a/java_console/ui/src/main/java/com/rusefi/ui/SlcanTab.java
+++ b/java_console/ui/src/main/java/com/rusefi/ui/SlcanTab.java
@@ -1,6 +1,7 @@
 package com.rusefi.ui;
 
 import com.devexperts.logging.Logging;
+import com.rusefi.io.can.HexUtil;
 import com.rusefi.io.can.slcan.SlcanClient;
 
 import javax.swing.*;
@@ -228,12 +229,10 @@ public class SlcanTab {
             return;
         }
         File file = chooser.getSelectedFile();
-        long firstMs = snapshot.get(0).wallClockMs;
         try (PrintWriter writer = new PrintWriter(Files.newBufferedWriter(file.toPath(), StandardCharsets.US_ASCII))) {
-            writer.println("; rusEFI SLCAN capture " + new Date() + ", " + snapshot.size() + " frame(s)");
-            writer.println("; relative-ms raw-slcan-line decoded");
             for (FrameRecord record : snapshot) {
-                writer.printf("%d %s %s%n", record.wallClockMs - firstMs, record.frame.raw, record.frame.decode());
+                String hexData = record.frame.rtr ? "" : HexUtil.asString(record.frame.data);
+                writer.printf("(%d.%06d) can0 %X#%s%n", record.wallClockMs / 1000, (record.wallClockMs % 1000) * 1000, record.frame.id, hexData);
             }
         } catch (IOException e) {
             messageHandler.accept("Failed to save: " + e);

--- a/java_console/ui/src/main/java/com/rusefi/ui/SlcanTab.java
+++ b/java_console/ui/src/main/java/com/rusefi/ui/SlcanTab.java
@@ -193,8 +193,8 @@ public class SlcanTab {
         synchronized (lock) {
             bufferSize = buffer.size();
             for (FrameRecord record : lastFrames) {
-                text.append(String.format("%s %-30s %s%n",
-                    timeFormat.format(new Date(record.wallClockMs)), record.frame.raw, record.frame.decode()));
+                text.append(String.format("%s %s%n",
+                    timeFormat.format(new Date(record.wallClockMs)), record.frame.decode()));
             }
         }
 

--- a/java_console/ui/src/test/java/com/rusefi/ui/SlcanUiSandbox.java
+++ b/java_console/ui/src/test/java/com/rusefi/ui/SlcanUiSandbox.java
@@ -1,19 +1,85 @@
 package com.rusefi.ui;
 
+import com.rusefi.AvailableHardware;
+import com.rusefi.ConnectivityContext;
+import com.rusefi.PortResult;
+import com.rusefi.ProductionConnectivity;
+import com.rusefi.io.LinkManager;
 import javax.swing.*;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Manual Swing sandbox showing {@link SlcanTab} in a standalone frame, no console needed.
  * Requires a rusEFI board exposing the CAN sniffer SLCAN channel as a secondary USB CDC port.
  *
- * @see com.rusefi.binaryprotocol.test.SlcanSandbox console variant
+ * console variant
  */
 public class SlcanUiSandbox {
     public static void main(String[] args) {
+        ConnectivityContext connectivityContext = ProductionConnectivity.CONTEXT;
+        AvailableHardware hardware = connectivityContext.getCurrentHardware();
+
+        if (hardware.isEmpty()) {
+            System.out.println("Scanning for hardware...");
+            CountDownLatch latch = new CountDownLatch(1);
+            connectivityContext.getPortScanner().addListener(currentHardware -> {
+                if (!currentHardware.isEmpty()) {
+                    latch.countDown();
+                }
+            });
+            try {
+                latch.await(10, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            hardware = connectivityContext.getCurrentHardware();
+        }
+
+        if (hardware.isEmpty()) {
+            System.err.println("No hardware found.");
+            return;
+        }
+
+        System.out.println("Found hardware: " + hardware);
+        List<PortResult> ecuPorts = hardware.getKnownPorts();
+        if (ecuPorts.isEmpty()) {
+            System.err.println("No ECU ports found.");
+            return;
+        }
+
+        PortResult ecuPort = ecuPorts.get(0);
+        System.out.println("Connecting to ECU on " + ecuPort.port + "...");
+
+        UIContext uiContext = new UIContext(connectivityContext.getConnectedEcuTarget());
+        LinkManager linkManager = uiContext.getLinkManager();
+
+        linkManager.startAndConnect(ecuPort.port, new com.rusefi.io.ConnectionStatusLogic.Listener() {
+            @Override
+            public void onConnectionStatus(boolean isConnected) {
+                if (isConnected) {
+                    System.out.println("Connected to ECU!");
+                } else {
+                    System.err.println("Connection status: not connected");
+                }
+            }
+
+            @Override
+            public void onConnectionEstablished() {
+                System.out.println("Connection established (signature fetched)!");
+            }
+
+            @Override
+            public void onConnectionFailed(String s) {
+                System.err.println("Connection failed: " + s);
+            }
+        });
+
         SwingUtilities.invokeLater(() -> {
-            JFrame frame = new JFrame("SLCAN Sandbox");
+            JFrame frame = new JFrame("SLCAN Sandbox - " + ecuPort.port);
             frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
-            frame.getContentPane().add(new SlcanTab().getContent());
+            frame.getContentPane().add(new SlcanTab(uiContext).getContent());
             frame.setSize(900, 600);
             frame.setLocationRelativeTo(null);
             frame.setVisible(true);


### PR DESCRIPTION
- use candump format to export traces
- better port autodetect on reconnect
- added checkboxes to manage `canSnifferN_read`, `canSnifferN_listenOurs` settings

There is an issue with a last point. Need to find a way to synchronize TuningPane with these settings. We have `uiContext.addConfigImageListener()` to track config changes, but for some reason TuningPane class doesnt use it.


<img width="686" height="191" alt="image" src="https://github.com/user-attachments/assets/08e87a37-f711-4cdd-a3a0-faf1428d92f3" />
