### PR TITLE
fix simulator: Burning lua script to simulator is not working

### DIFF
--- a/simulator/main.cpp
+++ b/simulator/main.cpp
@@ -277,7 +277,7 @@ bool intFlashCompare(flashaddr_t address, const char* buffer, size_t size) {
 	bool same = true;
 	size_t checked = 0;
 	while (same && checked < size && flash.get(ch)) {
-		if (static_cast<unsigned char>(ch) != buffer[checked]) {
+		if (ch != buffer[checked]) {
 			same = false;
 		}
 		checked++;


### PR DESCRIPTION
**Problem which is fixed by PR**:
   Burning lua script to simulator is not working under x86_64 systems (ubuntu/windows). Bug is related with integer promotion within `intFlashCompare` function. it's bad idea to compare unsigned values with signed ones because integer promotion. Simple code to test under different plaforms (it will not work under x86_64)
```
#include <type_traits>
#include <iostream>

int main() {
unsigned char b = -1;
char a = b;
std::cout << "char is signed: " << std::is_signed<char>::value << std::endl;
std::cout << "result of a == b: " << (a == b) << std::endl;
}
```

**Steps to reproduce from rusefi console**:
1. Download latest [bundle](https://github.com/rusefi/rusefi/releases/download/2026-09-07/rusefi_bundle_f429-discovery.zip)
2. Start rusefi console and then simulator form bundle
3. create simple lua script like `print('hello')` in Lua Scripting panel
4. Hit button load to Write To ECU
5. Hit button Burn to ECU (burning does not work see attached logs)

**Logs related with problem**
2026-09-07_17_55_22_741: EngineState: LUA: Tearing down instance...
2026-09-07_17_55_22_741: EngineState: LUA loading script length: 14...
2026-09-07_17_55_22_741: EngineState: LUA: hello
2026-09-07_17_55_22_741: EngineState: LUA script loaded successfully!
2026-09-07_17_55_40_575: EngineState: TS -> Burn, waiting for CRC
2026-09-07_17_55_41_656: EngineState: TS burn CRC timeout
2026-09-07_17_55_41_656: EngineState: Finishing pending TS burn
2026-09-07_17_55_41_656: EngineState: TS -> Burn, we are allowed to burn
2026-09-07_17_55_41_656: EngineState: unregistering N/A
2026-09-07_17_55_41_656: EngineState: unregistering N/A
2026-09-07_17_55_41_656: EngineState: unregistering N/A
2026-09-07_17_55_41_656: EngineState: unregistering N/A
2026-09-07_17_55_41_656: EngineState: setTpsAccelLen: Length should be positive [0]
2026-09-07_17_55_41_671: EngineState: Scheduling write
2026-09-07_17_55_41_671: EngineState: Burned in 0.0ms
2026-09-07_17_55_41_671: EngineState: Flash: Writing storage ID 1  @0x1... 15816 bytes
2026-09-07_17_55_41_671: EngineState: Flash: validation failed
2026-09-07_17_55_41_671: EngineState: Flash: Write done with error(s) after 0 mS
2026-09-07_17_55_41_671: EngineState: Flash: Writing storage ID 2  @0x2... 15816 bytes
2026-09-07_17_55_41_671: EngineState: Flash: validation failed
2026-09-07_17_55_41_671: EngineState: Flash: Write done with error(s) after 0 mS
2026-09-07_17_55_42_142: EngineState: Flash: Writing storage ID 1  @0x1... 15816 bytes
2026-09-07_17_55_42_142: EngineState: Flash: validation failed
2026-09-07_17_55_42_142: EngineState: Flash: Write done with error(s) after 0 mS
2026-09-07_17_55_42_142: EngineState: Flash: Writing storage ID 2  @0x2... 15816 bytes

