### PR TITLE
fix "purple tuning combo box have random width"

### DIFF
--- a/java_console/ui/src/main/java/com/rusefi/ui/widgets/tune/CalibrationDialogWidget.java
+++ b/java_console/ui/src/main/java/com/rusefi/ui/widgets/tune/CalibrationDialogWidget.java
@@ -12,7 +12,6 @@ import com.opensr5.ini.TsStringFunction;
 import com.opensr5.ini.ReadoutModel;
 import com.opensr5.ini.PanelModel;
 import com.opensr5.ini.TableModel;
-import com.opensr5.ini.field.EnumIniField;
 import com.opensr5.ini.field.IniField;
 import com.opensr5.ini.field.OrdinalOutOfRangeException;
 import com.rusefi.core.ISensorHolder;
@@ -192,7 +191,7 @@ public class CalibrationDialogWidget {
             contentPane.setAlignmentX(Component.LEFT_ALIGNMENT);
             fillPanel(contentPane, dialogModel, iniFileModel, ci,
                 getFieldLabelWidth(dialogModel, iniFileModel, new HashSet<>()),
-                getFieldComboWidth(dialogModel, iniFileModel, new HashSet<>()));
+                getFieldEditorWidth(dialogModel, iniFileModel, ci, new HashSet<>()));
 
             if (TriggerImageHelper.isTriggerPanel(dialogModel.getKey(), uiName)) {
                 addTriggerImage(contentPane, dialogModel.getKey(), uiName);
@@ -267,7 +266,7 @@ public class CalibrationDialogWidget {
     }
 
     private void fillPanel(JPanel container, DialogModel dialogModel, IniFileModel iniFileModel,
-                           ConfigurationImage ci, int fieldLabelWidth, int fieldComboWidth) {
+                           ConfigurationImage ci, int fieldLabelWidth, int fieldEditorWidth) {
         Runnable notifyEdit = () -> { if (onConfigChange != null) onConfigChange.accept(workingImage); };
 
         List<DialogModel.DialogEntry> entries = dialogModel.getOrderedEntries();
@@ -303,7 +302,7 @@ public class CalibrationDialogWidget {
             switch (entry.kind) {
                 case FIELD:
                     renderField(container, entry.getAs(DialogModel.Field.class), iniFileModel, ci,
-                        fieldLabelWidth, fieldComboWidth);
+                        fieldLabelWidth, fieldEditorWidth);
                     break;
                 case COMMAND:
                     container.add(CalibrationFieldFactory.createCommandRow(
@@ -318,7 +317,7 @@ public class CalibrationDialogWidget {
                     break;
                 case PANEL:
                     renderPanelEntry(container, entry.getAs(PanelModel.class), iniFileModel, ci,
-                            isBorderLayout, horizontalPanelRef, notifyEdit, fieldLabelWidth, fieldComboWidth);
+                            isBorderLayout, horizontalPanelRef, notifyEdit, fieldLabelWidth, fieldEditorWidth);
                     break;
             }
         }
@@ -351,28 +350,34 @@ public class CalibrationDialogWidget {
         return Math.min(width, CalibrationFieldFactory.MAX_LABEL_WIDTH);
     }
 
-    private static int getFieldComboWidth(DialogModel dialog, IniFileModel iniFileModel, Set<String> visited) {
+    private static int getFieldEditorWidth(DialogModel dialog, IniFileModel iniFileModel,
+                                           ConfigurationImage ci, Set<String> visited) {
         if (dialog == null || !visited.add(dialog.getKey())) {
             return 0;
         }
         int width = 0;
         for (DialogModel.Field field : dialog.getFields()) {
             Optional<IniField> iniField = iniFileModel.findIniField(field.getKey());
-            if (iniField.isPresent() && iniField.get() instanceof EnumIniField) {
-                EnumIniField enumField = (EnumIniField) iniField.get();
-                if (!CalibrationFieldFactory.isCheckboxEnum(enumField)) {
-                    width = Math.max(width, CalibrationFieldFactory.getComboBoxPreferredWidth(enumField));
+            if (iniField.isPresent()) {
+                try {
+                    String currentValue = ci == null ? "" :
+                        ConfigurationImageGetterSetter.getStringValue(iniField.get(), ci);
+                    width = Math.max(width,
+                        CalibrationFieldFactory.getFieldEditorPreferredWidth(iniField.get(), currentValue));
+                } catch (OrdinalOutOfRangeException e) {
+                    // The corresponding field row will render as a label instead of an editor.
                 }
             }
         }
         for (PanelModel panel : dialog.getPanels()) {
-            width = Math.max(width, getFieldComboWidth(panel.resolveDialog(iniFileModel), iniFileModel, visited));
+            width = Math.max(width,
+                getFieldEditorWidth(panel.resolveDialog(iniFileModel), iniFileModel, ci, visited));
         }
         return width;
     }
 
     private void renderField(JPanel container, DialogModel.Field field, IniFileModel iniFileModel,
-                              ConfigurationImage ci, int fieldLabelWidth, int fieldComboWidth) {
+                              ConfigurationImage ci, int fieldLabelWidth, int fieldEditorWidth) {
         Runnable onChange = () -> {
             refreshExpressions();
             if ("trigger_type".equalsIgnoreCase(field.getKey()) ||
@@ -386,7 +391,7 @@ public class CalibrationDialogWidget {
             try {
                 return CalibrationFieldFactory.createFieldRow(
                     field, value, ci, workingImage, onChange, onShowInPinout,
-                    fieldLabelWidth, fieldComboWidth);
+                    fieldLabelWidth, fieldEditorWidth);
             } catch (OrdinalOutOfRangeException e) {
                 log.warn("Skipping field " + field.getKey() + " with out-of-range ordinal: " + e.getMessage());
                 return CalibrationFieldFactory.createLabelRow(field);
@@ -507,7 +512,7 @@ public class CalibrationDialogWidget {
 
     private void renderPanelEntry(JPanel container, PanelModel panel, IniFileModel iniFileModel, ConfigurationImage ci,
                                    boolean isBorderLayout, JPanel[] horizontalPanelRef, Runnable notifyEdit,
-                                   int fieldLabelWidth, int fieldComboWidth) {
+                                   int fieldLabelWidth, int fieldEditorWidth) {
         String placement = panel.getPlacement();
 
         JPanel targetContainer;
@@ -578,7 +583,7 @@ public class CalibrationDialogWidget {
             panelWidget.setName(uiName);
             GradientTitleBorder.installBorder(uiName, panelWidget);
             fillPanel(panelWidget, subDialog, iniFileModel, ci,
-                Math.max(0, fieldLabelWidth - panelWidget.getInsets().left), fieldComboWidth);
+                Math.max(0, fieldLabelWidth - panelWidget.getInsets().left), fieldEditorWidth);
 
             if (TriggerImageHelper.isTriggerPanel(subDialog.getKey(), uiName) || "Sub Panel".equals(uiName)) {
                 addTriggerImage(panelWidget, subDialog.getKey(), uiName);

--- a/java_console/ui/src/main/java/com/rusefi/ui/widgets/tune/CalibrationDialogWidget.java
+++ b/java_console/ui/src/main/java/com/rusefi/ui/widgets/tune/CalibrationDialogWidget.java
@@ -12,6 +12,7 @@ import com.opensr5.ini.TsStringFunction;
 import com.opensr5.ini.ReadoutModel;
 import com.opensr5.ini.PanelModel;
 import com.opensr5.ini.TableModel;
+import com.opensr5.ini.field.EnumIniField;
 import com.opensr5.ini.field.IniField;
 import com.opensr5.ini.field.OrdinalOutOfRangeException;
 import com.rusefi.core.ISensorHolder;
@@ -190,7 +191,8 @@ public class CalibrationDialogWidget {
             applyLayout(contentPane, dialogModel.getLayoutHint());
             contentPane.setAlignmentX(Component.LEFT_ALIGNMENT);
             fillPanel(contentPane, dialogModel, iniFileModel, ci,
-                getFieldLabelWidth(dialogModel, iniFileModel, new HashSet<>()));
+                getFieldLabelWidth(dialogModel, iniFileModel, new HashSet<>()),
+                getFieldComboWidth(dialogModel, iniFileModel, new HashSet<>()));
 
             if (TriggerImageHelper.isTriggerPanel(dialogModel.getKey(), uiName)) {
                 addTriggerImage(contentPane, dialogModel.getKey(), uiName);
@@ -265,7 +267,7 @@ public class CalibrationDialogWidget {
     }
 
     private void fillPanel(JPanel container, DialogModel dialogModel, IniFileModel iniFileModel,
-                           ConfigurationImage ci, int fieldLabelWidth) {
+                           ConfigurationImage ci, int fieldLabelWidth, int fieldComboWidth) {
         Runnable notifyEdit = () -> { if (onConfigChange != null) onConfigChange.accept(workingImage); };
 
         List<DialogModel.DialogEntry> entries = dialogModel.getOrderedEntries();
@@ -300,7 +302,8 @@ public class CalibrationDialogWidget {
 
             switch (entry.kind) {
                 case FIELD:
-                    renderField(container, entry.getAs(DialogModel.Field.class), iniFileModel, ci, fieldLabelWidth);
+                    renderField(container, entry.getAs(DialogModel.Field.class), iniFileModel, ci,
+                        fieldLabelWidth, fieldComboWidth);
                     break;
                 case COMMAND:
                     container.add(CalibrationFieldFactory.createCommandRow(
@@ -315,7 +318,7 @@ public class CalibrationDialogWidget {
                     break;
                 case PANEL:
                     renderPanelEntry(container, entry.getAs(PanelModel.class), iniFileModel, ci,
-                            isBorderLayout, horizontalPanelRef, notifyEdit, fieldLabelWidth);
+                            isBorderLayout, horizontalPanelRef, notifyEdit, fieldLabelWidth, fieldComboWidth);
                     break;
             }
         }
@@ -348,8 +351,28 @@ public class CalibrationDialogWidget {
         return Math.min(width, CalibrationFieldFactory.MAX_LABEL_WIDTH);
     }
 
+    private static int getFieldComboWidth(DialogModel dialog, IniFileModel iniFileModel, Set<String> visited) {
+        if (dialog == null || !visited.add(dialog.getKey())) {
+            return 0;
+        }
+        int width = 0;
+        for (DialogModel.Field field : dialog.getFields()) {
+            Optional<IniField> iniField = iniFileModel.findIniField(field.getKey());
+            if (iniField.isPresent() && iniField.get() instanceof EnumIniField) {
+                EnumIniField enumField = (EnumIniField) iniField.get();
+                if (!CalibrationFieldFactory.isCheckboxEnum(enumField)) {
+                    width = Math.max(width, CalibrationFieldFactory.getComboBoxPreferredWidth(enumField));
+                }
+            }
+        }
+        for (PanelModel panel : dialog.getPanels()) {
+            width = Math.max(width, getFieldComboWidth(panel.resolveDialog(iniFileModel), iniFileModel, visited));
+        }
+        return width;
+    }
+
     private void renderField(JPanel container, DialogModel.Field field, IniFileModel iniFileModel,
-                             ConfigurationImage ci, int fieldLabelWidth) {
+                              ConfigurationImage ci, int fieldLabelWidth, int fieldComboWidth) {
         Runnable onChange = () -> {
             refreshExpressions();
             if ("trigger_type".equalsIgnoreCase(field.getKey()) ||
@@ -362,7 +385,8 @@ public class CalibrationDialogWidget {
         JPanel row = iniField.map(value -> {
             try {
                 return CalibrationFieldFactory.createFieldRow(
-                    field, value, ci, workingImage, onChange, onShowInPinout, fieldLabelWidth);
+                    field, value, ci, workingImage, onChange, onShowInPinout,
+                    fieldLabelWidth, fieldComboWidth);
             } catch (OrdinalOutOfRangeException e) {
                 log.warn("Skipping field " + field.getKey() + " with out-of-range ordinal: " + e.getMessage());
                 return CalibrationFieldFactory.createLabelRow(field);
@@ -482,8 +506,8 @@ public class CalibrationDialogWidget {
     }
 
     private void renderPanelEntry(JPanel container, PanelModel panel, IniFileModel iniFileModel, ConfigurationImage ci,
-                                  boolean isBorderLayout, JPanel[] horizontalPanelRef, Runnable notifyEdit,
-                                  int fieldLabelWidth) {
+                                   boolean isBorderLayout, JPanel[] horizontalPanelRef, Runnable notifyEdit,
+                                   int fieldLabelWidth, int fieldComboWidth) {
         String placement = panel.getPlacement();
 
         JPanel targetContainer;
@@ -554,7 +578,7 @@ public class CalibrationDialogWidget {
             panelWidget.setName(uiName);
             GradientTitleBorder.installBorder(uiName, panelWidget);
             fillPanel(panelWidget, subDialog, iniFileModel, ci,
-                Math.max(0, fieldLabelWidth - panelWidget.getInsets().left));
+                Math.max(0, fieldLabelWidth - panelWidget.getInsets().left), fieldComboWidth);
 
             if (TriggerImageHelper.isTriggerPanel(subDialog.getKey(), uiName) || "Sub Panel".equals(uiName)) {
                 addTriggerImage(panelWidget, subDialog.getKey(), uiName);

--- a/java_console/ui/src/main/java/com/rusefi/ui/widgets/tune/CalibrationFieldFactory.java
+++ b/java_console/ui/src/main/java/com/rusefi/ui/widgets/tune/CalibrationFieldFactory.java
@@ -55,6 +55,12 @@ public class CalibrationFieldFactory {
     static JPanel createFieldRow(DialogModel.Field field, IniField iniField, ConfigurationImage ci,
                                  ConfigurationImage workingImage, Runnable onChange,
                                  Consumer<String> onShowInPinout, int labelWidth) {
+        return createFieldRow(field, iniField, ci, workingImage, onChange, onShowInPinout, labelWidth, 0);
+    }
+
+    static JPanel createFieldRow(DialogModel.Field field, IniField iniField, ConfigurationImage ci,
+                                 ConfigurationImage workingImage, Runnable onChange,
+                                 Consumer<String> onShowInPinout, int labelWidth, int comboWidth) {
         JPanel row = createRowPanel();
         row.add(Box.createHorizontalStrut(10));
 
@@ -87,7 +93,8 @@ public class CalibrationFieldFactory {
                 row.add(checkBox);
                 value = () -> checkBox.isSelected() ? "enabled" : "disabled";
             } else {
-                JComboBox<String> comboBox = createComboBox(enumField, iniField, currentValue, workingImage, onChange);
+                JComboBox<String> comboBox = createComboBox(
+                    enumField, iniField, currentValue, workingImage, onChange, comboWidth);
                 row.add(comboBox);
                 value = () -> String.valueOf(comboBox.getSelectedItem());
                 JButton pinoutButton = createPinoutButton(comboBox, field.getKey(), onShowInPinout);
@@ -173,16 +180,19 @@ public class CalibrationFieldFactory {
         return checkBox;
     }
 
-    private static JComboBox<String> createComboBox(EnumIniField enumField, IniField iniField, String currentValue, ConfigurationImage workingImage, Runnable onChange) {
+    private static JComboBox<String> createComboBox(EnumIniField enumField, IniField iniField, String currentValue,
+                                                     ConfigurationImage workingImage, Runnable onChange, int comboWidth) {
         String cleanValue = currentValue.replace("\"", "");
-        String[] comboValues = enumField.getEnums().values().stream().filter(v -> !v.contains("INVALID")).toArray(String[]::new);
+        String[] comboValues = getComboValues(enumField);
         JComboBox<String> comboBox = new JComboBox<>(comboValues);
         applyStyle(comboBox);
         comboBox.setSelectedItem(cleanValue);
         comboBox.setToolTipText(cleanValue);
         applyBackgroundColor(comboBox, cleanValue);
         Dimension size = comboBox.getPreferredSize();
-        size.width = Math.min(size.width, MAX_COMBO_WIDTH);
+        size.width = comboWidth > 0
+            ? Math.min(comboWidth, MAX_COMBO_WIDTH)
+            : Math.min(size.width, MAX_COMBO_WIDTH);
         comboBox.setMinimumSize(new Dimension(0, size.height));
         comboBox.setPreferredSize(size);
         comboBox.setMaximumSize(size);
@@ -196,6 +206,18 @@ public class CalibrationFieldFactory {
             }
         });
         return comboBox;
+    }
+
+    static int getComboBoxPreferredWidth(EnumIniField enumField) {
+        JComboBox<String> comboBox = new JComboBox<>(getComboValues(enumField));
+        applyStyle(comboBox);
+        return Math.min(comboBox.getPreferredSize().width, MAX_COMBO_WIDTH);
+    }
+
+    private static String[] getComboValues(EnumIniField enumField) {
+        return enumField.getEnums().values().stream()
+            .filter(value -> !value.contains("INVALID"))
+            .toArray(String[]::new);
     }
 
     /**

--- a/java_console/ui/src/main/java/com/rusefi/ui/widgets/tune/CalibrationFieldFactory.java
+++ b/java_console/ui/src/main/java/com/rusefi/ui/widgets/tune/CalibrationFieldFactory.java
@@ -29,8 +29,29 @@ import java.util.regex.Pattern;
  * @see CalibrationDialogWidget
  */
 public class CalibrationFieldFactory {
-    static final int MAX_COMBO_WIDTH = 360;
-    static final int MAX_LABEL_WIDTH = 300;
+    static final int MAX_FIELD_EDITOR_WIDTH = 360;
+    static final int MAX_LABEL_WIDTH = 360;
+
+    private static class CalibrationTextField extends JTextField {
+        private int fieldEditorWidth;
+
+        CalibrationTextField(String text, int columns) {
+            super(text, columns);
+        }
+
+        void setFieldEditorWidth(int fieldEditorWidth) {
+            this.fieldEditorWidth = fieldEditorWidth;
+        }
+
+        @Override
+        public Dimension getPreferredSize() {
+            Dimension size = super.getPreferredSize();
+            if (fieldEditorWidth > 0) {
+                size.width = fieldEditorWidth;
+            }
+            return size;
+        }
+    }
 
     // we need to maintain this in sync with the ones used on tunerstudio.template
     private static final String[][] CheckboxPairs = {
@@ -60,7 +81,7 @@ public class CalibrationFieldFactory {
 
     static JPanel createFieldRow(DialogModel.Field field, IniField iniField, ConfigurationImage ci,
                                  ConfigurationImage workingImage, Runnable onChange,
-                                 Consumer<String> onShowInPinout, int labelWidth, int comboWidth) {
+                                 Consumer<String> onShowInPinout, int labelWidth, int fieldEditorWidth) {
         JPanel row = createRowPanel();
         row.add(Box.createHorizontalStrut(10));
 
@@ -94,7 +115,7 @@ public class CalibrationFieldFactory {
                 value = () -> checkBox.isSelected() ? "enabled" : "disabled";
             } else {
                 JComboBox<String> comboBox = createComboBox(
-                    enumField, iniField, currentValue, workingImage, onChange, comboWidth);
+                    enumField, iniField, currentValue, workingImage, onChange, fieldEditorWidth);
                 row.add(comboBox);
                 value = () -> String.valueOf(comboBox.getSelectedItem());
                 JButton pinoutButton = createPinoutButton(comboBox, field.getKey(), onShowInPinout);
@@ -105,7 +126,8 @@ public class CalibrationFieldFactory {
             }
         } else {
             String currentValue = ci == null ? "" : ConfigurationImageGetterSetter.getStringValue(iniField, ci);
-            JTextField textField = createTextField(iniField, currentValue, workingImage, onChange);
+            JTextField textField = createTextField(
+                iniField, currentValue, workingImage, onChange, fieldEditorWidth);
             row.add(textField);
             value = textField::getText;
         }
@@ -181,7 +203,8 @@ public class CalibrationFieldFactory {
     }
 
     private static JComboBox<String> createComboBox(EnumIniField enumField, IniField iniField, String currentValue,
-                                                     ConfigurationImage workingImage, Runnable onChange, int comboWidth) {
+                                                     ConfigurationImage workingImage, Runnable onChange,
+                                                     int fieldEditorWidth) {
         String cleanValue = currentValue.replace("\"", "");
         String[] comboValues = getComboValues(enumField);
         JComboBox<String> comboBox = new JComboBox<>(comboValues);
@@ -190,9 +213,9 @@ public class CalibrationFieldFactory {
         comboBox.setToolTipText(cleanValue);
         applyBackgroundColor(comboBox, cleanValue);
         Dimension size = comboBox.getPreferredSize();
-        size.width = comboWidth > 0
-            ? Math.min(comboWidth, MAX_COMBO_WIDTH)
-            : Math.min(size.width, MAX_COMBO_WIDTH);
+        size.width = fieldEditorWidth > 0
+            ? Math.min(fieldEditorWidth, MAX_FIELD_EDITOR_WIDTH)
+            : Math.min(size.width, MAX_FIELD_EDITOR_WIDTH);
         comboBox.setMinimumSize(new Dimension(0, size.height));
         comboBox.setPreferredSize(size);
         comboBox.setMaximumSize(size);
@@ -208,10 +231,20 @@ public class CalibrationFieldFactory {
         return comboBox;
     }
 
-    static int getComboBoxPreferredWidth(EnumIniField enumField) {
-        JComboBox<String> comboBox = new JComboBox<>(getComboValues(enumField));
-        applyStyle(comboBox);
-        return Math.min(comboBox.getPreferredSize().width, MAX_COMBO_WIDTH);
+    static int getFieldEditorPreferredWidth(IniField iniField, String currentValue) {
+        JComponent editor;
+        if (iniField instanceof EnumIniField) {
+            EnumIniField enumField = (EnumIniField) iniField;
+            if (isCheckboxEnum(enumField)) {
+                return 0;
+            }
+            JComboBox<String> comboBox = new JComboBox<>(getComboValues(enumField));
+            applyStyle(comboBox);
+            editor = comboBox;
+        } else {
+            editor = createTextFieldComponent(iniField, currentValue);
+        }
+        return Math.min(editor.getPreferredSize().width, MAX_FIELD_EDITOR_WIDTH);
     }
 
     private static String[] getComboValues(EnumIniField enumField) {
@@ -263,12 +296,15 @@ public class CalibrationFieldFactory {
             ? null : value;
     }
 
-    private static JTextField createTextField(IniField iniField, String currentValue, ConfigurationImage workingImage, Runnable onChange) {
-        int columns = iniField instanceof StringIniField
-            ? Math.min(((StringIniField) iniField).getSize(), 32) : 0;
-        JTextField textField = new JTextField(currentValue, columns);
-        applyStyle(textField);
-        applyBackgroundColor(textField, currentValue);
+    private static JTextField createTextField(IniField iniField, String currentValue,
+                                              ConfigurationImage workingImage, Runnable onChange,
+                                              int fieldEditorWidth) {
+        CalibrationTextField textField = createTextFieldComponent(iniField, currentValue);
+        if (fieldEditorWidth > 0) {
+            textField.setFieldEditorWidth(Math.min(fieldEditorWidth, MAX_FIELD_EDITOR_WIDTH));
+            Dimension size = textField.getPreferredSize();
+            textField.setMinimumSize(new Dimension(0, size.height));
+        }
         textField.setMaximumSize(textField.getPreferredSize());
         textField.getDocument().addDocumentListener(new DocumentListener() {
             private void sync() {
@@ -296,6 +332,15 @@ public class CalibrationFieldFactory {
                 sync();
             }
         });
+        return textField;
+    }
+
+    private static CalibrationTextField createTextFieldComponent(IniField iniField, String currentValue) {
+        int columns = iniField instanceof StringIniField
+            ? Math.min(((StringIniField) iniField).getSize(), 32) : 0;
+        CalibrationTextField textField = new CalibrationTextField(currentValue, columns);
+        applyStyle(textField);
+        applyBackgroundColor(textField, currentValue);
         return textField;
     }
 

--- a/java_console/ui/src/test/java/com/rusefi/ui/widgets/tune/CalibrationDialogWidgetTest.java
+++ b/java_console/ui/src/test/java/com/rusefi/ui/widgets/tune/CalibrationDialogWidgetTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.Test;
 import javax.swing.*;
 import java.awt.*;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -479,6 +480,42 @@ public class CalibrationDialogWidgetTest {
         assertEquals(CalibrationFieldFactory.MAX_COMBO_WIDTH, combo.getPreferredSize().width);
         assertEquals(0, combo.getMinimumSize().width);
         assertEquals(longOption, combo.getToolTipText());
+    }
+
+    @Test
+    public void testComboEditorsShareWidth() {
+        IniFileModel iniFileModel = mock(IniFileModel.class);
+        when(iniFileModel.getCurves()).thenReturn(Collections.emptyMap());
+
+        Map<Integer, String> shortValues = new HashMap<>();
+        shortValues.put(0, "Off");
+        shortValues.put(1, "On");
+        EnumIniField shortField = new EnumIniField("short", 0, FieldType.INT8,
+            new EnumIniField.EnumKeyValueMap(shortValues), 0, 0);
+
+        Map<Integer, String> longValues = new HashMap<>();
+        longValues.put(0, "NONE");
+        longValues.put(1, "B18 VVT2 or Idle or Low Side output 2");
+        EnumIniField longField = new EnumIniField("long", 1, FieldType.INT8,
+            new EnumIniField.EnumKeyValueMap(longValues), 0, 0);
+
+        when(iniFileModel.findIniField("short")).thenReturn(java.util.Optional.of(shortField));
+        when(iniFileModel.findIniField("long")).thenReturn(java.util.Optional.of(longField));
+
+        DialogModel dialog = new DialogModel("main", "Main", Arrays.asList(
+            new DialogModel.Field("short", "Short"),
+            new DialogModel.Field("long", "Long")), Collections.emptyList());
+
+        CalibrationDialogWidget widget = new CalibrationDialogWidget(new UIContext());
+        widget.update(dialog, iniFileModel, new ConfigurationImage(new byte[2]));
+
+        JComboBox<?> shortCombo = getComboBoxFromRow((JPanel) widget.getContentPane().getComponent(0));
+        JComboBox<?> longCombo = getComboBoxFromRow((JPanel) widget.getContentPane().getComponent(1));
+        assertNotNull(shortCombo);
+        assertNotNull(longCombo);
+        int expectedWidth = CalibrationFieldFactory.getComboBoxPreferredWidth(longField);
+        assertEquals(expectedWidth, shortCombo.getPreferredSize().width);
+        assertEquals(expectedWidth, longCombo.getPreferredSize().width);
     }
 
     @Test

--- a/java_console/ui/src/test/java/com/rusefi/ui/widgets/tune/CalibrationDialogWidgetTest.java
+++ b/java_console/ui/src/test/java/com/rusefi/ui/widgets/tune/CalibrationDialogWidgetTest.java
@@ -477,7 +477,7 @@ public class CalibrationDialogWidgetTest {
             }
         }
         assertNotNull(combo);
-        assertEquals(CalibrationFieldFactory.MAX_COMBO_WIDTH, combo.getPreferredSize().width);
+        assertEquals(CalibrationFieldFactory.MAX_FIELD_EDITOR_WIDTH, combo.getPreferredSize().width);
         assertEquals(0, combo.getMinimumSize().width);
         assertEquals(longOption, combo.getToolTipText());
     }
@@ -513,9 +513,39 @@ public class CalibrationDialogWidgetTest {
         JComboBox<?> longCombo = getComboBoxFromRow((JPanel) widget.getContentPane().getComponent(1));
         assertNotNull(shortCombo);
         assertNotNull(longCombo);
-        int expectedWidth = CalibrationFieldFactory.getComboBoxPreferredWidth(longField);
+        int expectedWidth = CalibrationFieldFactory.getFieldEditorPreferredWidth(longField, "");
         assertEquals(expectedWidth, shortCombo.getPreferredSize().width);
         assertEquals(expectedWidth, longCombo.getPreferredSize().width);
+    }
+
+    @Test
+    public void testTextAndComboEditorsShareWidth() {
+        IniFileModel iniFileModel = mock(IniFileModel.class);
+        when(iniFileModel.getCurves()).thenReturn(Collections.emptyMap());
+
+        Map<Integer, String> enumValues = new HashMap<>();
+        enumValues.put(0, "NONE");
+        enumValues.put(1, "B18 VVT2 or Idle or Low Side output 2");
+        EnumIniField enumField = new EnumIniField("mode", 0, FieldType.INT8,
+            new EnumIniField.EnumKeyValueMap(enumValues), 0, 0);
+        com.opensr5.ini.field.StringIniField textField =
+            new com.opensr5.ini.field.StringIniField("value", 1, 4);
+
+        when(iniFileModel.findIniField("mode")).thenReturn(java.util.Optional.of(enumField));
+        when(iniFileModel.findIniField("value")).thenReturn(java.util.Optional.of(textField));
+
+        DialogModel dialog = new DialogModel("main", "Main", Arrays.asList(
+            new DialogModel.Field("mode", "Mode"),
+            new DialogModel.Field("value", "Value")), Collections.emptyList());
+
+        CalibrationDialogWidget widget = new CalibrationDialogWidget(new UIContext());
+        widget.update(dialog, iniFileModel, new ConfigurationImage(new byte[5]));
+
+        JComboBox<?> combo = getComboBoxFromRow((JPanel) widget.getContentPane().getComponent(0));
+        JTextField text = getTextFieldFromRow((JPanel) widget.getContentPane().getComponent(1));
+        assertNotNull(combo);
+        assertNotNull(text);
+        assertEquals(combo.getPreferredSize().width, text.getPreferredSize().width);
     }
 
     @Test


### PR DESCRIPTION
all types of inputs (combo/numeric/string) now share the same width if they are on the same group

<img width="860" height="948" alt="image" src="https://github.com/user-attachments/assets/d581773a-1f9b-4768-8641-78bcf8c752ae" />

resolves #10140