### PR TITLE
OpenBLT support via CAN, generic wrappers to share between PCAN and SocketCAN implementations

### DIFF
--- a/java_console/io/src/main/java/com/rusefi/io/can/CanAddress.java
+++ b/java_console/io/src/main/java/com/rusefi/io/can/CanAddress.java
@@ -1,0 +1,51 @@
+package com.rusefi.io.can;
+
+import java.util.Objects;
+
+/** Immutable Classic CAN arbitration ID. */
+public final class CanAddress {
+    private static final int STANDARD_MAX_ID = 0x7FF;
+    private static final int EXTENDED_MAX_ID = 0x1FFFFFFF;
+
+    private final int id;
+    private final boolean extended;
+
+    public CanAddress(int id, boolean extended) {
+        int maxId = extended ? EXTENDED_MAX_ID : STANDARD_MAX_ID;
+        if (id < 0 || id > maxId) {
+            throw new IllegalArgumentException("CAN " + (extended ? "extended" : "standard") + " ID out of range: " + id);
+        }
+        this.id = id;
+        this.extended = extended;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public boolean isExtended() {
+        return extended;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+        if (!(other instanceof CanAddress)) {
+            return false;
+        }
+        CanAddress that = (CanAddress) other;
+        return id == that.id && extended == that.extended;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, extended);
+    }
+
+    @Override
+    public String toString() {
+        return "CanAddress{" + Integer.toHexString(id) + ", extended=" + extended + '}';
+    }
+}

--- a/java_console/io/src/main/java/com/rusefi/io/can/ClassicCanFrame.java
+++ b/java_console/io/src/main/java/com/rusefi/io/can/ClassicCanFrame.java
@@ -1,0 +1,46 @@
+package com.rusefi.io.can;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+/** Immutable Classic CAN frame with at most eight payload bytes. */
+public final class ClassicCanFrame {
+    private static final int MAX_PAYLOAD_BYTES = 8;
+
+    private final CanAddress address;
+    private final byte[] payload;
+
+    public ClassicCanFrame(CanAddress address, byte[] payload) {
+        this.address = Objects.requireNonNull(address, "address");
+        Objects.requireNonNull(payload, "payload");
+        if (payload.length > MAX_PAYLOAD_BYTES) {
+            throw new IllegalArgumentException("Classic CAN payload exceeds " + MAX_PAYLOAD_BYTES + " bytes: " + payload.length);
+        }
+        this.payload = Arrays.copyOf(payload, payload.length);
+    }
+
+    public CanAddress getAddress() {
+        return address;
+    }
+
+    public byte[] getPayload() {
+        return Arrays.copyOf(payload, payload.length);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+        if (!(other instanceof ClassicCanFrame)) {
+            return false;
+        }
+        ClassicCanFrame that = (ClassicCanFrame) other;
+        return address.equals(that.address) && Arrays.equals(payload, that.payload);
+    }
+
+    @Override
+    public int hashCode() {
+        return 31 * address.hashCode() + Arrays.hashCode(payload);
+    }
+}

--- a/java_console/io/src/main/java/com/rusefi/io/can/RawCanPort.java
+++ b/java_console/io/src/main/java/com/rusefi/io/can/RawCanPort.java
@@ -1,0 +1,16 @@
+package com.rusefi.io.can;
+
+import java.io.IOException;
+import java.util.Optional;
+
+/** Blocking Classic CAN port. Implementations must make close safe to call repeatedly. */
+public interface RawCanPort extends AutoCloseable {
+    void open(CanAddress receiveAddress) throws IOException;
+
+    void send(ClassicCanFrame frame) throws IOException;
+
+    Optional<ClassicCanFrame> receive(int timeoutMs) throws IOException;
+
+    @Override
+    void close() throws IOException;
+}

