### PR TITLE
SocketCAN: Add retries for ENOBUFS, improve handoff logic, add OpenBLT support

### DIFF
--- a/java_console/connectivity/src/main/java/com/rusefi/SerialPortScanner.java
+++ b/java_console/connectivity/src/main/java/com/rusefi/SerialPortScanner.java
@@ -209,14 +209,14 @@ public class SerialPortScanner implements PortScanner {
     // last-known results are reused between probes so the ProgramSelector menu stays stable.
     // [tag:better_ux_for_flashing]
     private static final long DEVICE_PROBE_INTERVAL_MS = 3000;
-    // Accessed only from the single "Ports Scanner" thread.
-    private long lastDeviceProbeMs = 0;
+    // SocketCAN invalidation is also requested by the firmware-update thread while scanning is suspended.
+    private volatile long lastDeviceProbeMs = 0;
     private boolean lastDfuConnected = false;
     private boolean lastStLinkConnected = false;
     private boolean lastPcanConnected = false;
     private boolean lastSocketCanAvailable = false;
     @Nullable
-    private PortResult lastSocketCanPort;
+    private volatile PortResult lastSocketCanPort;
 
     /**
      * Find all available serial ports and checks if simulator local TCP port is available.
@@ -425,5 +425,20 @@ public class SerialPortScanner implements PortScanner {
     @Override
     public void invalidatePort(String portName) {
         portCache.invalidate(portName);
+        if (LinkManager.SOCKET_CAN.equals(portName)) {
+            lastSocketCanPort = null;
+            lastDeviceProbeMs = probes.now() - DEVICE_PROBE_INTERVAL_MS;
+            synchronized (lock) {
+                final List<PortResult> ports = knownHardware.getKnownPorts().stream()
+                    .filter(port -> !LinkManager.SOCKET_CAN.equals(port.port))
+                    .collect(Collectors.toList());
+                knownHardware = new AvailableHardware(
+                    ports,
+                    knownHardware.isDfuFound(),
+                    knownHardware.isStLinkConnected(),
+                    knownHardware.isPCANConnected(),
+                    knownHardware.isSocketCanAvailable());
+            }
+        }
     }
 }

--- a/java_console/connectivity/src/test/java/com/rusefi/SerialPortScannerTest.java
+++ b/java_console/connectivity/src/test/java/com/rusefi/SerialPortScannerTest.java
@@ -283,6 +283,19 @@ public class SerialPortScannerTest {
     }
 
     @Test
+    public void invalidatingSocketCanDropsStaleEcuAndForcesAProbe() {
+        probes.socketCanResult = new PortResult(LinkManager.SOCKET_CAN, SerialPortType.Ecu);
+        scan(true);
+
+        scanner.invalidatePort(LinkManager.SOCKET_CAN);
+
+        assertTrue(knownPorts().isEmpty());
+        scan(true);
+        assertEquals(2, probes.socketCanInspectionCalls,
+            "SocketCAN must be reprobed immediately after a firmware handoff");
+    }
+
+    @Test
     public void unavailableSocketCanIsNotReported() {
         scan(true);
 

--- a/java_console/io/src/main/java/com/rusefi/io/BootloaderCommsHelper.java
+++ b/java_console/io/src/main/java/com/rusefi/io/BootloaderCommsHelper.java
@@ -5,13 +5,15 @@ import com.rusefi.binaryprotocol.BinaryProtocol;
 import java.io.IOException;
 
 public class BootloaderCommsHelper {
-    static void sendBootloaderRebootCommand(IoStream stream, UpdateOperationCallbacks callbacks, String cmd) {
+    static boolean sendBootloaderRebootCommand(IoStream stream, UpdateOperationCallbacks callbacks, String cmd) {
         byte[] command = BinaryProtocol.getTextCommandBytes(cmd);
         try {
             stream.sendPacket(command);
             callbacks.logLine(String.format("Reboot command [%s] sent into %s!\n", cmd, stream));
+            return true;
         } catch (IOException e) {
             callbacks.logLine("Error " + e);
+            return false;
         }
     }
 }

--- a/java_console/io/src/main/java/com/rusefi/io/can/SocketCANHelper.java
+++ b/java_console/io/src/main/java/com/rusefi/io/can/SocketCANHelper.java
@@ -7,6 +7,7 @@ import tel.schich.javacan.CanChannels;
 import tel.schich.javacan.CanFrame;
 import tel.schich.javacan.NetworkDevice;
 import tel.schich.javacan.RawCanChannel;
+import tel.schich.javacan.platform.linux.LinuxNativeOperationException;
 
 import java.io.IOException;
 
@@ -15,6 +16,10 @@ import static tel.schich.javacan.CanFrame.FD_NO_FLAGS;
 import static tel.schich.javacan.CanSocketOptions.RECV_OWN_MSGS;
 
 public class SocketCANHelper {
+    // javaCAN does not expose Linux ENOBUFS. A rejected write was not queued, so it is safe to retry after backpressure.
+    static final int LINUX_ENOBUFS = 105;
+    static final int ENOBUFS_RETRY_COUNT = 20;
+    private static final long ENOBUFS_RETRY_DELAY_MS = 1;
     private static Logging log = getLogging(SocketCANIoStream.class);
 
     @NotNull
@@ -55,10 +60,28 @@ public class SocketCANHelper {
 
     public static void send(int id, byte[] payload, RawCanChannel channel) {
         CanFrame packet = CanFrame.create(id, FD_NO_FLAGS, payload);
+        int retriesRemaining = ENOBUFS_RETRY_COUNT;
+        while (true) {
+            try {
+                channel.write(packet);
+                return;
+            } catch (LinuxNativeOperationException e) {
+                if (e.getErrorNumber() != LINUX_ENOBUFS || retriesRemaining-- == 0) {
+                    throw new IllegalStateException(e);
+                }
+                waitForTransmitQueue();
+            } catch (IOException e) {
+                throw new IllegalStateException(e);
+            }
+        }
+    }
+
+    private static void waitForTransmitQueue() {
         try {
-            channel.write(packet);
-        } catch (IOException e) {
-            throw new IllegalStateException(e);
+            Thread.sleep(ENOBUFS_RETRY_DELAY_MS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("Interrupted while waiting for the SocketCAN transmit queue", e);
         }
     }
 

--- a/java_console/io/src/main/java/com/rusefi/libopenblt/XcpLoader.java
+++ b/java_console/io/src/main/java/com/rusefi/libopenblt/XcpLoader.java
@@ -72,12 +72,38 @@ public class XcpLoader {
         try {
             mTransport.connect();
             connected = true;
-            connect();
+            connectForProgramming();
         } catch (IOException | RuntimeException | Error e) {
             if (connected) {
                 disconnectAfterFailure(e);
             }
             throw e;
+        }
+    }
+
+    /** Confirm that an XCP target is available without entering programming mode. */
+    public void probeAvailability() throws IOException {
+        boolean connected = false;
+        Throwable failure = null;
+        try {
+            mTransport.connect();
+            connected = true;
+            requestConnect();
+        } catch (IOException | RuntimeException | Error e) {
+            failure = e;
+            throw e;
+        } finally {
+            if (connected) {
+                try {
+                    mTransport.disconnect();
+                } catch (IOException | RuntimeException e) {
+                    if (failure != null) {
+                        failure.addSuppressed(e);
+                    } else {
+                        throw e;
+                    }
+                }
+            }
         }
     }
 
@@ -112,7 +138,20 @@ public class XcpLoader {
         }
     }
 
-    private void connect() throws IOException {
+    private void connectForProgramming() throws IOException {
+        TargetInfo ti = requestConnect();
+
+        if (mVerifyStationId) {
+            verifyStationId();
+        }
+
+        // Place the target in programming mode
+        ti.maxProgCto = programStart();
+
+        mTargetInfo = ti;
+    }
+
+    private TargetInfo requestConnect() throws IOException {
         byte[] request =
             ByteBuffer.allocate(2)
                 .put(XCPLOADER_CMD_CONNECT)
@@ -149,14 +188,7 @@ public class XcpLoader {
             throw new IllegalStateException("Controller returned invalid max DTO configuration: " + ti.maxDto);
         }
 
-        if (mVerifyStationId) {
-            verifyStationId();
-        }
-
-        // Place the target in programming mode
-        ti.maxProgCto = programStart();
-
-        mTargetInfo = ti;
+        return ti;
     }
 
     private void verifyStationId() throws IOException {

--- a/java_console/io/src/main/java/com/rusefi/libopenblt/transport/XcpCan.java
+++ b/java_console/io/src/main/java/com/rusefi/libopenblt/transport/XcpCan.java
@@ -5,6 +5,7 @@ import com.rusefi.io.can.ClassicCanFrame;
 import com.rusefi.io.can.RawCanPort;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
@@ -82,12 +83,15 @@ public class XcpCan implements IXcpTransport {
                 }
 
                 byte[] response = frame.get().getPayload();
-                if (response.length != expectResponseBytes) {
+                // Some deployed OpenBLT targets pad logical responses to a classic-CAN DLC of eight.
+                if (response.length < expectResponseBytes) {
                     throw new IOException("Unexpected XCP CAN response length for " + command(request)
-                        + ": expected " + expectResponseBytes
+                        + ": expected at least " + expectResponseBytes
                         + " but got " + response.length);
                 }
-                return response;
+                return response.length == expectResponseBytes
+                    ? response
+                    : Arrays.copyOf(response, expectResponseBytes);
             }
         }
     }

