### PR TITLE
Switch java console output channel polling to a subscription based polling

### DIFF
--- a/java_console/autotest/src/main/java/com/rusefi/simulator/SimulatorFunctionalTest.java
+++ b/java_console/autotest/src/main/java/com/rusefi/simulator/SimulatorFunctionalTest.java
@@ -40,27 +40,33 @@ public class SimulatorFunctionalTest {
     }
 
     public void mainTestBody() throws InterruptedException {
-        assertHappyTriggerSimulator();
-        assertVvtPosition();
-        assertRawAnalogPackets();
-        assertFsImageContainsIni();
+        SensorCentral sensorCentral = SensorCentral.getInstance();
+        try (SensorCentral.FullOutputLease lease = sensorCentral.acquireFullOutput()) {
+            if (sensorCentral.awaitFullSnapshot(lease.getGeneration(), Timeouts.BINARY_IO_TIMEOUT) == null) {
+                throw new IllegalStateException("No full output-channel snapshot from simulator");
+            }
+            assertHappyTriggerSimulator();
+            assertVvtPosition();
+            assertRawAnalogPackets();
+            assertFsImageContainsIni();
 
-        int vvtOutputFrequency = 300; // todo: move the constant to Fields
-        testPwmPin(bench_mode_e.BENCH_VVT0_VALVE, vvtOutputFrequency);
+            int vvtOutputFrequency = 300; // todo: move the constant to Fields
+            testPwmPin(bench_mode_e.BENCH_VVT0_VALVE, vvtOutputFrequency);
 
-        testOutputPin(bench_mode_e.BENCH_MAIN_RELAY, Integration.BENCH_MAIN_RELAY_DURATION);
-        testOutputPin(bench_mode_e.BENCH_FUEL_PUMP, Integration.BENCH_FUEL_PUMP_DURATION);
-        testOutputPin(bench_mode_e.BENCH_FAN_RELAY, Integration.BENCH_FAN_DURATION);
-        testOutputPin(bench_mode_e.HD_ACR, Integration.BENCH_AC_RELAY_DURATION);
-        testOutputPin(bench_mode_e.HD_ACR2, Integration.BENCH_AC_RELAY_DURATION);
-        testOutputPin(bench_mode_e.BENCH_AC_COMPRESSOR_RELAY, Integration.BENCH_AC_RELAY_DURATION);
-        testOutputPin(bench_mode_e.BENCH_STARTER_ENABLE_RELAY, Integration.BENCH_STARTER_DURATION);
-        EcuTestHelper ecu = new EcuTestHelper(linkManager);
+            testOutputPin(bench_mode_e.BENCH_MAIN_RELAY, Integration.BENCH_MAIN_RELAY_DURATION);
+            testOutputPin(bench_mode_e.BENCH_FUEL_PUMP, Integration.BENCH_FUEL_PUMP_DURATION);
+            testOutputPin(bench_mode_e.BENCH_FAN_RELAY, Integration.BENCH_FAN_DURATION);
+            testOutputPin(bench_mode_e.HD_ACR, Integration.BENCH_AC_RELAY_DURATION);
+            testOutputPin(bench_mode_e.HD_ACR2, Integration.BENCH_AC_RELAY_DURATION);
+            testOutputPin(bench_mode_e.BENCH_AC_COMPRESSOR_RELAY, Integration.BENCH_AC_RELAY_DURATION);
+            testOutputPin(bench_mode_e.BENCH_STARTER_ENABLE_RELAY, Integration.BENCH_STARTER_DURATION);
+            EcuTestHelper ecu = new EcuTestHelper(linkManager);
 
-        ecu.sendCommand(getDisableCommand(Integration.CMD_SELF_STIMULATION));
-        IoUtil.awaitRpm(0);
+            ecu.sendCommand(getDisableCommand(Integration.CMD_SELF_STIMULATION));
+            IoUtil.awaitRpm(0);
 
-        testOutputPin(bench_mode_e.BENCH_VVT0_VALVE, Integration.BENCH_VVT_DURATION);
+            testOutputPin(bench_mode_e.BENCH_VVT0_VALVE, Integration.BENCH_VVT_DURATION);
+        }
     }
 
     private void assertHappyTriggerSimulator() throws InterruptedException {

--- a/java_console/io/src/main/java/com/rusefi/Timeouts.java
+++ b/java_console/io/src/main/java/com/rusefi/Timeouts.java
@@ -19,6 +19,7 @@ public interface Timeouts {
 
     int CMD_TIMEOUT = 20 * SECOND;
     int SET_ENGINE_TIMEOUT = 60 * SECOND;
-    int TEXT_PULL_PERIOD = 100;
+    int OUTPUT_CHANNEL_PULL_PERIOD = Integer.getInteger("OUTPUT_CHANNEL_PULL_PERIOD", 50);
+    int FULL_OUTPUT_CHANNEL_PULL_PERIOD = Integer.getInteger("FULL_OUTPUT_CHANNEL_PULL_PERIOD", 100);
+    int TEXT_PULL_PERIOD = Integer.getInteger("TEXT_PULL_PERIOD", 100);
 }
-

--- a/java_console/io/src/main/java/com/rusefi/binaryprotocol/BinaryProtocol.java
+++ b/java_console/io/src/main/java/com/rusefi/binaryprotocol/BinaryProtocol.java
@@ -14,6 +14,8 @@ import com.rusefi.config.generated.Integration;
 import com.rusefi.Timeouts;
 import com.rusefi.binaryprotocol.test.Bug3923;
 import com.rusefi.core.Pair;
+import com.rusefi.core.OutputChannelDemand;
+import com.rusefi.core.OutputChannelSnapshot;
 import com.rusefi.core.RusEfiSignature;
 import com.rusefi.core.SensorCentral;
 import com.rusefi.core.SignatureHelper;
@@ -33,6 +35,7 @@ import jakarta.xml.bind.JAXBException;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.util.BitSet;
 import java.util.Arrays;
 import java.util.Objects;
 import java.util.concurrent.*;
@@ -62,6 +65,9 @@ public class BinaryProtocol {
     private final IoStream stream;
     private final Integer blockingFactorOverride;
     private boolean isBurnPending;
+    private long lastOutputFallbackGeneration = Long.MIN_VALUE;
+    private volatile boolean lastOutputPollWasFull = true;
+    private long nextTextPullNanos;
     public String signature;
     public boolean isGoodOutputChannels;
     // NotNull once connected
@@ -295,9 +301,11 @@ public class BinaryProtocol {
         Runnable textPull = new Runnable() {
             @Override
             public void run() {
+                Future<?> pendingPoll = null;
                 while (!stream.isClosed()) {
-                    if (linkManager.COMMUNICATION_QUEUE.isEmpty() && linkManager.getNeedPullData()) {
-                        linkManager.submit(new Runnable() {
+                    if ((pendingPoll == null || pendingPoll.isDone())
+                            && linkManager.COMMUNICATION_QUEUE.isEmpty() && linkManager.getNeedPullData()) {
+                        pendingPoll = linkManager.submit(new Runnable() {
                             @Override
                             public void run() {
                                 isGoodOutputChannels = requestOutputChannels();
@@ -305,7 +313,9 @@ public class BinaryProtocol {
                                 if (isGoodOutputChannels)
                                     HeartBeatListeners.onDataArrived();
                                 binaryProtocolLogger.compositeLogic(BinaryProtocol.this);
-                                if (linkManager.isNeedPullText()) {
+                                long now = System.nanoTime();
+                                if (linkManager.isNeedPullText() && now >= nextTextPullNanos) {
+                                    nextTextPullNanos = now + TimeUnit.MILLISECONDS.toNanos(Timeouts.TEXT_PULL_PERIOD);
                                     String text = requestPendingTextMessages();
                                     if (text != null) {
                                         textListener.onDataArrived((text + "\r\n").getBytes());
@@ -320,7 +330,9 @@ public class BinaryProtocol {
                             }
                         });
                     }
-                    sleep(Timeouts.TEXT_PULL_PERIOD);
+                    sleep(lastOutputPollWasFull
+                        ? Timeouts.FULL_OUTPUT_CHANNEL_PULL_PERIOD
+                        : Timeouts.OUTPUT_CHANNEL_PULL_PERIOD);
                 }
                 log.info("Port shutdown: Stopping text pull");
             }
@@ -836,21 +848,12 @@ public class BinaryProtocol {
     public String requestPendingTextMessages() {
         if (stream.isClosed())
             return null;
-        try {
-            byte[] response = executeCommand(Integration.TS_GET_TEXT, "text");
-            if (response == null) {
-                log.error("ERROR: TS_GET_TEXT failed");
-                return null;
-            }
-            if (response != null && response.length == 1) {
-                // todo: what is this sleep doing exactly?
-                Thread.sleep(100);
-            }
-            return new String(response, 1, response.length - 1);
-        } catch (InterruptedException e) {
-            log.error(e.toString());
+        byte[] response = executeCommand(Integration.TS_GET_TEXT, "text");
+        if (response == null) {
+            log.error("ERROR: TS_GET_TEXT failed");
             return null;
         }
+        return new String(response, 1, response.length - 1);
     }
 
     /**
@@ -859,41 +862,62 @@ public class BinaryProtocol {
      * @return true if successful
      */
     public boolean requestOutputChannels() {
+        OutputChannelDemand demand = SensorCentral.getInstance().getOutputChannelDemand();
+        if (linkManager.isNeedPullLiveData() && LiveDocsRegistry.INSTANCE.hasVisible()) {
+            demand = OutputChannelDemand.full(demand.getGeneration());
+        }
+        return requestOutputChannels(demand);
+    }
+
+    boolean requestOutputChannels(OutputChannelDemand demand) {
         if (stream.isClosed())
             return false;
 
+        OutputChannelPollPlan plan = OutputChannelPollPlan.create(iniFile, demand);
+        lastOutputPollWasFull = plan.isFull();
+        if (plan.isFull() && !demand.isFull() && !demand.getChannels().isEmpty()
+                && demand.getGeneration() != lastOutputFallbackGeneration) {
+            lastOutputFallbackGeneration = demand.getGeneration();
+            log.warn("Falling back to full output polling for unresolved demand " + demand.getChannels());
+        }
         // TODO: Get rid of the +1.  This adds a byte at the front to tack a fake TS response code on the front
         //  of the reassembled packet.
         int ochBlockSize = iniFile.getMetaInfo().getOchBlockSize();
         byte[] reassemblyBuffer = new byte[ochBlockSize + 1];
         reassemblyBuffer[0] = Integration.TS_RESPONSE_OK;
+        BitSet validBytes = new BitSet(ochBlockSize);
 
-        int reassemblyIdx = 0;
-        int remaining = ochBlockSize;
+        for (OutputChannelPollPlan.Range range : plan.getRanges()) {
+            int reassemblyIdx = range.getOffset();
+            int remaining = range.getSize();
 
-        while (remaining > 0) {
-            // If less than one full chunk left, do a smaller read
-            int chunkSize = Math.min(remaining, getBlockingFactor());
+            while (remaining > 0) {
+                // If less than one full chunk left, do a smaller read
+                int chunkSize = Math.min(remaining, getBlockingFactor());
 
-            byte[] response = executeCommand(
-                Integration.TS_OUTPUT_COMMAND,
-                GetOutputsCommand.createRequest(reassemblyIdx, chunkSize),
-                "output channels"
-            );
+                byte[] response = executeCommand(
+                    Integration.TS_OUTPUT_COMMAND,
+                    GetOutputsCommand.createRequest(reassemblyIdx, chunkSize),
+                    "output channels"
+                );
 
-            if (response == null || response.length != (chunkSize + 1) || response[0] != Integration.TS_RESPONSE_OK) {
-                return false;
+                if (response == null || response.length != (chunkSize + 1) || response[0] != Integration.TS_RESPONSE_OK) {
+                    return false;
+                }
+
+                // Copy this chunk in to the reassembly buffer
+                System.arraycopy(response, 1, reassemblyBuffer, reassemblyIdx + 1, chunkSize);
+                validBytes.set(reassemblyIdx, reassemblyIdx + chunkSize);
+                reassemblyIdx += chunkSize;
+                remaining -= chunkSize;
             }
-
-            // Copy this chunk in to the reassembly buffer
-            System.arraycopy(response, 1, reassemblyBuffer, reassemblyIdx + 1, chunkSize);
-            reassemblyIdx += chunkSize;
-            remaining -= chunkSize;
         }
 
-        state.setCurrentOutputs(reassemblyBuffer);
+        state.setCurrentOutputs(plan.isFull() ? reassemblyBuffer : null);
 
-        SensorCentral.getInstance().grabSensorValues(reassemblyBuffer, getIniFile(), getControllerConfiguration());
+        OutputChannelSnapshot snapshot = new OutputChannelSnapshot(
+            reassemblyBuffer, validBytes, demand.getChannels(), plan.getGeneration(), plan.isFull());
+        SensorCentral.getInstance().grabSensorValues(snapshot, getIniFile(), getControllerConfiguration());
         return true;
     }
 

--- a/java_console/io/src/main/java/com/rusefi/binaryprotocol/OutputChannelPollPlan.java
+++ b/java_console/io/src/main/java/com/rusefi/binaryprotocol/OutputChannelPollPlan.java
@@ -1,0 +1,191 @@
+package com.rusefi.binaryprotocol;
+
+import com.opensr5.ini.ExpressionEvaluator;
+import com.opensr5.ini.GaugeModel;
+import com.opensr5.ini.IniFileModel;
+import com.opensr5.ini.field.IniField;
+import com.rusefi.core.OutputChannelDemand;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+/** Byte ranges and direct channel roots required to satisfy an output-channel demand. */
+public final class OutputChannelPollPlan {
+    private static final int MERGE_GAP_BYTES = 16;
+    private static final String RUNTIME_DATA_RATE_GAUGE = "runtimedatarategauge";
+
+    private final List<Range> ranges;
+    private final Set<String> requestedChannelRoots;
+    private final boolean full;
+    private final long generation;
+
+    private OutputChannelPollPlan(List<Range> ranges, Set<String> requestedChannelRoots, boolean full, long generation) {
+        this.ranges = Collections.unmodifiableList(new ArrayList<>(ranges));
+        this.requestedChannelRoots = Collections.unmodifiableSet(new LinkedHashSet<>(requestedChannelRoots));
+        this.full = full;
+        this.generation = generation;
+    }
+
+    public static OutputChannelPollPlan create(IniFileModel ini, OutputChannelDemand demand) {
+        int blockSize = ini.getMetaInfo().getOchBlockSize();
+        if (demand.isFull() || demand.getChannels().isEmpty()) {
+            return full(blockSize, demand.getGeneration());
+        }
+
+        Map<String, IniField> outputChannels = normalize(ini.getAllOutputChannels());
+        Map<String, String> expressions = normalize(ini.getExpressionOutputChannels());
+        Map<String, GaugeModel> gauges = normalize(ini.getGauges());
+        List<Range> ranges = new ArrayList<>();
+        Set<String> roots = new LinkedHashSet<>();
+        Set<String> visiting = new HashSet<>();
+
+        for (String channel : demand.getChannels()) {
+            if (!resolve(channel, ini, outputChannels, expressions, gauges, visiting, roots, ranges, blockSize)) {
+                return full(blockSize, demand.getGeneration());
+            }
+        }
+        // A successful output poll must still perform ECU I/O for link health and rate timing.
+        if (ranges.isEmpty()) {
+            return full(blockSize, demand.getGeneration());
+        }
+        return new OutputChannelPollPlan(merge(ranges), roots, false, demand.getGeneration());
+    }
+
+    private static boolean resolve(String name, IniFileModel ini, Map<String, IniField> outputChannels,
+                                   Map<String, String> expressions, Map<String, GaugeModel> gauges,
+                                   Set<String> visiting, Set<String> roots, List<Range> ranges, int blockSize) {
+        if (name == null) {
+            return false;
+        }
+        String key = normalize(name);
+        IniField field = outputChannels.get(key);
+        if (field != null) {
+            int offset = field.getOffset();
+            int size = field.getSize();
+            if (offset < 0 || size <= 0 || offset > blockSize - size) {
+                return false;
+            }
+            roots.add(key);
+            ranges.add(new Range(offset, size));
+            return true;
+        }
+        if (RUNTIME_DATA_RATE_GAUGE.equals(key)) {
+            return true;
+        }
+        GaugeModel gauge = gauges.get(key);
+        if (gauge != null) {
+            return resolve(gauge.getChannel(), ini, outputChannels, expressions, gauges, visiting, roots, ranges, blockSize);
+        }
+        String expression = ExpressionEvaluator.looksLikeExpression(name) ? name : expressions.get(key);
+        if (expression == null) {
+            // Variables backed by configuration pages do not consume output-channel bytes.
+            return ini.findIniField(name).isPresent();
+        }
+        if (!visiting.add(key)) {
+            return false;
+        }
+        for (String variable : ExpressionEvaluator.extractVariables(expression)) {
+            if (!resolve(variable, ini, outputChannels, expressions, gauges, visiting, roots, ranges, blockSize)) {
+                visiting.remove(key);
+                return false;
+            }
+        }
+        visiting.remove(key);
+        return true;
+    }
+
+    private static List<Range> merge(List<Range> ranges) {
+        if (ranges.isEmpty()) {
+            return ranges;
+        }
+        ranges.sort(Comparator.comparingInt(Range::getOffset));
+        List<Range> merged = new ArrayList<>();
+        Range current = ranges.get(0);
+        for (int i = 1; i < ranges.size(); i++) {
+            Range next = ranges.get(i);
+            if (next.offset <= (long) current.offset + current.size + MERGE_GAP_BYTES) {
+                current = new Range(current.offset, Math.max(current.offset + current.size, next.offset + next.size) - current.offset);
+            } else {
+                merged.add(current);
+                current = next;
+            }
+        }
+        merged.add(current);
+        return merged;
+    }
+
+    private static OutputChannelPollPlan full(int blockSize, long generation) {
+        return new OutputChannelPollPlan(Collections.singletonList(new Range(0, Math.max(0, blockSize))),
+                Collections.emptySet(), true, generation);
+    }
+
+    private static <T> Map<String, T> normalize(Map<String, T> source) {
+        Map<String, T> result = new HashMap<>();
+        for (Map.Entry<String, T> entry : source.entrySet()) {
+            result.put(normalize(entry.getKey()), entry.getValue());
+        }
+        return result;
+    }
+
+    private static String normalize(String name) {
+        return name.toLowerCase(Locale.US);
+    }
+
+    public List<Range> getRanges() {
+        return ranges;
+    }
+
+    public Set<String> getRequestedChannelRoots() {
+        return requestedChannelRoots;
+    }
+
+    public boolean isFull() {
+        return full;
+    }
+
+    public long getGeneration() {
+        return generation;
+    }
+
+    public static final class Range {
+        private final int offset;
+        private final int size;
+
+        public Range(int offset, int size) {
+            if (offset < 0 || size < 0) {
+                throw new IllegalArgumentException("offset and size must be non-negative");
+            }
+            this.offset = offset;
+            this.size = size;
+        }
+
+        public int getOffset() {
+            return offset;
+        }
+
+        public int getSize() {
+            return size;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof Range)) return false;
+            Range range = (Range) o;
+            return offset == range.offset && size == range.size;
+        }
+
+        @Override
+        public int hashCode() {
+            return 31 * offset + size;
+        }
+    }
+}

--- a/java_console/io/src/main/java/com/rusefi/core/ISensorCentral.java
+++ b/java_console/io/src/main/java/com/rusefi/core/ISensorCentral.java
@@ -1,23 +1,33 @@
 package com.rusefi.core;
 
+import java.util.function.Consumer;
+
 /**
  * 11/16/2017
  * Andrey Belomutskiy, (c) 2013-2020
  */
 public interface ISensorCentral extends ISensorHolder {
     class ListenerToken {
-        private final ISensorCentral sensorCentralInstance;
-        private final String sensorName;
-        private final SensorCentral.SensorListener listener;
+        private final Runnable removeAction;
+        private final Consumer<Boolean> activeAction;
+        private boolean removed;
 
-        public ListenerToken(ISensorCentral instance, String sensorName, SensorCentral.SensorListener listener) {
-            this.sensorCentralInstance = instance;
-            this.sensorName = sensorName;
-            this.listener = listener;
+        public ListenerToken(Runnable removeAction, Consumer<Boolean> activeAction) {
+            this.removeAction = removeAction;
+            this.activeAction = activeAction;
         }
 
-        public void remove() {
-            sensorCentralInstance.removeListener(sensorName, listener);
+        public synchronized void setActive(boolean active) {
+            if (!removed) {
+                activeAction.accept(active);
+            }
+        }
+
+        public synchronized void remove() {
+            if (!removed) {
+                removed = true;
+                removeAction.run();
+            }
         }
     }
 

--- a/java_console/io/src/main/java/com/rusefi/core/ISensorHolder.java
+++ b/java_console/io/src/main/java/com/rusefi/core/ISensorHolder.java
@@ -15,9 +15,14 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.nio.ByteBuffer;
+import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 import static com.devexperts.logging.Logging.getLogging;
 import static com.rusefi.core.ByteBufferUtil.littleEndianWrap;
@@ -42,56 +47,116 @@ public interface ISensorHolder {
     }
 
     default void grabSensorValues(byte[] response, @NotNull IniFileModel ini, @Nullable ConfigurationImage configImage) {
+        grabSensorValues(OutputChannelSnapshot.full(response), ini, configImage);
+    }
+
+    default void grabSensorValues(OutputChannelSnapshot snapshot, @NotNull IniFileModel ini,
+                                  @Nullable ConfigurationImage configImage) {
+        byte[] response = snapshot.getResponse();
         // Use case-insensitive map so that gauge channel names like "CLTValue" match
         // output channel keys regardless of capitalisation differences.
         Map<String, Double> outputChannelValues = getOutputChannelMap();
         outputChannelValues.clear();
 
-        // Pass 1: read every direct output channel defined in the ini.
-        // This single pass covers what was previously spread across gauge, indicator,
-        // gauge-label, and datalog-only channels.
+        // Decode every complete direct field covered by the fetched ranges. A merged range
+        // may intentionally contain nearby fields not named by a consumer.
         for (String name : ini.getAllOutputChannels().keySet()) {
-            Double value = tryReadOutputChannel(response, name, ini, name);
+            Double value = tryReadOutputChannel(snapshot, response, name, ini, name);
             if (value != null) {
                 setValue(value, name);
                 outputChannelValues.put(name, value);
             }
         }
 
-        // Pass 2: evaluate expression-based gauge channels (e.g. "{ coolant * 1.8 + 32 }").
-        // These are not in allOutputChannels, so they were not handled by pass 1.
-        for (Map.Entry<String, GaugeModel> e : ini.getGauges().entrySet()) {
-            String channel = e.getValue().getChannel();
-            if (outputChannelValues.containsKey(channel))
-                continue;
-
-            // Skip the synthetic runtimeDataRateGauge — its value is published directly
-            // by SensorCentral, added around 1634284766aeee57bf1315e61238371ae8137758, not evaluated as an expression here.
-            // since this gauge is not real, we can't find it on the ini, but we find it inside the gauges, so we fail under the check of resolveExpression
-            // ending up with "Member not found for gauge" logs of around 30/second, not nice
-            if (com.opensr5.ini.ImmutableIniFileModel.RUNTIME_DATA_RATE_GAUGE.equalsIgnoreCase(e.getKey())) {
-                continue;
+        Set<String> expressionRoots = new LinkedHashSet<>();
+        if (snapshot.isFull()) {
+            expressionRoots.addAll(ini.getExpressionOutputChannels().keySet());
+            for (GaugeModel gauge : ini.getGauges().values()) {
+                expressionRoots.add(gauge.getChannel());
             }
-
-            String expression = resolveExpression(ini, channel);
-            if (expression == null) {
-                log.warn("Member not found for gauge " + e.getKey() + ": " + channel);
-                continue;
-            }
-
-            resolveExpressionVariables(response, ini, configImage, expression, outputChannelValues, outputChannelValues);
-
-            Double result = ExpressionEvaluator.tryEvaluateWithContext(expression, outputChannelValues);
-            if (result != null) {
-                setValue(result, channel);
-                outputChannelValues.put(channel, result);
-            } else {
-                log.warn("Could not evaluate expression for gauge " + e.getKey() + ": " + expression);
+        } else {
+            for (String requested : snapshot.getRequestedChannels()) {
+                GaugeModel gauge = ini.getGauge(requested);
+                expressionRoots.add(gauge == null ? requested : gauge.getChannel());
             }
         }
 
-        // Pass 3: resolve string-valued gauge labels (bitStringValue, stringValue).
+        for (String channel : expressionRoots) {
+            if (!com.opensr5.ini.ImmutableIniFileModel.RUNTIME_DATA_RATE_GAUGE.equalsIgnoreCase(channel)) {
+                resolveOutputValue(snapshot, response, ini, configImage, channel,
+                    outputChannelValues, new HashSet<>());
+            }
+        }
+
+        // Resolve string-valued gauge labels (bitStringValue, stringValue) from this
+        // snapshot's context. Missing variables leave their labels unresolved.
         onGaugeLabelsResolved(resolveGaugeLabels(ini, configImage, outputChannelValues));
+    }
+
+    @Nullable
+    default Double resolveOutputValue(OutputChannelSnapshot snapshot, byte[] response, IniFileModel ini,
+                                      @Nullable ConfigurationImage configImage, String requested,
+                                      Map<String, Double> context, Set<String> visiting) {
+        if (requested == null || requested.isEmpty()) {
+            return null;
+        }
+        if (context.containsKey(requested)) {
+            return context.get(requested);
+        }
+
+        GaugeModel gauge = ini.getGauge(requested);
+        String channel = gauge == null ? requested : gauge.getChannel();
+        if (!channel.equals(requested) && context.containsKey(channel)) {
+            return context.get(channel);
+        }
+
+        IniField field = getOutputChannel(ini, channel);
+        if (field != null) {
+            if (!snapshot.isRangeValid(field.getOffset(), field.getSize())) {
+                return null;
+            }
+            Double value = readFieldValue(response, channel, field);
+            if (value != null) {
+                context.put(channel, value);
+                setValue(value, channel);
+            }
+            return value;
+        }
+
+        String expression = resolveExpression(ini, channel);
+        if (expression == null || !visiting.add(channel.toLowerCase(Locale.US))) {
+            return null;
+        }
+
+        Map<String, Double> expressionContext = new LowercaseHashMap<>();
+        for (String variable : ExpressionEvaluator.extractVariables(expression)) {
+            Double value = resolveOutputValue(snapshot, response, ini, configImage, variable, context, visiting);
+            if (value == null && configImage != null) {
+                value = getConfigValue(variable, ini, configImage);
+            }
+            if (value == null) {
+                visiting.remove(channel.toLowerCase(Locale.US));
+                return null;
+            }
+            expressionContext.put(variable, value);
+        }
+
+        visiting.remove(channel.toLowerCase(Locale.US));
+        Double result = ExpressionEvaluator.tryEvaluateWithContext(expression, expressionContext);
+        if (result != null) {
+            context.put(channel, result);
+            setValue(result, channel);
+        }
+        return result;
+    }
+
+    @Nullable
+    static IniField getOutputChannel(IniFileModel ini, String channelName) {
+        try {
+            return ini.getOutputChannel(channelName);
+        } catch (IniMemberNotFound e) {
+            return null;
+        }
     }
 
     /**
@@ -115,6 +180,16 @@ public interface ISensorHolder {
             log.warn("Out of bounds reading output channel " + channelName + ": " + e.getMessage());
             return null;
         }
+    }
+
+    @Nullable
+    static Double tryReadOutputChannel(OutputChannelSnapshot snapshot, byte[] response, String label,
+                                       IniFileModel ini, String channelName) {
+        IniField field = getOutputChannel(ini, channelName);
+        if (field == null || !snapshot.isRangeValid(field.getOffset(), field.getSize())) {
+            return null;
+        }
+        return readFieldValue(response, label, field);
     }
 
     /**

--- a/java_console/io/src/main/java/com/rusefi/core/OutputChannelDemand.java
+++ b/java_console/io/src/main/java/com/rusefi/core/OutputChannelDemand.java
@@ -1,0 +1,45 @@
+package com.rusefi.core;
+
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Set;
+
+/** Immutable snapshot of output channels currently needed by consumers. */
+public final class OutputChannelDemand {
+    private final Set<String> channels;
+    private final boolean full;
+    private final long generation;
+
+    public OutputChannelDemand(Set<String> channels, boolean full, long generation) {
+        Objects.requireNonNull(channels, "channels");
+        Set<String> normalized = new LinkedHashSet<>();
+        for (String channel : channels) {
+            normalized.add(Objects.requireNonNull(channel, "channel").toLowerCase(Locale.US));
+        }
+        this.channels = Collections.unmodifiableSet(normalized);
+        this.full = full;
+        this.generation = generation;
+    }
+
+    public static OutputChannelDemand full(long generation) {
+        return new OutputChannelDemand(Collections.emptySet(), true, generation);
+    }
+
+    public static OutputChannelDemand selective(Set<String> channels, long generation) {
+        return new OutputChannelDemand(channels, false, generation);
+    }
+
+    public Set<String> getChannels() {
+        return channels;
+    }
+
+    public boolean isFull() {
+        return full;
+    }
+
+    public long getGeneration() {
+        return generation;
+    }
+}

--- a/java_console/io/src/main/java/com/rusefi/core/OutputChannelSnapshot.java
+++ b/java_console/io/src/main/java/com/rusefi/core/OutputChannelSnapshot.java
@@ -1,0 +1,58 @@
+package com.rusefi.core;
+
+import java.util.BitSet;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * One completed host poll of ECU output channels.
+ * Output-channel offsets exclude the response-code byte at response[0].
+ */
+public final class OutputChannelSnapshot {
+    private final byte[] response;
+    private final BitSet validBytes;
+    private final Set<String> requestedChannels;
+    private final long generation;
+    private final boolean full;
+
+    public OutputChannelSnapshot(byte[] response, BitSet validBytes, Set<String> requestedChannels,
+                                 long generation, boolean full) {
+        this.response = Objects.requireNonNull(response, "response").clone();
+        this.validBytes = (BitSet) Objects.requireNonNull(validBytes, "validBytes").clone();
+        this.requestedChannels = Collections.unmodifiableSet(
+            new LinkedHashSet<>(Objects.requireNonNull(requestedChannels, "requestedChannels")));
+        this.generation = generation;
+        this.full = full;
+    }
+
+    public static OutputChannelSnapshot full(byte[] response) {
+        BitSet validBytes = new BitSet(Math.max(0, response.length - 1));
+        validBytes.set(0, Math.max(0, response.length - 1));
+        return new OutputChannelSnapshot(response, validBytes, Collections.emptySet(), 0, true);
+    }
+
+    public byte[] getResponse() {
+        return response.clone();
+    }
+
+    public boolean isRangeValid(int offset, int size) {
+        if (offset < 0 || size < 0 || offset + size < offset || offset + size > response.length - 1) {
+            return false;
+        }
+        return size == 0 || validBytes.nextClearBit(offset) >= offset + size;
+    }
+
+    public Set<String> getRequestedChannels() {
+        return requestedChannels;
+    }
+
+    public long getGeneration() {
+        return generation;
+    }
+
+    public boolean isFull() {
+        return full;
+    }
+}

--- a/java_console/io/src/main/java/com/rusefi/core/SensorCentral.java
+++ b/java_console/io/src/main/java/com/rusefi/core/SensorCentral.java
@@ -8,7 +8,11 @@ import org.jetbrains.annotations.Nullable;
 import com.opensr5.ini.LowercaseHashMap;
 
 import java.util.*;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
 
 /**
  * This class keeps track of {@link Sensor} current values and {@link SensorCentral.SensorListener}.
@@ -75,12 +79,30 @@ public class SensorCentral implements ISensorCentral {
 
     // Keys normalized to lower-case (Locale.US) for O(1) HashMap lookup.
     // "coolant", "COOLANT", "Coolant" all resolve to the same listener list.
-    private final Map<String, List<SensorListener>> sensorListeners = new HashMap<>();
+    private final Map<String, List<SensorListenerHolder>> sensorListeners = new HashMap<>();
     private final List<ResponseListenerHolder> listeners = new CopyOnWriteArrayList<>();
+    private final List<SnapshotListener> snapshotListeners = new CopyOnWriteArrayList<>();
+    private final AtomicInteger fullOutputLeases = new AtomicInteger();
+    private final AtomicLong outputDemandGeneration = new AtomicLong();
+    private final Object snapshotMonitor = new Object();
+
+    private static class SensorListenerHolder {
+        private final String sensorName;
+        private final SensorListener listener;
+        private final boolean contributesDemand;
+        private volatile boolean active = true;
+
+        private SensorListenerHolder(String sensorName, SensorListener listener, boolean contributesDemand) {
+            this.sensorName = sensorName;
+            this.listener = listener;
+            this.contributesDemand = contributesDemand;
+        }
+    }
 
     private static class ResponseListenerHolder {
         private final ResponseListener listener;
-        private final SensorSubscription subscription;
+        private volatile SensorSubscription subscription;
+        private volatile boolean active = true;
 
         public ResponseListenerHolder(ResponseListener listener, SensorSubscription subscription) {
             this.listener = listener;
@@ -89,6 +111,7 @@ public class SensorCentral implements ISensorCentral {
     }
     private volatile Map<String, ResolvedGaugeLabels> resolvedGaugeLabels = Collections.emptyMap();
     private volatile byte[] response;
+    private volatile OutputChannelSnapshot currentSnapshot;
 
     // Sliding window of recent frame arrival timestamps (System.nanoTime), used to compute
     // the synthetic 'runtimeDataRateGauge' value (frames-per-second) once per ECU frame.
@@ -110,15 +133,29 @@ public class SensorCentral implements ISensorCentral {
 
     @Override
     public void grabSensorValues(byte[] response, @NotNull IniFileModel ini, @Nullable ConfigurationImage configImage) {
+        grabSensorValues(OutputChannelSnapshot.full(response), ini, configImage);
+        // Preserve the legacy full-frame API's identity contract for existing direct callers.
         this.response = response;
-        ISensorCentral.super.grabSensorValues(response, ini, configImage);
+    }
+
+    public void grabSensorValues(OutputChannelSnapshot snapshot, @NotNull IniFileModel ini,
+                                 @Nullable ConfigurationImage configImage) {
+        synchronized (snapshotMonitor) {
+            currentSnapshot = snapshot;
+            snapshotMonitor.notifyAll();
+        }
+        response = snapshot.isFull() ? snapshot.getResponse() : null;
+        ISensorCentral.super.grabSensorValues(snapshot, ini, configImage);
         updateRuntimeDataRate();
-        Set<String> updatedSensors = sensorsHolder.getSensorNames();
         for (ResponseListenerHolder holder : listeners) {
-            // todo: once we trust this! if (holder.subscription.isInterestedInAny(updatedSensors))
-            {
+            if (holder.active && (snapshot.isFull()
+                    || holder.subscription == null
+                    || holder.subscription.isInterestedInAny(snapshot.getRequestedChannels()))) {
                 holder.listener.onSensorUpdate();
             }
+        }
+        for (SnapshotListener listener : snapshotListeners) {
+            listener.onSnapshot(snapshot);
         }
     }
 
@@ -192,24 +229,30 @@ public class SensorCentral implements ISensorCentral {
         boolean isUpdated = sensorsHolder.setValue(value, sensorName);
         if (!isUpdated)
             return false;
-        List<SensorListener> listeners;
+        List<SensorListenerHolder> listeners;
         synchronized (sensorListeners) {
             listeners = sensorListeners.get(sensorName.toLowerCase(Locale.US));
         }
 
         if (listeners == null)
             return true;
-        for (SensorListener listener : listeners)
-            listener.onSensorUpdate(value);
+        for (SensorListenerHolder holder : listeners) {
+            if (holder.active) {
+                holder.listener.onSensorUpdate(value);
+            }
+        }
         return true;
     }
 
-    public void addListener(ResponseListener listener) {
-        addListener(listener, new SensorSubscription());
+    public ResponseListenerToken addListener(ResponseListener listener) {
+        return addListener(listener, new SensorSubscription());
     }
 
-    public void addListener(ResponseListener listener, SensorSubscription subscription) {
-        listeners.add(new ResponseListenerHolder(listener, subscription));
+    public ResponseListenerToken addListener(ResponseListener listener, SensorSubscription subscription) {
+        ResponseListenerHolder holder = new ResponseListenerHolder(listener, subscription);
+        listeners.add(holder);
+        outputDemandGeneration.incrementAndGet();
+        return new ResponseListenerToken(this, holder);
     }
 
     public SensorSubscription getSubscription(ResponseListener listener) {
@@ -222,32 +265,147 @@ public class SensorCentral implements ISensorCentral {
     }
 
     public void removeListener(ResponseListener listener) {
-        listeners.removeIf(holder -> holder.listener == listener);
+        boolean removed = listeners.removeIf(holder -> holder.listener == listener);
+        if (removed) {
+            outputDemandGeneration.incrementAndGet();
+        }
     }
 
     @Override
     public ListenerToken addListener(String sensorName, SensorListener listener) {
+        return addListener(sensorName, listener, true);
+    }
+
+    public ListenerToken addPassiveListener(String sensorName, SensorListener listener) {
+        return addListener(sensorName, listener, false);
+    }
+
+    private ListenerToken addListener(String sensorName, SensorListener listener, boolean contributesDemand) {
         String key = sensorName.toLowerCase(Locale.US);
-        List<SensorListener> listeners;
+        SensorListenerHolder holder = new SensorListenerHolder(key, listener, contributesDemand);
+        List<SensorListenerHolder> listeners;
         synchronized (sensorListeners) {
             listeners = sensorListeners.get(key);
             if (listeners == null)
                 listeners = new CopyOnWriteArrayList<>();
             sensorListeners.put(key, listeners);
         }
-        listeners.add(listener);
+        listeners.add(holder);
+        if (contributesDemand) {
+            outputDemandGeneration.incrementAndGet();
+        }
 
-        return new SensorCentral.ListenerToken(this, sensorName, listener);
+        return new SensorCentral.ListenerToken(
+            () -> removeListener(holder),
+            active -> setListenerActive(holder, active));
     }
 
     @Override
     public void removeListener(String sensorName, SensorListener listener) {
-        List<SensorListener> listeners;
+        List<SensorListenerHolder> listeners;
         synchronized (sensorListeners) {
             listeners = sensorListeners.get(sensorName.toLowerCase(Locale.US));
         }
-        if (listeners != null)
-            listeners.remove(listener);
+        if (listeners != null) {
+            for (SensorListenerHolder holder : listeners) {
+                if (holder.listener == listener) {
+                    removeListener(holder);
+                    return;
+                }
+            }
+        }
+    }
+
+    private void removeListener(SensorListenerHolder holder) {
+        synchronized (sensorListeners) {
+            List<SensorListenerHolder> holders = sensorListeners.get(holder.sensorName);
+            if (holders != null && holders.remove(holder)) {
+                if (holders.isEmpty()) {
+                    sensorListeners.remove(holder.sensorName);
+                }
+                if (holder.contributesDemand) {
+                    outputDemandGeneration.incrementAndGet();
+                }
+            }
+        }
+    }
+
+    private void setListenerActive(SensorListenerHolder holder, boolean active) {
+        if (holder.active != active) {
+            holder.active = active;
+            if (holder.contributesDemand) {
+                outputDemandGeneration.incrementAndGet();
+            }
+        }
+    }
+
+    public OutputChannelDemand getOutputChannelDemand() {
+        Set<String> channels = new LinkedHashSet<>();
+        synchronized (sensorListeners) {
+            for (List<SensorListenerHolder> holders : sensorListeners.values()) {
+                for (SensorListenerHolder holder : holders) {
+                    if (holder.active && holder.contributesDemand) {
+                        channels.add(holder.sensorName);
+                        break;
+                    }
+                }
+            }
+        }
+
+        boolean full = fullOutputLeases.get() > 0;
+        for (ResponseListenerHolder holder : listeners) {
+            if (!holder.active) {
+                continue;
+            }
+            SensorSubscription subscription = holder.subscription;
+            if (subscription == null || subscription.getSensorNames().isEmpty()) {
+                full = true;
+            } else {
+                channels.addAll(subscription.getSensorNames());
+            }
+        }
+        return new OutputChannelDemand(channels, full, outputDemandGeneration.get());
+    }
+
+    public FullOutputLease acquireFullOutput() {
+        fullOutputLeases.incrementAndGet();
+        long generation = outputDemandGeneration.incrementAndGet();
+        return new FullOutputLease(this, generation);
+    }
+
+    private void releaseFullOutput() {
+        int remaining = fullOutputLeases.decrementAndGet();
+        if (remaining < 0) {
+            fullOutputLeases.incrementAndGet();
+            throw new IllegalStateException("Unbalanced full-output lease release");
+        }
+        outputDemandGeneration.incrementAndGet();
+    }
+
+    public SnapshotListenerToken addSnapshotListener(SnapshotListener listener) {
+        snapshotListeners.add(listener);
+        return new SnapshotListenerToken(snapshotListeners, listener);
+    }
+
+    public OutputChannelSnapshot getCurrentSnapshot() {
+        return currentSnapshot;
+    }
+
+    @Nullable
+    public OutputChannelSnapshot awaitFullSnapshot(long generation, long timeoutMillis) throws InterruptedException {
+        long remainingNanos = TimeUnit.MILLISECONDS.toNanos(timeoutMillis);
+        long deadline = System.nanoTime() + remainingNanos;
+        synchronized (snapshotMonitor) {
+            while (currentSnapshot == null || !currentSnapshot.isFull()
+                    || currentSnapshot.getGeneration() < generation) {
+                if (remainingNanos <= 0) {
+                    return null;
+                }
+                TimeUnit.NANOSECONDS.timedWait(snapshotMonitor, remainingNanos);
+                remainingNanos = deadline - System.nanoTime();
+            }
+            return currentSnapshot;
+        }
     }
 
     /**
@@ -266,6 +424,10 @@ public class SensorCentral implements ISensorCentral {
     public void reset() {
         sensorsHolder.reset();
         response = null;
+        synchronized (snapshotMonitor) {
+            currentSnapshot = null;
+            snapshotMonitor.notifyAll();
+        }
         resolvedGaugeLabels = Collections.emptyMap();
         synchronized (frameTimestampsNanos) {
             frameTimestampsNanos.clear();
@@ -288,5 +450,79 @@ public class SensorCentral implements ISensorCentral {
 
     public interface ResponseListener {
         void onSensorUpdate();
+    }
+
+    public interface SnapshotListener {
+        void onSnapshot(OutputChannelSnapshot snapshot);
+    }
+
+    public static final class ResponseListenerToken {
+        private final SensorCentral central;
+        private final ResponseListenerHolder holder;
+        private final AtomicBoolean removed = new AtomicBoolean();
+
+        private ResponseListenerToken(SensorCentral central, ResponseListenerHolder holder) {
+            this.central = central;
+            this.holder = holder;
+        }
+
+        public void setActive(boolean active) {
+            if (!removed.get() && holder.active != active) {
+                holder.active = active;
+                central.outputDemandGeneration.incrementAndGet();
+            }
+        }
+
+        public void setSubscription(SensorSubscription subscription) {
+            if (!removed.get()) {
+                holder.subscription = subscription;
+                central.outputDemandGeneration.incrementAndGet();
+            }
+        }
+
+        public void remove() {
+            if (removed.compareAndSet(false, true) && central.listeners.remove(holder)) {
+                central.outputDemandGeneration.incrementAndGet();
+            }
+        }
+    }
+
+    public static final class SnapshotListenerToken {
+        private final List<SnapshotListener> listeners;
+        private final SnapshotListener listener;
+        private final AtomicBoolean removed = new AtomicBoolean();
+
+        private SnapshotListenerToken(List<SnapshotListener> listeners, SnapshotListener listener) {
+            this.listeners = listeners;
+            this.listener = listener;
+        }
+
+        public void remove() {
+            if (removed.compareAndSet(false, true)) {
+                listeners.remove(listener);
+            }
+        }
+    }
+
+    public static final class FullOutputLease implements AutoCloseable {
+        private final SensorCentral central;
+        private final long generation;
+        private final AtomicBoolean closed = new AtomicBoolean();
+
+        private FullOutputLease(SensorCentral central, long generation) {
+            this.central = central;
+            this.generation = generation;
+        }
+
+        public long getGeneration() {
+            return generation;
+        }
+
+        @Override
+        public void close() {
+            if (closed.compareAndSet(false, true)) {
+                central.releaseFullOutput();
+            }
+        }
     }
 }

--- a/java_console/io/src/main/java/com/rusefi/core/SensorSubscription.java
+++ b/java_console/io/src/main/java/com/rusefi/core/SensorSubscription.java
@@ -2,6 +2,7 @@ package com.rusefi.core;
 
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Locale;
 import java.util.Set;
 
 /**
@@ -12,7 +13,7 @@ public class SensorSubscription {
 
     public SensorSubscription(String... sensorNames) {
         for (String name : sensorNames) {
-            this.sensorNames.add(name.toLowerCase());
+            this.sensorNames.add(name.toLowerCase(Locale.US));
         }
     }
 
@@ -21,7 +22,7 @@ public class SensorSubscription {
     }
 
     public boolean isInterestedIn(String sensorName) {
-        return sensorNames.isEmpty() || sensorNames.contains(sensorName.toLowerCase());
+        return sensorNames.isEmpty() || sensorNames.contains(sensorName.toLowerCase(Locale.US));
     }
 
     public boolean isInterestedInAny(Set<String> updatedSensors) {
@@ -29,7 +30,7 @@ public class SensorSubscription {
             return true;
         }
         for (String updated : updatedSensors) {
-            if (sensorNames.contains(updated.toLowerCase())) {
+            if (sensorNames.contains(updated.toLowerCase(Locale.US))) {
                 return true;
             }
         }

--- a/java_console/io/src/main/java/com/rusefi/io/tcp/BinaryProtocolServer.java
+++ b/java_console/io/src/main/java/com/rusefi/io/tcp/BinaryProtocolServer.java
@@ -11,6 +11,8 @@ import com.rusefi.binaryprotocol.BinaryProtocolState;
 import com.rusefi.binaryprotocol.IncomingDataBuffer;
 import com.rusefi.binaryprotocol.IoHelper;
 import com.rusefi.config.generated.Integration;
+import com.rusefi.core.OutputChannelSnapshot;
+import com.rusefi.core.SensorCentral;
 import com.rusefi.util.HexBinary;
 import com.rusefi.io.LinkManager;
 import com.rusefi.io.commands.ByteRange;
@@ -148,51 +150,71 @@ public class BinaryProtocolServer {
 
         IncomingDataBuffer in = stream.getDataBuffer();
 
-        while (true) {
-            Integer length = getPendingPacketLengthOrHandleProtocolCommand(clientSocket, context, in);
-            if (length == null)
-                continue;
+        try (SensorCentral.FullOutputLease fullOutputLease = linkManager.getBinaryProtocol() == null
+            ? null
+            : SensorCentral.getInstance().acquireFullOutput()) {
+            while (true) {
+                Integer length = getPendingPacketLengthOrHandleProtocolCommand(clientSocket, context, in);
+                if (length == null)
+                    continue;
 
-            byte[] payload = getPacketContent(in, length);
+                byte[] payload = getPacketContent(in, length);
 
-            byte command = payload[0];
+                byte command = payload[0];
 
-            log.info("Got command " + BinaryProtocol.findCommand(command));
+                log.info("Got command " + BinaryProtocol.findCommand(command));
 
-            if (command == Integration.TS_HELLO_COMMAND) {
-                new HelloCommand(TS_SIGNATURE).handle(stream);
-            } else if (command == Integration.TS_GET_PROTOCOL_VERSION_COMMAND_F) {
-                stream.sendPacket((TS_OK + TS_PROTOCOL).getBytes());
-            } else if (command == Integration.TS_GET_FIRMWARE_VERSION) {
-                stream.sendPacket((TS_OK + "rusEFI proxy").getBytes());
-            } else if (command == Integration.TS_CRC_CHECK_COMMAND) {
-                handleCrc(linkManager, stream);
-            } else if (command == Integration.TS_READ_COMMAND) {
-                ByteRange byteRange = ByteRange.valueOf2(payload);
-                handleRead(linkManager, byteRange, stream);
-            } else if (command == Integration.TS_CHUNK_WRITE_COMMAND) {
-                ByteRange byteRange = ByteRange.valueOf(payload);
-                handleWrite(linkManager, payload, byteRange, stream);
-            } else if (command == Integration.TS_BURN_COMMAND) {
-                stream.sendPacket(new byte[]{TS_RESPONSE_BURN_OK});
-            } else if (command == Integration.TS_GET_COMPOSITE_BUFFER_DONE_DIFFERENTLY) {
-                System.err.println("NOT IMPLEMENTED TS_GET_COMPOSITE_BUFFER_DONE_DIFFERENTLY relay");
-                // todo: relay command
-                stream.sendPacket(TS_OK.getBytes());
-            } else if (command == Integration.TS_OUTPUT_COMMAND) {
-                BinaryProtocolState binaryProtocolState = linkManager.getBinaryProtocolState();
-                byte[] currentOutputs = binaryProtocolState.getCurrentOutputs();
+                if (command == Integration.TS_HELLO_COMMAND) {
+                    new HelloCommand(TS_SIGNATURE).handle(stream);
+                } else if (command == Integration.TS_GET_PROTOCOL_VERSION_COMMAND_F) {
+                    stream.sendPacket((TS_OK + TS_PROTOCOL).getBytes());
+                } else if (command == Integration.TS_GET_FIRMWARE_VERSION) {
+                    stream.sendPacket((TS_OK + "rusEFI proxy").getBytes());
+                } else if (command == Integration.TS_CRC_CHECK_COMMAND) {
+                    handleCrc(linkManager, stream);
+                } else if (command == Integration.TS_READ_COMMAND) {
+                    ByteRange byteRange = ByteRange.valueOf2(payload);
+                    handleRead(linkManager, byteRange, stream);
+                } else if (command == Integration.TS_CHUNK_WRITE_COMMAND) {
+                    ByteRange byteRange = ByteRange.valueOf(payload);
+                    handleWrite(linkManager, payload, byteRange, stream);
+                } else if (command == Integration.TS_BURN_COMMAND) {
+                    stream.sendPacket(new byte[]{TS_RESPONSE_BURN_OK});
+                } else if (command == Integration.TS_GET_COMPOSITE_BUFFER_DONE_DIFFERENTLY) {
+                    System.err.println("NOT IMPLEMENTED TS_GET_COMPOSITE_BUFFER_DONE_DIFFERENTLY relay");
+                    // todo: relay command
+                    stream.sendPacket(TS_OK.getBytes());
+                } else if (command == Integration.TS_OUTPUT_COMMAND) {
+                    byte[] currentOutputs;
+                    if (fullOutputLease == null) {
+                        currentOutputs = linkManager.getBinaryProtocolState().getCurrentOutputs();
+                    } else {
+                        OutputChannelSnapshot snapshot;
+                        try {
+                            snapshot = SensorCentral.getInstance().awaitFullSnapshot(
+                                fullOutputLease.getGeneration(), Timeouts.BINARY_IO_TIMEOUT);
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                            throw new IOException("Interrupted waiting for full output snapshot", e);
+                        }
+                        if (snapshot == null) {
+                            stream.sendPacket(new byte[]{(byte) Integration.TS_RESPONSE_UNDERRUN});
+                            continue;
+                        }
+                        currentOutputs = snapshot.getResponse();
+                    }
 
-                byte[] response = getOutputCommandResponse(payload, currentOutputs);
-                stream.sendPacket(response);
-            } else if (command == Integration.TS_GET_TEXT) {
-                // todo: relay command
-                System.err.println("NOT IMPLEMENTED TS_GET_TEXT relay");
-                stream.sendPacket(TS_OK.getBytes());
-            } else {
-                unknownCommands.incrementAndGet();
-                new IllegalStateException().printStackTrace();
-                log.info("Error: unexpected " + BinaryProtocol.findCommand(command));
+                    byte[] response = getOutputCommandResponse(payload, currentOutputs);
+                    stream.sendPacket(response);
+                } else if (command == Integration.TS_GET_TEXT) {
+                    // todo: relay command
+                    System.err.println("NOT IMPLEMENTED TS_GET_TEXT relay");
+                    stream.sendPacket(TS_OK.getBytes());
+                } else {
+                    unknownCommands.incrementAndGet();
+                    new IllegalStateException().printStackTrace();
+                    log.info("Error: unexpected " + BinaryProtocol.findCommand(command));
+                }
             }
         }
     }

--- a/java_console/io/src/main/java/com/rusefi/ui/livedocs/LiveDocsRegistry.java
+++ b/java_console/io/src/main/java/com/rusefi/ui/livedocs/LiveDocsRegistry.java
@@ -39,6 +39,15 @@ public enum LiveDocsRegistry {
         }
     }
 
+    public boolean hasVisible() {
+        for (LiveDocHolder holder : liveDocs) {
+            if (holder.isVisible()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     private void refresh(LiveDocHolder holder, live_data_e context, LiveDataProvider liveDataProvider) {
 
         byte[] response = liveDataProvider.provide(context);
@@ -60,12 +69,18 @@ public enum LiveDocsRegistry {
 */
             int structOffset = StateDictionary.INSTANCE.getOffset(context);
             byte[] overallOutputs = SensorCentral.getInstance().getResponse();
-
-            byte[] response = new byte[size];
-
-            System.arraycopy(overallOutputs, structOffset, overallOutputs, 0, size);
-            return response;
+            return sliceOutput(overallOutputs, structOffset, size);
         };
+    }
+
+    static byte[] sliceOutput(byte[] overallOutputs, int structOffset, int size) {
+        if (overallOutputs == null || structOffset < 0 || size < 0
+                || structOffset > overallOutputs.length - 1 - size) {
+            return null;
+        }
+        byte[] response = new byte[size];
+        System.arraycopy(overallOutputs, structOffset + 1, response, 0, size);
+        return response;
     }
 
     public interface LiveDataProvider {

--- a/java_console/io/src/test/java/com/rusefi/binaryprotocol/BinaryProtocolTest.java
+++ b/java_console/io/src/test/java/com/rusefi/binaryprotocol/BinaryProtocolTest.java
@@ -1,22 +1,35 @@
 package com.rusefi.binaryprotocol;
 
 import com.opensr5.ini.IniFileModel;
+import com.opensr5.ini.IniFileMetaInfo;
+import com.opensr5.ini.IniFileModelMocks;
+import com.opensr5.ini.field.IniField;
 import com.opensr5.io.DataListener;
 import com.rusefi.config.generated.Integration;
+import com.rusefi.core.OutputChannelDemand;
+import com.rusefi.core.OutputChannelSnapshot;
+import com.rusefi.core.SensorCentral;
 import com.rusefi.io.IoStream;
 import com.rusefi.io.LinkManager;
 import com.rusefi.io.serial.AbstractIoStream;
 import com.rusefi.io.tcp.TcpIoStream;
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.Field;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -144,6 +157,119 @@ public class BinaryProtocolTest {
         }
     }
 
+    @Test
+    public void issue10170EmptyDemandStillReadsTheWholeBlock() throws ReflectiveOperationException {
+        TestStream stream = new TestStream();
+        BinaryProtocol protocol = createProtocol(stream);
+        IniFileModel iniFile = IniFileModelMocks.empty();
+        IniFileMetaInfo metaInfo = mock(IniFileMetaInfo.class);
+        doReturn(TARGET_BLOCKING_FACTOR).when(iniFile).getBlockingFactor();
+        doReturn(metaInfo).when(iniFile).getMetaInfo();
+        doReturn(2500).when(metaInfo).getOchBlockSize();
+        doReturn(iniFile).when(protocol).getIniFile();
+        setIniFile(protocol, iniFile);
+
+        List<byte[]> requests = new ArrayList<>();
+        doAnswer(invocation -> {
+            byte[] request = invocation.getArgument(1);
+            requests.add(request.clone());
+            return new byte[unsignedShort(request, 2) + 1];
+        }).when(protocol).executeCommand(eq(Integration.TS_OUTPUT_COMMAND), any(byte[].class), anyString());
+
+        try {
+            // Empty demand is deliberately conservative because there is no explicitly
+            // classified consumer proving that a partial frame is sufficient.
+            assertTrue(protocol.requestOutputChannels());
+            assertEquals(3, requests.size());
+            assertOutputRequest(requests.get(0), 0, 1024);
+            assertOutputRequest(requests.get(1), 1024, 1024);
+            assertOutputRequest(requests.get(2), 2048, 452);
+        } finally {
+            stream.close();
+        }
+    }
+
+    @Test
+    public void issue10170OutputPollingReadsOnlyDemandedRanges() throws ReflectiveOperationException {
+        TestStream stream = new TestStream();
+        BinaryProtocol protocol = createProtocol(stream);
+        IniFileModel iniFile = IniFileModelMocks.empty();
+        IniFileMetaInfo metaInfo = mock(IniFileMetaInfo.class);
+        IniField rpm = mock(IniField.class);
+        doReturn(TARGET_BLOCKING_FACTOR).when(iniFile).getBlockingFactor();
+        doReturn(metaInfo).when(iniFile).getMetaInfo();
+        doReturn(3000).when(metaInfo).getOchBlockSize();
+        doReturn("rpm").when(rpm).getName();
+        doReturn(100).when(rpm).getOffset();
+        doReturn(2500).when(rpm).getSize();
+        doReturn(Collections.singletonMap("rpm", rpm)).when(iniFile).getAllOutputChannels();
+        doReturn(iniFile).when(protocol).getIniFile();
+        setIniFile(protocol, iniFile);
+
+        List<byte[]> requests = new ArrayList<>();
+        doAnswer(invocation -> {
+            byte[] request = invocation.getArgument(1);
+            requests.add(request.clone());
+            return new byte[unsignedShort(request, 2) + 1];
+        }).when(protocol).executeCommand(eq(Integration.TS_OUTPUT_COMMAND), any(byte[].class), anyString());
+
+        try {
+            assertTrue(protocol.requestOutputChannels(
+                OutputChannelDemand.selective(Collections.singleton("RPM"), 17)));
+            assertEquals(3, requests.size());
+            assertOutputRequest(requests.get(0), 100, 1024);
+            assertOutputRequest(requests.get(1), 1124, 1024);
+            assertOutputRequest(requests.get(2), 2148, 452);
+
+            OutputChannelSnapshot snapshot = SensorCentral.getInstance().getCurrentSnapshot();
+            assertNotNull(snapshot);
+            assertFalse(snapshot.isFull());
+            assertEquals(17, snapshot.getGeneration());
+            assertEquals(Collections.singleton("rpm"), snapshot.getRequestedChannels());
+            assertTrue(snapshot.isRangeValid(100, 2500));
+            assertFalse(snapshot.isRangeValid(0, 1));
+            assertNull(protocol.getBinaryProtocolState().getCurrentOutputs());
+        } finally {
+            stream.close();
+        }
+    }
+
+    @Test
+    public void issue10170FailedRangeDoesNotPublishPartialSnapshot() throws ReflectiveOperationException {
+        TestStream stream = new TestStream();
+        BinaryProtocol protocol = createProtocol(stream);
+        IniFileModel iniFile = IniFileModelMocks.empty();
+        IniFileMetaInfo metaInfo = mock(IniFileMetaInfo.class);
+        IniField rpm = mock(IniField.class);
+        doReturn(TARGET_BLOCKING_FACTOR).when(iniFile).getBlockingFactor();
+        doReturn(metaInfo).when(iniFile).getMetaInfo();
+        doReturn(2000).when(metaInfo).getOchBlockSize();
+        doReturn("rpm").when(rpm).getName();
+        doReturn(100).when(rpm).getOffset();
+        doReturn(1500).when(rpm).getSize();
+        doReturn(Collections.singletonMap("rpm", rpm)).when(iniFile).getAllOutputChannels();
+        doReturn(iniFile).when(protocol).getIniFile();
+        setIniFile(protocol, iniFile);
+
+        AtomicInteger commands = new AtomicInteger();
+        doAnswer(invocation -> {
+            byte[] request = invocation.getArgument(1);
+            return commands.incrementAndGet() == 1
+                ? new byte[unsignedShort(request, 2) + 1]
+                : null;
+        }).when(protocol).executeCommand(eq(Integration.TS_OUTPUT_COMMAND), any(byte[].class), anyString());
+
+        OutputChannelSnapshot before = SensorCentral.getInstance().getCurrentSnapshot();
+        try {
+            assertFalse(protocol.requestOutputChannels(
+                OutputChannelDemand.selective(Collections.singleton("rpm"), 18)));
+            assertEquals(2, commands.get());
+            assertSame(before, SensorCentral.getInstance().getCurrentSnapshot());
+        } finally {
+            stream.close();
+        }
+    }
+
     private static BinaryProtocol createProtocol(TestStream stream) {
         return createProtocol(stream, OVERRIDDEN_BLOCKING_FACTOR);
     }
@@ -201,5 +327,16 @@ public class BinaryProtocolTest {
         return ByteBuffer.wrap(bytes, offset, Short.BYTES)
             .order(ByteOrder.LITTLE_ENDIAN)
             .getShort() & 0xffff;
+    }
+
+    private static void assertOutputRequest(byte[] request, int offset, int size) {
+        assertEquals(offset, unsignedShort(request, 0));
+        assertEquals(size, unsignedShort(request, 2));
+    }
+
+    private static void setIniFile(BinaryProtocol protocol, IniFileModel iniFile) throws ReflectiveOperationException {
+        Field field = BinaryProtocol.class.getDeclaredField("iniFile");
+        field.setAccessible(true);
+        field.set(protocol, iniFile);
     }
 }

--- a/java_console/io/src/test/java/com/rusefi/core/SensorCentralTest.java
+++ b/java_console/io/src/test/java/com/rusefi/core/SensorCentralTest.java
@@ -3,16 +3,23 @@ package com.rusefi.core;
 import com.opensr5.ini.IniFileModel;
 import com.opensr5.ini.ImmutableIniFileModel;
 import com.opensr5.ini.IniFileModelMocks;
+import com.opensr5.ini.field.IniField;
+import com.opensr5.ini.field.ScalarIniField;
+import com.rusefi.config.FieldType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.BitSet;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class SensorCentralTest {
     private SensorCentral sensorCentral;
@@ -101,6 +108,94 @@ public class SensorCentralTest {
     }
 
     @Test
+    void listenerTokenControlsOutputDemand() {
+        ISensorCentral.ListenerToken token = sensorCentral.addListener("DemandedChannel", value -> { });
+        try {
+            assertTrue(sensorCentral.getOutputChannelDemand().getChannels().contains("demandedchannel"));
+
+            token.setActive(false);
+            assertFalse(sensorCentral.getOutputChannelDemand().getChannels().contains("demandedchannel"));
+
+            token.setActive(true);
+            assertTrue(sensorCentral.getOutputChannelDemand().getChannels().contains("demandedchannel"));
+        } finally {
+            token.remove();
+        }
+        assertFalse(sensorCentral.getOutputChannelDemand().getChannels().contains("demandedchannel"));
+    }
+
+    @Test
+    void passiveListenerReceivesValuesWithoutDemandingTheChannel() {
+        AtomicReference<Double> received = new AtomicReference<>();
+        ISensorCentral.ListenerToken token = sensorCentral.addPassiveListener("PassiveChannel", received::set);
+        try {
+            assertFalse(sensorCentral.getOutputChannelDemand().getChannels().contains("passivechannel"));
+            sensorCentral.setValue(12.5, "PassiveChannel");
+            assertEquals(12.5, received.get());
+        } finally {
+            token.remove();
+        }
+    }
+
+    @Test
+    void waitsForGenerationMatchedFullSnapshot() throws Exception {
+        SensorCentral.FullOutputLease lease = sensorCentral.acquireFullOutput();
+        AtomicReference<OutputChannelSnapshot> received = new AtomicReference<>();
+        Thread waiter = new Thread(() -> {
+            try {
+                received.set(sensorCentral.awaitFullSnapshot(lease.getGeneration(), 1000));
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        });
+
+        try {
+            waiter.start();
+            BitSet valid = new BitSet();
+            OutputChannelSnapshot stale = new OutputChannelSnapshot(
+                new byte[]{0}, valid, Collections.emptySet(), lease.getGeneration() - 1, true);
+            sensorCentral.grabSensorValues(stale, IniFileModelMocks.empty(), null);
+            OutputChannelSnapshot matching = new OutputChannelSnapshot(
+                new byte[]{0}, valid, Collections.emptySet(), lease.getGeneration(), true);
+            sensorCentral.grabSensorValues(matching, IniFileModelMocks.empty(), null);
+            waiter.join(1000);
+
+            assertFalse(waiter.isAlive());
+            assertSame(matching, received.get());
+        } finally {
+            waiter.interrupt();
+            lease.close();
+        }
+    }
+
+    @Test
+    void outputSnapshotOwnsItsResponseBytes() {
+        byte[] response = {0, 42};
+        BitSet valid = new BitSet();
+        valid.set(0);
+        OutputChannelSnapshot snapshot = new OutputChannelSnapshot(
+            response, valid, Collections.singleton("rpm"), 1, false);
+
+        response[1] = 7;
+        assertEquals(42, snapshot.getResponse()[1]);
+        byte[] copy = snapshot.getResponse();
+        copy[1] = 9;
+        assertEquals(42, snapshot.getResponse()[1]);
+    }
+
+    @Test
+    void fullOutputLeaseOverridesNamedDemandAndIsIdempotent() {
+        SensorCentral.FullOutputLease lease = sensorCentral.acquireFullOutput();
+        assertTrue(sensorCentral.getOutputChannelDemand().isFull());
+        long generation = lease.getGeneration();
+        assertEquals(generation, sensorCentral.getOutputChannelDemand().getGeneration());
+
+        lease.close();
+        lease.close();
+        assertTrue(sensorCentral.getOutputChannelDemand().getGeneration() > generation);
+    }
+
+    @Test
     void multipleListenersForSameSensor() {
         AtomicInteger callCount1 = new AtomicInteger(0);
         AtomicInteger callCount2 = new AtomicInteger(0);
@@ -145,6 +240,51 @@ public class SensorCentralTest {
         sensorCentral.grabSensorValues(new byte[10], ini, null);
         // todo: adjust once holder.subscription.isInterestedInAny
         assertEquals(2, callCount.get(), "Should notify for RPM");
+    }
+
+    @Test
+    void partialSnapshotNotifiesOnlyInterestedResponseListeners() {
+        AtomicInteger rpmCalls = new AtomicInteger();
+        AtomicInteger tpsCalls = new AtomicInteger();
+        SensorCentral.ResponseListenerToken rpm = sensorCentral.addListener(
+            rpmCalls::incrementAndGet, new SensorSubscription("RPM"));
+        SensorCentral.ResponseListenerToken tps = sensorCentral.addListener(
+            tpsCalls::incrementAndGet, new SensorSubscription("TPS"));
+
+        try {
+            OutputChannelSnapshot snapshot = new OutputChannelSnapshot(
+                new byte[2], new BitSet(), Set.of("TPS"), 10, false);
+            sensorCentral.grabSensorValues(snapshot, IniFileModelMocks.empty(), null);
+            assertEquals(0, rpmCalls.get());
+            assertEquals(1, tpsCalls.get());
+        } finally {
+            rpm.remove();
+            tps.remove();
+        }
+    }
+
+    @Test
+    void partialSnapshotDecodesOnlyValidFields() throws Exception {
+        ScalarIniField rpm = new ScalarIniField("rpm", 0, "RPM", FieldType.UINT16, 1, "0", 0);
+        ScalarIniField tps = new ScalarIniField("tps", 2, "%", FieldType.UINT8, 1, "0", 0);
+        Map<String, IniField> fields = new LinkedHashMap<>();
+        fields.put("rpm", rpm);
+        fields.put("tps", tps);
+        IniFileModel ini = IniFileModelMocks.empty();
+        when(ini.getAllOutputChannels()).thenReturn(fields);
+        when(ini.getOutputChannel("rpm")).thenReturn(rpm);
+        when(ini.getOutputChannel("tps")).thenReturn(tps);
+
+        BitSet valid = new BitSet();
+        valid.set(0, 2);
+        OutputChannelSnapshot snapshot = new OutputChannelSnapshot(
+            new byte[]{0, 42, 0, 99}, valid, Set.of("rpm"), 11, false);
+        sensorCentral.grabSensorValues(snapshot, ini, null);
+
+        assertEquals(42, sensorCentral.getValue("rpm"));
+        assertNotEquals(99, sensorCentral.getValue("tps"));
+        assertNull(sensorCentral.getResponse(), "Legacy raw response must not expose invalid bytes");
+        assertSame(snapshot, sensorCentral.getCurrentSnapshot());
     }
 
     @Test

--- a/java_console/io/src/test/java/com/rusefi/ui/livedocs/LiveDocsRegistryTest.java
+++ b/java_console/io/src/test/java/com/rusefi/ui/livedocs/LiveDocsRegistryTest.java
@@ -1,0 +1,24 @@
+package com.rusefi.ui.livedocs;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class LiveDocsRegistryTest {
+    @Test
+    void slicesOutputWithoutResponseCodeOrSourceMutation() {
+        byte[] overallOutputs = {0, 10, 11, 12, 13, 14};
+        byte[] original = overallOutputs.clone();
+
+        assertArrayEquals(new byte[]{11, 12, 13},
+            LiveDocsRegistry.sliceOutput(overallOutputs, 1, 3));
+        assertArrayEquals(original, overallOutputs);
+    }
+
+    @Test
+    void absentOrIncompleteOutputReturnsNoLiveData() {
+        assertNull(LiveDocsRegistry.sliceOutput(null, 0, 1));
+        assertNull(LiveDocsRegistry.sliceOutput(new byte[]{0, 10}, 1, 1));
+    }
+}

--- a/java_console/ui/src/main/java/com/rusefi/ConsoleUI.java
+++ b/java_console/ui/src/main/java/com/rusefi/ConsoleUI.java
@@ -9,6 +9,7 @@ import com.rusefi.autoupdate.Autoupdate;
 import com.rusefi.binaryprotocol.BinaryProtocolLogger;
 import com.rusefi.binaryprotocol.ShortcutsHelper;
 import com.rusefi.core.MessagesCentral;
+import com.rusefi.core.SensorCentral;
 import com.rusefi.core.net.ConnectionAndMeta;
 import com.rusefi.io.CommandQueue;
 import com.rusefi.io.LinkManager;
@@ -48,6 +49,8 @@ import com.rusefi.ui.basic.LoadTuneHelper;
 import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
@@ -90,6 +93,12 @@ public class ConsoleUI {
      * We can listen to tab activation event if we so desire
      */
     private final Map<Component, ActionListener> tabSelectedListeners = new HashMap<>();
+    private GaugesPanel gaugesPanel;
+    private TuningPane tuningPane;
+    private Component gaugesTab;
+    private Component tuningTab;
+    private SensorCentral.FullOutputLease unclassifiedTabLease;
+    private boolean nonTabContentActive;
 
     public ConsoleUI(String port, SerialPortType serialPortType, ConnectivityContext connectivityContext) {
         this(new UIContext(connectivityContext.getConnectedEcuTarget()), port, serialPortType, false,
@@ -260,7 +269,10 @@ public class ConsoleUI {
 
         JButton launchWizardButton = getLaunchWizardButton(mainFrame, rootPanel, wizardContainer, rootCardLayout);
 
-        wizardContainer.setOnWizardExit(() -> rootCardLayout.show(rootPanel, "console"));
+        wizardContainer.setOnWizardExit(() -> {
+            rootCardLayout.show(rootPanel, "console");
+            setNonTabContentActive(false);
+        });
         wizardContainer.setMessageHandler(mainFrame::showMessageOverlay);
         wizardContainer.setOnDontShowAgain(() -> {
             getConfig().getRoot().setBoolProperty(AUTO_LAUNCH_WIZARD, false);
@@ -281,6 +293,7 @@ public class ConsoleUI {
                 for (WizardStepDescriptor d : WizardCatalog.standaloneAutoLaunch()) {
                     if (!d.applicable.test(uiContext)) continue;
                     if (d.needsAttention == null || !d.needsAttention.test(uiContext)) continue;
+                    setNonTabContentActive(true);
                     WizardStep step = d.factory.apply(uiContext);
                     wizardContainer.startSingleStep(step);
                     rootCardLayout.show(rootPanel, "wizard");
@@ -290,6 +303,7 @@ public class ConsoleUI {
                 if (UiProperties.isWizardAutoLaunchEnabled()
                     && getConfig().getRoot().getBoolProperty(AUTO_LAUNCH_WIZARD, true)
                     && wizardContainer.hasIncompleteSteps()) {
+                    setNonTabContentActive(true);
                     wizardContainer.startWizard(true);
                     rootCardLayout.show(rootPanel, "wizard");
                 }
@@ -334,7 +348,9 @@ public class ConsoleUI {
         // will be shown immediately on startup — in that case build eagerly (#9715).
         int savedTabIndex = getConfig().getRoot().getIntProperty(TAB_INDEX, DEFAULT_TAB_INDEX);
         if (isOffline || !linkManager.isLogViewer()) {
-            tabbedPane.addTab("Gauges", new GaugesPanel(uiContext, getConfig().getRoot().getChild("gauges")).getContent());
+            gaugesPanel = new GaugesPanel(uiContext, getConfig().getRoot().getChild("gauges"));
+            gaugesTab = gaugesPanel.getContent();
+            tabbedPane.addTab("Gauges", gaugesTab);
 
             MessagesPane messagesPane = new MessagesPane(uiContext, getConfig().getRoot().getChild("messages"));
             tabbedPaneAdd("Messages", messagesPane.getContent(), messagesPane.getTabSelectedListener());
@@ -416,6 +432,7 @@ console live data tab is broken #8402
                 }
                 TuningPane tp = new TuningPane(uiContext, offlineImage, getConfig().getRoot().getChild("tuning"));
                 tuningHolder[0] = tp;
+                tuningPane = tp;
                 tp.setErrorHandler(mainFrame::showMessageOverlay);
                 tp.setFirmwareUpdateInProgress(deviceSessionManager.getState() == SessionState.FLASHING);
                 tp.setShowTuningTab(() -> tabbedPane.selectTab("Tuning"));
@@ -433,10 +450,11 @@ console live data tab is broken #8402
                         pinoutPane.highlightByEnumValue(enumValue);
                     });
                 }
+                updateOutputPollingForSelectedTab();
             };
 
             int tuningIndex = tabbedPane.tabbedPane.getTabCount();
-            tabbedPane.addTab("Tuning", new InitOnFirstPaintPanel() {
+            tuningTab = new InitOnFirstPaintPanel() {
                 @Override
                 protected JPanel createContent() {
                     buildTuning.run();
@@ -444,7 +462,8 @@ console live data tab is broken #8402
                     wrapper.add(tuningHolder[0].getContent(), BorderLayout.CENTER);
                     return wrapper;
                 }
-            }.getContent());
+            }.getContent();
+            tabbedPane.addTab("Tuning", tuningTab);
             // Until Tuning is built, the menu actions build it on first click then delegate; once
             // built, buildTuning re-points the menu at the real actions.
             mainFrame.setTuneActions(
@@ -490,9 +509,13 @@ console live data tab is broken #8402
                 picker -> {
                     rollbackPicker.removeAll();
                     rollbackPicker.add(picker, BorderLayout.CENTER);
+                    setNonTabContentActive(true);
                     rootCardLayout.show(rootPanel, "rollback");
                 },
-                () -> rootCardLayout.show(rootPanel, "console"));
+                () -> {
+                    rootCardLayout.show(rootPanel, "console");
+                    setNonTabContentActive(false);
+                });
             tabbedPane.addTab("Device", devicePane.getContent());
             mainFrame.setUpdateEcuAction(() -> {
                 tabbedPane.selectTab("Device");
@@ -558,12 +581,14 @@ console live data tab is broken #8402
                     JTabbedPane pane = (JTabbedPane) e.getSource();
                     int selectedIndex = pane.getSelectedIndex();
                     System.out.println("Selected paneNo: " + selectedIndex);
+                    updateOutputPollingForSelectedTab();
                     ActionListener actionListener = tabSelectedListeners.get(pane.getComponentAt(selectedIndex));
                     if (actionListener != null)
                         actionListener.actionPerformed(null);
                 }
             }
         });
+        updateOutputPollingForSelectedTab();
 
         ShortcutsHelper.installConnectAndDisconnect(uiContext, tabbedPane.tabbedPane,
             () -> !Boolean.TRUE.equals(tabbedPane.tabbedPane.getClientProperty("isUpdating"))
@@ -571,6 +596,12 @@ console live data tab is broken #8402
         AutoupdateUtil.setAppIcon(mainFrame.getFrame().getFrame());
 
         unsupportedEcuHost.setNormalContent(mainFrame.wrapContentWithInstallerBanner(rootPanel));
+        mainFrame.getFrame().getFrame().addWindowListener(new WindowAdapter() {
+            @Override
+            public void windowClosed(WindowEvent e) {
+                releaseOutputPolling();
+            }
+        });
         mainFrame.getFrame().showFrame(unsupportedEcuHost.getContent());
     }
 
@@ -582,6 +613,7 @@ console live data tab is broken #8402
                 mainFrame.showMessageOverlay("Please connect to an ECU before launching the wizard.");
                 return;
             }
+            setNonTabContentActive(true);
             wizardContainer.startWizard();
             rootCardLayout.show(rootPanel, "wizard");
         });
@@ -677,6 +709,46 @@ console live data tab is broken #8402
     private void tabbedPaneAdd(String title, JComponent component, ActionListener tabSelectedListener) {
         tabSelectedListeners.put(component, tabSelectedListener);
         tabbedPane.addTab(title, component);
+    }
+
+    private void updateOutputPollingForSelectedTab() {
+        Component selected = tabbedPane.tabbedPane.getSelectedComponent();
+        boolean gaugesActive = !nonTabContentActive && selected != null && selected == gaugesTab;
+        boolean tuningActive = !nonTabContentActive && selected != null && selected == tuningTab;
+
+        if (gaugesPanel != null) {
+            gaugesPanel.setActive(gaugesActive);
+        }
+        if (tuningPane != null) {
+            tuningPane.setActive(tuningActive);
+        }
+
+        if (gaugesActive || tuningActive) {
+            if (unclassifiedTabLease != null) {
+                unclassifiedTabLease.close();
+                unclassifiedTabLease = null;
+            }
+        } else if (unclassifiedTabLease == null) {
+            unclassifiedTabLease = SensorCentral.getInstance().acquireFullOutput();
+        }
+    }
+
+    private void setNonTabContentActive(boolean active) {
+        nonTabContentActive = active;
+        updateOutputPollingForSelectedTab();
+    }
+
+    private void releaseOutputPolling() {
+        if (gaugesPanel != null) {
+            gaugesPanel.destroy();
+        }
+        if (tuningPane != null) {
+            tuningPane.destroy();
+        }
+        if (unclassifiedTabLease != null) {
+            unclassifiedTabLease.close();
+            unclassifiedTabLease = null;
+        }
     }
 
     private static void awtCode(String[] args, CompletableFuture<Autoupdate.UpdateOutcome> updateOutcome) {

--- a/java_console/ui/src/main/java/com/rusefi/sensor_logs/SensorLogger.java
+++ b/java_console/ui/src/main/java/com/rusefi/sensor_logs/SensorLogger.java
@@ -6,6 +6,7 @@ import com.opensr5.ini.field.IniField;
 import com.opensr5.ini.field.ScalarIniField;
 import com.rusefi.binaryprotocol.BinaryProtocol;
 import com.rusefi.config.FieldType;
+import com.rusefi.core.OutputChannelSnapshot;
 import com.rusefi.core.SensorCentral;
 import com.rusefi.ui.UIContext;
 
@@ -50,8 +51,10 @@ public class SensorLogger {
     }
 
     private final UIContext uiContext;
-    private final SensorCentral.ResponseListener responseListener = this::writeSensorLogLine;
     private BinarySensorLog<CustomBinaryLogEntry> sensorLog;
+    private SensorCentral.FullOutputLease fullOutputLease;
+    private SensorCentral.SnapshotListenerToken snapshotListenerToken;
+    private byte[] currentResponse;
 
     public SensorLogger(UIContext uiContext) {
         this.uiContext = uiContext;
@@ -68,24 +71,35 @@ public class SensorLogger {
         }
 
         sensorLog = new BinarySensorLog<>(sensor -> {
-            byte[] response = SensorCentral.getInstance().getResponse();
-            return response == null ? 0.0 : sensor.getValue(response);
+            return currentResponse == null ? 0.0 : sensor.getValue(currentResponse);
         }, outputChannels, System::currentTimeMillis, file.getAbsolutePath());
-        SensorCentral.getInstance().addListener(responseListener);
+        SensorCentral sensorCentral = SensorCentral.getInstance();
+        fullOutputLease = sensorCentral.acquireFullOutput();
+        snapshotListenerToken = sensorCentral.addSnapshotListener(this::writeSensorLogLine);
         return true;
     }
 
-    private synchronized void writeSensorLogLine() {
-        if (sensorLog != null) {
+    private synchronized void writeSensorLogLine(OutputChannelSnapshot snapshot) {
+        if (sensorLog != null && fullOutputLease != null && snapshot.isFull()
+                && snapshot.getGeneration() >= fullOutputLease.getGeneration()) {
+            currentResponse = snapshot.getResponse();
             sensorLog.writeSensorLogLine();
         }
     }
 
     public synchronized void stop() {
-        SensorCentral.getInstance().removeListener(responseListener);
+        if (snapshotListenerToken != null) {
+            snapshotListenerToken.remove();
+            snapshotListenerToken = null;
+        }
         if (sensorLog != null) {
             sensorLog.close();
             sensorLog = null;
+        }
+        currentResponse = null;
+        if (fullOutputLease != null) {
+            fullOutputLease.close();
+            fullOutputLease = null;
         }
     }
 

--- a/java_console/ui/src/main/java/com/rusefi/ui/GaugesGridElement.java
+++ b/java_console/ui/src/main/java/com/rusefi/ui/GaugesGridElement.java
@@ -24,6 +24,7 @@ public class GaugesGridElement {
     private final UIContext uiContext;
     private final Node config;
     private final String gaugeName;
+    private volatile boolean destroyed;
 
     private GaugesGridElement(UIContext uiContext, Node config, String gaugeName) {
         this.uiContext = uiContext;
@@ -47,6 +48,9 @@ public class GaugesGridElement {
     }
 
     private void rebuild() {
+        if (destroyed) {
+            return;
+        }
         // Clear existing components before rebuilding to prevent duplication on reconnect
         wrapper.removeAllChildrenAndListeners();
         if (config.getBoolProperty(IS_LIVE_GRAPH)) {
@@ -96,6 +100,7 @@ public class GaugesGridElement {
      * to prevent stale listeners from accumulating and keeping Radial gauge images alive.
      */
     public void destroy() {
+        destroyed = true;
         if (connectionStatusListener != null) {
             ConnectionStatusLogic.INSTANCE.removeListener(connectionStatusListener);
             connectionStatusListener = null;
@@ -107,8 +112,13 @@ public class GaugesGridElement {
 
     public static GaugesGridElement create(UIContext uiContext, final Node config, String gaugeName) {
         GaugesGridElement gaugesGridElement = new GaugesGridElement(uiContext, config, gaugeName);
-        gaugesGridElement.connectionStatusListener = isConnected ->
-            SwingUtilities.invokeLater(gaugesGridElement::rebuild);
+        gaugesGridElement.connectionStatusListener = isConnected -> {
+            if (SwingUtilities.isEventDispatchThread()) {
+                gaugesGridElement.rebuild();
+            } else {
+                SwingUtilities.invokeLater(gaugesGridElement::rebuild);
+            }
+        };
         ConnectionStatusLogic.INSTANCE.addAndFireListener(gaugesGridElement.connectionStatusListener);
         return gaugesGridElement;
     }

--- a/java_console/ui/src/main/java/com/rusefi/ui/GaugesGridElement.java
+++ b/java_console/ui/src/main/java/com/rusefi/ui/GaugesGridElement.java
@@ -36,8 +36,14 @@ public class GaugesGridElement {
 
         JMenuItem switchToGauge = getJMenuItem("Switch to Gauge Mode", false);
 
-        wrapper.add(new SensorLiveGraph(uiContext, config.getChild("top"), gaugeName, switchToGauge));
-        wrapper.add(new SensorLiveGraph(uiContext, config.getChild("bottom"), Sensor.RPMGauge.name(), switchToGauge));
+        addLiveGraph(new SensorLiveGraph(uiContext, config.getChild("top"), gaugeName, switchToGauge));
+        addLiveGraph(new SensorLiveGraph(uiContext, config.getChild("bottom"), Sensor.RPMGauge.name(), switchToGauge));
+    }
+
+    private void addLiveGraph(SensorLiveGraph graph) {
+        wrapper.addCleanupAction(graph::destroy);
+        wrapper.addActiveStateAction(graph::setActive);
+        wrapper.add(graph);
     }
 
     private void rebuild() {
@@ -78,6 +84,10 @@ public class GaugesGridElement {
 
     public JPanelWithListener getContent() {
         return wrapper;
+    }
+
+    public void setActive(boolean active) {
+        wrapper.setActive(active);
     }
 
     /**

--- a/java_console/ui/src/main/java/com/rusefi/ui/GaugesPanel.java
+++ b/java_console/ui/src/main/java/com/rusefi/ui/GaugesPanel.java
@@ -3,6 +3,9 @@ package com.rusefi.ui;
 import com.devexperts.logging.FileLogger;
 import com.devexperts.logging.Logging;
 import com.rusefi.core.Sensor;
+import com.rusefi.core.ISensorCentral;
+import com.rusefi.core.SensorCentral;
+import com.rusefi.core.WellKnownGauges;
 import com.rusefi.core.preferences.storage.Node;
 import com.rusefi.ui.util.UiUtils;
 import com.rusefi.ui.widgets.AnyCommand;
@@ -53,11 +56,17 @@ public class GaugesPanel {
     private final UIContext uiContext;
     /** Tracked so we can call destroy() before replacing on grid resize. */
     private final List<GaugesGridElement> gaugeElements = new ArrayList<>();
+    private final ISensorCentral.ListenerToken rpmDemandToken;
+    private RpmLabel rpmLabel;
+    private boolean active;
 
     public GaugesPanel(UIContext uiContext, final Node config) {
         this.uiContext = uiContext;
         gauges = new GaugesGrid(DEFAULT_ROWS, DEFAULT_COLUMNS);
         this.config = config;
+        rpmDemandToken = SensorCentral.getInstance().addListener(
+            WellKnownGauges.RPMGauge.getOutputChannelName(), value -> { });
+        rpmDemandToken.setActive(false);
 
         int rows = config.getIntProperty(GAUGES_ROWS, DEFAULT_ROWS);
         int columns = config.getIntProperty(GAUGES_COLUMNS, DEFAULT_COLUMNS);
@@ -113,7 +122,8 @@ public class GaugesPanel {
         JPanel leftUpperPanel = new JPanel(new FlowLayout(FlowLayout.LEFT, 5, 0));
         leftUpperPanel.add(createPauseButton());
         leftUpperPanel.add(createSaveImageButton());
-        leftUpperPanel.add(new RpmLabel(uiContext, 2).getContent());
+        rpmLabel = new RpmLabel(uiContext, 2);
+        leftUpperPanel.add(rpmLabel.getContent());
         AnyCommand command = AnyCommand.createField(uiContext, config, false, false);
         leftUpperPanel.add(command.getContent());
         return leftUpperPanel;
@@ -155,6 +165,7 @@ public class GaugesPanel {
             // sometimes grid is quite large so we shall be careful with default sensor index
             String defaultGaugeName = defaultLayout.get(Math.min(i, defaultLayout.size() - 1));
             GaugesGridElement element = GaugesGridElement.create(uiContext, config.getChild("element_" + i), defaultGaugeName);
+            element.setActive(active);
             gaugeElements.add(element);
             gauges.panel.add(element.getContent());
         }
@@ -173,6 +184,23 @@ public class GaugesPanel {
 
     public JComponent getContent() {
         return content;
+    }
+
+    public void setActive(boolean active) {
+        this.active = active;
+        rpmDemandToken.setActive(active);
+        for (GaugesGridElement element : gaugeElements) {
+            element.setActive(active);
+        }
+    }
+
+    public void destroy() {
+        for (GaugesGridElement element : gaugeElements) {
+            element.destroy();
+        }
+        gaugeElements.clear();
+        rpmDemandToken.remove();
+        rpmLabel.destroy();
     }
 
     public static class DetachedRepository {

--- a/java_console/ui/src/main/java/com/rusefi/ui/RpmLabel.java
+++ b/java_console/ui/src/main/java/com/rusefi/ui/RpmLabel.java
@@ -1,8 +1,5 @@
 package com.rusefi.ui;
 
-import com.rusefi.core.Sensor;
-import com.rusefi.core.SensorCentral;
-import com.rusefi.core.WellKnownGauges;
 import com.rusefi.io.ConnectionStatusLogic;
 
 import javax.swing.*;
@@ -20,6 +17,8 @@ public class RpmLabel {
 
     private final JLabel rpmValue = new JLabel();
     private final JLabel rpmCaption = new JLabel("RPM:");
+    private final RpmModel.RpmListener rpmListener;
+    private final ConnectionStatusLogic.Listener connectionStatusListener;
 
     public RpmLabel(UIContext uiContext) {
         this(uiContext, 1);
@@ -40,16 +39,15 @@ public class RpmLabel {
         }
         content.add(rpmValue, "grow, wrap");
 
-        RpmModel.getInstance().addListener(new RpmModel.RpmListener() {
-            public void onRpmChange(RpmModel rpm) {
-                if (ConnectionStatusLogic.INSTANCE.isConnected()) {
-                    updateRpmValue(rpm.getSmoothedValue());
-                    rpmValue.setForeground(Color.green);
-                }
+        rpmListener = rpm -> {
+            if (ConnectionStatusLogic.INSTANCE.isConnected()) {
+                updateRpmValue(rpm.getSmoothedValue());
+                rpmValue.setForeground(Color.green);
             }
-        });
+        };
+        RpmModel.getInstance().addListener(rpmListener);
 
-        ConnectionStatusLogic.INSTANCE.addAndFireListener(new ConnectionStatusLogic.Listener() {
+        connectionStatusListener = new ConnectionStatusLogic.Listener() {
             @Override
             public void onConnectionStatus(boolean isConnected) {
                 if (isConnected) {
@@ -60,7 +58,8 @@ public class RpmLabel {
                     rpmValue.setForeground(Color.red);
                 }
             }
-        });
+        };
+        ConnectionStatusLogic.INSTANCE.addAndFireListener(connectionStatusListener);
         setSize(size);
     }
 
@@ -82,6 +81,11 @@ public class RpmLabel {
         Font font = new Font(f.getName(), f.getStyle(), fontSize);
         setFont(font);
         return this;
+    }
+
+    public void destroy() {
+        RpmModel.getInstance().removeListener(rpmListener);
+        ConnectionStatusLogic.INSTANCE.removeListener(connectionStatusListener);
     }
 
     private void setFont(Font font) {

--- a/java_console/ui/src/main/java/com/rusefi/ui/RpmModel.java
+++ b/java_console/ui/src/main/java/com/rusefi/ui/RpmModel.java
@@ -1,11 +1,10 @@
 package com.rusefi.ui;
 
-import com.rusefi.core.Sensor;
 import com.rusefi.core.SensorCentral;
 import com.rusefi.core.WellKnownGauges;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
  * Model for RPM reading with a feature of smoothing the displayed value: new value is not displayed if updated
@@ -20,7 +19,7 @@ public class RpmModel {
     private static final double SMOOTHING_RATIO = 0.05;
     private int displayedValue;
     private int value;
-    private final List<RpmListener> listeners = new ArrayList<>();
+    private final List<RpmListener> listeners = new CopyOnWriteArrayList<>();
     private long timeAtLastUpdate;
 
     public static RpmModel getInstance() {
@@ -28,7 +27,8 @@ public class RpmModel {
     }
 
     private RpmModel() {
-        SensorCentral.getInstance().addListener(WellKnownGauges.RPMGauge.getOutputChannelName(), value -> setValue((int) value));
+        SensorCentral.getInstance().addPassiveListener(
+            WellKnownGauges.RPMGauge.getOutputChannelName(), value -> setValue((int) value));
     }
 
     public void setValue(int rpm) {
@@ -55,6 +55,10 @@ public class RpmModel {
 
     public void addListener(RpmListener listener) {
         listeners.add(listener);
+    }
+
+    public void removeListener(RpmListener listener) {
+        listeners.remove(listener);
     }
 
     interface RpmListener {

--- a/java_console/ui/src/main/java/com/rusefi/ui/SensorLiveGraph.java
+++ b/java_console/ui/src/main/java/com/rusefi/ui/SensorLiveGraph.java
@@ -2,16 +2,14 @@ package com.rusefi.ui;
 
 import com.opensr5.ini.GaugeModel;
 import com.opensr5.ini.IniFileModel;
-import com.opensr5.ini.field.IniField;
-import com.opensr5.ini.field.ScalarIniField;
 import com.rusefi.NamedThreadFactory;
 import com.rusefi.binaryprotocol.BinaryProtocol;
+import com.rusefi.core.ISensorCentral;
 import com.rusefi.core.Sensor;
 import com.rusefi.core.SensorCategory;
 import com.rusefi.core.SensorCentral;
 import com.rusefi.core.preferences.storage.Node;
 import com.rusefi.core.ui.AutoupdateUtil;
-import com.rusefi.sensor_logs.CustomBinaryLogEntry;
 import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
@@ -44,6 +42,10 @@ public class SensorLiveGraph extends JPanel {
     private boolean autoScale;
     private double customUpper;
     private double customLower;
+    private final Thread thread;
+    private volatile boolean active = true;
+    private volatile boolean running = true;
+    private ISensorCentral.ListenerToken demandToken;
 
     public SensorLiveGraph(UIContext uiContext, Node config, final String defaultGaugeName, JMenuItem extraItem) {
         this.uiContext = uiContext;
@@ -51,8 +53,6 @@ public class SensorLiveGraph extends JPanel {
         this.extraItem = extraItem;
         this.gaugeName = config.getProperty(SENSOR_TYPE, defaultGaugeName);
 
-        Thread thread = THREAD_FACTORY.newThread(createRunnable());
-        thread.start();
         period = ChangePeriod.lookup(config.getProperty(PERIOD));
         if (period == null) {
             period = ChangePeriod._200;
@@ -60,6 +60,9 @@ public class SensorLiveGraph extends JPanel {
         autoScale = config.getBoolProperty(USE_AUTO_SCALE);
         customUpper = config.getDoubleProperty(UPPER, Double.NaN);
         customLower = config.getDoubleProperty(LOWER, Double.NaN);
+        updateDemandToken();
+        thread = THREAD_FACTORY.newThread(createRunnable());
+        thread.start();
 
         MouseListener mouseListener = new MouseAdapter() {
             @Override
@@ -82,13 +85,15 @@ public class SensorLiveGraph extends JPanel {
         return new Runnable() {
             @Override
             public void run() {
-                while (true) {
+                while (running) {
                     try {
                         Thread.sleep(period.getMs());
                     } catch (InterruptedException e) {
-                        throw new IllegalStateException(e);
+                        if (!running) {
+                            return;
+                        }
                     }
-                    if (!GaugesPanel.IS_PAUSED)
+                    if (active && !GaugesPanel.IS_PAUSED)
                         grabNewValue();
                 }
             }
@@ -96,34 +101,19 @@ public class SensorLiveGraph extends JPanel {
     }
 
     private void grabNewValue() {
-        double value = Double.NaN;
-        String channelName = null;
+        String channelName = gaugeName;
         BinaryProtocol bp = uiContext.getLinkManager().getBinaryProtocol();
-        byte[] response = SensorCentral.getInstance().getResponse();
-        if (bp != null && response != null) {
+        if (bp != null) {
             IniFileModel iniFile = bp.getIniFileNullable();
             if (iniFile != null) {
-                try {
-                    GaugeModel gaugeModel = iniFile.getGauge(gaugeName);
-                    if (gaugeModel != null) {
-                        channelName = gaugeModel.getChannel();
-                        IniField field = iniFile.getOutputChannel(channelName);
-                        if (field instanceof ScalarIniField) {
-                            CustomBinaryLogEntry entry = new CustomBinaryLogEntry(channelName, field);
-                            value = entry.getValue(response) * entry.getScale();
-                        }
-                    }
-                } catch (Exception e) {
-                    // fall back to sensor central
+                GaugeModel gaugeModel = iniFile.getGauge(gaugeName);
+                if (gaugeModel != null) {
+                    channelName = gaugeModel.getChannel();
                 }
             }
         }
 
-        if (Double.isNaN(value) && channelName != null) {
-            value = SensorCentral.getInstance().getValue(channelName);
-        }
-
-        addValue(value);
+        addValue(SensorCentral.getInstance().getValue(channelName));
         SwingUtilities.invokeLater(new Runnable() {
             @Override
             public void run() {
@@ -283,6 +273,31 @@ public class SensorLiveGraph extends JPanel {
         this.gaugeName = gaugeName;
         values.clear();
         config.setProperty(SENSOR_TYPE, gaugeName);
+        updateDemandToken();
+    }
+
+    private void updateDemandToken() {
+        if (demandToken != null) {
+            demandToken.remove();
+        }
+        demandToken = SensorCentral.getInstance().addListener(gaugeName, value -> { });
+        demandToken.setActive(active);
+    }
+
+    public void setActive(boolean active) {
+        this.active = active;
+        if (demandToken != null) {
+            demandToken.setActive(active);
+        }
+    }
+
+    public void destroy() {
+        running = false;
+        thread.interrupt();
+        if (demandToken != null) {
+            demandToken.remove();
+            demandToken = null;
+        }
     }
 
     private synchronized void addValue(double value) {

--- a/java_console/ui/src/main/java/com/rusefi/ui/TuningPane.java
+++ b/java_console/ui/src/main/java/com/rusefi/ui/TuningPane.java
@@ -10,6 +10,7 @@ import com.opensr5.ini.IndicatorModel;
 import com.opensr5.ini.IniFileModel;
 import com.rusefi.binaryprotocol.BinaryProtocol;
 import com.rusefi.core.SensorCentral;
+import com.rusefi.core.SensorSubscription;
 import com.rusefi.maintenance.OfflineEditMigration;
 import com.rusefi.io.ConnectionStatusLogic;
 import com.rusefi.core.preferences.storage.Node;
@@ -28,7 +29,9 @@ import javax.swing.*;
 import javax.swing.Action;
 import java.awt.*;
 import java.util.List;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
@@ -60,6 +63,11 @@ public class TuningPane {
     /** Fired when the user opens Wiring/Pinout from a pin-enum field. Wired from ConsoleUI after construction. */
     private Consumer<String> navigateToPinout;
     private Runnable showTuningTab = () -> { };
+    private SensorCentral.ResponseListenerToken eventTriggerToken;
+    private IndicatorPanel frontPageIndicatorPanel;
+    private ConnectionStatusLogic.Listener connectionStatusListener;
+    private boolean active;
+    private boolean destroyed;
 
     public TuningPane(UIContext uiContext) {
         this(uiContext, null, null);
@@ -214,7 +222,8 @@ public class TuningPane {
                 }
             }
         };
-        SensorCentral.getInstance().addListener(eventTriggerListener);
+        eventTriggerToken = SensorCentral.getInstance().addListener(eventTriggerListener, new SensorSubscription());
+        eventTriggerToken.setActive(false);
 
         // When the ECU disconnects (e.g. after a firmware flash or board swap), drop stale
         // undo/redo state so the next connection starts fresh, but preserve sessionImage
@@ -222,7 +231,7 @@ public class TuningPane {
         // Without clearing sessionImage, the old board's image would be used as the diff
         // baseline in uploadChangesWithoutBurn — but that's fine because on reconnect
         // we re-seed from the ECU below.
-        ConnectionStatusLogic.INSTANCE.addListener(isConnected -> {
+        connectionStatusListener = isConnected -> {
             if (!isConnected) {
                 SwingUtilities.invokeLater(() -> {
                     toolbar.onDisconnect();
@@ -232,6 +241,7 @@ public class TuningPane {
                 });
             } else {
                 SwingUtilities.invokeLater(() -> {
+                    updateEventTriggerDemand();
                     triggerPrevValues.clear();
                     BinaryProtocol bp = uiContext.getBinaryProtocol();
                     if (bp == null || bp.getControllerConfiguration() == null) {
@@ -261,14 +271,15 @@ public class TuningPane {
                     uiContext.fireConfigImageChanged(sessionImage.get());
                 });
             }
-        });
+        };
+        ConnectionStatusLogic.INSTANCE.addListener(connectionStatusListener);
 
         JPanel northPanel = new JPanel();
         northPanel.setLayout(new BoxLayout(northPanel, BoxLayout.Y_AXIS));
         northPanel.add(toolbar.getPanel());
-        JPanel indicatorPanel = buildFrontendIndicatorPanel(uiContext);
-        if (indicatorPanel != null) {
-            northPanel.add(indicatorPanel);
+        frontPageIndicatorPanel = buildFrontendIndicatorPanel(uiContext);
+        if (frontPageIndicatorPanel != null) {
+            northPanel.add(frontPageIndicatorPanel.getPanel());
         }
         if (gaugeStrip != null) {
             northPanel.add(gaugeStrip.getContent());
@@ -282,7 +293,7 @@ public class TuningPane {
     }
 
 
-    private static JPanel buildFrontendIndicatorPanel(UIContext uiContext) {
+    private static IndicatorPanel buildFrontendIndicatorPanel(UIContext uiContext) {
         IniFileModel ini = uiContext.iniFileState.getIniFileModel();
         if (ini == null) {
             return null;
@@ -295,11 +306,55 @@ public class TuningPane {
         if (indicators.isEmpty()) {
             return null;
         }
-        return new IndicatorPanel(indicators, ini, 0).getPanel();
+        return new IndicatorPanel(indicators, ini, 0);
     }
 
     public JPanel getContent() {
         return content;
+    }
+
+    public void setActive(boolean active) {
+        if (destroyed) {
+            return;
+        }
+        this.active = active;
+        if (gaugeStrip != null) {
+            gaugeStrip.setActive(active);
+        }
+        right.setActive(active);
+        if (frontPageIndicatorPanel != null) {
+            frontPageIndicatorPanel.setActive(active);
+        }
+        updateEventTriggerDemand();
+    }
+
+    public void destroy() {
+        if (destroyed) {
+            return;
+        }
+        destroyed = true;
+        active = false;
+        if (gaugeStrip != null) {
+            gaugeStrip.destroy();
+        }
+        right.destroy();
+        if (frontPageIndicatorPanel != null) {
+            frontPageIndicatorPanel.destroy();
+        }
+        eventTriggerToken.remove();
+        ConnectionStatusLogic.INSTANCE.removeListener(connectionStatusListener);
+    }
+
+    private void updateEventTriggerDemand() {
+        Set<String> channels = new HashSet<>();
+        IniFileModel ini = uiContext.iniFileState.getIniFileModel();
+        if (ini != null) {
+            for (EventTriggerModel trigger : ini.getEventTriggers()) {
+                channels.addAll(ExpressionEvaluator.extractVariables(trigger.getExpression()));
+            }
+        }
+        eventTriggerToken.setSubscription(new SensorSubscription(channels.toArray(new String[0])));
+        eventTriggerToken.setActive(active && !channels.isEmpty());
     }
 
     public void setNavigateToPinout(Consumer<String> navigateToPinout) {

--- a/java_console/ui/src/main/java/com/rusefi/ui/widgets/DetachedSensor.java
+++ b/java_console/ui/src/main/java/com/rusefi/ui/widgets/DetachedSensor.java
@@ -54,6 +54,7 @@ public class DetachedSensor {
     private static final int _5_VOLTS_WITH_DECIMAL = 50;
 
     private final JPanel content = new JPanel(new BorderLayout());
+    private final JPanelWithListener gaugeWrapper = new JPanelWithListener(new BorderLayout());
     private final JFrame frame;
     private final JPanel mockControlPanel = new JPanel(new BorderLayout());
     private String gaugeName;
@@ -77,16 +78,20 @@ public class DetachedSensor {
                 uiContext.DetachedRepositoryINSTANCE.remove(DetachedSensor.this);
                 frame.dispose();
             }
+
+            @Override
+            public void windowClosed(WindowEvent e) {
+                gaugeWrapper.removeAllChildrenAndListeners();
+            }
         });
         create();
 //        showMockControl();
     }
 
     private void create() {
-        JPanelWithListener wrapper = new JPanelWithListener(new BorderLayout());
         SensorGauge.GaugeChangeListener listener = this::onChange;
-        SensorGauge.createGaugeBody(uiContext, gaugeName, wrapper, listener, null);
-        content.add(wrapper, BorderLayout.CENTER);
+        SensorGauge.createGaugeBody(uiContext, gaugeName, gaugeWrapper, listener, null);
+        content.add(gaugeWrapper, BorderLayout.CENTER);
         content.add(mockControlPanel, BorderLayout.SOUTH);
 
         frame.add(content);

--- a/java_console/ui/src/main/java/com/rusefi/ui/widgets/JPanelWithListener.java
+++ b/java_console/ui/src/main/java/com/rusefi/ui/widgets/JPanelWithListener.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.awt.*;
 import java.awt.event.MouseListener;
 import java.util.LinkedList;
+import java.util.function.Consumer;
 
 /**
  * Andrey Belomutskiy, (c) 2013-2020
@@ -13,6 +14,8 @@ import java.util.LinkedList;
 public class JPanelWithListener extends JPanel {
     private final List<MouseListener> listeners = new LinkedList<>();
     private final List<Runnable> cleanupActions = new LinkedList<>();
+    private final List<Consumer<Boolean>> activeStateActions = new LinkedList<>();
+    private boolean active = true;
 
     public JPanelWithListener(LayoutManager layoutManager) {
         super(layoutManager);
@@ -40,6 +43,29 @@ public class JPanelWithListener extends JPanel {
         cleanupActions.add(action);
     }
 
+    public void addActiveStateAction(Consumer<Boolean> action) {
+        boolean currentActive;
+        synchronized (this) {
+            activeStateActions.add(action);
+            currentActive = active;
+        }
+        action.accept(currentActive);
+    }
+
+    public void setActive(boolean active) {
+        List<Consumer<Boolean>> toRun;
+        synchronized (this) {
+            if (this.active == active) {
+                return;
+            }
+            this.active = active;
+            toRun = new LinkedList<>(activeStateActions);
+        }
+        for (Consumer<Boolean> action : toRun) {
+            action.accept(active);
+        }
+    }
+
     public void removeAllChildrenAndListeners() {
         removeAll();
         removeAllMouseListeners();
@@ -47,6 +73,7 @@ public class JPanelWithListener extends JPanel {
         synchronized (this) {
             toRun = new LinkedList<>(cleanupActions);
             cleanupActions.clear();
+            activeStateActions.clear();
         }
         for (Runnable action : toRun) {
             action.run();

--- a/java_console/ui/src/main/java/com/rusefi/ui/widgets/SensorGauge.java
+++ b/java_console/ui/src/main/java/com/rusefi/ui/widgets/SensorGauge.java
@@ -75,17 +75,21 @@ public class SensorGauge {
 
     static void createGauge(UIContext uiContext, String gaugeName, JPanelWithListener wrapper, GaugeChangeListener listener, JMenuItem extraMenuItem,
                             GaugeModel gaugeModel) {
-        final Radial gauge = createRadial(gaugeModel.getHighValue(), gaugeModel.getLowValue(), gaugeModel);
+        final Radial gauge = GraphicsEnvironment.isHeadless()
+            ? null
+            : createRadial(gaugeModel.getHighValue(), gaugeModel.getLowValue(), gaugeModel);
 
-        UiUtils.setToolTip(gauge, HINT_LINE_1, HINT_LINE_2);
-        UiUtils.setToolTip(wrapper, HINT_LINE_1, HINT_LINE_2);
+        if (gauge != null) {
+            UiUtils.setToolTip(gauge, HINT_LINE_1, HINT_LINE_2);
+            UiUtils.setToolTip(wrapper, HINT_LINE_1, HINT_LINE_2);
 
-        gauge.setBackgroundColor(BackgroundColor.LIGHT_GRAY);
+            gauge.setBackgroundColor(BackgroundColor.LIGHT_GRAY);
+        }
 
         String channelName = gaugeModel.getChannel();
         ISensorCentral.ListenerToken valueToken = SensorCentral.getInstance().addListener(channelName,
             value -> {
-                if (GaugesPanel.IS_PAUSED)
+                if (gauge == null || GaugesPanel.IS_PAUSED)
                     return;
                 gauge.setValue(value);
             }
@@ -100,11 +104,13 @@ public class SensorGauge {
         boolean dynamicUnits = gaugeModel.getUnitsValue().isExpression()
             && TsStringFunction.containsStringFunction(gaugeModel.getUnits());
         if (dynamicTitle || dynamicUnits) {
-            if (dynamicTitle) {
-                gauge.setTitle("");
-            }
-            if (dynamicUnits) {
-                gauge.setUnitString("");
+            if (gauge != null) {
+                if (dynamicTitle) {
+                    gauge.setTitle("");
+                }
+                if (dynamicUnits) {
+                    gauge.setUnitString("");
+                }
             }
             final String[] lastLabels = {null, null}; // [title, units]
             Set<String> labelsSensors = new HashSet<>();
@@ -115,8 +121,9 @@ public class SensorGauge {
                 labelsSensors.addAll(ExpressionEvaluator.extractVariables(gaugeModel.getUnits()));
             }
 
-            SensorCentral.ResponseListener responseListener = () ->
-                SwingUtilities.invokeLater(() -> {
+            SensorCentral.ResponseListener responseListener = gauge == null
+                ? () -> { }
+                : () -> SwingUtilities.invokeLater(() -> {
                     ISensorHolder.ResolvedGaugeLabels labels = SensorCentral.getInstance().getResolvedLabels(gaugeName);
                     if (labels != null) {
                         boolean changed = false;
@@ -141,20 +148,25 @@ public class SensorGauge {
             responseToken = null;
         }
 
-        gauge.setValue(SensorCentral.getInstance().getValue(channelName));
-        gauge.setLcdDecimals(2);
+        if (gauge != null) {
+            gauge.setValue(SensorCentral.getInstance().getValue(channelName));
+            gauge.setLcdDecimals(2);
+        }
 
-        MouseListener mouseListener = new MouseAdapter() {
-            @Override
-            public void mouseClicked(MouseEvent e) {
-                if (SwingUtilities.isRightMouseButton(e)) {
-                    showPopupMenu(uiContext, e, wrapper, listener, extraMenuItem);
-                } else if (e.getClickCount() == 2) {
-                    handleDoubleClick(uiContext, e, gauge, gaugeName);
+        MouseListener mouseListener = null;
+        if (gauge != null) {
+            mouseListener = new MouseAdapter() {
+                @Override
+                public void mouseClicked(MouseEvent e) {
+                    if (SwingUtilities.isRightMouseButton(e)) {
+                        showPopupMenu(uiContext, e, wrapper, listener, extraMenuItem);
+                    } else if (e.getClickCount() == 2) {
+                        handleDoubleClick(uiContext, e, gauge, gaugeName);
+                    }
                 }
-            }
-        };
-        gauge.addMouseListener(mouseListener);
+            };
+            gauge.addMouseListener(mouseListener);
+        }
         // Remove previous gauge's children and run its cleanup actions (removes its
         // SensorCentral listeners), then register cleanup for the new listeners above.
         wrapper.removeAllChildrenAndListeners();
@@ -164,8 +176,10 @@ public class SensorGauge {
             wrapper.addCleanupAction(responseToken::remove);
             wrapper.addActiveStateAction(responseToken::setActive);
         }
-        wrapper.addMouseListener(mouseListener);
-        wrapper.add(gauge, BorderLayout.CENTER);
+        if (mouseListener != null) {
+            wrapper.addMouseListener(mouseListener);
+        }
+        wrapper.add(gauge == null ? new JLabel(gaugeModel.getTitle()) : gauge, BorderLayout.CENTER);
         AutoupdateUtil.trueLayoutAndRepaint(wrapper.getParent());
     }
 

--- a/java_console/ui/src/main/java/com/rusefi/ui/widgets/SensorGauge.java
+++ b/java_console/ui/src/main/java/com/rusefi/ui/widgets/SensorGauge.java
@@ -4,6 +4,7 @@ import com.devexperts.logging.Logging;
 import com.opensr5.ini.ExpressionEvaluator;
 import com.opensr5.ini.GaugeModel;
 import com.opensr5.ini.IniFileModel;
+import com.opensr5.ini.TsStringFunction;
 import com.rusefi.binaryprotocol.BinaryProtocol;
 import com.rusefi.core.ISensorCentral;
 import com.rusefi.core.ISensorHolder;
@@ -93,20 +94,28 @@ public class SensorGauge {
         // For expression-based labels, show empty placeholder until resolved by the data cycle.
         // Cache last-applied values to avoid calling setTitle/setUnitString (and the
         // reInitialize() they trigger in SteelSeries) on every response frame unchanged.
-        final SensorCentral.ResponseListener responseListener;
-        if (gaugeModel.getTitleValue().isExpression() || gaugeModel.getUnitsValue().isExpression()) {
-            if (gaugeModel.getTitleValue().isExpression()) {
+        final SensorCentral.ResponseListenerToken responseToken;
+        boolean dynamicTitle = gaugeModel.getTitleValue().isExpression()
+            && TsStringFunction.containsStringFunction(gaugeModel.getTitle());
+        boolean dynamicUnits = gaugeModel.getUnitsValue().isExpression()
+            && TsStringFunction.containsStringFunction(gaugeModel.getUnits());
+        if (dynamicTitle || dynamicUnits) {
+            if (dynamicTitle) {
                 gauge.setTitle("");
             }
-            if (gaugeModel.getUnitsValue().isExpression()) {
+            if (dynamicUnits) {
                 gauge.setUnitString("");
             }
             final String[] lastLabels = {null, null}; // [title, units]
             Set<String> labelsSensors = new HashSet<>();
-            labelsSensors.addAll(ExpressionEvaluator.extractVariables(gaugeModel.getTitle()));
-            labelsSensors.addAll(ExpressionEvaluator.extractVariables(gaugeModel.getUnits()));
+            if (dynamicTitle) {
+                labelsSensors.addAll(ExpressionEvaluator.extractVariables(gaugeModel.getTitle()));
+            }
+            if (dynamicUnits) {
+                labelsSensors.addAll(ExpressionEvaluator.extractVariables(gaugeModel.getUnits()));
+            }
 
-            responseListener = () ->
+            SensorCentral.ResponseListener responseListener = () ->
                 SwingUtilities.invokeLater(() -> {
                     ISensorHolder.ResolvedGaugeLabels labels = SensorCentral.getInstance().getResolvedLabels(gaugeName);
                     if (labels != null) {
@@ -126,9 +135,10 @@ public class SensorGauge {
                         }
                     }
                 });
-            SensorCentral.getInstance().addListener(responseListener, new SensorSubscription(labelsSensors.toArray(new String[0])));
+            responseToken = SensorCentral.getInstance().addListener(
+                responseListener, new SensorSubscription(labelsSensors.toArray(new String[0])));
         } else {
-            responseListener = null;
+            responseToken = null;
         }
 
         gauge.setValue(SensorCentral.getInstance().getValue(channelName));
@@ -149,8 +159,10 @@ public class SensorGauge {
         // SensorCentral listeners), then register cleanup for the new listeners above.
         wrapper.removeAllChildrenAndListeners();
         wrapper.addCleanupAction(valueToken::remove);
-        if (responseListener != null) {
-            wrapper.addCleanupAction(() -> SensorCentral.getInstance().removeListener(responseListener));
+        wrapper.addActiveStateAction(valueToken::setActive);
+        if (responseToken != null) {
+            wrapper.addCleanupAction(responseToken::remove);
+            wrapper.addActiveStateAction(responseToken::setActive);
         }
         wrapper.addMouseListener(mouseListener);
         wrapper.add(gauge, BorderLayout.CENTER);
@@ -233,5 +245,3 @@ public class SensorGauge {
         return radial1;
     }
 }
-
-

--- a/java_console/ui/src/main/java/com/rusefi/ui/widgets/TextGauge.java
+++ b/java_console/ui/src/main/java/com/rusefi/ui/widgets/TextGauge.java
@@ -4,6 +4,7 @@ import com.devexperts.logging.Logging;
 import com.opensr5.ini.ExpressionEvaluator;
 import com.opensr5.ini.GaugeModel;
 import com.opensr5.ini.IniFileModel;
+import com.opensr5.ini.TsStringFunction;
 import com.rusefi.core.ISensorCentral;
 import com.rusefi.core.ISensorHolder;
 import com.rusefi.core.SensorCentral;
@@ -37,7 +38,9 @@ public class TextGauge {
     private final JLabel unitsLabel = new JLabel();
 
     private ISensorCentral.ListenerToken valueToken;
-    private SensorCentral.ResponseListener responseListener;
+    private SensorCentral.ResponseListenerToken responseToken;
+    private final ConnectionStatusLogic.Listener connectionStatusListener;
+    private boolean active;
 
     public TextGauge(UIContext uiContext, String channelName, Consumer<String> onChannelChange) {
         content.setBorder(BorderFactory.createCompoundBorder(
@@ -75,14 +78,15 @@ public class TextGauge {
 
         setChannel(uiContext, channelName);
 
-        ConnectionStatusLogic.INSTANCE.addAndFireListener(isConnected -> {
+        connectionStatusListener = isConnected -> {
             if (!isConnected) {
                 SwingUtilities.invokeLater(() -> {
                     valueLabel.setText(NO_CONNECTION);
                     valueLabel.setForeground(Color.RED);
                 });
             }
-        });
+        };
+        ConnectionStatusLogic.INSTANCE.addAndFireListener(connectionStatusListener);
     }
 
     private void setChannel(UIContext uiContext, String gaugeName) {
@@ -93,14 +97,18 @@ public class TextGauge {
 
         final String channel = (gaugeModel != null) ? gaugeModel.getChannel() : gaugeName;
 
-        // Handle expression-based labels the same way SensorGauge does
-        if (gaugeModel != null && (gaugeModel.getTitleValue().isExpression() || gaugeModel.getUnitsValue().isExpression())) {
-            if (gaugeModel.getTitleValue().isExpression()) {
+        // Handle dynamic string labels the same way SensorGauge does.
+        boolean dynamicTitle = gaugeModel != null && gaugeModel.getTitleValue().isExpression()
+            && TsStringFunction.containsStringFunction(gaugeModel.getTitle());
+        boolean dynamicUnits = gaugeModel != null && gaugeModel.getUnitsValue().isExpression()
+            && TsStringFunction.containsStringFunction(gaugeModel.getUnits());
+        if (dynamicTitle || dynamicUnits) {
+            if (dynamicTitle) {
                 titleLabel.setText("");
             } else {
                 titleLabel.setText(gaugeModel.getTitle());
             }
-            if (gaugeModel.getUnitsValue().isExpression()) {
+            if (dynamicUnits) {
                 unitsLabel.setText("");
             } else {
                 unitsLabel.setText(gaugeModel.getUnits());
@@ -108,10 +116,14 @@ public class TextGauge {
 
             final String[] lastLabels = {null, null};
             Set<String> labelsSensors = new HashSet<>();
-            labelsSensors.addAll(ExpressionEvaluator.extractVariables(gaugeModel.getTitle()));
-            labelsSensors.addAll(ExpressionEvaluator.extractVariables(gaugeModel.getUnits()));
+            if (dynamicTitle) {
+                labelsSensors.addAll(ExpressionEvaluator.extractVariables(gaugeModel.getTitle()));
+            }
+            if (dynamicUnits) {
+                labelsSensors.addAll(ExpressionEvaluator.extractVariables(gaugeModel.getUnits()));
+            }
 
-            responseListener = () ->
+            SensorCentral.ResponseListener responseListener = () ->
                 SwingUtilities.invokeLater(() -> {
                     ISensorHolder.ResolvedGaugeLabels labels = SensorCentral.getInstance().getResolvedLabels(gaugeName);
                     if (labels != null) {
@@ -131,13 +143,14 @@ public class TextGauge {
                         }
                     }
                 });
-            SensorCentral.getInstance().addListener(responseListener, new SensorSubscription(labelsSensors.toArray(new String[0])));
+            responseToken = SensorCentral.getInstance().addListener(
+                responseListener, new SensorSubscription(labelsSensors.toArray(new String[0])));
         } else {
             final String title = (gaugeModel != null) ? gaugeModel.getTitle() : gaugeName;
             final String units = (gaugeModel != null) ? gaugeModel.getUnits() : "";
             titleLabel.setText(title);
             unitsLabel.setText(units);
-            responseListener = null;
+            responseToken = null;
         }
 
         valueToken = SensorCentral.getInstance().addListener(channel, value ->
@@ -148,6 +161,7 @@ public class TextGauge {
                 }
             })
         );
+        setActive(active);
 
         Double currentValue = SensorCentral.getInstance().getValue(channel);
         if (currentValue != null && ConnectionStatusLogic.INSTANCE.isConnected()) {
@@ -191,14 +205,25 @@ public class TextGauge {
             valueToken.remove();
             valueToken = null;
         }
-        if (responseListener != null) {
-            SensorCentral.getInstance().removeListener(responseListener);
-            responseListener = null;
+        if (responseToken != null) {
+            responseToken.remove();
+            responseToken = null;
+        }
+    }
+
+    public void setActive(boolean active) {
+        this.active = active;
+        if (valueToken != null) {
+            valueToken.setActive(active);
+        }
+        if (responseToken != null) {
+            responseToken.setActive(active);
         }
     }
 
     public void destroy() {
         cleanup();
+        ConnectionStatusLogic.INSTANCE.removeListener(connectionStatusListener);
     }
 
     public JPanel getContent() {

--- a/java_console/ui/src/main/java/com/rusefi/ui/widgets/TextGaugeStrip.java
+++ b/java_console/ui/src/main/java/com/rusefi/ui/widgets/TextGaugeStrip.java
@@ -67,6 +67,12 @@ public class TextGaugeStrip {
         return content;
     }
 
+    public void setActive(boolean active) {
+        for (TextGauge gauge : gauges) {
+            gauge.setActive(active);
+        }
+    }
+
     public void destroy() {
         for (TextGauge gauge : gauges) {
             gauge.destroy();

--- a/java_console/ui/src/main/java/com/rusefi/ui/widgets/tune/CalibrationDialogWidget.java
+++ b/java_console/ui/src/main/java/com/rusefi/ui/widgets/tune/CalibrationDialogWidget.java
@@ -62,6 +62,9 @@ public class CalibrationDialogWidget {
     private final List<IndicatorPanel> indicatorPanels = new ArrayList<>();
     private final List<ReadoutLabelEntry> readoutEntries = new ArrayList<>();
     private final List<GaugeReadoutEntry> gaugeReadoutEntries = new ArrayList<>();
+    private final SensorCentral.ResponseListenerToken readoutListenerToken;
+    private boolean active;
+    private boolean hasReadoutDemand;
     private static final int READOUT_GAUGE_SIZE = 150;
     /** Called after each user edit with the current working image, so listeners can re-evaluate their own expressions. */
     private Consumer<ConfigurationImage> onConfigChange;
@@ -133,29 +136,12 @@ public class CalibrationDialogWidget {
         contentPane.setAlignmentX(Component.LEFT_ALIGNMENT);
         // Refresh readouts whenever the ECU sends new output-channel data.
         // Indicator panels register their own SensorCentral listeners independently.
-        SensorCentral.getInstance().addListener(() -> {
+        readoutListenerToken = SensorCentral.getInstance().addListener(() -> {
             if (!readoutEntries.isEmpty() || !gaugeReadoutEntries.isEmpty()) {
                 SwingUtilities.invokeLater(this::refreshReadouts);
             }
-        }, new SensorSubscription() {
-            @Override
-            public boolean isInterestedInAny(Set<String> updatedSensors) {
-                if (readoutEntries.isEmpty() && gaugeReadoutEntries.isEmpty()) {
-                    return false;
-                }
-                for (ReadoutLabelEntry entry : readoutEntries) {
-                    if (updatedSensors.contains(entry.channel.toLowerCase())) return true;
-                }
-                for (GaugeReadoutEntry entry : gaugeReadoutEntries) {
-                    if (updatedSensors.contains(entry.channel.toLowerCase())) return true;
-                    // Also interested if ANY sensor updated if we have expression labels,
-                    // because we don't know which sensors are in the expression without parsing it again.
-                    // But we could parse it once. For now, let's be safe.
-                    if (entry.hasExpressionLabels) return true;
-                }
-                return false;
-            }
-        });
+        }, new SensorSubscription());
+        readoutListenerToken.setActive(false);
     }
 
     private static void applyLayout(JPanel panel, String layoutHint) {
@@ -178,6 +164,7 @@ public class CalibrationDialogWidget {
      */
     public void reset() {
         workingImage = null;
+        clearLiveComponents();
         contentPane.removeAll();
         contentPane.revalidate();
         contentPane.repaint();
@@ -189,10 +176,8 @@ public class CalibrationDialogWidget {
         currentViewRestorer = () -> update(capturedDm, capturedIni, workingImage);
         workingImage = ci != null ? ci.clone() : null;
         currentIniFileModel = iniFileModel;
+        clearLiveComponents();
         expressionRows.clear();
-        indicatorPanels.clear();
-        readoutEntries.clear();
-        gaugeReadoutEntries.clear();
         triggerImageUpdaters.clear();
         contentPane.removeAll();
         if (dialogModel != null) {
@@ -211,6 +196,7 @@ public class CalibrationDialogWidget {
                 addTriggerImage(contentPane, dialogModel.getKey(), uiName);
             }
         }
+        updateLiveDemand();
         contentPane.revalidate();
         contentPane.repaint();
         // After the initial layout gives children their actual widths,
@@ -235,6 +221,7 @@ public class CalibrationDialogWidget {
         final String capturedKey = key;
         final IniFileModel capturedIniForRestore = iniFileModel;
         currentViewRestorer = () -> update(capturedKey, capturedIniForRestore, workingImage);
+        clearLiveComponents();
         contentPane.removeAll();
         if (key != null) {
             DialogModel dialog = iniFileModel.getDialogs().get(key);
@@ -272,6 +259,7 @@ public class CalibrationDialogWidget {
                 }
             }
         }
+        updateLiveDemand();
         contentPane.revalidate();
         contentPane.repaint();
     }
@@ -401,6 +389,7 @@ public class CalibrationDialogWidget {
     private void renderIndicatorGroup(JPanel container, List<IndicatorModel> indicators, IniFileModel iniFileModel, ConfigurationImage ci, int cols) {
         IndicatorPanel ip = new IndicatorPanel(indicators, iniFileModel, Math.max(1, cols));
         ip.refresh(workingImage != null ? workingImage : ci);
+        ip.setActive(active);
         indicatorPanels.add(ip);
         container.add(ip.getPanel());
     }
@@ -415,6 +404,55 @@ public class CalibrationDialogWidget {
             }
         }
         container.add(gaugePanel);
+    }
+
+    private void clearLiveComponents() {
+        for (IndicatorPanel indicatorPanel : indicatorPanels) {
+            indicatorPanel.destroy();
+        }
+        indicatorPanels.clear();
+        readoutEntries.clear();
+        gaugeReadoutEntries.clear();
+        hasReadoutDemand = false;
+        readoutListenerToken.setActive(false);
+    }
+
+    private void updateLiveDemand() {
+        Set<String> channels = new LinkedHashSet<>();
+        for (ReadoutLabelEntry entry : readoutEntries) {
+            channels.add(entry.channel);
+        }
+        for (GaugeReadoutEntry entry : gaugeReadoutEntries) {
+            channels.add(entry.channel);
+            if (entry.hasExpressionLabels && currentIniFileModel != null) {
+                GaugeModel gauge = currentIniFileModel.getGauge(entry.gaugeName);
+                if (gauge != null) {
+                    if (gauge.getTitleValue().isExpression()) {
+                        channels.addAll(ExpressionEvaluator.extractVariables(gauge.getTitle()));
+                    }
+                    if (gauge.getUnitsValue().isExpression()) {
+                        channels.addAll(ExpressionEvaluator.extractVariables(gauge.getUnits()));
+                    }
+                }
+            }
+        }
+        hasReadoutDemand = !channels.isEmpty();
+        readoutListenerToken.setSubscription(new SensorSubscription(channels.toArray(new String[0])));
+        readoutListenerToken.setActive(active && hasReadoutDemand);
+    }
+
+    public void setActive(boolean active) {
+        this.active = active;
+        readoutListenerToken.setActive(active && hasReadoutDemand);
+        for (IndicatorPanel indicatorPanel : indicatorPanels) {
+            indicatorPanel.setActive(active);
+        }
+    }
+
+    public void destroy() {
+        active = false;
+        clearLiveComponents();
+        readoutListenerToken.remove();
     }
 
     private static String toBorderConstraint(String placement) {

--- a/java_console/ui/src/main/java/com/rusefi/ui/widgets/tune/IndicatorPanel.java
+++ b/java_console/ui/src/main/java/com/rusefi/ui/widgets/tune/IndicatorPanel.java
@@ -29,6 +29,8 @@ public class IndicatorPanel {
     private final JPanel panel;
     private final List<IndicatorModel> indicators;
     private final IniFileModel ini;
+    private final SensorCentral.ResponseListenerToken listenerToken;
+    private final boolean hasDemand;
     private ConfigurationImage currentImage;
 
     /**
@@ -58,18 +60,28 @@ public class IndicatorPanel {
         Set<String> allSensors = new HashSet<>();
         for (IndicatorModel model : this.indicators) {
             allSensors.addAll(ExpressionEvaluator.extractVariables(model.getExpression()));
-            allSensors.addAll(ExpressionEvaluator.extractVariables(model.getOnLabel()));
-            allSensors.addAll(ExpressionEvaluator.extractVariables(model.getOffLabel()));
+            addLabelVariables(allSensors, model.getOnLabel());
+            addLabelVariables(allSensors, model.getOffLabel());
         }
+        hasDemand = !allSensors.isEmpty();
 
-        SensorCentral.getInstance().addListener(() -> {
+        listenerToken = SensorCentral.getInstance().addListener(() -> {
             final ConfigurationImage snap = currentImage;
             SwingUtilities.invokeLater(() -> applyAll(snap));
         }, new SensorSubscription(allSensors.toArray(new String[0])));
+        listenerToken.setActive(false);
     }
 
     public JPanel getPanel() {
         return panel;
+    }
+
+    public void setActive(boolean active) {
+        listenerToken.setActive(active && hasDemand);
+    }
+
+    public void destroy() {
+        listenerToken.remove();
     }
 
     /**
@@ -130,8 +142,8 @@ public class IndicatorPanel {
     static void applyState(JLabel label, IndicatorModel indicator, IniFileModel ini, ConfigurationImage ci) {
         Set<String> vars = new HashSet<>();
         vars.addAll(ExpressionEvaluator.extractVariables(indicator.getExpression()));
-        vars.addAll(ExpressionEvaluator.extractVariables(indicator.getOnLabel()));
-        vars.addAll(ExpressionEvaluator.extractVariables(indicator.getOffLabel()));
+        addLabelVariables(vars, indicator.getOnLabel());
+        addLabelVariables(vars, indicator.getOffLabel());
         Map<String, Double> context = new HashMap<>();
         for (String var : vars) {
             Optional<IniField> field = ini.findIniField(var);
@@ -159,6 +171,12 @@ public class IndicatorPanel {
         label.setToolTipText(text);
         label.setBackground(bg);
         label.setForeground(fg);
+    }
+
+    private static void addLabelVariables(Set<String> variables, String label) {
+        if (TsStringFunction.containsStringFunction(label)) {
+            variables.addAll(ExpressionEvaluator.extractVariables(label));
+        }
     }
 
     static String resolveLabel(String raw, IniFileModel ini, Map<String, Double> context) {

--- a/java_console/ui/src/test/java/com/rusefi/sensor_logs/SensorLoggerTest.java
+++ b/java_console/ui/src/test/java/com/rusefi/sensor_logs/SensorLoggerTest.java
@@ -6,6 +6,7 @@ import com.opensr5.ini.field.IniField;
 import com.opensr5.ini.field.ScalarIniField;
 import com.rusefi.binaryprotocol.BinaryProtocol;
 import com.rusefi.config.FieldType;
+import com.rusefi.core.OutputChannelSnapshot;
 import com.rusefi.core.SensorCentral;
 import com.rusefi.ui.UIContext;
 import org.junit.jupiter.api.Test;
@@ -16,6 +17,7 @@ import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.BitSet;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -62,11 +64,24 @@ class SensorLoggerTest {
             assertTrue(logger.start(file.toFile()));
             assertTrue(logger.isLogging());
             assertTrue(logger.start(file.toFile()));
-            SensorCentral.getInstance().grabSensorValues(new byte[]{0, 42, 0, 7, 2, -46, 4}, ini, null);
+            SensorCentral sensorCentral = SensorCentral.getInstance();
+            long generation = sensorCentral.getOutputChannelDemand().getGeneration();
+            assertTrue(sensorCentral.getOutputChannelDemand().isFull());
+
+            byte[] response = {0, 42, 0, 7, 2, -46, 4};
+            BitSet valid = new BitSet(response.length - 1);
+            valid.set(0, response.length - 1);
+            sensorCentral.grabSensorValues(new OutputChannelSnapshot(
+                response, valid, Collections.emptySet(), generation - 1, true), ini, null);
+            sensorCentral.grabSensorValues(new OutputChannelSnapshot(
+                response, valid, Collections.singleton("rpm"), generation, false), ini, null);
+            sensorCentral.grabSensorValues(new OutputChannelSnapshot(
+                response, valid, Collections.emptySet(), generation, true), ini, null);
         } finally {
             logger.stop();
         }
         assertFalse(logger.isLogging());
+        assertFalse(SensorCentral.getInstance().getOutputChannelDemand().isFull());
         assertTrue(Files.exists(file));
 
         ByteBuffer data = ByteBuffer.wrap(Files.readAllBytes(file)).order(ByteOrder.BIG_ENDIAN);
@@ -78,6 +93,9 @@ class SensorLoggerTest {
         assertEquals(1, data.get());
         assertEquals(1234, data.getShort());
         assertEquals(1234, data.getShort());
+        assertEquals(1, data.remaining(), "One checksum byte should follow the only log row");
+        data.get();
+        assertFalse(data.hasRemaining(), "Only the generation-matched full snapshot should be logged");
     }
 
     private static String readFieldName(ByteBuffer data, int index) {

--- a/java_console/ui/src/test/java/com/rusefi/ui/GaugesPanelOutputDemandTest.java
+++ b/java_console/ui/src/test/java/com/rusefi/ui/GaugesPanelOutputDemandTest.java
@@ -1,0 +1,67 @@
+package com.rusefi.ui;
+
+import com.opensr5.ini.GaugeModel;
+import com.opensr5.ini.IniFileModelMocks;
+import com.opensr5.ini.IniValue;
+import com.rusefi.core.SensorCentral;
+import com.rusefi.core.WellKnownGauges;
+import com.rusefi.core.preferences.storage.Node;
+import org.junit.jupiter.api.Test;
+
+import javax.swing.SwingUtilities;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class GaugesPanelOutputDemandTest {
+    private static final String CHANNEL = "issue10170GaugeChannel";
+
+    @Test
+    void onlyActivePanelDemandsItsGaugeChannels() throws Exception {
+        IniFileModelMocks.GaugeRegistry gauges = IniFileModelMocks.mutableWithGauges();
+        gauges.register(new GaugeModel(
+            "RPMGauge", CHANNEL,
+            IniValue.ofExpression("RPM - engine speed"),
+            IniValue.ofExpression("{ bitStringValue(labels, useMetricOnInterface) }"),
+            IniValue.ofNumeric(0), IniValue.ofNumeric(8000),
+            IniValue.ofNumeric(0), IniValue.ofNumeric(1000),
+            IniValue.ofNumeric(7000), IniValue.ofNumeric(8000),
+            IniValue.ofNumeric(0), IniValue.ofNumeric(0)));
+
+        UIContext context = new UIContext();
+        context.iniFileState.setIniFileModelForTest(gauges.model);
+        Node config = new Node();
+        config.setProperty("gauges_rows", 1);
+        config.setProperty("gauges_cols", 1);
+
+        GaugesPanel[] holder = new GaugesPanel[1];
+        SwingUtilities.invokeAndWait(() -> holder[0] = new GaugesPanel(context, config));
+        SwingUtilities.invokeAndWait(() -> { });
+        GaugesPanel panel = holder[0];
+
+        assertFalse(hasChannelDemand());
+        assertFalse(hasDemand(WellKnownGauges.RPMGauge.getOutputChannelName()));
+        SwingUtilities.invokeAndWait(() -> panel.setActive(true));
+        assertTrue(hasChannelDemand());
+        assertTrue(hasDemand(WellKnownGauges.RPMGauge.getOutputChannelName()));
+        assertTrue(hasDemand("useMetricOnInterface"));
+        assertFalse(hasDemand("engine"));
+        assertFalse(hasDemand("rpm"));
+        assertFalse(hasDemand("speed"));
+        SwingUtilities.invokeAndWait(() -> panel.setActive(false));
+        assertFalse(hasChannelDemand());
+        assertFalse(hasDemand(WellKnownGauges.RPMGauge.getOutputChannelName()));
+
+        SwingUtilities.invokeAndWait(panel::destroy);
+        assertFalse(hasChannelDemand());
+    }
+
+    private static boolean hasChannelDemand() {
+        return hasDemand(CHANNEL);
+    }
+
+    private static boolean hasDemand(String channel) {
+        return SensorCentral.getInstance().getOutputChannelDemand().getChannels()
+            .contains(channel.toLowerCase());
+    }
+}

--- a/java_console/ui/src/test/java/com/rusefi/ui/GaugesPanelOutputDemandTest.java
+++ b/java_console/ui/src/test/java/com/rusefi/ui/GaugesPanelOutputDemandTest.java
@@ -39,20 +39,22 @@ class GaugesPanelOutputDemandTest {
         SwingUtilities.invokeAndWait(() -> { });
         GaugesPanel panel = holder[0];
 
-        assertFalse(hasChannelDemand());
-        assertFalse(hasDemand(WellKnownGauges.RPMGauge.getOutputChannelName()));
-        SwingUtilities.invokeAndWait(() -> panel.setActive(true));
-        assertTrue(hasChannelDemand());
-        assertTrue(hasDemand(WellKnownGauges.RPMGauge.getOutputChannelName()));
-        assertTrue(hasDemand("useMetricOnInterface"));
-        assertFalse(hasDemand("engine"));
-        assertFalse(hasDemand("rpm"));
-        assertFalse(hasDemand("speed"));
-        SwingUtilities.invokeAndWait(() -> panel.setActive(false));
-        assertFalse(hasChannelDemand());
-        assertFalse(hasDemand(WellKnownGauges.RPMGauge.getOutputChannelName()));
-
-        SwingUtilities.invokeAndWait(panel::destroy);
+        try {
+            assertFalse(hasChannelDemand());
+            assertFalse(hasDemand(WellKnownGauges.RPMGauge.getOutputChannelName()));
+            SwingUtilities.invokeAndWait(() -> panel.setActive(true));
+            assertTrue(hasChannelDemand());
+            assertTrue(hasDemand(WellKnownGauges.RPMGauge.getOutputChannelName()));
+            assertTrue(hasDemand("useMetricOnInterface"));
+            assertFalse(hasDemand("engine"));
+            assertFalse(hasDemand("rpm"));
+            assertFalse(hasDemand("speed"));
+            SwingUtilities.invokeAndWait(() -> panel.setActive(false));
+            assertFalse(hasChannelDemand());
+            assertFalse(hasDemand(WellKnownGauges.RPMGauge.getOutputChannelName()));
+        } finally {
+            SwingUtilities.invokeAndWait(panel::destroy);
+        }
         assertFalse(hasChannelDemand());
     }
 

--- a/java_console/ui/src/test/java/com/rusefi/ui/widgets/tune/CalibrationDialogWidgetTest.java
+++ b/java_console/ui/src/test/java/com/rusefi/ui/widgets/tune/CalibrationDialogWidgetTest.java
@@ -5,10 +5,12 @@ import com.opensr5.ini.DialogModel;
 import com.opensr5.ini.IndicatorModel;
 import com.opensr5.ini.IniFileModel;
 import com.opensr5.ini.PanelModel;
+import com.opensr5.ini.ReadoutModel;
 import com.opensr5.ini.TableModel;
 import com.opensr5.ini.field.ArrayIniField;
 import com.opensr5.ini.field.EnumIniField;
 import com.rusefi.config.FieldType;
+import com.rusefi.core.SensorCentral;
 import com.rusefi.ui.UIContext;
 import com.rusefi.ui.laf.GradientTitleBorder;
 import org.junit.jupiter.api.Test;
@@ -26,6 +28,35 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 public class CalibrationDialogWidgetTest {
+
+    @Test
+    public void activeReadoutControlsOutputDemand() {
+        String channel = "issue10170TuningReadout";
+        IniFileModel ini = mock(IniFileModel.class);
+        DialogModel dialog = new DialogModel(
+            "readouts", "Readouts",
+            Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), Collections.emptyList(),
+            Collections.singletonList(ReadoutModel.ofRef(channel)), 1, Collections.emptyList(), null, null);
+        CalibrationDialogWidget widget = new CalibrationDialogWidget(new UIContext());
+
+        try {
+            widget.update(dialog, ini, null);
+            assertFalse(hasDemand(channel));
+            widget.setActive(true);
+            assertTrue(hasDemand(channel));
+            widget.setActive(false);
+            assertFalse(hasDemand(channel));
+        } finally {
+            widget.destroy();
+        }
+        widget.setActive(true);
+        assertFalse(hasDemand(channel));
+    }
+
+    private static boolean hasDemand(String channel) {
+        return SensorCentral.getInstance().getOutputChannelDemand().getChannels()
+            .contains(channel.toLowerCase());
+    }
 
     @Test
     public void testLayout() {

--- a/java_console/ui/src/test/java/com/rusefi/ui/widgets/tune/IndicatorPanelOutputDemandTest.java
+++ b/java_console/ui/src/test/java/com/rusefi/ui/widgets/tune/IndicatorPanelOutputDemandTest.java
@@ -1,0 +1,43 @@
+package com.rusefi.ui.widgets.tune;
+
+import com.opensr5.ini.IndicatorModel;
+import com.opensr5.ini.IniFileModel;
+import com.rusefi.core.SensorCentral;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+class IndicatorPanelOutputDemandTest {
+    private static final String CHANNEL = "issue10170FrontIndicator";
+
+    @Test
+    void onlyActiveIndicatorDemandsExpressionChannels() {
+        IndicatorModel indicator = new IndicatorModel(
+            "{ " + CHANNEL + " > 0 }", "Off", "On", "black", "white", "green", "white");
+        IndicatorPanel panel = new IndicatorPanel(
+            Collections.singletonList(indicator), mock(IniFileModel.class), 0);
+
+        try {
+            assertFalse(hasDemand());
+            panel.setActive(true);
+            assertTrue(hasDemand());
+            assertFalse(SensorCentral.getInstance().getOutputChannelDemand().getChannels().contains("off"));
+            assertFalse(SensorCentral.getInstance().getOutputChannelDemand().getChannels().contains("on"));
+            panel.setActive(false);
+            assertFalse(hasDemand());
+        } finally {
+            panel.destroy();
+        }
+        panel.setActive(true);
+        assertFalse(hasDemand());
+    }
+
+    private static boolean hasDemand() {
+        return SensorCentral.getInstance().getOutputChannelDemand().getChannels()
+            .contains(CHANNEL.toLowerCase());
+    }
+}


### PR DESCRIPTION
-  polling interval: 100 ms → 50 ms.
- Full-output polling remains at 100 ms. (ie the binary logging #9940 ) 
- Text polling remains capped at 100 ms, measured around 8 Hz.

test over CAN:
before:
<img width="415" height="357" alt="image" src="https://github.com/user-attachments/assets/f7579a84-22f5-4a27-9c07-adbb9a249b0a" />

now:
<img width="480" height="476" alt="image" src="https://github.com/user-attachments/assets/981e710b-6a2d-4ece-b9cb-ebb2964e5a72" />


sorry on advance for the PR on Mamut size
resolves #10170