### PR TITLE
Fix #10144: Bind modal dialogs to active parent window to prevent focus loss on Linux

### DIFF
--- a/java_console/core_ui/src/main/java/com/rusefi/core/ui/ErrorMessageHelper.java
+++ b/java_console/core_ui/src/main/java/com/rusefi/core/ui/ErrorMessageHelper.java
@@ -2,6 +2,7 @@ package com.rusefi.core.ui;
 
 import org.jetbrains.annotations.NotNull;
 
+import java.awt.*;
 import javax.swing.*;
 
 public class ErrorMessageHelper {
@@ -17,14 +18,28 @@ public class ErrorMessageHelper {
         return frame;
     }
 
-    public static void showErrorDialog(String message, String title) {
-        JFrame parent = createOnTopParent();
-        JOptionPane.showMessageDialog(parent,
+	public static void showErrorDialog(String message, String title) {
+        boolean createdNewFrame = false;
+        Component parent = null;
+        for (Window w : Window.getWindows()) {
+            if (w.isShowing() && w instanceof JFrame) {
+                parent = w;
+                break;
+            }
+        }
+        if (parent == null) {
+            parent = createOnTopParent();
+            createdNewFrame = true;
+        }
+        JOptionPane.showMessageDialog(
+            parent,
             message,
             title,
             JOptionPane.ERROR_MESSAGE
         );
-        parent.setVisible(false);
-        parent.dispose();
+        if (createdNewFrame && parent instanceof JFrame) {
+            ((JFrame) parent).setVisible(false);
+            ((JFrame) parent).dispose();
+        }
     }
 }


### PR DESCRIPTION
### Problem Description
Resolves **#10144**. On Linux window managers, error dialogs sink behind the main application window or disappear when switching windows using `Alt+Tab`.

### Root Cause
`ErrorMessageHelper` created unparented "ghost" `JFrame` instances for popups. Linux window managers require a parent-child relationship (`WM_TRANSIENT_FOR`) to stack modal dialogs correctly above parent windows. Without it, the main window covers the dialog on window focus changes.

### Key Changes
* **Active Frame Discovery:** Updated `ErrorMessageHelper.showErrorDialog()` to scan `Window.getWindows()` for an active `JFrame` and set it as the parent for `JOptionPane`.
* **Resource Cleanup:** Added `createdNewFrame` tracking so temporary fallback frames are explicitly hidden and disposed (`dispose()`) upon dismissal, preventing memory leaks and orphaned window handles.

### Testing
* Verified build compilation (`./gradlew classes -x test`).
* Confirmed proper modal z-ordering and `Alt+Tab` retention on Linux.