--- a/java_console/io/src/main/java/com/rusefi/io/can/SocketCanRawPort.java
+++ b/java_console/io/src/main/java/com/rusefi/io/can/SocketCanRawPort.java
@@ -1,0 +1,140 @@
+package com.rusefi.io.can;
+
+import tel.schich.javacan.CanChannels;
+import tel.schich.javacan.CanFilter;
+import tel.schich.javacan.CanFrame;
+import tel.schich.javacan.CanId;
+import tel.schich.javacan.NetworkDevice;
+import tel.schich.javacan.RawCanChannel;
+import tel.schich.javacan.platform.linux.LinuxNativeOperationException;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.Optional;
+
+import static tel.schich.javacan.CanFrame.FD_NO_FLAGS;
+import static tel.schich.javacan.CanSocketOptions.FILTER;
+import static tel.schich.javacan.CanSocketOptions.RECV_OWN_MSGS;
+import static tel.schich.javacan.CanSocketOptions.SO_RCVTIMEO;
+
+public class SocketCanRawPort implements RawCanPort {
+    private final Object lifecycleLock = new Object();
+    private final String deviceName;
+    private final NetworkDeviceLookup networkDeviceLookup;
+    private final RawCanChannelFactory channelFactory;
+
+    private RawCanChannel channel;
+
+    public SocketCanRawPort() {
+        this(System.getProperty("CAN_DEVICE_NAME", "can0"), NetworkDevice::lookup, CanChannels::newRawChannel);
+    }
+
+    SocketCanRawPort(String deviceName, NetworkDeviceLookup networkDeviceLookup, RawCanChannelFactory channelFactory) {
+        this.deviceName = deviceName;
+        this.networkDeviceLookup = networkDeviceLookup;
+        this.channelFactory = channelFactory;
+    }
+
+    @Override
+    public void open(CanAddress address) throws IOException {
+        synchronized (lifecycleLock) {
+            if (channel != null) {
+                throw new IOException("SocketCAN port is already open");
+            }
+
+            RawCanChannel newChannel = null;
+            try {
+                NetworkDevice device = networkDeviceLookup.lookup(deviceName);
+                newChannel = channelFactory.create();
+                newChannel.bind(device);
+                newChannel.configureBlocking(true);
+                newChannel.setOption(RECV_OWN_MSGS, false);
+                newChannel.setOption(FILTER, new CanFilter[]{new CanFilter(rawId(address))});
+                channel = newChannel;
+            } catch (IOException e) {
+                closeAfterFailedOpen(newChannel, e);
+                throw e;
+            }
+        }
+    }
+
+    @Override
+    public void send(ClassicCanFrame frame) throws IOException {
+        CanAddress address = frame.getAddress();
+        CanFrame canFrame = address.isExtended()
+            ? CanFrame.createExtended(address.getId(), FD_NO_FLAGS, frame.getPayload())
+            : CanFrame.create(address.getId(), FD_NO_FLAGS, frame.getPayload());
+        currentChannel().write(canFrame);
+    }
+
+    @Override
+    public Optional<ClassicCanFrame> receive(int timeoutMs) throws IOException {
+        RawCanChannel currentChannel = currentChannel();
+        currentChannel.setOption(SO_RCVTIMEO, Duration.ofMillis(timeoutMs));
+
+        final CanFrame frame;
+        try {
+            frame = currentChannel.read();
+        } catch (LinuxNativeOperationException e) {
+            if (e.mayTryAgain()) {
+                return Optional.empty();
+            }
+            throw e;
+        }
+
+        if (frame.isFDFrame() || frame.isError() || frame.isRemoteTransmissionRequest()) {
+            throw new IOException("Received unsupported CAN frame");
+        }
+
+        byte[] payload = new byte[frame.getDataLength()];
+        frame.getData(payload, 0, payload.length);
+        return Optional.of(new ClassicCanFrame(new CanAddress(frame.getId(), frame.isExtended()), payload));
+    }
+
+    @Override
+    public void close() throws IOException {
+        RawCanChannel currentChannel;
+        synchronized (lifecycleLock) {
+            currentChannel = channel;
+            channel = null;
+        }
+
+        if (currentChannel != null) {
+            currentChannel.close();
+        }
+    }
+
+    private RawCanChannel currentChannel() throws IOException {
+        synchronized (lifecycleLock) {
+            if (channel == null) {
+                throw new IOException("SocketCAN port is not open");
+            }
+            return channel;
+        }
+    }
+
+    private static int rawId(CanAddress address) {
+        return address.isExtended() ? address.getId() | CanId.EFF_FLAG : address.getId();
+    }
+
+    private static void closeAfterFailedOpen(RawCanChannel channel, IOException originalException) {
+        if (channel == null) {
+            return;
+        }
+        try {
+            channel.close();
+        } catch (IOException closeException) {
+            originalException.addSuppressed(closeException);
+        }
+    }
+}
+
+@FunctionalInterface
+interface NetworkDeviceLookup {
+    NetworkDevice lookup(String name) throws IOException;
+}
+
+@FunctionalInterface
+interface RawCanChannelFactory {
+    RawCanChannel create() throws IOException;
+}

