### PR TITLE
Harden storage persistence and SD/USB handoff

### DIFF
--- a/firmware/controllers/extra_flash_pages.cpp
+++ b/firmware/controllers/extra_flash_pages.cpp
@@ -96,7 +96,9 @@ void burnExtraFlashPage(StorageItemId id) {
 	// A full config burn erases the sector, then burnExtraFlashPages()
 	// writes all extra pages into the now-blank region in one pass.
 	(void)id;
-	writeToFlashNow();
+	// Queue the normal guarded settings write. A forced write can halt an F4
+	// while the engine is running, stopping fuel and ignition outputs.
+	setNeedToWriteConfiguration();
 #else
 	// MFS/SD boards or simulator: write the specific page directly to all backends.
 	if (id == EFI_SECOND_TABLES_RECORD_ID) {

--- a/firmware/controllers/long_term_fuel_trim.cpp
+++ b/firmware/controllers/long_term_fuel_trim.cpp
@@ -28,21 +28,20 @@ static LtftState ltftState;
 // LTFT to VE table custom apply algo
 std::optional<setup_custom_board_overrides_type> custom_board_LtftTrimToVeApply;
 
-void LtftState::save() {
+bool LtftState::save() {
 #if EFI_PROD_CODE
-	storageWrite(EFI_LTFT_RECORD_ID, (const uint8_t *)trims, sizeof(trims));
+	return storageWrite(EFI_LTFT_RECORD_ID, (const uint8_t *)trims, sizeof(trims)) == StorageStatus::Ok;
+#else
+	return true;
 #endif //EFI_PROD_CODE
 }
 
-void LtftState::load() {
+bool LtftState::load() {
 #if EFI_PROD_CODE
-	if (storageRead(EFI_LTFT_RECORD_ID, (uint8_t *)trims, sizeof(trims)) != StorageStatus::Ok) {
+	return storageRead(EFI_LTFT_RECORD_ID, (uint8_t *)trims, sizeof(trims)) == StorageStatus::Ok;
 #else
-	if (1) {
+	return false;
 #endif
-		//Reset to some defaules
-		reset();
-	}
 }
 
 void LtftState::reset() {
@@ -233,21 +232,37 @@ ClosedLoopFuelResult LongTermFuelTrim::getTrims(float rpm, float fuelLoad) {
 
 // Called from storage manager thread when requested ID is ready
 void LongTermFuelTrim::load() {
-	m_state->load();
+	// A storage backend can become ready after the startup timeout. Accept that
+	// delayed load while stopped, but never replace live trims while running.
+#if EFI_SHAFT_POSITION_INPUT
+	if (!ltftLoadPending && !engine->rpmCalculator.isStopped()) {
+		efiPrintf("LTFT: ignoring delayed calibration load");
+		return;
+	}
+#endif
+
+	const bool loaded = m_state && m_state->load();
 
 	ltftLoadPending = false;
+	ltftLoadError = !loaded;
+	if (!loaded) {
+		efiPrintf("LTFT: calibration file is unavailable or invalid; keeping RAM trims");
+	}
 }
 
-void LongTermFuelTrim::store() {
+bool LongTermFuelTrim::store() {
 	// TODO: lock to avoid modification while writing
 	ltftSavePending = true;
 
-	if (m_state) {
-		m_state->save();
-	}
+	const bool stored = m_state && m_state->save();
 
 	// TODO: unlock
 	ltftSavePending = false;
+	if (!stored) {
+		efiPrintf("LTFT: failed to store calibrations; write remains pending");
+	}
+
+	return stored;
 }
 
 void LongTermFuelTrim::reset() {
@@ -300,8 +315,7 @@ void LongTermFuelTrim::onSlowCallback() {
 		(engine->rpmCalculator.getSecondsSinceEngineStart(getTimeNowNt()) > 5.0) &&
 #endif
 		(1)) {
-		efiPrintf("LTFT: failed to load calibrations");
-		m_state->reset();
+		efiPrintf("LTFT: calibration load delayed; continuing with RAM trims");
 		ltftLoadPending = false;
 		ltftLoadError = true;
 	}

--- a/firmware/controllers/long_term_fuel_trim.h
+++ b/firmware/controllers/long_term_fuel_trim.h
@@ -14,8 +14,8 @@ struct LtftState {
   // todo: probably reuse page_2_generated.h?
 	float trims[FT_BANK_COUNT][VE_LOAD_COUNT][VE_RPM_COUNT];
 
-	void save();
-	void load();
+	bool save();
+	bool load();
 	void reset();
 	void applyToVe();
 	// Development only, to be removed
@@ -32,7 +32,7 @@ public:
 	void learn(ClosedLoopFuelResult clResult, float rpm, float fuelLoad);
 	ClosedLoopFuelResult getTrims(float rpm, float fuelLoad);
 	void load();
-	void store();
+	bool store();
 	void reset();
 	void applyTrimsToVe();
 	bool isVeUpdated();

--- a/firmware/controllers/storage.cpp
+++ b/firmware/controllers/storage.cpp
@@ -29,8 +29,13 @@ std::optional<setup_custom_bool_type> custom_board_allowFlashNow;
 bool storageAllowWriteID(StorageItemId id)
 {
 #if (EFI_STORAGE_INT_FLASH == TRUE) || defined(EFI_UNIT_TEST)
-	if ((id == EFI_SETTINGS_RECORD_ID) ||
-		(id == EFI_SETTINGS_BACKUP_RECORD_ID)) {
+	bool mayWriteInternalFlash = (id == EFI_SETTINGS_RECORD_ID) ||
+		(id == EFI_SETTINGS_BACKUP_RECORD_ID);
+#if EFI_STORAGE_INT_FLASH == TRUE
+	mayWriteInternalFlash = mayWriteInternalFlash || (getExtraPageFlashOffset(id) > 0);
+#endif
+
+	if (mayWriteInternalFlash) {
 		// special case, settings can be stored in internal flash
 
 		// writing internal flash can cause cpu freeze
@@ -56,7 +61,7 @@ bool storageAllowWriteID(StorageItemId id)
 	}
 #endif // EFI_STORAGE_INT_FLASH
 
-	// TODO: we expect every other ID to be stored in external flash...
+	// Remaining IDs are stored in external storage on this configuration.
 	return true;
 }
 #endif // EFI_CONFIGURATION_STORAGE || defined(EFI_UNIT_TEST)
@@ -100,8 +105,7 @@ static bool storageWriteID(uint32_t id) {
 		return writeToFlashNowImpl();
 #if EFI_LTFT_CONTROL
 	} else if (id == EFI_LTFT_RECORD_ID) {
-		engine->module<LongTermFuelTrim>()->store();
-		return true;
+		return engine->module<LongTermFuelTrim>()->store();
 #endif
 	} else if (id == EFI_SECOND_TABLES_RECORD_ID) {
 		burnExtraFlashPage(EFI_SECOND_TABLES_RECORD_ID);
@@ -397,9 +401,9 @@ bool storageIsBusy() {
 		chibios_rt::CriticalSectionLocker csl;
 		requestQueued = storageManagerMb.getUsedCountI() > 0;
 	}
-	// a pendingWrites bit stays set while storageWriteID() is executing, so
-	// this also covers a write that is currently in flight
-	return requestQueued || (pendingWrites != 0);
+	// Pending bits stay set while the corresponding operation is executing, so
+	// this also covers reads and writes that are currently in flight.
+	return requestQueued || (pendingWrites != 0) || (pendingReads != 0);
 }
 
 bool storageWaitIdle(unsigned int timeoutMs) {

--- a/firmware/controllers/storage.h
+++ b/firmware/controllers/storage.h
@@ -83,7 +83,7 @@ bool storagRequestUnregisterStorage(StorageType id);
 bool getNeedToWriteConfiguration();
 
 /**
- * @return true if any storage write is queued or currently executing
+ * @return true if any storage request is queued or currently executing
  */
 bool storageIsBusy();
 

--- a/firmware/controllers/storage_sd.cpp
+++ b/firmware/controllers/storage_sd.cpp
@@ -35,6 +35,9 @@ public:
 
 private:
 	const char *getIdFileName(size_t id);
+	const char *getIdTemporaryFileName(size_t id);
+	const char *getIdBackupFileName(size_t id);
+	StorageStatus readExactFile(const char *fileName, uint8_t *ptr, size_t size);
 	FIL *m_fd;
 };
 
@@ -51,6 +54,32 @@ const char *SettingStorageSD::getIdFileName(size_t id) {
 	}
 }
 
+const char *SettingStorageSD::getIdTemporaryFileName(size_t id) {
+	switch (id) {
+	case EFI_LTFT_RECORD_ID:
+		return "ltft.tmp";
+	case EFI_SECOND_TABLES_RECORD_ID:
+		return "second_tables.tmp";
+	case EFI_LUA_PAGE_RECORD_ID:
+		return "lua_script.tmp";
+	default:
+		return nullptr;
+	}
+}
+
+const char *SettingStorageSD::getIdBackupFileName(size_t id) {
+	switch (id) {
+	case EFI_LTFT_RECORD_ID:
+		return "ltft.bak";
+	case EFI_SECOND_TABLES_RECORD_ID:
+		return "second_tables.bak";
+	case EFI_LUA_PAGE_RECORD_ID:
+		return "lua_script.bak";
+	default:
+		return nullptr;
+	}
+}
+
 bool SettingStorageSD::isReady() {
 	return (sdCardGetCurrentMode() == SD_MODE_ECU);
 }
@@ -61,8 +90,10 @@ bool SettingStorageSD::isIdSupported(size_t id) {
 
 StorageStatus SettingStorageSD::store(size_t id, const uint8_t *ptr, size_t size) {
 	const char *fileName = getIdFileName(id);
+	const char *temporaryFileName = getIdTemporaryFileName(id);
+	const char *backupFileName = getIdBackupFileName(id);
 
-	if (fileName == nullptr) {
+	if ((fileName == nullptr) || (temporaryFileName == nullptr) || (backupFileName == nullptr)) {
 		return StorageStatus::NotSupported;
 	}
 
@@ -76,10 +107,11 @@ StorageStatus SettingStorageSD::store(size_t id, const uint8_t *ptr, size_t size
 	efiPrintf("SD: Writing storage ID %d  %s... %d bytes", id, fileName, size);
 	efitick_t startNt = getTimeNowNt();
 
-	/* Create new or truncate file. */
-	FRESULT err = f_open(m_fd, fileName, FA_CREATE_ALWAYS | FA_WRITE);
+	// Never truncate the last known-good file. Write and flush a sibling first,
+	// then rotate the old primary to a backup before promoting the new file.
+	FRESULT err = f_open(m_fd, temporaryFileName, FA_CREATE_ALWAYS | FA_WRITE);
 	if (err != FR_OK) {
-		printFatFsError("SD: failed to create file", err);
+		printFatFsError("SD: failed to create temporary file", err);
 		return StorageStatus::Failed;
 	}
 
@@ -96,7 +128,51 @@ StorageStatus SettingStorageSD::store(size_t id, const uint8_t *ptr, size_t size
 		status = StorageStatus::Failed;
 	}
 
-	f_close(m_fd);
+	if (status == StorageStatus::Ok) {
+		err = f_sync(m_fd);
+		if (err != FR_OK) {
+			printFatFsError("SD: failed to sync temporary file", err);
+			status = StorageStatus::Failed;
+		}
+	}
+
+	err = f_close(m_fd);
+	if (err != FR_OK) {
+		printFatFsError("SD: failed to close temporary file", err);
+		status = StorageStatus::Failed;
+	}
+
+	if (status != StorageStatus::Ok) {
+		(void)f_unlink(temporaryFileName);
+		return status;
+	}
+
+	err = f_unlink(backupFileName);
+	if ((err != FR_OK) && (err != FR_NO_FILE)) {
+		printFatFsError("SD: failed to remove previous backup", err);
+		(void)f_unlink(temporaryFileName);
+		return StorageStatus::Failed;
+	}
+
+	bool primaryMoved = false;
+	err = f_rename(fileName, backupFileName);
+	if (err == FR_OK) {
+		primaryMoved = true;
+	} else if (err != FR_NO_FILE) {
+		printFatFsError("SD: failed to preserve previous file", err);
+		(void)f_unlink(temporaryFileName);
+		return StorageStatus::Failed;
+	}
+
+	err = f_rename(temporaryFileName, fileName);
+	if (err != FR_OK) {
+		printFatFsError("SD: failed to promote temporary file", err);
+		if (primaryMoved) {
+			(void)f_rename(backupFileName, fileName);
+		}
+		(void)f_unlink(temporaryFileName);
+		return StorageStatus::Failed;
+	}
 
 	efitick_t endNt = getTimeNowNt();
 	int elapsed_Ms = US2MS(NT2US(endNt - startNt));
@@ -106,10 +182,44 @@ StorageStatus SettingStorageSD::store(size_t id, const uint8_t *ptr, size_t size
 	return status;
 }
 
+StorageStatus SettingStorageSD::readExactFile(const char *fileName, uint8_t *ptr, size_t size) {
+	FRESULT err = f_open(m_fd, fileName, FA_READ);
+	if (err != FR_OK) {
+		return (err == FR_NO_FILE) ? StorageStatus::NotFound : StorageStatus::Failed;
+	}
+
+	const FSIZE_t fileSize = f_size(m_fd);
+	if (fileSize != size) {
+		efiPrintf("SD: invalid storage file size %d != %d for %s", (size_t)fileSize, size, fileName);
+		(void)f_close(m_fd);
+		return StorageStatus::Failed;
+	}
+
+	size_t bytesRead = 0;
+	err = f_read(m_fd, ptr, size, &bytesRead);
+	StorageStatus status = StorageStatus::Ok;
+	if (err != FR_OK) {
+		printFatFsError("SD: failed to read", err);
+		status = StorageStatus::Failed;
+	} else if (bytesRead != size) {
+		efiPrintf("SD: failed to read whole file %d != %d", bytesRead, size);
+		status = StorageStatus::Failed;
+	}
+
+	err = f_close(m_fd);
+	if (err != FR_OK) {
+		printFatFsError("SD: failed to close file", err);
+		status = StorageStatus::Failed;
+	}
+
+	return status;
+}
+
 StorageStatus SettingStorageSD::read(size_t id, uint8_t *ptr, size_t size) {
 	const char *fileName = getIdFileName(id);
+	const char *backupFileName = getIdBackupFileName(id);
 
-	if (fileName == nullptr) {
+	if ((fileName == nullptr) || (backupFileName == nullptr)) {
 		return StorageStatus::NotSupported;
 	}
 
@@ -122,27 +232,14 @@ StorageStatus SettingStorageSD::read(size_t id, uint8_t *ptr, size_t size) {
 
 	efiPrintf("SD: Reading storage ID %d %s ... %d bytes", id, fileName, size);
 
-	/* Create new or truncate file. */
-	FRESULT err = f_open(m_fd, fileName, FA_READ);
-	if (err != FR_OK) {
-		printFatFsError("SD: failed to open file", err);
-		return StorageStatus::NotFound;
+	StorageStatus status = readExactFile(fileName, ptr, size);
+	if (status != StorageStatus::Ok) {
+		efiPrintf("SD: primary storage file invalid, trying %s", backupFileName);
+		status = readExactFile(backupFileName, ptr, size);
+		if (status == StorageStatus::Ok) {
+			efiPrintf("SD: recovered storage ID %d from backup", id);
+		}
 	}
-
-	StorageStatus status = StorageStatus::Ok;
-	size_t bytesRead = 0;
-	err = f_read(m_fd, ptr, size, &bytesRead);
-	if (err != FR_OK) {
-		printFatFsError("SD: failed to read", err);
-		status = StorageStatus::Failed;
-	}
-
-	if (bytesRead != size) {
-		efiPrintf("SD: failed to read whole file %d != %d", bytesRead, size);
-		status = StorageStatus::Failed;
-	}
-
-	f_close(m_fd);
 
 	efiPrintf("SD: Reading done");
 

--- a/firmware/controllers/system/resource_protector.h
+++ b/firmware/controllers/system/resource_protector.h
@@ -129,7 +129,18 @@ public:
 				return nullptr;
 			}
 
-			if (chCondWaitTimeoutS(&cond_var, remaining) != MSG_OK) {
+			// MutexLocker uses the normal thread-level mutex API, so the matching
+			// condition wait must also be the normal API. Calling the S-class API
+			// here without chSysLock() triggers a ChibiOS system-state panic.
+			const msg_t waitResult = chCondWaitTimeout(&cond_var, remaining);
+			if (waitResult == MSG_TIMEOUT) {
+				// ChibiOS deliberately does not reacquire the mutex on timeout.
+				// Reacquire it so MutexLocker's destructor can release it safely.
+				mutex.lock();
+				return nullptr;
+			}
+
+			if (waitResult != MSG_OK) {
 				return nullptr;
 			}
 		}

--- a/firmware/hw_layer/mmc_card.cpp
+++ b/firmware/hw_layer/mmc_card.cpp
@@ -73,6 +73,7 @@
 #include "resource_protector.h"
 
 #if EFI_STORAGE_SD == TRUE
+#include "storage.h"
 #include "storage_sd.h"
 #endif // EFI_STORAGE_SD
 
@@ -1068,6 +1069,12 @@ static SD_MODE sdModeSelector() {
 	}
 
 #if HAL_USE_USB_MSD
+	// Let startup storage consumers finish before giving the raw block device
+	// to the PC. The next pass transitions to PC/MSD mode automatically.
+	if (storageIsBusy()) {
+		return SD_MODE_ECU;
+	}
+
 	if (usbConnected) {
 		return SD_MODE_PC;
 	}
@@ -1152,6 +1159,14 @@ static int sdModeExecuter(SD_MODE mode)
 		// nothing to do in these state, just sleep
 		return 0;
 	case SD_MODE_ECU:
+		// Automatic USB startup briefly mounts the filesystem for storage reads.
+		// Do not create a log during this transient mount before MSD takes over.
+#if HAL_USE_USB_MSD
+		if (usbConnected && !engineConfiguration->alwaysWriteSdCard && !sdTargetModeRequested) {
+			return 0;
+		}
+#endif
+
 		if (sdNeedRemoveReports) {
 			errorHandlerDeleteReports();
 			sdNeedRemoveReports = false;


### PR DESCRIPTION
## Problem

SD-backed storage records were written directly to their final files, so an interrupted or failed write could leave the only copy truncated or incomplete. Storage failures were not consistently propagated, a failed LTFT load could clear valid RAM state, and USB mass storage could take ownership of the card before startup reads completed. Extra internal-flash pages could also bypass the guarded configuration-write path. Separately, the resource protector used a ChibiOS S-class condition wait without the required system lock.

## Solution

- Write SD records through a temporary file, sync and close it, rotate the previous primary to a backup, then promote the new file.
- Validate exact file sizes and recover from the backup when the primary is invalid.
- Propagate LTFT storage status and preserve RAM trims when loading fails.
- Prevent delayed calibration loads from replacing live state while the engine is running.
- Include pending reads in storage busy state and defer USB mass-storage ownership until startup reads complete.
- Avoid starting the logger during the transient startup mount used for storage reads.
- Route extra internal-flash pages through the guarded settings-write path.
- Use the thread-level ChibiOS condition wait and restore mutex ownership after timeout.

## Validation

- Built `uaefi` firmware with GCC 14.1.0 and LTO (742,780 bytes of flash, 98.56%).
- Ran `git diff --check`.
- Hardware runtime testing has not been performed.
