### PR TITLE
Add Trigger gauge preset for triggerToothAngleError (Sync: trigger angle error)

### DIFF
--- a/firmware/tunerstudio/gauge_declarations.ini
+++ b/firmware/tunerstudio/gauge_declarations.ini
@@ -2,6 +2,7 @@
 gaugeCategory = Trigger
 	triggerErrorsCounterGauge = totalTriggerErrorCounter, "Trigger error count", "count",	0,	15000,	0,	0,	10,  300,	0,	0
 	triggerSyncGapRatioGauge = trgtriggerSyncGapRatio,"triggerSyncGapRatio", "", -10000,10000, -10000,-10000, 10000,10000, 3,3
+	triggerAngleErrorGauge = triggerToothAngleError,"Sync: trigger angle error", "deg", -30,30, -30,-15, 15,30, 1,1
 	triggerStateIndexGauge = trgtriggerStateIndex,"triggerStateIndex", "",       -10000,10000, -10000,-10000, 10000,10000, 3,3
 	triggerPrimaryFallCounterGauge = triggerPrimaryFall,"triggerPrimaryFall", "", 0,10000.0, 0,10000.0, 0,10000.0, 3,3
 	triggerPrimaryRiseCounterGauge = triggerPrimaryRise,"triggerPrimaryRise", "", 0,10000.0, 0,10000.0, 0,10000.0, 3,3


### PR DESCRIPTION
## Summary
- `triggerToothAngleError` is already exposed as an `[OutputChannels]` entry (used for datalogging), but has no preset in the "Trigger" quick-gauge category in `gauge_declarations.ini`, unlike its sibling `triggerSyncGapRatio`.
- This adds `triggerAngleErrorGauge` so it shows up in the right-click "Trigger" gauge menu in TunerStudio, same as the other trigger diagnostic gauges.

## Details
Warning/danger thresholds (±15°/±30°) are based on real-world values observed on a Mitsubishi 4G63 (microRusEFI, symmetrical crank + cam phase sync): idle/low-RPM average error 2-5°, occasional peaks up to ~20-22° at idle, tightening to ~2° at high RPM.

## Test plan
- [ ] Confirm the new gauge appears under Trigger in TunerStudio's gauge picker after a normal firmware/ini rebuild
- [ ] Confirm the gauge reads the same value as the `Sync: trigger angle error` datalog field