--- a/java_console/io/src/main/java/com/rusefi/libopenblt/transport/XcpCan.java
+++ b/java_console/io/src/main/java/com/rusefi/libopenblt/transport/XcpCan.java
@@ -1,0 +1,108 @@
+package com.rusefi.libopenblt.transport;
+
+import com.rusefi.io.can.CanAddress;
+import com.rusefi.io.can.ClassicCanFrame;
+import com.rusefi.io.can.RawCanPort;
+
+import java.io.IOException;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+/** XCP transport carried in one Classic CAN frame per request and response. */
+public class XcpCan implements IXcpTransport {
+    private static final int MAX_PAYLOAD_BYTES = 8;
+
+    private final Object lock = new Object();
+    private final RawCanPort port;
+    private final CanAddress requestAddress;
+    private final CanAddress responseAddress;
+    private boolean connected;
+
+    public XcpCan(RawCanPort port, CanAddress requestAddress, CanAddress responseAddress) {
+        this.port = java.util.Objects.requireNonNull(port, "port");
+        this.requestAddress = java.util.Objects.requireNonNull(requestAddress, "requestAddress");
+        this.responseAddress = java.util.Objects.requireNonNull(responseAddress, "responseAddress");
+    }
+
+    @Override
+    public void connect() throws IOException {
+        synchronized (lock) {
+            if (connected) {
+                throw new IllegalStateException("Cannot connect when already connected");
+            }
+            port.open(responseAddress);
+            connected = true;
+        }
+    }
+
+    @Override
+    public void disconnect() throws IOException {
+        synchronized (lock) {
+            if (connected) {
+                try {
+                    port.close();
+                } finally {
+                    connected = false;
+                }
+            }
+        }
+    }
+
+    @Override
+    public byte[] sendPacket(byte[] request, int timeoutMs, int expectResponseBytes) throws IOException {
+        if (request == null || request.length > MAX_PAYLOAD_BYTES) {
+            throw new IllegalArgumentException("XCP CAN request must contain at most " + MAX_PAYLOAD_BYTES + " bytes");
+        }
+        if (expectResponseBytes < 0 || expectResponseBytes > MAX_PAYLOAD_BYTES) {
+            throw new IllegalArgumentException("XCP CAN expected response must contain from 0 to " + MAX_PAYLOAD_BYTES + " bytes");
+        }
+        if (timeoutMs < 0) {
+            throw new IllegalArgumentException("timeoutMs must not be negative");
+        }
+
+        synchronized (lock) {
+            checkConnected();
+            port.send(new ClassicCanFrame(requestAddress, request));
+
+            long deadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(timeoutMs);
+            while (true) {
+                long remainingNanos = deadline - System.nanoTime();
+                if (remainingNanos <= 0) {
+                    throw timeout(request, timeoutMs);
+                }
+
+                long remainingMillis = TimeUnit.NANOSECONDS.toMillis(remainingNanos);
+                int remainingMs = (int) Math.min(Integer.MAX_VALUE, Math.max(1, remainingMillis));
+                Optional<ClassicCanFrame> frame = port.receive(remainingMs);
+                if (!frame.isPresent()) {
+                    throw timeout(request, timeoutMs);
+                }
+                if (!responseAddress.equals(frame.get().getAddress())) {
+                    continue;
+                }
+
+                byte[] response = frame.get().getPayload();
+                if (response.length != expectResponseBytes) {
+                    throw new IOException("Unexpected XCP CAN response length for " + command(request)
+                        + ": expected " + expectResponseBytes
+                        + " but got " + response.length);
+                }
+                return response;
+            }
+        }
+    }
+
+    private void checkConnected() {
+        if (!connected) {
+            throw new IllegalStateException("CAN port is not open");
+        }
+    }
+
+    private static IOException timeout(byte[] request, int timeoutMs) {
+        return new IOException("XCP CAN timeout waiting for response to " + command(request) + ", timeoutMs=" + timeoutMs);
+    }
+
+    private static String command(byte[] request) {
+        return request.length == 0 ? "empty request" : "command 0x" + Integer.toHexString(request[0] & 0xFF);
+    }
+}

