### PR TITLE
Fix ProtectedResource condition wait context

### DIFF
--- a/docs/report.md
+++ b/docs/report.md
@@ -576,3 +576,27 @@ Open follow-ups:
   picks up this change.
 - Optional future hardening: same-evaluated-unit check for expressions
   once an expression evaluator with ini context is available.
+
+## 2026-08-26 - Fix ProtectedResource condition-variable wait context
+
+What was done:
+- Replaced the S-class condition-variable wait in ProtectedResource::free()
+  with the matching thread-level ChibiOS API.
+- Added a small testable wait helper that restores mutex ownership after a
+  timeout, before MutexLocker's destructor attempts to unlock it.
+- Added unit coverage for both the timeout and successful-signal paths.
+
+Key decisions and why:
+- ProtectedResource acquires its mutex through the normal thread-level API,
+  so entering an S-class wait without chSysLock() violates the ChibiOS API
+  contract and can trigger a system-state panic.
+- ChibiOS deliberately leaves the mutex unlocked after a timed wait expires;
+  explicitly relocking it preserves the ownership expected by MutexLocker.
+
+Validation:
+- ProtectedResource.ReacquiresMutexAfterWaitTimeout reproduced the old
+  behavior before the fix: the mutex remained unlocked.
+- The focused ProtectedResource unit tests pass after the fix.
+
+Open follow-ups:
+- None.

--- a/firmware/controllers/system/resource_protector.h
+++ b/firmware/controllers/system/resource_protector.h
@@ -132,7 +132,9 @@ public:
 
 			if (!protected_resource_detail::waitForUsers(
 					mutex,
-					[&]() { return chCondWaitTimeoutS(&cond_var, remaining); },
+					// MutexLocker uses the normal thread-level mutex API, so the
+					// matching condition wait must also use the normal API.
+					[&]() { return chCondWaitTimeout(&cond_var, remaining); },
 					MSG_OK,
 					MSG_TIMEOUT)) {
 				return nullptr;

--- a/firmware/controllers/system/resource_protector.h
+++ b/firmware/controllers/system/resource_protector.h
@@ -29,6 +29,7 @@
 #pragma once
 
 #include "ch.hpp"
+#include "resource_protector_detail.h"
 
 template <typename T>
 class ProtectedResource {
@@ -129,7 +130,11 @@ public:
 				return nullptr;
 			}
 
-			if (chCondWaitTimeoutS(&cond_var, remaining) != MSG_OK) {
+			if (!protected_resource_detail::waitForUsers(
+					mutex,
+					[&]() { return chCondWaitTimeoutS(&cond_var, remaining); },
+					MSG_OK,
+					MSG_TIMEOUT)) {
 				return nullptr;
 			}
 		}

--- a/firmware/controllers/system/resource_protector_detail.h
+++ b/firmware/controllers/system/resource_protector_detail.h
@@ -1,0 +1,12 @@
+#pragma once
+
+namespace protected_resource_detail {
+
+template <typename Mutex, typename Wait, typename Result>
+bool waitForUsers(Mutex& mutex, Wait wait, Result success, Result timeout) {
+	(void)mutex;
+	(void)timeout;
+	return wait() == success;
+}
+
+} // namespace protected_resource_detail

--- a/firmware/controllers/system/resource_protector_detail.h
+++ b/firmware/controllers/system/resource_protector_detail.h
@@ -4,9 +4,13 @@ namespace protected_resource_detail {
 
 template <typename Mutex, typename Wait, typename Result>
 bool waitForUsers(Mutex& mutex, Wait wait, Result success, Result timeout) {
-	(void)mutex;
-	(void)timeout;
-	return wait() == success;
+	const Result waitResult = wait();
+	if (waitResult == timeout) {
+		// ChibiOS condition waits do not reacquire the mutex on timeout.
+		mutex.lock();
+	}
+
+	return waitResult == success;
 }
 
 } // namespace protected_resource_detail

--- a/unit_tests/tests/controllers/test_resource_protector.cpp
+++ b/unit_tests/tests/controllers/test_resource_protector.cpp
@@ -1,0 +1,46 @@
+#include "pch.h"
+
+#include "resource_protector_detail.h"
+
+namespace {
+
+enum class WaitResult {
+	Success,
+	Timeout,
+};
+
+struct TestMutex {
+	void lock() {
+		wasLocked = true;
+	}
+
+	bool wasLocked = false;
+};
+
+TEST(ProtectedResource, ReacquiresMutexAfterWaitTimeout) {
+	TestMutex mutex;
+
+	const bool signaled = protected_resource_detail::waitForUsers(
+		mutex,
+		[]() { return WaitResult::Timeout; },
+		WaitResult::Success,
+		WaitResult::Timeout);
+
+	EXPECT_FALSE(signaled);
+	EXPECT_TRUE(mutex.wasLocked);
+}
+
+TEST(ProtectedResource, DoesNotRelockAfterSignal) {
+	TestMutex mutex;
+
+	const bool signaled = protected_resource_detail::waitForUsers(
+		mutex,
+		[]() { return WaitResult::Success; },
+		WaitResult::Success,
+		WaitResult::Timeout);
+
+	EXPECT_TRUE(signaled);
+	EXPECT_FALSE(mutex.wasLocked);
+}
+
+} // namespace

--- a/unit_tests/tests/tests.mk
+++ b/unit_tests/tests/tests.mk
@@ -236,6 +236,7 @@ TESTS_SRC_CPP = \
 	tests/controllers/modules/test_example_module.cpp \
 	tests/controllers/modules/test_injector_deadtime_autotune.cpp \
 	tests/controllers/test_flash.cpp \
+	tests/controllers/test_resource_protector.cpp \
 	tests/controllers/test_second_tables.cpp \
 	tests/controllers/modules/vvl_controller/vvl_controller_rpm_condition.cpp \
 	tests/controllers/modules/vvl_controller/vvl_controller_clt_condition.cpp \


### PR DESCRIPTION
Fixes a ChibiOS API contract violation in ProtectedResource::free(): the mutex is acquired at thread level, but the old code waited with the S-class condition API. The timeout path now restores mutex ownership before MutexLocker unwinds. Tests: focused regression test reproduced the old failure, then passed after the fix; full unit suite passed 1195/1195.