--- a/java_console/io/src/test/java/com/rusefi/io/BootloaderCommsHelperTest.java
+++ b/java_console/io/src/test/java/com/rusefi/io/BootloaderCommsHelperTest.java
@@ -1,0 +1,24 @@
+package com.rusefi.io;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+
+class BootloaderCommsHelperTest {
+    @Test
+    void reportsWhetherTheRebootPacketWasSent() throws IOException {
+        IoStream stream = mock(IoStream.class);
+        UpdateOperationCallbacks callbacks = mock(UpdateOperationCallbacks.class);
+
+        assertTrue(BootloaderCommsHelper.sendBootloaderRebootCommand(stream, callbacks, "reboot_openblt"));
+
+        doThrow(new IOException("write failed")).when(stream).sendPacket(any(byte[].class));
+        assertFalse(BootloaderCommsHelper.sendBootloaderRebootCommand(stream, callbacks, "reboot_openblt"));
+    }
+}

--- a/java_console/io/src/test/java/com/rusefi/io/can/SocketCanRawPortTest.java
+++ b/java_console/io/src/test/java/com/rusefi/io/can/SocketCanRawPortTest.java
@@ -14,12 +14,15 @@ import java.time.Duration;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static tel.schich.javacan.CanFrame.FD_NO_FLAGS;
@@ -61,6 +64,43 @@ class SocketCanRawPortTest {
         assertEquals(0x1abcde, frames.getAllValues().get(0).getId());
         assertFalse(frames.getAllValues().get(1).isExtended());
         assertEquals(0x123, frames.getAllValues().get(1).getId());
+    }
+
+    @Test
+    void socketCanSendOnLinuxTransmitQueueBackpressure() throws IOException {
+        LinuxNativeOperationException queueFull =
+            new LinuxNativeOperationException("write", 105, "No buffer space available");
+        when(channel.write(any(CanFrame.class))).thenThrow(queueFull).thenReturn(channel);
+
+        assertDoesNotThrow(() -> SocketCANHelper.send(0x710, new byte[]{1, 2}, channel));
+
+        verify(channel, times(2)).write(any(CanFrame.class));
+    }
+
+    @Test
+    void socketCanSendBoundsLinuxTransmitQueueBackpressure() throws IOException {
+        LinuxNativeOperationException queueFull =
+            new LinuxNativeOperationException("write", 105, "No buffer space available");
+        when(channel.write(any(CanFrame.class))).thenThrow(queueFull);
+
+        IllegalStateException exception = assertThrows(IllegalStateException.class,
+            () -> SocketCANHelper.send(0x710, new byte[]{1, 2}, channel));
+
+        assertEquals(queueFull, exception.getCause());
+        verify(channel, times(SocketCANHelper.ENOBUFS_RETRY_COUNT + 1)).write(any(CanFrame.class));
+    }
+
+    @Test
+    void socketCanSendDoesNotRetryOtherLinuxWriteFailures() throws IOException {
+        LinuxNativeOperationException tryAgain = new LinuxNativeOperationException(
+            "write", LinuxNativeOperationException.EAGAIN, "Try again");
+        when(channel.write(any(CanFrame.class))).thenThrow(tryAgain);
+
+        IllegalStateException exception = assertThrows(IllegalStateException.class,
+            () -> SocketCANHelper.send(0x710, new byte[]{1, 2}, channel));
+
+        assertEquals(tryAgain, exception.getCause());
+        verify(channel).write(any(CanFrame.class));
     }
 
     @Test

--- a/java_console/io/src/test/java/com/rusefi/libopenblt/XcpLoaderProbeTest.java
+++ b/java_console/io/src/test/java/com/rusefi/libopenblt/XcpLoaderProbeTest.java
@@ -1,0 +1,64 @@
+package com.rusefi.libopenblt;
+
+import com.rusefi.libopenblt.transport.IXcpTransport;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class XcpLoaderProbeTest {
+    @Test
+    void availabilityProbeConnectsWithoutStartingProgramming() throws IOException {
+        RecordingTransport transport = new RecordingTransport();
+        XcpLoader loader = new XcpLoader(transport, new XcpSettings());
+
+        loader.probeAvailability();
+
+        assertEquals(1, transport.connects);
+        assertEquals(1, transport.disconnects);
+        assertEquals(java.util.Collections.singletonList(0xFF), transport.commands);
+    }
+
+    @Test
+    void failedAvailabilityProbeStillDisconnects() {
+        RecordingTransport transport = new RecordingTransport();
+        transport.failConnectCommand = true;
+        XcpLoader loader = new XcpLoader(transport, new XcpSettings());
+
+        assertThrows(IOException.class, loader::probeAvailability);
+
+        assertEquals(1, transport.connects);
+        assertEquals(1, transport.disconnects);
+        assertEquals(java.util.Collections.singletonList(0xFF), transport.commands);
+    }
+
+    private static class RecordingTransport implements IXcpTransport {
+        final List<Integer> commands = new ArrayList<>();
+        int connects;
+        int disconnects;
+        boolean failConnectCommand;
+
+        @Override
+        public void connect() {
+            connects++;
+        }
+
+        @Override
+        public void disconnect() {
+            disconnects++;
+        }
+
+        @Override
+        public byte[] sendPacket(byte[] request, int timeoutMs, int expectResponseBytes) throws IOException {
+            commands.add(request[0] & 0xFF);
+            if (failConnectCommand) {
+                throw new IOException("No OpenBLT response");
+            }
+            return new byte[]{(byte) 0xFF, 0, 0, 8, 8, 0, 0, 0};
+        }
+    }
+}

--- a/java_console/io/src/test/java/com/rusefi/libopenblt/transport/XcpCanTest.java
+++ b/java_console/io/src/test/java/com/rusefi/libopenblt/transport/XcpCanTest.java
@@ -45,6 +45,28 @@ class XcpCanTest {
     }
 
     @Test