--- a/java_console/io/src/test/java/com/rusefi/io/can/CanAddressTest.java
+++ b/java_console/io/src/test/java/com/rusefi/io/can/CanAddressTest.java
@@ -1,0 +1,25 @@
+package com.rusefi.io.can;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CanAddressTest {
+    @Test
+    void acceptsTheLimitsForBothAddressFormats() {
+        assertEquals(0x7ff, new CanAddress(0x7ff, false).getId());
+        assertEquals(0x1fffffff, new CanAddress(0x1fffffff, true).getId());
+        assertFalse(new CanAddress(1, false).isExtended());
+        assertTrue(new CanAddress(1, true).isExtended());
+    }
+
+    @Test
+    void rejectsIdsOutsideTheSelectedAddressFormat() {
+        assertThrows(IllegalArgumentException.class, () -> new CanAddress(-1, false));
+        assertThrows(IllegalArgumentException.class, () -> new CanAddress(0x800, false));
+        assertThrows(IllegalArgumentException.class, () -> new CanAddress(0x20000000, true));
+    }
+}

--- a/java_console/io/src/test/java/com/rusefi/io/can/ClassicCanFrameTest.java
+++ b/java_console/io/src/test/java/com/rusefi/io/can/ClassicCanFrameTest.java
@@ -1,0 +1,26 @@
+package com.rusefi.io.can;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ClassicCanFrameTest {
+    @Test
+    void defensivelyCopiesPayloadAtBothBoundaries() {
+        byte[] payload = {1, 2};
+        ClassicCanFrame frame = new ClassicCanFrame(new CanAddress(0x123, false), payload);
+
+        payload[0] = 3;
+        byte[] received = frame.getPayload();
+        received[1] = 4;
+
+        assertArrayEquals(new byte[]{1, 2}, frame.getPayload());
+    }
+
+    @Test
+    void rejectsPayloadLargerThanClassicCan() {
+        assertThrows(IllegalArgumentException.class,
+            () -> new ClassicCanFrame(new CanAddress(0x123, false), new byte[9]));
+    }
+}

