### PR TITLE
Potential memleak fixed for lua handle, explicit constructor was adde…

### DIFF
--- a/firmware/controllers/lua/lua.cpp
+++ b/firmware/controllers/lua/lua.cpp
@@ -64,12 +64,12 @@ static void loadLibraries(LuaHandle& ls) {
 }
 
 static LuaHandle setupLuaState(lua_Alloc alloc) {
-	LuaHandle ls = lua_newstate(alloc, NULL);
+	LuaHandle ls(lua_newstate(alloc, NULL));
 
 	if (!ls) {
 		criticalError("Failed to start Lua interpreter");
 
-		return nullptr;
+		return ls;
 	}
 
 	lua_atpanic(ls, [](lua_State* l) {

--- a/firmware/controllers/lua/rusefi_lua.h
+++ b/firmware/controllers/lua/rusefi_lua.h
@@ -7,7 +7,8 @@
 class LuaHandle final {
 public:
 	LuaHandle() : LuaHandle(nullptr) { }
-	LuaHandle(lua_State* ptr) : m_ptr(ptr) { }
+	// Explicit constructor to avoid accidential captures
+	explicit LuaHandle(lua_State* ptr) : m_ptr(ptr) { }
 
 	// Don't allow copying!
 	LuaHandle(const LuaHandle&) = delete;
@@ -21,9 +22,12 @@ public:
 
 	// Move assignment operator
 	LuaHandle& operator=(LuaHandle&& rhs) {
+		if(this == &rhs)
+			return *this;
+		// Don't forget to swap values, otherwise potential memory leak
+		lua_State* lhs_handle = m_ptr;
 		m_ptr = rhs.m_ptr;
-		rhs.m_ptr = nullptr;
-
+		rhs.m_ptr = lhs_handle;
 		return *this;
 	}
 


### PR DESCRIPTION
This PR is related with small improvements for LuaHandle:

1. Usually it's good idea to have explicit constructor in order to prevent any accidential captures of native handles. 
2. Move assingment had potential memory leak. Currently this operator is not used in codebase, but I decided to fix it just in case.

P.S. These fixes lead me to the thought to create special allocator to check potential mem leaks in unit tests. Is it good idea to cover such cases? I may add it later in separate PR