+    void programStartResponseInPaddedClassicCanFrame() throws IOException {
+        FakeRawCanPort port = new FakeRawCanPort();
+        port.frames.add(new ClassicCanFrame(RESPONSE,
+            new byte[]{(byte) 0xFF, 0, 0, 8, 0, 0, 0, 0}));
+        XcpCan transport = connected(port);
+
+        assertArrayEquals(new byte[]{(byte) 0xFF, 0, 0, 8, 0, 0, 0},
+            transport.sendPacket(new byte[]{(byte) 0xD2}, 100, 7));
+    }
+
+    @Test
+    void positiveAcknowledgementInPaddedClassicCanFrame() throws IOException {
+        FakeRawCanPort port = new FakeRawCanPort();
+        port.frames.add(new ClassicCanFrame(RESPONSE,
+            new byte[]{(byte) 0xFF, 0, 0, 0, 0, 0, 0, 0}));
+        XcpCan transport = connected(port);
+
+        assertArrayEquals(new byte[]{(byte) 0xFF},
+            transport.sendPacket(new byte[]{(byte) 0xD1}, 100, 1));
+    }
+
+    @Test
     void timeoutDoesNotWaitAgainAfterPortReportsNoFrame() throws IOException {
         FakeRawCanPort port = new FakeRawCanPort();
         XcpCan transport = connected(port);

--- a/java_console/shared_io/src/main/resources/shared_io.properties
+++ b/java_console/shared_io/src/main/resources/shared_io.properties
@@ -7,6 +7,7 @@ firmware_rollback_root_url=https://rusefi.com/build_server/lts
 pinout_base_url=https://rusefi.com/docs/
 pinout_meta_name=boards_meta.yaml
 show_pcan=false
+show_can_openblt=false
 show_simulator=true
 binary_config_image=true
 write_readme_html=true

--- a/java_console/ui/src/main/java/com/rusefi/UiProperties.java
+++ b/java_console/ui/src/main/java/com/rusefi/UiProperties.java
@@ -5,6 +5,7 @@ import com.rusefi.core.net.PropertiesHolder;
 
 public class UiProperties {
     public static final String SKIP_ECU_TYPE_DETECTION = "skip_ecu_type_detection";
+    public static final String SHOW_CAN_OPENBLT = "show_can_openblt";
 
     public static boolean usePCAN() {
         return ConnectionAndMeta.getBoolean("show_pcan", PropertiesHolder.INSTANCE.getProperties());
@@ -12,6 +13,13 @@ public class UiProperties {
 
     public static boolean useSimulator() {
         return ConnectionAndMeta.getBoolean("show_simulator", PropertiesHolder.INSTANCE.getProperties());
+    }
+
+    public static boolean isCanOpenBltEnabled() {
+        String override = System.getProperty(SHOW_CAN_OPENBLT);
+        return override != null
+            ? Boolean.parseBoolean(override)
+            : ConnectionAndMeta.getBoolean(SHOW_CAN_OPENBLT, PropertiesHolder.INSTANCE.getProperties());
     }
 
     public static String getWhiteLabel() {

--- a/java_console/ui/src/main/java/com/rusefi/io/BootloaderHelper.java
+++ b/java_console/ui/src/main/java/com/rusefi/io/BootloaderHelper.java
@@ -58,7 +58,6 @@ public class BootloaderHelper {
             }
         }
 
-        BootloaderCommsHelper.sendBootloaderRebootCommand(stream, callbacks, command);
-        return true;
+        return BootloaderCommsHelper.sendBootloaderRebootCommand(stream, callbacks, command);
     }
 }

--- a/java_console/ui/src/main/java/com/rusefi/maintenance/CalibrationsHelper.java
+++ b/java_console/ui/src/main/java/com/rusefi/maintenance/CalibrationsHelper.java
@@ -168,13 +168,13 @@ public class CalibrationsHelper {
                 // to re-probe on the next cycle and prevents returning stale results (e.g. a
                 // port that vanished after an ECU reboot and re-enumeration).
                 for (PortResult p : knownPorts) {
-                    if (!osPorts.contains(p.port)) {
+                    if (!isPortPresent(p, osPorts)) {
                         connectivityContext.getPortScanner().invalidatePort(p.port);
                     }
                 }
                 final List<PortResult> matching = knownPorts.stream()
                     .filter(p -> portTypeMatches.test(p.type))
-                    .filter(p -> osPorts.contains(p.port))
+                    .filter(p -> isPortPresent(p, osPorts))
                     .collect(Collectors.toList());
                 foundPorts.addAll(matching);
                 if (!foundPorts.isEmpty()) {
@@ -197,6 +197,10 @@ public class CalibrationsHelper {
         return foundPorts;
     }
 
+    static boolean isPortPresent(final PortResult port, final Set<String> osPorts) {
+        return LinkManager.isSpecialNotSerial(port.port) || osPorts.contains(port.port);
+    }
+
     public static boolean updateFirmwareAndRestorePreviousCalibrations(
         final JComponent parent,
         final PortResult originalEcuPort,
@@ -217,6 +221,21 @@ public class CalibrationsHelper {
         @Nullable final BinaryProtocol bp,
         @Nullable final LinkManager lm,
         final UpdateOperationCallbacks callbacks,
+        final Supplier<Boolean> updateFirmware,
+        final ConnectivityContext connectivityContext,
+        final FirmwareUpdatePolicy policy
+    ) {
+        return updateFirmwareAndRestorePreviousCalibrations(
+            parent, originalEcuPort, bp, lm, callbacks, () -> true, updateFirmware, connectivityContext, policy);
+    }
+
+    static boolean updateFirmwareAndRestorePreviousCalibrations(
+        final JComponent parent,
+        final PortResult originalEcuPort,
+        @Nullable final BinaryProtocol bp,
+        @Nullable final LinkManager lm,
+        final UpdateOperationCallbacks callbacks,
+        final Supplier<Boolean> beforeDisconnect,
         final Supplier<Boolean> updateFirmware,
         final ConnectivityContext connectivityContext,
         final FirmwareUpdatePolicy policy
@@ -288,9 +307,8 @@ public class CalibrationsHelper {
 
         prevCalibrations = calibrations;
 
-        // Always disconnect before flashing - the port must be free for ECU reboot to OpenBLT
-        if (bp != null && lm != null) {
-            lm.disconnect();
+        if (!prepareFirmwareHandoff(bp, lm, beforeDisconnect)) {
+            return false;
         }
 
         if (!skipCalibrationRestore && !prevCalibrations.isPresent()) {
@@ -747,6 +765,22 @@ public class CalibrationsHelper {
                 callbacks.logLine("Failed to back up merged tune from ECU...");
                 return false;
             }
+        }
+        return true;
+    }
+
+    static boolean prepareFirmwareHandoff(
+        @Nullable BinaryProtocol bp,
+        @Nullable LinkManager lm,
+        Supplier<Boolean> beforeDisconnect
+    ) {
+        if (!beforeDisconnect.get()) {
+            return false;
+        }
+
+        // Always disconnect before flashing - the port must be free for ECU reboot to OpenBLT.
+        if (bp != null && lm != null) {
+            lm.disconnect();
         }
         return true;
     }

--- a/java_console/ui/src/main/java/com/rusefi/maintenance/OpenBltFlasher.java
+++ b/java_console/ui/src/main/java/com/rusefi/maintenance/OpenBltFlasher.java
@@ -25,6 +25,9 @@ public class OpenBltFlasher {
 
     // 16 full PROGRAM_MAX packets with a 240-byte CTO, while still updating progress often.
     private static final int PROGRAM_CHUNK_SIZE = 16 * 239;
+    // A failed probe can consume the 50 ms XCP T6 timeout plus this 200 ms pause.
+    private static final int CAN_BOOTLOADER_ATTEMPTS = 240;
+    private static final long CAN_BOOTLOADER_RETRY_DELAY_MS = 200;
 
     private static final Logging log = getLogging(OpenBltFlasher.class);
 
@@ -33,6 +36,20 @@ public class OpenBltFlasher {
 
     private List<SrecParser.SRecord> mSegments;
     private int mTotalFileSize;
+
+    static final class PreparedFirmware {
+        private final List<SrecParser.SRecord> segments;
+        private final int totalFileSize;
+
+        private PreparedFirmware(List<SrecParser.SRecord> segments, int totalFileSize) {
+            this.segments = segments;
+            this.totalFileSize = totalFileSize;
+        }
+    }
+
+    interface RetryPause {
+        void pause() throws InterruptedException;
+    }
 
     OpenBltFlasher(IXcpTransport transport, XcpSettings settings, OpenbltJni.OpenbltCallbacks callbacks) {
         mLoader = new XcpLoader(transport, settings);
@@ -61,8 +78,44 @@ public class OpenBltFlasher {
     }
 
     public static void flashCan(String fileName, RawCanPort port, OpenbltJni.OpenbltCallbacks callbacks) throws IOException {
+        flashCan(fileName, port, callbacks, CAN_BOOTLOADER_ATTEMPTS,
+            () -> Thread.sleep(CAN_BOOTLOADER_RETRY_DELAY_MS));
+    }
+
+    static void flashCan(PreparedFirmware firmware, RawCanPort port,
+                         OpenbltJni.OpenbltCallbacks callbacks) throws IOException {
+        flashCan(firmware, port, callbacks, CAN_BOOTLOADER_ATTEMPTS,
+            () -> Thread.sleep(CAN_BOOTLOADER_RETRY_DELAY_MS));
+    }
+
+    static void flashCan(String fileName, RawCanPort port, OpenbltJni.OpenbltCallbacks callbacks,
+                         int bootloaderAttempts, RetryPause retryPause) throws IOException {
+        flashCan(prepareFirmware(fileName, callbacks), port, callbacks, bootloaderAttempts, retryPause);
+    }
+
+    static void flashCan(PreparedFirmware firmware, RawCanPort port, OpenbltJni.OpenbltCallbacks callbacks,
+                         int bootloaderAttempts, RetryPause retryPause) throws IOException {
         OpenBltFlasher f = OpenBltFlasher.makeCan(port, new XcpSettings(), callbacks);
-        f.flash(fileName);
+        f.usePreparedFirmware(firmware);
+        f.awaitBootloader(bootloaderAttempts, retryPause);
+        f.execute(true);
+    }
+
+    static PreparedFirmware prepareFirmware(String fileName, OpenbltJni.OpenbltCallbacks callbacks) throws IOException {
+        callbacks.setPhase("Load firmware file", false);
+
+        SrecParser file = new SrecParser();
+        file.parse(new File(fileName));
+        List<SrecParser.SRecord> segments = file.getSegments();
+        if (segments.isEmpty()) {
+            throw new IOException("Firmware file contains no data records");
+        }
+
+        int totalFileSize = segments.stream().map(s -> s.data.length).reduce(0, Integer::sum);
+        callbacks.log("Firmware file parsed:");
+        callbacks.log(String.format("\tfirst address: 0x%08X", segments.get(0).address));
+        callbacks.log("\ttotal size: " + totalFileSize);
+        return new PreparedFirmware(segments, totalFileSize);
     }
 
     public static void eraseSerial(OpenBltWipeArtifact artifact, String port,
@@ -113,13 +166,41 @@ public class OpenBltFlasher {
         }
     }
 
-    private void loadFile(String filename) throws IOException {
-        mCallbacks.setPhase("Load firmware file", false);
-//        mCallbacks.log("Parsing firmware file...");
+    private void awaitBootloader(int attempts, RetryPause retryPause) throws IOException {
+        if (attempts <= 0) {
+            throw new IllegalArgumentException("Bootloader attempt count must be positive");
+        }
 
-        SrecParser file = new SrecParser();
-        file.parse(new File(filename));
-        setSegments(file.getSegments(), "Firmware file");
+        mCallbacks.setPhase("Wait for CAN bootloader", false);
+        IOException lastFailure = null;
+        for (int attempt = 1; attempt <= attempts; attempt++) {
+            try {
+                mLoader.probeAvailability();
+                return;
+            } catch (IOException e) {
+                lastFailure = e;
+            }
+
+            if (attempt < attempts) {
+                try {
+                    retryPause.pause();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new IOException("Interrupted while waiting for OpenBLT over CAN", e);
+                }
+            }
+        }
+
+        throw new IOException("OpenBLT did not respond over CAN after " + attempts + " attempts", lastFailure);
+    }
+
+    private void loadFile(String filename) throws IOException {
+        usePreparedFirmware(prepareFirmware(filename, mCallbacks));
+    }
+
+    private void usePreparedFirmware(PreparedFirmware firmware) {
+        mSegments = firmware.segments;
+        mTotalFileSize = firmware.totalFileSize;
     }
 
     private void setSegments(List<SrecParser.SRecord> segments, String description) throws IOException {

--- a/java_console/ui/src/main/java/com/rusefi/maintenance/ProgramSelector.java
+++ b/java_console/ui/src/main/java/com/rusefi/maintenance/ProgramSelector.java
@@ -13,6 +13,7 @@ import com.rusefi.io.LinkManager;
 import com.rusefi.io.UpdateOperationCallbacks;
 import com.rusefi.core.ui.AutoupdateUtil;
 import com.rusefi.io.IoStream;
+import com.rusefi.io.can.SocketCanRawPort;
 import com.rusefi.io.serial.BufferedSerialIoStream;
 import com.rusefi.maintenance.jobs.*;
 import com.rusefi.ui.basic.SingleAsyncJobExecutor;
@@ -33,6 +34,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.io.EOFException;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BooleanSupplier;
 import java.util.function.Consumer;
@@ -46,6 +48,10 @@ import static com.rusefi.maintenance.CallbacksWaitingUtil.waitForPredicate;
 import static com.rusefi.maintenance.UpdateMode.*;
 
 public class ProgramSelector {
+    interface SocketCanFlashAction {
+        void flash(String fileName, OpenbltJni.OpenbltCallbacks callbacks) throws IOException;
+    }
+
     private static final Logging log = getLogging(ProgramSelector.class);
     private final JPanel content = new JPanel(new BorderLayout());
     private final JLabel noHardware = new JLabel("Nothing detected");
@@ -161,9 +167,13 @@ public class ProgramSelector {
         final PortResult selected = (PortResult) comboPorts.getSelectedItem();
         return resolveFlashPort(
             selected,
-            isLiveConnection(),
+            hasMatchingLiveConnection(
+                selected,
+                isLiveConnection(),
+                linkManager == null ? null : linkManager.getLastTriedPort()),
             connectivityContext.getCurrentHardware().getKnownPorts(SerialPortType.Dfu),
-            connectivityContext.getCurrentHardware().getKnownPorts(OpenBlt)
+            connectivityContext.getCurrentHardware().getKnownPorts(OpenBlt),
+            UiProperties.isCanOpenBltEnabled()
         );
     }
 
@@ -175,8 +185,12 @@ public class ProgramSelector {
         @Nullable final PortResult selected,
         final boolean liveConnection,
         final List<PortResult> dfuPorts,
-        final List<PortResult> bltPorts
+        final List<PortResult> bltPorts,
+        final boolean socketCanOpenBltEnabled
     ) {
+        if (isSocketCanEcu(selected)) {
+            return socketCanOpenBltEnabled && liveConnection ? selected : null;
+        }
         if (selected != null && (selected.type == OpenBlt || selected.type == SerialPortType.Dfu)) {
             return selected;
         }
@@ -192,6 +206,15 @@ public class ProgramSelector {
             }
         }
         return isUnflashableEcu(selected) ? null : selected;
+    }
+
+    static boolean hasMatchingLiveConnection(
+        @Nullable PortResult selected,
+        boolean liveConnection,
+        @Nullable String connectedPort
+    ) {
+        return liveConnection
+            && (!isSocketCanEcu(selected) || LinkManager.SOCKET_CAN.equals(connectedPort));
     }
 
     private void executeJob(JComponent parent, UpdateMode selectedMode, PortResult selectedPort) {
@@ -442,6 +465,130 @@ public class ProgramSelector {
             connectivityContext, policy);
     }
 
+    public static boolean flashOpenbltSocketCanAutomatic(
+        JComponent parent,
+        PortResult ecuPort,
+        BinaryProtocol bp,
+        LinkManager lm,
+        UpdateOperationCallbacks callbacks,
+        ConnectivityContext connectivityContext,
+        @Nullable String firmwareSrecFile,
+        CalibrationsHelper.FirmwareUpdatePolicy policy
+    ) {
+        if (!LinkManager.SOCKET_CAN.equals(ecuPort.port)
+            || lm == null
+            || bp == null
+            || !LinkManager.SOCKET_CAN.equals(lm.getLastTriedPort())) {
+            callbacks.logLine("SocketCAN firmware update requires a live SocketCAN ECU connection.");
+            return false;
+        }
+
+        if (!MaintenanceUtil.ensureFirmwareForConnectedTarget(
+            callbacks, connectivityContext.getConnectedEcuTarget())) {
+            return false;
+        }
+
+        final String fileName = firmwareSrecFile != null
+            ? firmwareSrecFile
+            : FindFileHelper.findSrecFileForConnectedBoard(connectivityContext.getConnectedEcuTarget());
+        if (fileName == null) {
+            callbacks.logLine(".srec image file not found");
+            return false;
+        }
+        if (!MaintenanceUtil.confirmFirmwareMatchesBoard(
+            fileName, callbacks, connectivityContext.getConnectedEcuTarget())) {
+            callbacks.logLine("Firmware update aborted - firmware/board mismatch.");
+            return false;
+        }
+
+        final OpenBltFlasher.PreparedFirmware preparedFirmware;
+        try {
+            preparedFirmware = OpenBltFlasher.prepareFirmware(fileName, makeOpenbltCallbacks(callbacks));
+        } catch (IOException e) {
+            callbacks.logLine("Unable to load firmware file: " + e.getMessage());
+            return false;
+        }
+
+        return updateFirmwareAndRestorePreviousCalibrations(
+            parent, ecuPort, bp, lm, callbacks,
+            () -> prepareSocketCanHandoff(lm, callbacks,
+                () -> OpenbltRebooter.rebootToOpenblt(parent, bp, callbacks)),
+            () -> socketCanUpdateFirmware(callbacks, connectivityContext, fileName, preparedFirmware),
+            connectivityContext, policy);
+    }
+
+    static boolean prepareSocketCanHandoff(
+        LinkManager lm,
+        UpdateOperationCallbacks callbacks,
+        BooleanSupplier rebootToOpenBlt
+    ) {
+        final boolean[] commandSent = {false};
+        try {
+            lm.submit(() -> commandSent[0] = rebootToOpenBlt.getAsBoolean()).get();
+            if (!commandSent[0]) {
+                callbacks.logLine("SocketCAN OpenBLT reboot command was not sent.");
+            }
+            return commandSent[0];
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            callbacks.logLine("Interrupted while sending the SocketCAN OpenBLT reboot command.");
+        } catch (ExecutionException e) {
+            callbacks.logLine("Failed to send the SocketCAN OpenBLT reboot command: " + e.getCause());
+        }
+        return false;
+    }
+
+    private static boolean socketCanUpdateFirmware(
+        UpdateOperationCallbacks callbacks,
+        ConnectivityContext connectivityContext,
+        String fileName,
+        OpenBltFlasher.PreparedFirmware preparedFirmware
+    ) {
+        return flashSocketCanWithSuspendedScanner(
+            fileName,
+            callbacks,
+            connectivityContext.getPortScanner(),
+            (firmware, openbltCallbacks) -> OpenBltFlasher.flashCan(
+                preparedFirmware, new SocketCanRawPort(), openbltCallbacks));
+    }
+
+    static boolean flashSocketCanWithSuspendedScanner(
+        String fileName,
+        UpdateOperationCallbacks callbacks,
+        PortScanner scanner,
+        SocketCanFlashAction flashAction
+    ) {
+        try {
+            try {
+                if (!scanner.suspend().await(30, TimeUnit.SECONDS)) {
+                    callbacks.logLine("Timed out waiting for SocketCAN discovery to stop.");
+                    return false;
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                callbacks.logLine("Interrupted while waiting for SocketCAN discovery to stop.");
+                return false;
+            }
+
+            final OpenbltJni.OpenbltCallbacks openbltCallbacks = makeOpenbltCallbacks(callbacks);
+            callbacks.logLine("flashSocketCan " + fileName);
+            flashAction.flash(fileName, openbltCallbacks);
+            callbacks.logLine("Update completed successfully!");
+            return true;
+        } catch (Throwable e) {
+            callbacks.logLine("flashOpenBltSocketCan Error: " + e);
+            log.error("flashOpenBltSocketCan " + e, e);
+            return false;
+        } finally {
+            // Remove the pre-flash ECU result so calibration restore waits for a fresh firmware reply.
+            try {
+                scanner.invalidatePort(LinkManager.SOCKET_CAN);
+            } finally {
+                scanner.resume();
+            }
+        }
+    }
+
     private static boolean bltUpdateFirmware(JComponent parent, PortResult ecuPort, UpdateOperationCallbacks callbacks,
                                              ConnectivityContext connectivityContext, @Nullable String firmwareSrecFile) {
         // Suspend the scanner for the entire reboot → detect → flash sequence so it
@@ -666,10 +813,12 @@ public class ProgramSelector {
         }
 
         int menuItemCount = popupMenu.getComponentCount();
+        PortResult flashPort = resolveFlashPort();
+        boolean hasFirmwareTarget = hasFirmwareTarget(hasSerialPorts, flashPort);
 
         splitButton.setPopupMenu(menuItemCount > 0 ? popupMenu : null);
         splitButton.setMainButtonEnabled(shouldEnableMainButton(
-            hasSerialPorts, hasDfuDevice, isJobRunning, mainButtonModeFor(resolveFlashPort()), canUseDfu));
+            hasFirmwareTarget, hasDfuDevice, isJobRunning, mainButtonModeFor(flashPort), canUseDfu));
         splitButton.setArrowButtonEnabled(menuItemCount > 0 && !isJobRunning);
 
         // Keep the main-button mode/label in sync with the connection state too (not just combo changes):
@@ -684,18 +833,22 @@ public class ProgramSelector {
         return ports.stream().anyMatch(port -> port.type != SerialPortType.Dfu && !isUnflashableEcu(port));
     }
 
+    static boolean hasFirmwareTarget(boolean hasSerialPorts, @Nullable PortResult flashPort) {
+        return hasSerialPorts || isSocketCanEcu(flashPort);
+    }
+
     static boolean isEmergencyWipeAvailable(@Nullable PortResult port) {
         return OpenBltWipeArtifact.isAvailableFor(port);
     }
 
     static boolean shouldEnableMainButton(
-        boolean hasSerialPorts,
+        boolean hasFirmwareTarget,
         boolean hasDfuDevice,
         boolean jobRunning,
         UpdateMode mode,
         boolean supportsDfu
     ) {
-        boolean targetAvailable = mode == DFU_MANUAL ? hasDfuDevice : hasSerialPorts;
+        boolean targetAvailable = mode == DFU_MANUAL ? hasDfuDevice : hasFirmwareTarget;
         boolean modeSupported = mode != DFU_MANUAL || supportsDfu;
         return targetAvailable && modeSupported && !jobRunning;
     }
@@ -765,6 +918,10 @@ public class ProgramSelector {
         return port != null && (port.isUnsupportedEcu()
             || port.type == SerialPortType.EcuUnknown
             || LinkManager.SOCKET_CAN.equals(port.port));
+    }
+
+    private static boolean isSocketCanEcu(@Nullable PortResult port) {
+        return port != null && LinkManager.SOCKET_CAN.equals(port.port) && port.isEcu();
     }
 
 }

--- a/java_console/ui/src/main/java/com/rusefi/maintenance/jobs/AbstractAutoFlashJob.java
+++ b/java_console/ui/src/main/java/com/rusefi/maintenance/jobs/AbstractAutoFlashJob.java
@@ -114,10 +114,19 @@ abstract class AbstractAutoFlashJob extends AsyncJobWithContext<SerialPortWithPa
         final long bootloaderGraceMs = 5_000;
         while (clock.millis() < deadline) {
             final AvailableHardware hw = connectivityContext.getCurrentHardware();
+            String fallbackPort = null;
             for (final PortResult p : hw.getKnownPorts()) {
                 if (p.isEcu()) {
-                    return p.port;
+                    if (p.port.equals(context.getPort().port)) {
+                        return p.port;
+                    }
+                    if (fallbackPort == null) {
+                        fallbackPort = p.port;
+                    }
                 }
+            }
+            if (fallbackPort != null && !LinkManager.SOCKET_CAN.equals(context.getPort().port)) {
+                return fallbackPort;
             }
             final boolean inBootloader = !hw.getKnownPorts(SerialPortType.OpenBlt).isEmpty() || hw.isDfuFound();
             if (inBootloader && (clock.millis() - start) > bootloaderGraceMs) {

--- a/java_console/ui/src/main/java/com/rusefi/maintenance/jobs/OpenBltAutoJob.java
+++ b/java_console/ui/src/main/java/com/rusefi/maintenance/jobs/OpenBltAutoJob.java
@@ -30,13 +30,19 @@ public class OpenBltAutoJob extends AbstractAutoFlashJob {
     public OpenBltAutoJob(final PortResult port, final JComponent parent, final ConnectivityContext connectivityContext,
                           final @Nullable LinkManager linkManager, final @Nullable String firmwareSrecFile,
                           final CalibrationsHelper.FirmwareUpdatePolicy policy) {
-        super("OpenBLT via Serial", port, parent, connectivityContext, linkManager);
+        super(LinkManager.SOCKET_CAN.equals(port.port) ? "OpenBLT via SocketCAN" : "OpenBLT via Serial",
+            port, parent, connectivityContext, linkManager);
         this.firmwareSrecFile = firmwareSrecFile;
         this.policy = policy;
     }
 
     @Override
     protected boolean flash(final LinkManager lm, final BinaryProtocol bp, final UpdateOperationCallbacks callbacks) {
+        if (LinkManager.SOCKET_CAN.equals(context.getPort().port)) {
+            return ProgramSelector.flashOpenbltSocketCanAutomatic(
+                context.getParent(), context.getPort(), bp, lm, callbacks, connectivityContext,
+                firmwareSrecFile, policy);
+        }
         return ProgramSelector.flashOpenbltSerialAutomatic(
             context.getParent(), context.getPort(), bp, lm, callbacks, connectivityContext, firmwareSrecFile, policy);
     }

--- a/java_console/ui/src/main/java/com/rusefi/maintenance/jobs/OpenbltRebooter.java
+++ b/java_console/ui/src/main/java/com/rusefi/maintenance/jobs/OpenbltRebooter.java
@@ -28,12 +28,13 @@ public class OpenbltRebooter {
      * Send reboot-to-OpenBLT via an already-open BinaryProtocol connection.
      * Use this from ConsoleUI context where the port is held by LinkManager.
      */
-    public static void rebootToOpenblt(JComponent parent, BinaryProtocol binaryProtocol, UpdateOperationCallbacks callbacks) {
+    public static boolean rebootToOpenblt(JComponent parent, BinaryProtocol binaryProtocol, UpdateOperationCallbacks callbacks) {
         if (binaryProtocol == null) {
             callbacks.logLine("Not connected?");
             callbacks.error();
-            return;
+            return false;
         }
-        BootloaderHelper.sendBootloaderRebootCommand(parent, binaryProtocol.signature, binaryProtocol.getStream(), callbacks, Integration.CMD_REBOOT_OPENBLT);
+        return BootloaderHelper.sendBootloaderRebootCommand(
+            parent, binaryProtocol.signature, binaryProtocol.getStream(), callbacks, Integration.CMD_REBOOT_OPENBLT);
     }
 }

--- a/java_console/ui/src/test/java/com/rusefi/UiPropertiesTest.java
+++ b/java_console/ui/src/test/java/com/rusefi/UiPropertiesTest.java
@@ -1,0 +1,26 @@
+package com.rusefi;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class UiPropertiesTest {
+    @Test
+    void canOpenBltSystemPropertyOverridesTheResource() {
+        String previous = System.getProperty(UiProperties.SHOW_CAN_OPENBLT);
+        try {
+            System.setProperty(UiProperties.SHOW_CAN_OPENBLT, "false");
+            assertFalse(UiProperties.isCanOpenBltEnabled());
+
+            System.setProperty(UiProperties.SHOW_CAN_OPENBLT, "true");
+            assertTrue(UiProperties.isCanOpenBltEnabled());
+        } finally {
+            if (previous == null) {
+                System.clearProperty(UiProperties.SHOW_CAN_OPENBLT);
+            } else {
+                System.setProperty(UiProperties.SHOW_CAN_OPENBLT, previous);
+            }
+        }
+    }
+}

--- a/java_console/ui/src/test/java/com/rusefi/maintenance/CalibrationsHelperContextTest.java
+++ b/java_console/ui/src/test/java/com/rusefi/maintenance/CalibrationsHelperContextTest.java
@@ -1,10 +1,23 @@
 package com.rusefi.maintenance;
 
+import com.rusefi.PortResult;
+import com.rusefi.SerialPortType;
+import com.rusefi.binaryprotocol.BinaryProtocol;
+import com.rusefi.io.LinkManager;
 import com.rusefi.io.UpdateOperationCallbacks;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
 import static com.rusefi.maintenance.CalibrationsHelper.isUiContext;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 public class CalibrationsHelperContextTest {
 
@@ -48,5 +61,45 @@ public class CalibrationsHelperContextTest {
         };
 
         assertTrue(isUiContext(customCallbacks), "Custom callbacks should be considered UI context");
+    }
+
+    @Test
+    public void specialTransportDoesNotNeedAnOsSerialPort() {
+        final Set<String> noSerialPorts = Collections.emptySet();
+
+        assertTrue(CalibrationsHelper.isPortPresent(
+            new PortResult(LinkManager.SOCKET_CAN, SerialPortType.Ecu), noSerialPorts));
+        assertFalse(CalibrationsHelper.isPortPresent(
+            new PortResult("COM5", SerialPortType.Ecu), noSerialPorts));
+        assertTrue(CalibrationsHelper.isPortPresent(
+            new PortResult("COM5", SerialPortType.Ecu), Collections.singleton("COM5")));
+    }
+
+    @Test
+    public void firmwareHandoffHookRunsBeforeDisconnect() {
+        List<String> events = new ArrayList<>();
+        LinkManager linkManager = mock(LinkManager.class);
+        doAnswer(invocation -> {
+            events.add("disconnect");
+            return null;
+        }).when(linkManager).disconnect();
+
+        assertTrue(CalibrationsHelper.prepareFirmwareHandoff(
+            mock(BinaryProtocol.class), linkManager, () -> {
+                events.add("handoff");
+                return true;
+            }));
+
+        assertEquals(Arrays.asList("handoff", "disconnect"), events);
+    }
+
+    @Test
+    public void failedFirmwareHandoffDoesNotDisconnect() {
+        LinkManager linkManager = mock(LinkManager.class);
+
+        assertFalse(CalibrationsHelper.prepareFirmwareHandoff(
+            mock(BinaryProtocol.class), linkManager, () -> false));
+
+        verifyNoInteractions(linkManager);
     }
 }

--- a/java_console/ui/src/test/java/com/rusefi/maintenance/OpenBltCanFlasherTest.java
+++ b/java_console/ui/src/test/java/com/rusefi/maintenance/OpenBltCanFlasherTest.java
@@ -18,6 +18,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class OpenBltCanFlasherTest {
@@ -37,12 +38,97 @@ class OpenBltCanFlasherTest {
         OpenBltFlasher.flashCan(firmware.toString(), port, callbacks());
 
         assertEquals(RESPONSE, port.openAddress);
-        assertEquals(1, port.closeCount);
+        assertEquals(2, port.openCount);
+        assertEquals(2, port.closeCount);
         assertTrue(port.sent.stream().allMatch(frame -> REQUEST.equals(frame.getAddress())));
-        assertEquals(Arrays.asList(0xFF, 0xD2, 0xF6, 0xD1, 0xF6, 0xC9, 0xD0, 0xD0, 0xCF),
+        assertEquals(Arrays.asList(0xFF, 0xFF, 0xD2, 0xF6, 0xD1, 0xF6, 0xC9, 0xD0, 0xD0, 0xCF),
             port.sent.stream()
                 .map(frame -> frame.getPayload()[0] & 0xFF)
                 .collect(Collectors.toList()));
+    }
+
+    @Test
+    void rejectsInvalidFirmwareBeforeOpeningCan() throws IOException {
+        Path firmware = tempDir.resolve("invalid.srec");
+        Files.write(firmware, "not an S-record".getBytes(StandardCharsets.US_ASCII));
+        ScriptedCanPort port = new ScriptedCanPort();
+
+        assertThrows(IOException.class,
+            () -> OpenBltFlasher.flashCan(firmware.toString(), port, callbacks(), 3, () -> { }));
+
+        assertEquals(0, port.openCount);
+        assertTrue(port.sent.isEmpty());
+    }
+
+    @Test
+    void preparedFirmwareIsNotReadAgainAfterHandoffStarts() throws IOException {
+        Path firmware = firmwareFile();
+        OpenbltJni.OpenbltCallbacks callbacks = callbacks();
+        OpenBltFlasher.PreparedFirmware prepared =
+            OpenBltFlasher.prepareFirmware(firmware.toString(), callbacks);
+        Files.delete(firmware);
+        ScriptedCanPort port = new ScriptedCanPort();
+
+        OpenBltFlasher.flashCan(prepared, port, callbacks, 3, () -> { });
+
+        assertEquals(2, port.openCount);
+        assertTrue(commands(port).contains(0xD1));
+    }
+
+    @Test
+    void retriesOnlyConnectWhileLiveFirmwareReboots() throws IOException {
+        Path firmware = firmwareFile();
+        ScriptedCanPort port = new ScriptedCanPort();
+        port.connectResponsesToSkip = 1;
+
+        OpenBltFlasher.flashCan(firmware.toString(), port, callbacks(), 3, () -> { });
+
+        assertEquals(Arrays.asList(0xFF, 0xFF, 0xFF, 0xD2),
+            commands(port).subList(0, 4));
+        assertEquals(3, port.openCount);
+        assertEquals(3, port.closeCount);
+    }
+
+    @Test
+    void givesUpBeforeProgrammingWhenBootloaderDoesNotReply() throws IOException {
+        Path firmware = firmwareFile();
+        ScriptedCanPort port = new ScriptedCanPort();
+        port.connectResponsesToSkip = Integer.MAX_VALUE;
+
+        assertThrows(IOException.class,
+            () -> OpenBltFlasher.flashCan(firmware.toString(), port, callbacks(), 3, () -> { }));
+
+        assertEquals(Arrays.asList(0xFF, 0xFF, 0xFF), commands(port));
+        assertEquals(3, port.openCount);
+        assertEquals(3, port.closeCount);
+    }
+
+    @Test
+    void doesNotRetryAfterEraseBegins() throws IOException {
+        Path firmware = firmwareFile();
+        ScriptedCanPort port = new ScriptedCanPort();
+        port.failProgramClear = true;
+
+        assertThrows(IOException.class,
+            () -> OpenBltFlasher.flashCan(firmware.toString(), port, callbacks(), 3, () -> { }));
+
+        assertEquals(2, commands(port).stream().filter(command -> command == 0xFF).count());
+        assertEquals(1, commands(port).stream().filter(command -> command == 0xD1).count());
+        assertEquals(2, port.openCount);
+        assertEquals(2, port.closeCount);
+    }
+
+    private Path firmwareFile() throws IOException {
+        Path firmware = tempDir.resolve("test.srec");
+        Files.write(firmware, record(0x08008000L, new byte[]{1, 2, 3, 4, 5, 6, 7, 8})
+            .getBytes(StandardCharsets.US_ASCII));
+        return firmware;
+    }
+
+    private static List<Integer> commands(ScriptedCanPort port) {
+        return port.sent.stream()
+            .map(frame -> frame.getPayload()[0] & 0xFF)
+            .collect(Collectors.toList());
     }
 
     private static String record(long address, byte[] data) {
@@ -86,11 +172,15 @@ class OpenBltCanFlasherTest {
         final List<ClassicCanFrame> sent = new ArrayList<>();
         final ArrayDeque<ClassicCanFrame> responses = new ArrayDeque<>();
         CanAddress openAddress;
+        int openCount;
         int closeCount;
+        int connectResponsesToSkip;
+        boolean failProgramClear;
 
         @Override
         public void open(CanAddress receiveAddress) {
             openAddress = receiveAddress;
+            openCount++;
         }
 
         @Override
@@ -98,13 +188,20 @@ class OpenBltCanFlasherTest {
             sent.add(frame);
             int command = frame.getPayload()[0] & 0xFF;
             if (command == 0xFF) {
+                if (connectResponsesToSkip > 0) {
+                    connectResponsesToSkip--;
+                    return;
+                }
                 responses.add(new ClassicCanFrame(RESPONSE,
                     new byte[]{(byte) 0xFF, 0, 0, 8, 8, 0, 0, 0}));
             } else if (command == 0xD2) {
                 responses.add(new ClassicCanFrame(RESPONSE,
-                    new byte[]{(byte) 0xFF, 0, 0, 8, 0, 0, 0}));
+                    new byte[]{(byte) 0xFF, 0, 0, 8, 0, 0, 0, 0}));
+            } else if (command == 0xD1 && failProgramClear) {
+                return;
             } else {
-                responses.add(new ClassicCanFrame(RESPONSE, new byte[]{(byte) 0xFF}));
+                responses.add(new ClassicCanFrame(RESPONSE,
+                    new byte[]{(byte) 0xFF, 0, 0, 0, 0, 0, 0, 0}));
             }
         }
 

--- a/java_console/ui/src/test/java/com/rusefi/maintenance/ProgramSelectorSocketCanTest.java
+++ b/java_console/ui/src/test/java/com/rusefi/maintenance/ProgramSelectorSocketCanTest.java
@@ -1,0 +1,152 @@
+package com.rusefi.maintenance;
+
+import com.rusefi.ConnectivityContext;
+import com.rusefi.FakePortScanner;
+import com.rusefi.PortResult;
+import com.rusefi.PortScanner;
+import com.rusefi.SerialPortType;
+import com.rusefi.binaryprotocol.BinaryProtocol;
+import com.rusefi.io.LinkManager;
+import com.rusefi.io.UpdateOperationCallbacks;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class ProgramSelectorSocketCanTest {
+    private static final String FIRMWARE = "firmware.srec";
+
+    @Test
+    void scannerIsSuspendedForTheWholeFlashAndInvalidatedBeforeResume() {
+        FakePortScanner scanner = new FakePortScanner();
+        UpdateOperationCallbacks callbacks = mock(UpdateOperationCallbacks.class);
+
+        boolean result = ProgramSelector.flashSocketCanWithSuspendedScanner(
+            FIRMWARE,
+            callbacks,
+            scanner,
+            (fileName, openbltCallbacks) -> {
+                assertEquals(FIRMWARE, fileName);
+                assertEquals(1, scanner.suspendCount);
+                assertEquals(0, scanner.resumeCount);
+                assertTrue(scanner.invalidatedPorts.isEmpty());
+            });
+
+        assertTrue(result);
+        assertEquals(Collections.singletonList(LinkManager.SOCKET_CAN), scanner.invalidatedPorts);
+        assertEquals(1, scanner.resumeCount);
+    }
+
+    @Test
+    void scannerIsInvalidatedAndResumedWhenFlashFails() {
+        FakePortScanner scanner = new FakePortScanner();
+
+        boolean result = ProgramSelector.flashSocketCanWithSuspendedScanner(
+            FIRMWARE,
+            mock(UpdateOperationCallbacks.class),
+            scanner,
+            (fileName, openbltCallbacks) -> {
+                throw new IOException("flash failed");
+            });
+
+        assertFalse(result);
+        assertEquals(Collections.singletonList(LinkManager.SOCKET_CAN), scanner.invalidatedPorts);
+        assertEquals(1, scanner.resumeCount);
+    }
+
+    @Test
+    void scannerResumesEvenWhenInvalidationFails() {
+        PortScanner scanner = mock(PortScanner.class);
+        when(scanner.suspend()).thenReturn(new CountDownLatch(0));
+        doThrow(new IllegalStateException("invalidation failed"))
+            .when(scanner).invalidatePort(LinkManager.SOCKET_CAN);
+
+        assertThrows(IllegalStateException.class, () ->
+            ProgramSelector.flashSocketCanWithSuspendedScanner(
+                FIRMWARE,
+                mock(UpdateOperationCallbacks.class),
+                scanner,
+                (fileName, openbltCallbacks) -> { }));
+
+        verify(scanner).resume();
+    }
+
+    @Test
+    void automaticEntryRejectsALiveSerialConnectionForSocketCanTarget() {
+        LinkManager linkManager = mock(LinkManager.class);
+        when(linkManager.getLastTriedPort()).thenReturn("COM5");
+        UpdateOperationCallbacks callbacks = mock(UpdateOperationCallbacks.class);
+        FakePortScanner scanner = new FakePortScanner();
+
+        boolean result = ProgramSelector.flashOpenbltSocketCanAutomatic(
+            null,
+            new PortResult(LinkManager.SOCKET_CAN, SerialPortType.Ecu),
+            mock(BinaryProtocol.class),
+            linkManager,
+            callbacks,
+            new ConnectivityContext(scanner),
+            null,
+            CalibrationsHelper.FirmwareUpdatePolicy.FORWARD_MIGRATION);
+
+        assertFalse(result);
+        verify(callbacks).logLine("SocketCAN firmware update requires a live SocketCAN ECU connection.");
+        assertEquals(0, scannerOperations(scanner));
+    }
+
+    @Test
+    void socketCanHandoffRunsOneRebootOnTheCommunicationExecutor() {
+        LinkManager linkManager = mock(LinkManager.class);
+        List<String> events = new ArrayList<>();
+        when(linkManager.submit(any(Runnable.class))).thenAnswer(invocation -> {
+            events.add("submit");
+            ((Runnable) invocation.getArgument(0)).run();
+            return CompletableFuture.completedFuture(null);
+        });
+
+        assertTrue(ProgramSelector.prepareSocketCanHandoff(
+            linkManager, mock(UpdateOperationCallbacks.class), () -> {
+                events.add("reboot");
+                return true;
+            }));
+
+        assertEquals(Arrays.asList("submit", "reboot"), events);
+        verify(linkManager, times(1)).submit(any(Runnable.class));
+    }
+
+    @Test
+    void failedSocketCanRebootDoesNotDisconnect() {
+        LinkManager linkManager = mock(LinkManager.class);
+        when(linkManager.submit(any(Runnable.class))).thenAnswer(invocation -> {
+            ((Runnable) invocation.getArgument(0)).run();
+            return CompletableFuture.completedFuture(null);
+        });
+
+        assertFalse(CalibrationsHelper.prepareFirmwareHandoff(
+            mock(BinaryProtocol.class), linkManager,
+            () -> ProgramSelector.prepareSocketCanHandoff(
+                linkManager, mock(UpdateOperationCallbacks.class), () -> false)));
+
+        verify(linkManager, never()).disconnect();
+    }
+
+    private static int scannerOperations(FakePortScanner scanner) {
+        return scanner.suspendCount + scanner.resumeCount + scanner.invalidatedPorts.size();
+    }
+}

--- a/java_console/ui/src/test/java/com/rusefi/maintenance/ProgramSelectorTest.java
+++ b/java_console/ui/src/test/java/com/rusefi/maintenance/ProgramSelectorTest.java
@@ -60,14 +60,14 @@ public class ProgramSelectorTest {
     @Test
     public void selectedDfuPortIsUsedDirectly() {
         PortResult dfu = port(SerialPortType.Dfu);
-        assertSame(dfu, resolveFlashPort(dfu, false, NO_PORTS, NO_PORTS));
-        assertSame(dfu, resolveFlashPort(dfu, true, NO_PORTS, NO_PORTS));
+        assertSame(dfu, resolveFlashPort(dfu, false, NO_PORTS, NO_PORTS, false));
+        assertSame(dfu, resolveFlashPort(dfu, true, NO_PORTS, NO_PORTS, false));
     }
 
     @Test
     public void selectedOpenBltPortIsUsedDirectly() {
         PortResult blt = port(SerialPortType.OpenBlt);
-        assertSame(blt, resolveFlashPort(blt, false, NO_PORTS, NO_PORTS));
+        assertSame(blt, resolveFlashPort(blt, false, NO_PORTS, NO_PORTS, false));
     }
 
     @Test
@@ -76,13 +76,14 @@ public class ProgramSelectorTest {
         // button becomes "Manual DFU Update" rather than a dead OpenBLT action.
         PortResult dfu = port(SerialPortType.Dfu);
         PortResult blt = port(SerialPortType.OpenBlt);
-        assertSame(dfu, resolveFlashPort(null, false, Collections.singletonList(dfu), Collections.singletonList(blt)));
+        assertSame(dfu, resolveFlashPort(
+            null, false, Collections.singletonList(dfu), Collections.singletonList(blt), false));
     }
 
     @Test
     public void offlineWithNullSelectionFallsBackToDetectedOpenBlt() {
         PortResult blt = port(SerialPortType.OpenBlt);
-        assertSame(blt, resolveFlashPort(null, false, NO_PORTS, Collections.singletonList(blt)));
+        assertSame(blt, resolveFlashPort(null, false, NO_PORTS, Collections.singletonList(blt), false));
     }
 
     @Test
@@ -90,28 +91,38 @@ public class ProgramSelectorTest {
         PortResult ecu = port(SerialPortType.Ecu);
         PortResult dfu = port(SerialPortType.Dfu);
         // With a live ECU connection we do not override with detected bootloader ports.
-        assertSame(ecu, resolveFlashPort(ecu, true, Collections.singletonList(dfu), NO_PORTS));
+        assertSame(ecu, resolveFlashPort(ecu, true, Collections.singletonList(dfu), NO_PORTS, false));
     }
 
     @Test
     public void nothingDetectedResolvesToNull() {
-        assertNull(resolveFlashPort(null, false, NO_PORTS, NO_PORTS));
+        assertNull(resolveFlashPort(null, false, NO_PORTS, NO_PORTS, false));
     }
 
     @Test
     public void unsupportedEcuCannotBeSelectedForFlashing() {
         PortResult unsupported = port(SerialPortType.UnsupportedEcu);
-        assertNull(resolveFlashPort(unsupported, false, NO_PORTS, NO_PORTS));
-        assertNull(resolveFlashPort(unsupported, true, NO_PORTS, NO_PORTS));
-        assertNull(resolveFlashPort(port(SerialPortType.EcuUnknown), true, NO_PORTS, NO_PORTS));
+        assertNull(resolveFlashPort(unsupported, false, NO_PORTS, NO_PORTS, false));
+        assertNull(resolveFlashPort(unsupported, true, NO_PORTS, NO_PORTS, false));
+        assertNull(resolveFlashPort(port(SerialPortType.EcuUnknown), true, NO_PORTS, NO_PORTS, false));
     }
 
     @Test
-    public void socketCanEcuCannotBeSelectedForSerialFlashing() {
+    public void socketCanAutoUpdateRequiresOptInAndLiveConnection() {
         PortResult socketCan = new PortResult(LinkManager.SOCKET_CAN, SerialPortType.Ecu);
 
-        assertNull(resolveFlashPort(socketCan, true, NO_PORTS, NO_PORTS));
+        assertNull(resolveFlashPort(socketCan, true, NO_PORTS, NO_PORTS, false));
+        assertNull(resolveFlashPort(socketCan, false, NO_PORTS, NO_PORTS, true));
+        PortResult resolved = resolveFlashPort(socketCan, true, NO_PORTS, NO_PORTS, true);
+        assertSame(socketCan, resolved);
+        assertEquals(OPENBLT_AUTO, mainButtonModeFor(resolved, true));
         assertFalse(ProgramSelector.hasRealSerialPort(Collections.singletonList(socketCan)));
+        assertTrue(ProgramSelector.hasFirmwareTarget(false, resolved));
+        assertFalse(ProgramSelector.hasMatchingLiveConnection(socketCan, true, "COM5"));
+        assertTrue(ProgramSelector.hasMatchingLiveConnection(socketCan, true, LinkManager.SOCKET_CAN));
+        assertTrue(ProgramSelector.shouldEnableMainButton(
+            ProgramSelector.hasFirmwareTarget(false, resolved),
+            false, false, mainButtonModeFor(resolved, true), false));
     }
 
     // ---- combined: resolved port feeds the button mode ----
@@ -119,7 +130,7 @@ public class ProgramSelectorTest {
     @Test
     public void offlineDfuHotPlugResultsInManualDfuMode() {
         PortResult dfu = port(SerialPortType.Dfu);
-        PortResult resolved = resolveFlashPort(null, false, Collections.singletonList(dfu), NO_PORTS);
+        PortResult resolved = resolveFlashPort(null, false, Collections.singletonList(dfu), NO_PORTS, false);
         assertEquals(DFU_MANUAL, mainButtonModeFor(resolved, false));
     }
 
@@ -130,7 +141,8 @@ public class ProgramSelectorTest {
         // bootloader, not the stale selection, so recovery flashes the right port.
         PortResult staleEcu = new PortResult("COM_OLD", SerialPortType.Ecu);
         PortResult renumberedBlt = new PortResult("COM_NEW", SerialPortType.OpenBlt);
-        PortResult resolved = resolveFlashPort(staleEcu, false, NO_PORTS, Collections.singletonList(renumberedBlt));
+        PortResult resolved = resolveFlashPort(
+            staleEcu, false, NO_PORTS, Collections.singletonList(renumberedBlt), false);
         assertSame(renumberedBlt, resolved);
         assertEquals(OPENBLT_MANUAL, mainButtonModeFor(resolved, false));
     }
@@ -143,7 +155,7 @@ public class ProgramSelectorTest {
         PortResult dfu = port(SerialPortType.Dfu);
         PortResult blt = port(SerialPortType.OpenBlt);
         PortResult resolved = resolveFlashPort(staleEcu, false,
-            Collections.singletonList(dfu), Collections.singletonList(blt));
+            Collections.singletonList(dfu), Collections.singletonList(blt), false);
         assertSame(dfu, resolved);
         assertEquals(DFU_MANUAL, mainButtonModeFor(resolved, false));
     }
@@ -153,7 +165,7 @@ public class ProgramSelectorTest {
         // A second board sitting in a bootloader while another ECU is live-connected: the explicit
         // bootloader selection must be flashed manually, not rerouted through the live AUTO path.
         PortResult blt = port(SerialPortType.OpenBlt);
-        PortResult resolved = resolveFlashPort(blt, true, NO_PORTS, NO_PORTS);
+        PortResult resolved = resolveFlashPort(blt, true, NO_PORTS, NO_PORTS, false);
         assertSame(blt, resolved);
         assertEquals(OPENBLT_MANUAL, mainButtonModeFor(resolved, true));
     }

--- a/java_console/ui/src/test/java/com/rusefi/maintenance/jobs/AbstractAutoFlashJobAwaitEcuPortTest.java
+++ b/java_console/ui/src/test/java/com/rusefi/maintenance/jobs/AbstractAutoFlashJobAwaitEcuPortTest.java
@@ -177,6 +177,44 @@ public class AbstractAutoFlashJobAwaitEcuPortTest {
     }
 
     @Test
+    public void socketCanEcuCountsAsConnectable() {
+        scanner.fireHardwareChange(hw(ecu(LinkManager.SOCKET_CAN)));
+
+        assertEquals(LinkManager.SOCKET_CAN, job.awaitEcuPort(60_000, clock));
+        assertEquals(0, clock.sleepCalls);
+    }
+
+    @Test
+    public void originalSocketCanTransportIsPreferredOverAnotherEcu() {
+        AbstractAutoFlashJob socketCanJob = new AbstractAutoFlashJob(
+            "test", ecu(LinkManager.SOCKET_CAN), null,
+            new ConnectivityContext(scanner), null) {
+            @Override
+            protected boolean flash(LinkManager lm, BinaryProtocol bp, UpdateOperationCallbacks cb) {
+                throw new UnsupportedOperationException("not exercised");
+            }
+        };
+        scanner.fireHardwareChange(hw(ecu("COM5"), ecu(LinkManager.SOCKET_CAN)));
+
+        assertEquals(LinkManager.SOCKET_CAN, socketCanJob.awaitEcuPort(60_000, clock));
+    }
+
+    @Test
+    public void socketCanRecoveryDoesNotFallBackToASerialEcu() {
+        AbstractAutoFlashJob socketCanJob = new AbstractAutoFlashJob(
+            "test", ecu(LinkManager.SOCKET_CAN), null,
+            new ConnectivityContext(scanner), null) {
+            @Override
+            protected boolean flash(LinkManager lm, BinaryProtocol bp, UpdateOperationCallbacks cb) {
+                throw new UnsupportedOperationException("not exercised");
+            }
+        };
+        scanner.fireHardwareChange(hw(ecu("COM5")));
+
+        assertNull(socketCanJob.awaitEcuPort(1_000, clock));
+    }
+
+    @Test
     public void completionRunsAfterReconnectRecovery() {
         LinkManager linkManager = mock(LinkManager.class);
         BinaryProtocol binaryProtocol = mock(BinaryProtocol.class);

--- a/java_tools/version/src/main/java/com/rusefi/UiVersion.java
+++ b/java_tools/version/src/main/java/com/rusefi/UiVersion.java
@@ -5,5 +5,5 @@ public interface UiVersion {
      * *** BE CAREFUL WE HAVE SEPARATE AUTOUPDATE_VERSION also managed manually ***
      * @see com.rusefi.autoupdate.Autoupdate#AUTOUPDATE_VERSION
      */
-    int CONSOLE_VERSION = 20260902;
+    int CONSOLE_VERSION = 20260904;
 }


### PR DESCRIPTION
resolves #10137

now auto connect over SocketCAN works, also firmware updates over CAN

new flag for enable OpenBLT via can is: `show_can_openblt`
will default to true after we finish the work over PCAN, SocketCAN side is done

<img width="1770" height="1586" alt="image" src="https://github.com/user-attachments/assets/82284829-36a3-4729-92f5-cd1b9710e199" />