--- a/java_console/io/src/test/java/com/rusefi/io/can/SocketCanRawPortTest.java
+++ b/java_console/io/src/test/java/com/rusefi/io/can/SocketCanRawPortTest.java
@@ -1,0 +1,114 @@
+package com.rusefi.io.can;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import tel.schich.javacan.CanFilter;
+import tel.schich.javacan.CanFrame;
+import tel.schich.javacan.CanId;
+import tel.schich.javacan.NetworkDevice;
+import tel.schich.javacan.RawCanChannel;
+import tel.schich.javacan.platform.linux.LinuxNativeOperationException;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static tel.schich.javacan.CanFrame.FD_NO_FLAGS;
+import static tel.schich.javacan.CanSocketOptions.FILTER;
+import static tel.schich.javacan.CanSocketOptions.RECV_OWN_MSGS;
+import static tel.schich.javacan.CanSocketOptions.SO_RCVTIMEO;
+
+class SocketCanRawPortTest {
+    private final NetworkDevice device = mock(NetworkDevice.class);
+    private final RawCanChannel channel = mock(RawCanChannel.class);
+
+    @Test
+    void openConfiguresBlockingSocketWithoutEchoAndFiltersExactExtendedId() throws IOException {
+        SocketCanRawPort port = port();
+
+        port.open(new CanAddress(0x1abcde, true));
+
+        verify(channel).bind(device);
+        verify(channel).configureBlocking(true);
+        verify(channel).setOption(RECV_OWN_MSGS, false);
+        ArgumentCaptor<CanFilter[]> filters = ArgumentCaptor.forClass(CanFilter[].class);
+        verify(channel).setOption(org.mockito.ArgumentMatchers.eq(FILTER), filters.capture());
+        assertEquals(1, filters.getValue().length);
+        assertEquals(0x1abcde | CanId.EFF_FLAG, filters.getValue()[0].getId());
+        assertEquals(CanFilter.EXACT & ~CanId.ERR_FLAG, filters.getValue()[0].getMask());
+    }
+
+    @Test
+    void sendMapsExtendedAndStandardAddressesToTheirWireFormats() throws IOException {
+        SocketCanRawPort port = port();
+        port.open(new CanAddress(0x123, false));
+
+        port.send(new ClassicCanFrame(new CanAddress(0x1abcde, true), new byte[]{1, 2}));
+        port.send(new ClassicCanFrame(new CanAddress(0x123, false), new byte[]{3}));
+
+        ArgumentCaptor<CanFrame> frames = ArgumentCaptor.forClass(CanFrame.class);
+        verify(channel, org.mockito.Mockito.times(2)).write(frames.capture());
+        assertTrue(frames.getAllValues().get(0).isExtended());
+        assertEquals(0x1abcde, frames.getAllValues().get(0).getId());
+        assertFalse(frames.getAllValues().get(1).isExtended());
+        assertEquals(0x123, frames.getAllValues().get(1).getId());
+    }
+
+    @Test
+    void receiveMapsTimeoutToEmptyAndConfiguresSocketTimeout() throws IOException {
+        SocketCanRawPort port = port();
+        port.open(new CanAddress(0x123, false));
+        doThrow(new LinuxNativeOperationException("read", LinuxNativeOperationException.EAGAIN, "try again"))
+            .when(channel).read();
+
+        assertEquals(Optional.empty(), port.receive(125));
+        verify(channel).setOption(SO_RCVTIMEO, Duration.ofMillis(125));
+    }
+
+    @Test
+    void receiveConvertsAddressAndPayload() throws IOException {
+        SocketCanRawPort port = port();
+        port.open(new CanAddress(0x123, false));
+        when(channel.read()).thenReturn(CanFrame.createExtended(0x1abcde, FD_NO_FLAGS, new byte[]{1, 2, 3}));
+
+        ClassicCanFrame frame = port.receive(20).orElseThrow(AssertionError::new);
+
+        assertEquals(0x1abcde, frame.getAddress().getId());
+        assertTrue(frame.getAddress().isExtended());
+        assertArrayEquals(new byte[]{1, 2, 3}, frame.getPayload());
+    }
+
+    @Test
+    void openClosesPartiallyConfiguredChannel() throws IOException {
+        doThrow(new IOException("configuration failed")).when(channel).configureBlocking(true);
+        SocketCanRawPort port = port();
+
+        assertThrows(IOException.class, () -> port.open(new CanAddress(0x123, false)));
+
+        verify(channel).close();
+    }
+
+    @Test
+    void closeIsIdempotent() throws IOException {
+        SocketCanRawPort port = port();
+        port.open(new CanAddress(0x123, false));
+
+        port.close();
+        port.close();
+
+        verify(channel).close();
+    }
+
+    private SocketCanRawPort port() {
+        return new SocketCanRawPort("vcan0", name -> device, () -> channel);
+    }
+}

