### PR TITLE
Enable SocketCAN support and improve detection for ECUs via CAN

### DIFF
--- a/java_console/bin/socketcan_connector.sh
+++ b/java_console/bin/socketcan_connector.sh
@@ -1,1 +1,1 @@
-java -jar rusefi_console.jar pcan_connector
+java -jar rusefi_console.jar socketcan_connector

--- a/java_console/connectivity/src/main/java/com/rusefi/AvailableHardware.java
+++ b/java_console/connectivity/src/main/java/com/rusefi/AvailableHardware.java
@@ -13,12 +13,20 @@ public class AvailableHardware {
     private final boolean dfuFound;
     private final boolean stLinkConnected;
     private final boolean PCANConnected;
+    private final boolean socketCanAvailable;
 
-    public AvailableHardware(List<PortResult> ports, boolean dfuFound, boolean stLinkConnected, boolean PCANConnected) {
+    public AvailableHardware(List<PortResult> ports, boolean dfuFound, boolean stLinkConnected,
+                             boolean PCANConnected) {
+        this(ports, dfuFound, stLinkConnected, PCANConnected, false);
+    }
+
+    public AvailableHardware(List<PortResult> ports, boolean dfuFound, boolean stLinkConnected,
+                             boolean PCANConnected, boolean socketCanAvailable) {
         this.ports = ports;
         this.dfuFound = dfuFound;
         this.stLinkConnected = stLinkConnected;
         this.PCANConnected = PCANConnected;
+        this.socketCanAvailable = socketCanAvailable;
     }
 
     @NotNull
@@ -40,6 +48,7 @@ public class AvailableHardware {
 
     public boolean isStLinkConnected() {return stLinkConnected;}
     public boolean isPCANConnected(){return PCANConnected;}
+    public boolean isSocketCanAvailable() {return socketCanAvailable;}
 
     public boolean isPortAvailable(final PortResult port) {
         return ports.contains(port);
@@ -50,7 +59,11 @@ public class AvailableHardware {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         AvailableHardware that = (AvailableHardware) o;
-        return dfuFound == that.dfuFound && stLinkConnected == that.stLinkConnected && PCANConnected == that.PCANConnected && ports.equals(that.ports);
+        return dfuFound == that.dfuFound
+            && stLinkConnected == that.stLinkConnected
+            && PCANConnected == that.PCANConnected
+            && socketCanAvailable == that.socketCanAvailable
+            && ports.equals(that.ports);
     }
 
     public boolean isEmpty() {
@@ -64,7 +77,7 @@ public class AvailableHardware {
             ", dfuFound=" + dfuFound +
             ", stLinkConnected=" + stLinkConnected +
             ", PCANConnected=" + PCANConnected +
+            ", socketCanAvailable=" + socketCanAvailable +
             '}';
     }
 }
-

--- a/java_console/connectivity/src/main/java/com/rusefi/SerialPortScanner.java
+++ b/java_console/connectivity/src/main/java/com/rusefi/SerialPortScanner.java
@@ -1,7 +1,5 @@
 package com.rusefi;
 
-import com.rusefi.core.OsUtil;
-
 import com.devexperts.logging.Logging;
 import com.rusefi.io.LinkManager;
 import org.jetbrains.annotations.NotNull;
@@ -30,7 +28,6 @@ import java.util.stream.Collectors;
 public class SerialPortScanner implements PortScanner {
     private final static Logging log = Logging.getLogging(SerialPortScanner.class);
 
-    private static final boolean SHOW_SOCKETCAN = OsUtil.isLinux();
     private static final long DETECTED_ECU_CACHE_MS = 3000;
 
     /**
@@ -49,6 +46,13 @@ public class SerialPortScanner implements PortScanner {
         Collection<String> listTcpPorts();
 
         PortResult inspectTcpPort(String tcpPort);
+
+        /**
+         * @return null when SocketCAN is unavailable, CAN when the interface opens without an ECU reply,
+         * or an ECU classification when rusEFI replies
+         */
+        @Nullable
+        PortResult inspectSocketCan();
 
         boolean isLiveEcuConnected();
 
@@ -80,7 +84,8 @@ public class SerialPortScanner implements PortScanner {
 
     private final Object lock = new Object();
     @NotNull
-    private AvailableHardware knownHardware = new AvailableHardware(Collections.emptyList(), false, false, false);
+    private AvailableHardware knownHardware = new AvailableHardware(
+        Collections.emptyList(), false, false, false, false);
 
     private final List<PortScanner.Listener> listeners = new CopyOnWriteArrayList<>();
 
@@ -209,6 +214,9 @@ public class SerialPortScanner implements PortScanner {
     private boolean lastDfuConnected = false;
     private boolean lastStLinkConnected = false;
     private boolean lastPcanConnected = false;
+    private boolean lastSocketCanAvailable = false;
+    @Nullable
+    private PortResult lastSocketCanPort;
 
     /**
      * Find all available serial ports and checks if simulator local TCP port is available.
@@ -219,6 +227,7 @@ public class SerialPortScanner implements PortScanner {
         boolean dfuConnected;
         boolean stLinkConnected;
         boolean PCANConnected;
+        boolean socketCanAvailable;
 
         // ttyS* are legacy motherboard UARTs on Linux — never a rusEFI ECU and they stall
         // the binary protocol handshake for seconds.  Drop them before the scan pipeline.
@@ -257,9 +266,6 @@ public class SerialPortScanner implements PortScanner {
         livePortNames.addAll(tcpPorts);
         portCache.retainAll(livePortNames);
 
-        // Sort ports by their type to put your ECU at the top
-        ports.sort(Comparator.comparingInt(a -> a.type.sortOrder));
-
         if (includeSlowLookup) {
             for (String tcpPort : tcpPorts) {
                 final Optional<PortResult> cachedPort = portCache.get(tcpPort, probes.now());
@@ -284,32 +290,43 @@ public class SerialPortScanner implements PortScanner {
                 lastDfuConnected = probes.isDfuDeviceConnected();
                 lastStLinkConnected = probes.isStLinkConnected();
                 lastPcanConnected = probes.isPcanConnected();
+                PortResult socketCanResult = probes.inspectSocketCan();
+                lastSocketCanAvailable = socketCanResult != null;
+                lastSocketCanPort = socketCanResult != null
+                    && socketCanResult.type != SerialPortType.CAN
+                    && socketCanResult.type != SerialPortType.Unknown
+                    ? socketCanResult
+                    : null;
                 lastDeviceProbeMs = now;
             }
             dfuConnected = lastDfuConnected;
             stLinkConnected = lastStLinkConnected;
             PCANConnected = lastPcanConnected;
+            socketCanAvailable = lastSocketCanAvailable;
         } else {
             dfuConnected = false;
             stLinkConnected = false;
             PCANConnected = false;
+            socketCanAvailable = lastSocketCanAvailable;
         }
 /*
         if (PCANConnected)
             ports.add(new PortResult(LinkManager.PCAN, SerialPortType.CAN));
  */
-/*
-        if (SHOW_SOCKETCAN)
-            ports.add(new PortResult(LinkManager.SOCKET_CAN, SerialPortType.CAN));
-*/
+        if (lastSocketCanPort != null) {
+            ports.add(lastSocketCanPort);
+        }
         // Surface a DFU device (STM32 built-in bootloader) as a synthetic, non-connectable port so a
         // running console can offer DFU flashing in-session [tag:better_ux_for_flashing]. dfuConnected stays exposed via
         // AvailableHardware.isDfuFound() for the existing ProgramSelector menu logic.
         if (dfuConnected) {
             ports.add(new PortResult(LinkManager.DFU, SerialPortType.Dfu));
         }
+        // Sort after every transport and synthetic device has been added.
+        ports.sort(Comparator.comparingInt(a -> a.type.sortOrder));
         boolean isListUpdated;
-        AvailableHardware currentHardware = new AvailableHardware(ports, dfuConnected, stLinkConnected, PCANConnected);
+        AvailableHardware currentHardware = new AvailableHardware(
+            ports, dfuConnected, stLinkConnected, PCANConnected, socketCanAvailable);
         synchronized (lock) {
             isListUpdated = !knownHardware.equals(currentHardware);
             knownHardware = currentHardware;

--- a/java_console/connectivity/src/test/java/com/rusefi/AvailableHardwareTest.java
+++ b/java_console/connectivity/src/test/java/com/rusefi/AvailableHardwareTest.java
@@ -67,6 +67,11 @@ public class AvailableHardwareTest {
         assertFalse(new AvailableHardware(Collections.emptyList(), true, false, false).isEmpty(), "DFU counts as hardware");
         assertFalse(new AvailableHardware(Collections.emptyList(), false, true, false).isEmpty(), "ST-Link counts as hardware");
         assertFalse(new AvailableHardware(Collections.emptyList(), false, false, true).isEmpty(), "PCAN counts as hardware");
+
+        AvailableHardware socketCanOnly = new AvailableHardware(
+            Collections.emptyList(), false, false, false, true);
+        assertTrue(socketCanOnly.isSocketCanAvailable());
+        assertTrue(socketCanOnly.isEmpty(), "a CAN interface without an ECU is not actionable hardware");
     }
 
     @Test
@@ -78,5 +83,6 @@ public class AvailableHardwareTest {
         assertNotEquals(base, new AvailableHardware(Collections.singletonList(ECU), true, false, false));
         assertNotEquals(base, new AvailableHardware(Collections.singletonList(ECU), false, true, false));
         assertNotEquals(base, new AvailableHardware(Collections.singletonList(ECU), false, false, true));
+        assertNotEquals(base, new AvailableHardware(Collections.singletonList(ECU), false, false, false, true));
     }
 }

--- a/java_console/connectivity/src/test/java/com/rusefi/SerialPortScannerTest.java
+++ b/java_console/connectivity/src/test/java/com/rusefi/SerialPortScannerTest.java
@@ -32,6 +32,8 @@ public class SerialPortScannerTest {
         Collection<String> tcpPorts = new ArrayList<>();
         int tcpInspectionCalls;
         PortResult tcpResult;
+        int socketCanInspectionCalls;
+        PortResult socketCanResult;
         boolean liveEcuConnected;
         boolean dfuConnected;
         int deviceProbeCalls;
@@ -57,6 +59,12 @@ public class SerialPortScannerTest {
         public PortResult inspectTcpPort(String tcpPort) {
             tcpInspectionCalls++;
             return tcpResult != null ? tcpResult : new PortResult(tcpPort, SerialPortType.Unknown);
+        }
+
+        @Override
+        public PortResult inspectSocketCan() {
+            socketCanInspectionCalls++;
+            return socketCanResult;
         }
 
         @Override
@@ -237,24 +245,72 @@ public class SerialPortScannerTest {
         scan(false);
 
         assertEquals(0, probes.deviceProbeCalls);
+        assertEquals(0, probes.socketCanInspectionCalls);
         assertFalse(scanner.getCurrentHardware().isDfuFound());
+    }
+
+    @Test
+    public void availableSocketCanWithoutEcuIsNotASelectablePort() {
+        probes.socketCanResult = new PortResult(LinkManager.SOCKET_CAN, SerialPortType.CAN);
+
+        scan(true);
+
+        assertEquals(1, probes.socketCanInspectionCalls);
+        assertTrue(scanner.getCurrentHardware().isSocketCanAvailable());
+        assertTrue(knownPorts().isEmpty(), "a CAN interface without an ECU is status, not a connect target");
+    }
+
+    @Test
+    public void socketCanEcuIsPublishedAsAConnectableEcu() {
+        probes.socketCanResult = new PortResult(LinkManager.SOCKET_CAN, SerialPortType.Ecu);
+
+        scan(true);
+
+        assertTrue(scanner.getCurrentHardware().isSocketCanAvailable());
+        assertEquals(java.util.Collections.singletonList(probes.socketCanResult), knownPorts());
+    }
+
+    @Test
+    public void fastScanPreservesPreviouslyDetectedSocketCanState() {
+        probes.socketCanResult = new PortResult(LinkManager.SOCKET_CAN, SerialPortType.Ecu);
+        scan(true);
+
+        scan(false);
+
+        assertEquals(1, probes.socketCanInspectionCalls);
+        assertTrue(scanner.getCurrentHardware().isSocketCanAvailable());
+        assertEquals(java.util.Collections.singletonList(probes.socketCanResult), knownPorts());
+    }
+
+    @Test
+    public void unavailableSocketCanIsNotReported() {
+        scan(true);
+
+        assertEquals(1, probes.socketCanInspectionCalls);
+        assertFalse(scanner.getCurrentHardware().isSocketCanAvailable());
+        assertTrue(knownPorts().isEmpty());
     }
 
     @Test
     public void deviceProbesAreThrottledAndLastKnownValuesReusedBetweenProbes() {
         probes.dfuConnected = true;
+        probes.socketCanResult = new PortResult(LinkManager.SOCKET_CAN, SerialPortType.CAN);
 
         scan(true);
         assertEquals(1, probes.deviceProbeCalls);
+        assertEquals(1, probes.socketCanInspectionCalls);
 
         probes.time += 1000; // within the throttle interval
         scan(true);
         assertEquals(1, probes.deviceProbeCalls, "device probes must not run every scan cycle");
+        assertEquals(1, probes.socketCanInspectionCalls);
         assertTrue(scanner.getCurrentHardware().isDfuFound(), "last-known result must be reused, not dropped");
+        assertTrue(scanner.getCurrentHardware().isSocketCanAvailable());
 
         probes.time += 3000; // past the throttle interval
         scan(true);
         assertEquals(2, probes.deviceProbeCalls);
+        assertEquals(2, probes.socketCanInspectionCalls);
     }
 
     @Test
@@ -266,6 +322,22 @@ public class SerialPortScannerTest {
 
         assertEquals(0, probes.deviceProbeCalls,
             "a connected board cannot also be a DFU device; the scan thread must stay responsive");
+        assertEquals(0, probes.socketCanInspectionCalls);
+    }
+
+    @Test
+    public void connectedSocketCanEcuIsNotReprobed() {
+        probes.socketCanResult = new PortResult(LinkManager.SOCKET_CAN, SerialPortType.Ecu);
+        scan(true);
+
+        probes.liveEcuConnected = true;
+        probes.socketCanResult = new PortResult(LinkManager.SOCKET_CAN, SerialPortType.CAN);
+        probes.time += 3001;
+        scan(true);
+
+        assertEquals(1, probes.socketCanInspectionCalls);
+        assertEquals(java.util.Collections.singletonList(
+            new PortResult(LinkManager.SOCKET_CAN, SerialPortType.Ecu)), knownPorts());
     }
 
     @Test

--- a/java_console/io/src/main/java/com/rusefi/io/LinkManager.java
+++ b/java_console/io/src/main/java/com/rusefi/io/LinkManager.java
@@ -19,6 +19,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.io.Closeable;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;
@@ -444,8 +445,10 @@ public class LinkManager implements Closeable {
         log.info("restart: closing current connection");
         close(); // Explicitly kill the connection (call connectors destructor??????)
 
-        final Set<String> ports = getCommPorts();
-        final boolean isPortAvailableAgain = ports.contains(lastTriedPort);
+        // SocketCAN is a named transport rather than an OS serial port. Avoid serial enumeration and
+        // let its stream factory decide whether the configured CAN interface is available again.
+        final Set<String> ports = isSocketCan(lastTriedPort) ? Collections.emptySet() : getCommPorts();
+        final boolean isPortAvailableAgain = isPortAvailableForReconnect(lastTriedPort, ports);
         log.info("restart isPortAvailableAgain=" + isPortAvailableAgain + " port=" + lastTriedPort);
         if (isPortAvailableAgain) {
             // Use isScanningForEcu=true to prevent ExitUtil.exit() on failure —
@@ -455,6 +458,10 @@ public class LinkManager implements Closeable {
         } else {
             log.info("restart: port not available, skipping connect");
         }
+    }
+
+    static boolean isPortAvailableForReconnect(String port, Set<String> serialPorts) {
+        return isSocketCan(port) || serialPorts.contains(port);
     }
 
     @Override

--- a/java_console/io/src/main/java/com/rusefi/io/can/SocketCANHelper.java
+++ b/java_console/io/src/main/java/com/rusefi/io/can/SocketCANHelper.java
@@ -19,18 +19,38 @@ public class SocketCANHelper {
 
     @NotNull
     public static RawCanChannel createSocket() {
-        final RawCanChannel socket;
         try {
             NetworkDevice canInterface = NetworkDevice.lookup(System.getProperty("CAN_DEVICE_NAME", "can0"));
-            socket = CanChannels.newRawChannel();
+            return createSocket(canInterface, CanChannels::newRawChannel);
+        } catch (IOException e) {
+            throw new IllegalStateException("Error looking up", e);
+        }
+    }
+
+    static RawCanChannel createSocket(NetworkDevice canInterface, ChannelFactory channelFactory) {
+        RawCanChannel socket = null;
+        try {
+            socket = channelFactory.create();
             socket.bind(canInterface);
 
             socket.configureBlocking(true); // we want reader thread to wait for messages
             socket.setOption(RECV_OWN_MSGS, false);
+            return socket;
         } catch (IOException e) {
+            if (socket != null) {
+                try {
+                    socket.close();
+                } catch (IOException closeException) {
+                    e.addSuppressed(closeException);
+                }
+            }
             throw new IllegalStateException("Error looking up", e);
         }
-        return socket;
+    }
+
+    @FunctionalInterface
+    interface ChannelFactory {
+        RawCanChannel create() throws IOException;
     }
 
     public static void send(int id, byte[] payload, RawCanChannel channel) {

--- a/java_console/io/src/main/java/com/rusefi/io/can/SocketCANIoStream.java
+++ b/java_console/io/src/main/java/com/rusefi/io/can/SocketCANIoStream.java
@@ -14,7 +14,7 @@ import org.jetbrains.annotations.Nullable;
 import tel.schich.javacan.RawCanChannel;
 
 import java.io.IOException;
-import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 import static com.devexperts.logging.Logging.getLogging;
@@ -24,6 +24,7 @@ public class SocketCANIoStream extends AbstractIoStream {
     static Logging log = getLogging(SocketCANIoStream.class);
     private final IncomingDataBuffer dataBuffer;
     private final RawCanChannel socket;
+    private final ExecutorService readerExecutor;
 
     private final IsoTpCanDecoder canDecoder = new IsoTpCanDecoder() {
         @Override
@@ -40,17 +41,24 @@ public class SocketCANIoStream extends AbstractIoStream {
     };
 
     private void sendCanPacket(byte[] total) {
-        if (log.debugEnabled())
+        if (log.debugEnabled()){
             log.debug("-------sendIsoTp " + total.length + " byte(s):");
+        }
 
-        if (log.debugEnabled())
+        if (log.debugEnabled()){
             log.debug("Sending " + HexBinary.printHexBinary(total));
+        }
 
         SocketCANHelper.send(isoTpConnector.canId(), total, socket);
     }
 
     public SocketCANIoStream() {
-        socket = SocketCANHelper.createSocket();
+        this(SocketCANHelper.createSocket(), Executors.newSingleThreadExecutor(BinaryProtocolServer.getThreadFactory("SocketCAN reader")));
+    }
+
+    SocketCANIoStream(RawCanChannel socket, ExecutorService readerExecutor) {
+        this.socket = socket;
+        this.readerExecutor = readerExecutor;
         // buffer could only be created once socket variable is not null due to callback
         dataBuffer = createDataBuffer();
     }
@@ -67,15 +75,14 @@ public class SocketCANIoStream extends AbstractIoStream {
 
     @Override
     public void setInputListener(DataListener listener) {
-        Executor threadExecutor = Executors.newSingleThreadExecutor(BinaryProtocolServer.getThreadFactory("SocketCAN reader"));
-        threadExecutor.execute(() -> {
+        readerExecutor.execute(() -> {
             while (!isClosed()) {
                 readOnePacket(listener);
             }
         });
     }
 
-    private void readOnePacket(DataListener listener) {
+    void readOnePacket(DataListener listener) {
         try {
             CanConnector.CanPacket rx = SocketCANHelper.read(socket);
             if (rx.id() != CAN_ECU_SERIAL_TX_ID) {
@@ -86,8 +93,25 @@ public class SocketCANIoStream extends AbstractIoStream {
             byte[] decode = canDecoder.decodePacket(rx.payload());
             listener.onDataArrived(decode);
         } catch (IOException e) {
-            throw new IllegalStateException(e);
+            if (isClosed())
+                return;
+            log.warn("SocketCAN read failed, closing stream: " + e.getMessage());
+            close();
         }
+    }
+
+    @Override
+    public void close() {
+        if (isClosed())
+            return;
+
+        super.close();
+        try {
+            socket.close();
+        } catch (IOException e) {
+            log.warn("Error closing SocketCAN channel", e);
+        }
+        readerExecutor.shutdownNow();
     }
 
     @Override

--- a/java_console/io/src/main/java/com/rusefi/io/can/isotp/IsoTpCanDecoder.java
+++ b/java_console/io/src/main/java/com/rusefi/io/can/isotp/IsoTpCanDecoder.java
@@ -59,6 +59,7 @@ public abstract class IsoTpCanDecoder {
                 break;
             case IsoTpConstants.ISO_TP_FRAME_FIRST:
                 this.waitingForNumBytes = ((data[isoHeaderByteIndex] & 0xf) << 8) | data[isoHeaderByteIndex + 1];
+                setComplete(false);
                 if (log.debugEnabled())
                     log.debug("Total expected: " + waitingForNumBytes);
                 this.waitingForFrameIndex = 1;
@@ -69,8 +70,17 @@ public abstract class IsoTpCanDecoder {
                 break;
             case IsoTpConstants.ISO_TP_FRAME_CONSECUTIVE:
                 frameIdx = data[isoHeaderByteIndex] & 0xf;
-                if (this.waitingForNumBytes < 0 || this.waitingForFrameIndex != frameIdx) {
-                    throw new IllegalStateException("ISO_TP_FRAME_CONSECUTIVE: That's an abnormal situation, and we probably should react? waitingForNumBytes=" + waitingForNumBytes + " waitingForFrameIndex=" + waitingForFrameIndex + " frameIdx=" + frameIdx);
+                if (this.waitingForNumBytes <= 0) {
+                    if (log.debugEnabled())
+                        log.debug("Ignoring ISO-TP consecutive frame while no message is active: frameIdx=" + frameIdx);
+                    reset();
+                    return new byte[0];
+                }
+                if (this.waitingForFrameIndex != frameIdx) {
+                    log.warn("Aborting out-of-sequence ISO-TP message: waitingForNumBytes="
+                        + waitingForNumBytes + " waitingForFrameIndex=" + waitingForFrameIndex + " frameIdx=" + frameIdx);
+                    reset();
+                    return new byte[0];
                 }
                 this.waitingForFrameIndex = (this.waitingForFrameIndex + 1) & 0xf;
                 numBytesAvailable = Math.min(this.waitingForNumBytes, dataSize - 1 - isoHeaderByteIndex);
@@ -104,5 +114,11 @@ public abstract class IsoTpCanDecoder {
 
     public boolean isComplete() {
         return isComplete;
+    }
+
+    private void reset() {
+        waitingForNumBytes = 0;
+        waitingForFrameIndex = 0;
+        setComplete(false);
     }
 }

--- a/java_console/io/src/test/java/com/rusefi/io/LinkManagerCompatibilityListenerTest.java
+++ b/java_console/io/src/test/java/com/rusefi/io/LinkManagerCompatibilityListenerTest.java
@@ -6,13 +6,26 @@ import com.rusefi.core.io.UnsupportedEcuInfo;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class LinkManagerCompatibilityListenerTest {
+    @Test
+    public void socketCanCanReconnectWithoutAppearingAsASerialPort() {
+        assertTrue(LinkManager.isPortAvailableForReconnect(
+            LinkManager.SOCKET_CAN, Collections.emptySet()));
+        assertFalse(LinkManager.isPortAvailableForReconnect(
+            "COM7", Collections.emptySet()));
+        assertTrue(LinkManager.isPortAvailableForReconnect(
+            "COM7", Collections.singleton("COM7")));
+    }
+
     @Test
     public void unsupportedEventCarriesPortAndIdentity() {
         AtomicReference<String> reportedPort = new AtomicReference<>();

--- a/java_console/io/src/test/java/com/rusefi/io/can/isotp/IsoTpCanDecoderTest.java
+++ b/java_console/io/src/test/java/com/rusefi/io/can/isotp/IsoTpCanDecoderTest.java
@@ -13,6 +13,44 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 public class IsoTpCanDecoderTest {
     @Test
+    public void consecutiveFrameWithoutFirstFrameIsIgnoredAndDecoderRecovers() {
+        IsoTpCanDecoder decoder = new TestIsoTpCanDecoder();
+
+        assertArrayEquals(new byte[0],
+            decoder.decodePacket(new byte[]{0x21, 1, 2, 3, 4, 5, 6, 7}));
+        assertArrayEquals(new byte[]{0x12, 0x34},
+            decoder.decodePacket(new byte[]{0x02, 0x12, 0x34}));
+    }
+
+    @Test
+    public void duplicateConsecutiveFrameAfterCompletedMessageIsIgnored() {
+        IsoTpCanDecoder decoder = new TestIsoTpCanDecoder();
+        decoder.decodePacket(new byte[]{0x10, 0x0B, 1, 2, 3, 4, 5, 6});
+        decoder.decodePacket(new byte[]{0x21, 7, 8, 9, 10, 11, 0, 0});
+
+        assertArrayEquals(new byte[0],
+            decoder.decodePacket(new byte[]{0x21, 7, 8, 9, 10, 11, 0, 0}));
+        assertArrayEquals(new byte[]{0x12, 0x34},
+            decoder.decodePacket(new byte[]{0x02, 0x12, 0x34}));
+    }
+
+    @Test
+    public void wrongSequenceAbortsCurrentMessageAndAllowsANewOne() {
+        IsoTpCanDecoder decoder = new TestIsoTpCanDecoder();
+        byte[] firstFrame = new byte[]{0x10, 0x08, 1, 2, 3, 4, 5, 6};
+        byte[] firstConsecutiveFrame = new byte[]{0x21, 7, 8, 0, 0, 0, 0, 0};
+        decoder.decodePacket(firstFrame);
+
+        assertArrayEquals(new byte[0],
+            decoder.decodePacket(new byte[]{0x22, 7, 8, 0, 0, 0, 0, 0}));
+        assertArrayEquals(new byte[0], decoder.decodePacket(firstConsecutiveFrame));
+
+        assertArrayEquals(new byte[]{1, 2, 3, 4, 5, 6}, decoder.decodePacket(firstFrame));
+        assertArrayEquals(new byte[]{7, 8}, decoder.decodePacket(firstConsecutiveFrame));
+        assertTrue(decoder.isComplete());
+    }
+
+    @Test
     public void decodeSingleFrame() {
         IsoTpCanDecoder decoder = new TestIsoTpCanDecoder();
         byte[] result1 = decoder.decodePacket(new byte[]{0x4, 1, 2, 3, 4});

--- a/java_console/readme.md
+++ b/java_console/readme.md
@@ -8,6 +8,50 @@ rusEFI frontend applications is historically known as rusEFI console.
 
 Here we have source code for rusEFI console: while [TunerStudio](http://www.tunerstudio.com/index.php/products/tuner-studio) is the primary calibration frontend application we need secondary app for firmware update and some advanced troubleshooting. One day we shall combine but not yet :(
 
+## Linux SocketCAN
+
+The console automatically probes a Linux SocketCAN interface for a rusEFI ECU.
+It uses `can0` by default. The interface bitrate must match the ECU configuration;
+the standard rusEFI default is 500 kbit/s.
+
+Configure and enable `can0`:
+
+```bash
+sudo ip link set can0 down
+sudo ip link set can0 type can bitrate 500000 restart-ms 100
+sudo ip link set can0 up
+```
+
+Verify the interface state and bitrate:
+
+```bash
+ip -details -statistics link show can0
+```
+
+The output should report `state UP` and `bitrate 500000`. To monitor received
+traffic with the `can-utils` package:
+
+```bash
+candump can0
+```
+
+To use another SocketCAN interface, set the Java system property before `-jar`:
+
+```bash
+java -DCAN_DEVICE_NAME=can1 -jar rusefi_console.jar
+```
+
+Troubleshooting:
+
+- `Cannot find device "can0"`: the CAN adapter driver has not created the
+  interface. Native SocketCAN adapters usually create it automatically; serial
+  SLCAN adapters require adapter-specific `slcand` setup first.
+- `Network is down`: the interface exists but is not `UP`; run the configuration
+  commands above.
+- `CAN connected, but no ECU replied`: the interface is active, but no valid
+  rusEFI response was received. Check that the bitrate matches the ECU, the ECU
+  is powered, CAN high/low are not swapped, and the bus is correctly terminated.
+
 See also http://rusefi.com/build_server/ for pre-compiled full bundle
 
 🔴 not main folder for java code - it's [../java_tools](../java_tools) where primary build.gradle is located 🔴

--- a/java_console/ui/src/main/java/com/rusefi/EcuHardwareProbes.java
+++ b/java_console/ui/src/main/java/com/rusefi/EcuHardwareProbes.java
@@ -1,10 +1,13 @@
 package com.rusefi;
 
 import com.devexperts.logging.Logging;
+import com.rusefi.autodetect.SerialAutoChecker;
+import com.rusefi.core.OsUtil;
 import com.rusefi.io.ConnectionStatusLogic;
 import com.rusefi.io.IoStream;
 import com.rusefi.io.LinkManager;
 import com.rusefi.io.UpdateOperationCallbacks;
+import com.rusefi.io.can.SocketCANIoStream;
 import com.rusefi.io.serial.BufferedSerialIoStream;
 import com.rusefi.io.tcp.TcpConnector;
 import com.rusefi.maintenance.CalibrationsHelper;
@@ -64,6 +67,11 @@ public class EcuHardwareProbes implements SerialPortScanner.HardwareProbes {
     }
 
     @Override
+    public PortResult inspectSocketCan() {
+        return inspectSocketCan(REAL_SOCKET_CAN_PROBE);
+    }
+
+    @Override
     public boolean isLiveEcuConnected() {
         return ConnectionStatusLogic.INSTANCE.isConnected();
     }
@@ -86,6 +94,52 @@ public class EcuHardwareProbes implements SerialPortScanner.HardwareProbes {
     @Override
     public long now() {
         return System.currentTimeMillis();
+    }
+
+    interface SocketCanProbe {
+        boolean isSupported();
+
+        IoStream open();
+
+        String readSignature(IoStream stream);
+    }
+
+    static final SocketCanProbe REAL_SOCKET_CAN_PROBE = new SocketCanProbe() {
+        @Override
+        public boolean isSupported() {
+            return OsUtil.isLinux();
+        }
+
+        @Override
+        public IoStream open() {
+            return SocketCANIoStream.create();
+        }
+
+        @Override
+        public String readSignature(IoStream stream) {
+            return SerialAutoChecker.checkResponse(stream, null);
+        }
+    };
+
+    /**
+     * SocketCAN discovery has three outcomes: null means the configured interface is unavailable,
+     * CAN means it opened but no rusEFI ECU replied, and ECU means it returned a valid signature.
+     */
+    static PortResult inspectSocketCan(SocketCanProbe probe) {
+        if (!probe.isSupported()) {
+            return null;
+        }
+        try (IoStream stream = probe.open()) {
+            if (stream == null) {
+                return null;
+            }
+            String signature = probe.readSignature(stream);
+            return new PortResult(LinkManager.SOCKET_CAN,
+                signature == null ? SerialPortType.CAN : SerialPortType.Ecu);
+        } catch (RuntimeException | LinkageError e) {
+            log.info("SocketCAN is unavailable: " + e.getMessage());
+            return null;
+        }
     }
 
     /**

--- a/java_console/ui/src/main/java/com/rusefi/StartupFrame.java
+++ b/java_console/ui/src/main/java/com/rusefi/StartupFrame.java
@@ -84,6 +84,7 @@ public class StartupFrame {
     public static final String CHECK_TS_RUNNING = "check_ts_running";
     private static final String STARTUP_TAB_INDEX = "startup_tab_index";
     private static final String NO_PORTS_FOUND = "<html>No ports found!<br>Confirm blue LED is blinking</html>";
+    private static final String SOCKET_CAN_WITHOUT_ECU = "CAN connected, but no ECU replied";
     public static final String SCANNING_PORTS = "Scanning ports";
     private static final String CARD_SCANNING = "scanning";
     private static final String CARD_STARTUP = "startup";
@@ -636,8 +637,9 @@ public class StartupFrame {
             .orElse(null);
         boolean hasOpenBlt = openBltPort != null;
         if (ports.isEmpty()) {
-            noPortsMessage.setForeground(Color.red);
-            noPortsMessage.setText(NO_PORTS_FOUND);
+            String message = emptyHardwareMessage(currentHardware);
+            noPortsMessage.setForeground(SOCKET_CAN_WITHOUT_ECU.equals(message) ? Color.darkGray : Color.red);
+            noPortsMessage.setText(message);
         } else if (hasOpenBlt) {
             // A board sitting in the OpenBLT bootloader has no running firmware to auto-connect to —
             // mirror the auto-connect status line and point the user at the firmware-update flow.
@@ -666,6 +668,15 @@ public class StartupFrame {
             log.info("Single ECU detected, auto-connecting in background: " + target);
             autoConnect(target);
         }
+    }
+
+    static String emptyHardwareMessage(AvailableHardware hardware) {
+        boolean onlySocketCanDetected = hardware.isSocketCanAvailable()
+            && hardware.getKnownPorts().isEmpty()
+            && !hardware.isDfuFound()
+            && !hardware.isStLinkConnected()
+            && !hardware.isPCANConnected();
+        return onlySocketCanDetected ? SOCKET_CAN_WITHOUT_ECU : NO_PORTS_FOUND;
     }
 
     public static void setFrameIcon(Frame frame) {

--- a/java_console/ui/src/main/java/com/rusefi/maintenance/ProgramSelector.java
+++ b/java_console/ui/src/main/java/com/rusefi/maintenance/ProgramSelector.java
@@ -762,7 +762,9 @@ public class ProgramSelector {
     }
 
     private static boolean isUnflashableEcu(@Nullable PortResult port) {
-        return port != null && (port.isUnsupportedEcu() || port.type == SerialPortType.EcuUnknown);
+        return port != null && (port.isUnsupportedEcu()
+            || port.type == SerialPortType.EcuUnknown
+            || LinkManager.SOCKET_CAN.equals(port.port));
     }
 
 }

--- a/java_console/ui/src/main/java/com/rusefi/ui/basic/FirmwareRollbackController.java
+++ b/java_console/ui/src/main/java/com/rusefi/ui/basic/FirmwareRollbackController.java
@@ -120,7 +120,7 @@ public final class FirmwareRollbackController {
             return false;
         }
         final Optional<PortResult> port = portProvider.get();
-        if (!hasLiveConnection() || !port.isPresent() || !port.get().isEcu()) {
+        if (!hasLiveConnection() || !port.isPresent() || !isSerialFirmwareUpdateSupported(port.get())) {
             return false;
         }
         if (isBusy()) {
@@ -137,7 +137,7 @@ public final class FirmwareRollbackController {
     }
 
     public void refresh(@Nullable PortResult port) {
-        if (port == null) {
+        if (!isSerialFirmwareUpdateSupported(port)) {
             reset();
             return;
         }
@@ -166,10 +166,11 @@ public final class FirmwareRollbackController {
 
     public void refreshButton() {
         final Optional<PortResult> port = portProvider.get();
-        final boolean visible = isRollbackButtonVisible(enabled, BundleUtil.readBundleFullNameNotNull());
+        final boolean visible = isRollbackButtonVisible(enabled, BundleUtil.readBundleFullNameNotNull())
+            && (!port.isPresent() || !LinkManager.SOCKET_CAN.equals(port.get().port));
         final boolean available = visible
             && port.isPresent()
-            && port.get().isEcu()
+            && isSerialFirmwareUpdateSupported(port.get())
             && hasLiveConnection()
             && !resolver.rollbackCandidates(builds, currentFirmwareSha(port.get())).isEmpty();
         rollbackButton.setVisible(visible);
@@ -179,7 +180,8 @@ public final class FirmwareRollbackController {
 
     private void showRollbackPicker() {
         final Optional<PortResult> port = portProvider.get();
-        if (!externallyIdle.getAsBoolean() || !hasLiveConnection() || !port.isPresent() || !port.get().isEcu()) {
+        if (!externallyIdle.getAsBoolean() || !hasLiveConnection() || !port.isPresent()
+            || !isSerialFirmwareUpdateSupported(port.get())) {
             return;
         }
         final String currentSha = currentFirmwareSha(port.get());
@@ -209,7 +211,7 @@ public final class FirmwareRollbackController {
             builds = Collections.emptyList();
             return;
         }
-        if (!port.isEcu()) {
+        if (!isSerialFirmwareUpdateSupported(port)) {
             return;
         }
 
@@ -317,7 +319,7 @@ public final class FirmwareRollbackController {
         if (!currentPort.isPresent()
             || !currentPort.get().port.equals(requestedPort.port)
             || currentPort.get().type != requestedPort.type
-            || !currentPort.get().isEcu()
+            || !isSerialFirmwareUpdateSupported(currentPort.get())
             || !externallyIdle.getAsBoolean()
             || !hasLiveConnection()
             || requestedGeneration != discoveryGeneration
@@ -357,6 +359,9 @@ public final class FirmwareRollbackController {
         CalibrationsHelper.FirmwareUpdatePolicy policy,
         JComponent source
     ) {
+        if (!isSerialFirmwareUpdateSupported(port)) {
+            return null;
+        }
         if (port.type == SerialPortType.Ecu) {
             return artifacts.getBinPath()
                 .map(path -> (AsyncJob) new DfuAutoJob(
@@ -370,6 +375,10 @@ public final class FirmwareRollbackController {
                 .orElse(null);
         }
         return null;
+    }
+
+    static boolean isSerialFirmwareUpdateSupported(@Nullable PortResult port) {
+        return port != null && port.isEcu() && !LinkManager.SOCKET_CAN.equals(port.port);
     }
 
     private String currentFirmwareSha(final PortResult port) {

--- a/java_console/ui/src/test/java/com/rusefi/EcuHardwareProbesInspectTest.java
+++ b/java_console/ui/src/test/java/com/rusefi/EcuHardwareProbesInspectTest.java
@@ -3,6 +3,8 @@ package com.rusefi;
 import com.fazecast.jSerialComm.SerialPortInvalidPortException;
 import com.opensr5.ConfigurationImageWithMeta;
 import com.rusefi.core.io.UnsupportedEcuInfo;
+import com.rusefi.io.IoStream;
+import com.rusefi.io.LinkManager;
 import com.rusefi.maintenance.CalibrationsInfo;
 import com.rusefi.updater.OpenbltDetectorStrategy.OpenbltInfo;
 import org.junit.jupiter.api.AfterEach;
@@ -17,6 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
@@ -88,10 +91,76 @@ public class EcuHardwareProbesInspectTest {
         return calibrations;
     }
 
+    private static class FakeSocketCanProbe implements EcuHardwareProbes.SocketCanProbe {
+        boolean supported = true;
+        RuntimeException openFailure;
+        String signature;
+        final IoStream stream = mock(IoStream.class);
+        int openCalls;
+
+        @Override
+        public boolean isSupported() {
+            return supported;
+        }
+
+        @Override
+        public IoStream open() {
+            openCalls++;
+            if (openFailure != null) {
+                throw openFailure;
+            }
+            return stream;
+        }
+
+        @Override
+        public String readSignature(IoStream stream) {
+            return signature;
+        }
+    }
+
     @AfterEach
     public void clearInterruptFlag() {
         // the interrupt-during-backoff path re-interrupts the thread; never leak that into other tests
         Thread.interrupted();
+    }
+
+    @Test
+    public void unsupportedPlatformDoesNotOpenSocketCan() {
+        FakeSocketCanProbe probe = new FakeSocketCanProbe();
+        probe.supported = false;
+
+        assertNull(EcuHardwareProbes.inspectSocketCan(probe));
+        assertEquals(0, probe.openCalls);
+    }
+
+    @Test
+    public void missingSocketCanInterfaceIsUnavailable() {
+        FakeSocketCanProbe probe = new FakeSocketCanProbe();
+        probe.openFailure = new IllegalStateException("no can0");
+
+        assertNull(EcuHardwareProbes.inspectSocketCan(probe));
+        assertEquals(1, probe.openCalls);
+    }
+
+    @Test
+    public void socketCanWithoutEcuReplyReportsTheInterfaceOnly() {
+        FakeSocketCanProbe probe = new FakeSocketCanProbe();
+
+        PortResult result = EcuHardwareProbes.inspectSocketCan(probe);
+
+        assertEquals(new PortResult(LinkManager.SOCKET_CAN, SerialPortType.CAN), result);
+        verify(probe.stream).close();
+    }
+
+    @Test
+    public void socketCanWithValidSignatureReportsAnEcu() {
+        FakeSocketCanProbe probe = new FakeSocketCanProbe();
+        probe.signature = "rusEFI master.2026.09.02.test.123456";
+
+        PortResult result = EcuHardwareProbes.inspectSocketCan(probe);
+
+        assertEquals(new PortResult(LinkManager.SOCKET_CAN, SerialPortType.Ecu), result);
+        verify(probe.stream).close();
     }
 
     @Test

--- a/java_console/ui/src/test/java/com/rusefi/maintenance/ProgramSelectorTest.java
+++ b/java_console/ui/src/test/java/com/rusefi/maintenance/ProgramSelectorTest.java
@@ -2,6 +2,7 @@ package com.rusefi.maintenance;
 
 import com.rusefi.PortResult;
 import com.rusefi.SerialPortType;
+import com.rusefi.io.LinkManager;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
@@ -103,6 +104,14 @@ public class ProgramSelectorTest {
         assertNull(resolveFlashPort(unsupported, false, NO_PORTS, NO_PORTS));
         assertNull(resolveFlashPort(unsupported, true, NO_PORTS, NO_PORTS));
         assertNull(resolveFlashPort(port(SerialPortType.EcuUnknown), true, NO_PORTS, NO_PORTS));
+    }
+
+    @Test
+    public void socketCanEcuCannotBeSelectedForSerialFlashing() {
+        PortResult socketCan = new PortResult(LinkManager.SOCKET_CAN, SerialPortType.Ecu);
+
+        assertNull(resolveFlashPort(socketCan, true, NO_PORTS, NO_PORTS));
+        assertFalse(ProgramSelector.hasRealSerialPort(Collections.singletonList(socketCan)));
     }
 
     // ---- combined: resolved port feeds the button mode ----

--- a/java_console/ui/src/test/java/com/rusefi/ui/basic/FirmwareRollbackControllerTest.java
+++ b/java_console/ui/src/test/java/com/rusefi/ui/basic/FirmwareRollbackControllerTest.java
@@ -1,6 +1,9 @@
 package com.rusefi.ui.basic;
 
 import com.rusefi.core.io.BundleInfo;
+import com.rusefi.PortResult;
+import com.rusefi.SerialPortType;
+import com.rusefi.io.LinkManager;
 import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
@@ -11,6 +14,16 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class FirmwareRollbackControllerTest {
+    @Test
+    void serialFirmwareUpdateRejectsSocketCanEcu() {
+        assertFalse(FirmwareRollbackController.isSerialFirmwareUpdateSupported(
+            new PortResult(LinkManager.SOCKET_CAN, SerialPortType.Ecu)));
+        assertTrue(FirmwareRollbackController.isSerialFirmwareUpdateSupported(
+            new PortResult("COM7", SerialPortType.Ecu)));
+        assertFalse(FirmwareRollbackController.isSerialFirmwareUpdateSupported(
+            new PortResult("COM7", SerialPortType.OpenBlt)));
+    }
+
     @Test
     void enablesHistoryOnlyForLtsBundles() {
         BundleInfo lts = new BundleInfo("lts-26-test", null, "uaefi");

--- a/java_tools/version/src/main/java/com/rusefi/UiVersion.java
+++ b/java_tools/version/src/main/java/com/rusefi/UiVersion.java
@@ -5,5 +5,5 @@ public interface UiVersion {
      * *** BE CAREFUL WE HAVE SEPARATE AUTOUPDATE_VERSION also managed manually ***
      * @see com.rusefi.autoupdate.Autoupdate#AUTOUPDATE_VERSION
      */
-    int CONSOLE_VERSION = 20260901;
+    int CONSOLE_VERSION = 20260902;
 }


### PR DESCRIPTION
happy ecu via CAN on linux:

```
I 260902 154825.285 [ECU Communication Executor1] IsoTpConnector - -------sendBytesToCan 7 byte(s):
I 260902 154825.285 [ECU Communication Executor1] IsoTpConnector - 00 01 38 FA 00 57 13 
I 260902 154825.287 [ECU Communication Executor1] IsoTpConnector - -------sendBytesToCan 7 byte(s):
I 260902 154825.287 [ECU Communication Executor1] IsoTpConnector - 00 01 47 3A BA 3B BE 
I 260902 154825.388 [ECU Communication Executor1] IsoTpConnector - -------sendBytesToCan 11 byte(s):
I 260902 154825.388 [ECU Communication Executor1] IsoTpConnector - 00 05 4F 00 00 00 04 1B EC FC 9C 
I 260902 154825.437 [ECU Communication Executor1] IsoTpConnector - -------sendBytesToCan 11 byte(s):
I 260902 154825.437 [ECU Communication Executor1] IsoTpConnector - 00 05 4F 00 04 00 04 1C E5 54 40 
I 260902 154825.489 [ECU Communication Executor1] IsoTpConnector - -------sendBytesToCan 11 byte(s):
I 260902 154825.489 [ECU Communication Executor1] IsoTpConnector - 00 05 4F 00 08 98 00 AB 0A 69 2F 
I 260902 154825.499 [ECU Communication Executor1] IsoTpConnector - -------sendBytesToCan 7 byte(s):
I 260902 154825.499 [ECU Communication Executor1] IsoTpConnector - 00 01 38 FA 00 57 13 
I 260902 154825.504 [ECU Communication Executor1] IsoTpConnector - -------sendBytesToCan 7 byte(s):
I 260902 154825.504 [ECU Communication Executor1] IsoTpConnector - 00 01 47 3A BA 3B BE 
I 260902 154825.589 [Ports Scanner] SerialPortScanner - getCommPorts (filtered): []
``` 

related #10137 