### PR TITLE
Fan PWM: guard initialization against non-positive frequency

### DIFF
--- a/firmware/controllers/modules/fan_control/fan_control.cpp
+++ b/firmware/controllers/modules/fan_control/fan_control.cpp
@@ -79,8 +79,12 @@ void FanController::initPwm() {
 	if (!isBrainPinValid(getConfigPin())) {
 		return;
 	}
-	startSimplePwm(&m_pwm, "Fan PWM", &engine->scheduler, &getPin(), getPwmFrequency(), 0);
-	m_pwmInitialized = true;
+
+	float freq = getPwmFrequency();
+    if (freq > 0) {
+        startSimplePwm(&m_pwm, "Fan PWM", &engine->scheduler, &getPin(), freq, 0);
+        m_pwmInitialized = true;
+	}
 #endif
 }
 


### PR DESCRIPTION
### Problem
When fan PWM frequency is unconfigured or zero (such as on legacy tunes or during bench tests), calling `startSimplePwm` with a non-positive frequency causes division-by-zero/assertion issues in the scheduler.

### Solution
Add a guard in `FanController::initPwm()` to only initialize and start simple PWM when `getPwmFrequency() > 0`.

Closes #10109