--- a/java_console/io/src/test/java/com/rusefi/libopenblt/transport/XcpCanTest.java
+++ b/java_console/io/src/test/java/com/rusefi/libopenblt/transport/XcpCanTest.java
@@ -1,0 +1,112 @@
+package com.rusefi.libopenblt.transport;
+
+import com.rusefi.io.can.CanAddress;
+import com.rusefi.io.can.ClassicCanFrame;
+import com.rusefi.io.can.RawCanPort;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class XcpCanTest {
+    private static final CanAddress REQUEST = new CanAddress(0x10667, true);
+    private static final CanAddress RESPONSE = new CanAddress(0x107e1, true);
+
+    @Test
+    void opensResponseFilterSendsRequestAndSkipsUnrelatedFrames() throws IOException {
+        FakeRawCanPort port = new FakeRawCanPort();
+        port.frames.add(new ClassicCanFrame(new CanAddress(0x123, false), new byte[]{9}));
+        port.frames.add(new ClassicCanFrame(RESPONSE, new byte[]{1, 2}));
+        XcpCan transport = new XcpCan(port, REQUEST, RESPONSE);
+
+        transport.connect();
+        byte[] response = transport.sendPacket(new byte[]{(byte) 0xff}, 100, 2);
+
+        assertEquals(RESPONSE, port.openAddress);
+        assertEquals(new ClassicCanFrame(REQUEST, new byte[]{(byte) 0xff}), port.sent.get(0));
+        assertArrayEquals(new byte[]{1, 2}, response);
+    }
+
+    @Test
+    void rejectsUnexpectedResponseLength() throws IOException {
+        FakeRawCanPort port = new FakeRawCanPort();
+        port.frames.add(new ClassicCanFrame(RESPONSE, new byte[]{1}));
+        XcpCan transport = connected(port);
+
+        assertThrows(IOException.class, () -> transport.sendPacket(new byte[]{1}, 100, 2));
+    }
+
+    @Test
+    void timeoutDoesNotWaitAgainAfterPortReportsNoFrame() throws IOException {
+        FakeRawCanPort port = new FakeRawCanPort();
+        XcpCan transport = connected(port);
+
+        assertThrows(IOException.class, () -> transport.sendPacket(new byte[]{1}, 100, 1));
+
+        assertEquals(1, port.receiveTimeouts.size());
+        assertTrue(port.receiveTimeouts.get(0) >= 0 && port.receiveTimeouts.get(0) <= 100);
+    }
+
+    @Test
+    void disconnectClosesPortOnlyOnce() throws IOException {
+        FakeRawCanPort port = new FakeRawCanPort();
+        XcpCan transport = connected(port);
+
+        transport.disconnect();
+        transport.disconnect();
+
+        assertEquals(1, port.closeCount);
+        assertThrows(IllegalStateException.class, () -> transport.sendPacket(new byte[]{1}, 1, 1));
+    }
+
+    @Test
+    void rejectsPayloadsThatCannotFitInClassicCan() throws IOException {
+        XcpCan transport = connected(new FakeRawCanPort());
+
+        assertThrows(IllegalArgumentException.class, () -> transport.sendPacket(new byte[9], 1, 1));
+        assertThrows(IllegalArgumentException.class, () -> transport.sendPacket(new byte[1], 1, 9));
+    }
+
+    private static XcpCan connected(FakeRawCanPort port) throws IOException {
+        XcpCan transport = new XcpCan(port, REQUEST, RESPONSE);
+        transport.connect();
+        return transport;
+    }
+
+    private static class FakeRawCanPort implements RawCanPort {
+        final ArrayDeque<ClassicCanFrame> frames = new ArrayDeque<>();
+        final List<ClassicCanFrame> sent = new ArrayList<>();
+        final List<Integer> receiveTimeouts = new ArrayList<>();
+        CanAddress openAddress;
+        int closeCount;
+
+        @Override
+        public void open(CanAddress receiveAddress) {
+            openAddress = receiveAddress;
+        }
+
+        @Override
+        public void send(ClassicCanFrame frame) {
+            sent.add(frame);
+        }
+
+        @Override
+        public Optional<ClassicCanFrame> receive(int timeoutMs) {
+            receiveTimeouts.add(timeoutMs);
+            return frames.isEmpty() ? Optional.empty() : Optional.of(frames.remove());
+        }
+
+        @Override
+        public void close() {
+            closeCount++;
+        }
+    }
+}

--- a/java_console/ui/src/main/java/com/rusefi/maintenance/OpenBltFlasher.java
+++ b/java_console/ui/src/main/java/com/rusefi/maintenance/OpenBltFlasher.java
@@ -1,10 +1,13 @@
 package com.rusefi.maintenance;
 
 import com.devexperts.logging.Logging;
+import com.rusefi.io.can.CanAddress;
+import com.rusefi.io.can.RawCanPort;
 import com.rusefi.libopenblt.XcpLoader;
 import com.rusefi.libopenblt.XcpSettings;
 import com.rusefi.libopenblt.file.SrecParser;
 import com.rusefi.libopenblt.transport.IXcpTransport;
+import com.rusefi.libopenblt.transport.XcpCan;
 import com.rusefi.libopenblt.transport.XcpNet;
 import com.rusefi.libopenblt.transport.XcpSerial;
 
@@ -16,6 +19,10 @@ import java.util.List;
 import static com.devexperts.logging.Logging.getLogging;
 
 public class OpenBltFlasher {
+    // Defaults from firmware/hw_layer/openblt/efi_blt_ids.h, represented without OS-specific EFF bits.
+    private static final CanAddress RUSEFI_OPENBLT_REQUEST = new CanAddress(0x10667, true);
+    private static final CanAddress RUSEFI_OPENBLT_RESPONSE = new CanAddress(0x107E1, true);
+
     // 16 full PROGRAM_MAX packets with a 240-byte CTO, while still updating progress often.
     private static final int PROGRAM_CHUNK_SIZE = 16 * 239;
 
@@ -43,8 +50,18 @@ public class OpenBltFlasher {
         return new OpenBltFlasher(transport, settings, callbacks);
     }
 
+    public static OpenBltFlasher makeCan(RawCanPort port, XcpSettings settings, OpenbltJni.OpenbltCallbacks callbacks) {
+        IXcpTransport transport = new XcpCan(port, RUSEFI_OPENBLT_REQUEST, RUSEFI_OPENBLT_RESPONSE);
+        return new OpenBltFlasher(transport, settings, callbacks);
+    }
+
     public static void flashSerial(String fileName, String port, OpenbltJni.OpenbltCallbacks callbacks) throws IOException {
         OpenBltFlasher f = OpenBltFlasher.makeSerial(port, new XcpSettings(), callbacks);
+        f.flash(fileName);
+    }
+
+    public static void flashCan(String fileName, RawCanPort port, OpenbltJni.OpenbltCallbacks callbacks) throws IOException {
+        OpenBltFlasher f = OpenBltFlasher.makeCan(port, new XcpSettings(), callbacks);
         f.flash(fileName);
     }
 

--- a/java_console/ui/src/test/java/com/rusefi/maintenance/OpenBltCanFlasherTest.java
+++ b/java_console/ui/src/test/java/com/rusefi/maintenance/OpenBltCanFlasherTest.java
@@ -1,0 +1,121 @@
+package com.rusefi.maintenance;
+
+import com.rusefi.io.can.CanAddress;
+import com.rusefi.io.can.ClassicCanFrame;
+import com.rusefi.io.can.RawCanPort;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class OpenBltCanFlasherTest {
+    private static final CanAddress REQUEST = new CanAddress(0x10667, true);
+    private static final CanAddress RESPONSE = new CanAddress(0x107E1, true);
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void flashesThroughSharedExtendedCanTransportWithEightByteCto() throws IOException {
+        Path firmware = tempDir.resolve("test.srec");
+        Files.write(firmware, record(0x08008000L, new byte[]{1, 2, 3, 4, 5, 6, 7, 8})
+            .getBytes(StandardCharsets.US_ASCII));
+        ScriptedCanPort port = new ScriptedCanPort();
+
+        OpenBltFlasher.flashCan(firmware.toString(), port, callbacks());
+
+        assertEquals(RESPONSE, port.openAddress);
+        assertEquals(1, port.closeCount);
+        assertTrue(port.sent.stream().allMatch(frame -> REQUEST.equals(frame.getAddress())));
+        assertEquals(Arrays.asList(0xFF, 0xD2, 0xF6, 0xD1, 0xF6, 0xC9, 0xD0, 0xD0, 0xCF),
+            port.sent.stream()
+                .map(frame -> frame.getPayload()[0] & 0xFF)
+                .collect(Collectors.toList()));
+    }
+
+    private static String record(long address, byte[] data) {
+        byte[] body = new byte[4 + data.length];
+        for (int i = 0; i < 4; i++) {
+            body[i] = (byte) (address >> (8 * (3 - i)));
+        }
+        System.arraycopy(data, 0, body, 4, data.length);
+        int count = body.length + 1;
+        int sum = count;
+        StringBuilder result = new StringBuilder(String.format("S3%02X", count));
+        for (byte value : body) {
+            sum += value & 0xFF;
+            result.append(String.format("%02X", value & 0xFF));
+        }
+        return result.append(String.format("%02X%n", (~sum) & 0xFF)).toString();
+    }
+
+    private static OpenbltJni.OpenbltCallbacks callbacks() {
+        return new OpenbltJni.OpenbltCallbacks() {
+            @Override
+            public void log(String line) {
+            }
+
+            @Override
+            public void updateProgress(int percent) {
+            }
+
+            @Override
+            public void error(String line) {
+                throw new AssertionError(line);
+            }
+
+            @Override
+            public void setPhase(String title, boolean hasProgress) {
+            }
+        };
+    }
+
+    private static class ScriptedCanPort implements RawCanPort {
+        final List<ClassicCanFrame> sent = new ArrayList<>();
+        final ArrayDeque<ClassicCanFrame> responses = new ArrayDeque<>();
+        CanAddress openAddress;
+        int closeCount;
+
+        @Override
+        public void open(CanAddress receiveAddress) {
+            openAddress = receiveAddress;
+        }
+
+        @Override
+        public void send(ClassicCanFrame frame) {
+            sent.add(frame);
+            int command = frame.getPayload()[0] & 0xFF;
+            if (command == 0xFF) {
+                responses.add(new ClassicCanFrame(RESPONSE,
+                    new byte[]{(byte) 0xFF, 0, 0, 8, 8, 0, 0, 0}));
+            } else if (command == 0xD2) {
+                responses.add(new ClassicCanFrame(RESPONSE,
+                    new byte[]{(byte) 0xFF, 0, 0, 8, 0, 0, 0}));
+            } else {
+                responses.add(new ClassicCanFrame(RESPONSE, new byte[]{(byte) 0xFF}));
+            }
+        }
+
+        @Override
+        public Optional<ClassicCanFrame> receive(int timeoutMs) {
+            return responses.isEmpty() ? Optional.empty() : Optional.of(responses.remove());
+        }
+
+        @Override
+        public void close() {
+            closeCount++;
+        }
+    }
+}


### PR DESCRIPTION
related #10137

next PR implementing into SocketCAN
next of that, removing some duplicated code on PCAN and also use this new classes